### PR TITLE
[1/2] Migrate Kotlin metadata tests to JDK 25

### DIFF
--- a/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "app.cash.sqldelight:runtime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "app.cash.sqldelight:runtime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "app.cash.sqldelight:async-extensions-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/async-extensions-jvm/2.3.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'com.h2database:h2:2.3.230'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "app.cash.sqldelight:jdbc-driver:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'com.h2database:h2:2.3.230'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/jdbc-driver/2.3.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/sqlite-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/sqlite-driver/2.3.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/sqlite-driver/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/sqlite-driver/2.3.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(21)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = "21"
 }
 
 graalvmNative {

--- a/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
+++ b/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.akuleshov7:ktoml-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
+++ b/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.akuleshov7:ktoml-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
+++ b/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
+++ b/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
+++ b/tests/src/com.akuleshov7/ktoml-core-jvm/0.7.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.akuleshov7:ktoml-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-kotlin/2.17.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-core-jvm/5.1.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
+++ b/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.colormath:colormath-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
+++ b/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
+++ b/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.github.ajalt.colormath:colormath-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
+++ b/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
+++ b/tests/src/com.github.ajalt.colormath/colormath-jvm/3.6.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.github.ajalt.colormath:colormath-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-core-jvm/3.0.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-jvm-graal-ffi-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-graal-ffi-jvm/3.0.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.moshi:moshi-adapters:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.moshi:moshi-adapters:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-adapters/1.15.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.moshi:moshi-adapters:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/mockwebserver/4.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.0.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
+++ b/tests/src/com.squareup.okio/okio-jvm/3.6.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.okio:okio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-atomic-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-atomic-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-atomic-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-atomic-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-core-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-fx-coroutines-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-fx-coroutines-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-fx-coroutines-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-fx-coroutines-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.github.oshai:kotlin-logging-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
+++ b/tests/src/io.github.oshai/kotlin-logging-jvm/8.0.01/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:core-jvmcommon:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:core-jvmcommon:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:core-jvmcommon:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/core-jvmcommon/0.91.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.kotest:kotest-assertions-shared-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.kotest:kotest-assertions-shared-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-assertions-shared-jvm/6.1.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.kotest:kotest-assertions-shared-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
@@ -15,6 +15,14 @@ dependencies {
     testImplementation "io.kotest:kotest-extensions-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
 tasks.withType(Test).configureEach {
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED',
             '--add-opens=java.base/java.lang=ALL-UNNAMED'

--- a/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 tasks.withType(Test).configureEach {

--- a/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.kotest:kotest-extensions-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 tasks.withType(Test).configureEach {
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED',
             '--add-opens=java.base/java.lang=ALL-UNNAMED'

--- a/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-extensions-jvm/6.1.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.kotest:kotest-extensions-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 tasks.withType(Test).configureEach {
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED',

--- a/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.kotest:kotest-runner-junit-platform-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.kotest:kotest-runner-junit-platform-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-runner-junit-platform-jvm/6.1.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.kotest:kotest-runner-junit-platform-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-apache5-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-apache5-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-apache5-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-apache5-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-cio-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-cio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-java-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-java-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-java-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-java-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-okhttp-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-okhttp-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-okhttp-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-okhttp-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-events-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-events-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-events-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-events-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-network-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-network-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-network-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-jvm/3.4.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-cbor-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-cbor-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-cbor-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
     id "org.jetbrains.kotlin.plugin.serialization" version "2.3.20"
 }
 

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-auth-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-cio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-cio-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-status-pages-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-status-pages-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-websockets-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-websockets-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-test-dispatcher-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-test-dispatcher-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-test-dispatcher-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-test-dispatcher-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-utils-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-utils-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-utils-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-utils-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-websockets-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-websockets-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websockets-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-websockets-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.mockk:mockk-agent-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.mockk:mockk-agent-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-jvm/1.14.9/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.mockk:mockk-agent-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.mockk:mockk-dsl-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.mockk:mockk-dsl-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-dsl-jvm/1.14.9/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.mockk:mockk-dsl-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-json:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-json:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-json/1.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-json:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-common:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-common/2.3.21/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
@@ -17,15 +17,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 String findRuntimeClasspathJar(String prefix) {
     File match = sourceSets.test.runtimeClasspath.files.find { File candidate ->
         candidate.name.startsWith(prefix) && candidate.name.endsWith(".jar")

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 String findRuntimeClasspathJar(String prefix) {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
@@ -17,6 +17,14 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
 String findRuntimeClasspathJar(String prefix) {
     File match = sourceSets.test.runtimeClasspath.files.find { File candidate ->
         candidate.name.startsWith(prefix) && candidate.name.endsWith(".jar")

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jsr223/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 Provider<Directory> generatedTestRuntimePropertiesDir = layout.buildDirectory.dir("generated/test-runtime-properties")
 
 dependencies {
@@ -19,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 String findRuntimeClasspathJar(String prefix) {
     File match = sourceSets.test.runtimeClasspath.files.find { File candidate ->

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-jvm/2.3.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -18,6 +18,15 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-test-junit:1.7.10'
 
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -18,15 +18,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-test-junit:1.7.10'
 
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
@@ -20,11 +21,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit/1.2.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-testng:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-testng:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-testng/2.3.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-testng:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-guava/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8/1.6.4/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx3/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-datetime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-datetime-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-datetime-jvm/0.7.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-datetime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-html-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-html-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-html-jvm/0.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-html-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-bytestring-jvm/0.8.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-hocon:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-hocon:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-hocon/1.11.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-hocon:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.8.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-properties-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-properties-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-properties-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
     id "org.jetbrains.kotlin.plugin.serialization" version "2.3.20"
 }
 

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-properties-jvm/1.11.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
+++ b/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
+++ b/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
+++ b/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "tools.jackson.module:jackson-module-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
+++ b/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "tools.jackson.module:jackson-module-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
+++ b/tests/src/tools.jackson.module/jackson-module-kotlin/3.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "tools.jackson.module:jackson-module-kotlin:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {


### PR DESCRIPTION
## Summary

- migrate the first balanced half of Kotlin metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `jvmToolchain(testJvmVersion)` and `kotlinOptions.jvmTarget = testJvmVersion.toString()` declarations so Kotlin and Java test compilation stay aligned
- switch Kotlin Gradle plugin declarations to `alias(libs.plugins.kotlin.jvm)`
- covers 58 libraries / 61 test build files, balanced to roughly 62 tested-version batches / 186 metadata jobs
- leave `app.cash.sqldelight:sqlite-driver` pinned to JDK 21 for now because it is currently blocked by an unrelated GraalVM/native-image transient tracked in #8446

Part of #8435

## Testing

- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew javaTest -Pcoordinates=org.jetbrains.kotlin:kotlin-stdlib:1.3.72 --stacktrace`
- `git diff --check master...kotlin-jdk25-tests-1`