### PR TITLE
[2/2] Migrate Kotlin metadata tests to JDK 25

### DIFF
--- a/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "app.cash.sqldelight:coroutines-extensions-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "app.cash.sqldelight:coroutines-extensions-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/coroutines-extensions-jvm/2.3.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "app.cash.sqldelight:coroutines-extensions-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "app.cash.sqldelight:runtime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "app.cash.sqldelight:runtime-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "app.cash.sqldelight:runtime-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
+++ b/tests/src/app.cash.sqldelight/runtime-jvm/2.3.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
+++ b/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
+++ b/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
+++ b/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "app.cash.turbine:turbine-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
+++ b/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "app.cash.turbine:turbine-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
+++ b/tests/src/app.cash.turbine/turbine-jvm/1.2.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "app.cash.turbine:turbine-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
+++ b/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'com.squareup.okio:okio-jvm:3.16.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
+++ b/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'com.squareup.okio:okio-jvm:3.16.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
+++ b/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.charleskorn.kaml:kaml-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
+++ b/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
+++ b/tests/src/com.charleskorn.kaml/kaml-jvm/0.104.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
+++ b/tests/src/com.github.ajalt.clikt/clikt-jvm/5.1.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.github.ajalt.clikt:clikt-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 tasks.withType(Test).configureEach {
     jvmArgs += [
         "--enable-native-access=ALL-UNNAMED"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
@@ -16,6 +16,14 @@ dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
 tasks.withType(Test).configureEach {
     jvmArgs += [
         "--enable-native-access=ALL-UNNAMED"

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ajalt.mordant:mordant-jvm-ffm-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 tasks.withType(Test).configureEach {
     jvmArgs += [

--- a/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
+++ b/tests/src/com.github.ajalt.mordant/mordant-jvm-ffm-jvm/3.0.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 tasks.withType(Test).configureEach {

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.sksamuel.hoplite:hoplite-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.sksamuel.hoplite:hoplite-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
+++ b/tests/src/com.sksamuel.hoplite/hoplite-core/2.9.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.sksamuel.hoplite:hoplite-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.moshi:moshi-kotlin:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.moshi:moshi-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
+++ b/tests/src/com.squareup.moshi/moshi-kotlin/1.15.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.moshi:moshi-kotlin:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "com.squareup.okhttp3:logging-interceptor:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.squareup.okhttp3:logging-interceptor:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
+++ b/tests/src/com.squareup.okhttp3/logging-interceptor/4.12.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "com.squareup.okhttp3:logging-interceptor:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-annotations-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-annotations-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-annotations-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-annotations-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-autoclose-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-autoclose-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-autoclose-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-autoclose-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-exception-utils-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-exception-utils-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-exception-utils-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-exception-utils-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-fx-coroutines-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.arrow-kt:arrow-fx-coroutines-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.arrow-kt:arrow-resilience-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
+++ b/tests/src/io.arrow-kt/arrow-resilience-jvm/2.2.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:serialization-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:serialization-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
+++ b/tests/src/io.github.pdvrieze.xmlutil/serialization-jvm/0.91.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.github.pdvrieze.xmlutil:serialization-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
+++ b/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
@@ -24,11 +24,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
+++ b/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
+++ b/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.github.resilience4j:resilience4j-kotlin:$libraryVersion"
@@ -24,11 +25,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
+++ b/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
@@ -22,6 +22,15 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
+++ b/tests/src/io.github.resilience4j/resilience4j-kotlin/2.4.0/build.gradle
@@ -22,15 +22,6 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.kotest:kotest-common-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.kotest:kotest-common-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-common-jvm/6.1.11/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.kotest:kotest-common-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.kotest:kotest-property-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.kotest:kotest-property-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
+++ b/tests/src/io.kotest/kotest-property-jvm/6.1.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.kotest:kotest-property-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-content-negotiation-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-content-negotiation-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-core-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-mock-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-client-core-jvm/3.2.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-client-logging-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-client-logging-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-client-logging-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-client-logging-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
+++ b/tests/src/io.ktor/ktor-http-cio-jvm/3.4.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-http-cio-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-io-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-io-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-io-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-io-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-certificates-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-network-tls-certificates-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-network-tls-certificates-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-network-tls-certificates-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-json-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-json-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-json-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
     id "org.jetbrains.kotlin.plugin.serialization" version "2.3.20"
 }
 

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-json-jvm/3.2.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-protobuf-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-protobuf-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
     id "org.jetbrains.kotlin.plugin.serialization" version "2.3.20"
 }
 

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-serialization-kotlinx-protobuf-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-serialization-kotlinx-protobuf-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-auth-jwt-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-auth-jwt-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-content-negotiation-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-server-content-negotiation-jvm/3.2.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-sessions-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-sessions-jvm/3.4.3/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
+++ b/tests/src/io.ktor/ktor-server-test-host-jvm/3.4.3/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-server-test-host-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-sse-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-sse-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-sse-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-sse-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.ktor:ktor-websocket-serialization-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.ktor:ktor-websocket-serialization-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
+++ b/tests/src/io.ktor/ktor-websocket-serialization-jvm/3.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.ktor:ktor-websocket-serialization-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.mockk:mockk-agent-api-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.mockk:mockk-agent-api-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.mockk:mockk-agent-api-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-agent-api-jvm/1.14.9/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "io.mockk:mockk-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "io.mockk:mockk-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.mockk:mockk-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
+++ b/tests/src/io.mockk/mockk-core-jvm/1.14.9/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
+++ b/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "net.thauvin.erik.urlencoder:urlencoder-lib-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
+++ b/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "net.thauvin.erik.urlencoder:urlencoder-lib-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
+++ b/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "net.thauvin.erik.urlencoder:urlencoder-lib-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
+++ b/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
+++ b/tests/src/net.thauvin.erik.urlencoder/urlencoder-lib-jvm/1.6.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.0.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.1.1/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-core:$libraryVersion"
@@ -19,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
@@ -17,6 +17,15 @@ dependencies {
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre11'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
@@ -17,15 +17,6 @@ dependencies {
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre11'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-core/1.3.0/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-dao:$libraryVersion"
@@ -19,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
@@ -17,6 +17,15 @@ dependencies {
     testImplementation 'com.h2database:h2:2.1.214'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-dao/1.2.0/build.gradle
@@ -17,15 +17,6 @@ dependencies {
     testImplementation 'com.h2database:h2:2.1.214'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-jdbc:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-jdbc:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-jdbc:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-jdbc/1.0.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.exposed:exposed-kotlin-datetime:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-kotlin-datetime:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
+++ b/tests/src/org.jetbrains.exposed/exposed-kotlin-datetime/1.2.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.exposed:exposed-kotlin-datetime:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
@@ -18,15 +18,6 @@ dependencies {
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
@@ -18,6 +18,15 @@ dependencies {
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-android-extensions-runtime/1.3.72/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-android-extensions-runtime:$libraryVersion"
@@ -20,11 +21,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
@@ -18,15 +18,6 @@ dependencies {
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
@@ -20,11 +20,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-parcelize-runtime:$libraryVersion"
@@ -20,11 +21,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-parcelize-runtime/1.7.10/build.gradle
@@ -18,6 +18,15 @@ dependencies {
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-reflect/1.7.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/2.3.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test-junit5/2.3.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-test/2.0.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:atomicfu-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:atomicfu-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/atomicfu-jvm/0.19.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:atomicfu-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-cli-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-cli-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-cli-jvm/0.3.6/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-cli-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-collections-immutable-jvm/0.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-rx2/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-slf4j/1.10.2/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-coroutines-test-jvm/1.10.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-core-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-io-core-jvm/0.8.2/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-io-core-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
@@ -15,15 +15,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
@@ -15,6 +15,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-cbor-jvm:$libraryVersion"
@@ -17,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json-io-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.6.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-io-core-jvm:0.6.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation 'com.squareup.okio:okio:3.9.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json-okio-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation 'com.squareup.okio:okio:3.9.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
@@ -11,6 +11,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm:$libraryVersion"
@@ -18,11 +19,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(25)
+    jvmToolchain(testJvmVersion)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
+    kotlinOptions.jvmTarget = testJvmVersion.toString()
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
@@ -6,7 +6,7 @@
  */
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
     id "org.jetbrains.kotlin.plugin.serialization" version "2.3.20"
 }
 

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
@@ -16,15 +16,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
-
-kotlin {
-    jvmToolchain(25)
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "25"
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "21"
+    kotlinOptions.jvmTarget = "25"
 }
 
 graalvmNative {

--- a/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
+++ b/tests/src/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/build.gradle
@@ -16,6 +16,15 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
+
+kotlin {
+    jvmToolchain(25)
+}
+
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "25"
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"


### PR DESCRIPTION
## Summary

- migrate the second balanced half of Kotlin metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `jvmToolchain(testJvmVersion)` and `kotlinOptions.jvmTarget = testJvmVersion.toString()` declarations so Kotlin and Java test compilation stay aligned
- switch Kotlin Gradle plugin declarations to `alias(libs.plugins.kotlin.jvm)`
- covers 58 libraries / 64 test build files, balanced to roughly 62 tested-version batches / 186 metadata jobs

Part of #8435

## Testing

- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew javaTest -Pcoordinates=app.cash.turbine:turbine-jvm:1.2.1 --stacktrace`
- `git diff --check master...kotlin-jdk25-tests-2`