### PR TITLE
Split library-update tested-version aliases

### DIFF
--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -317,6 +317,41 @@ paths. If any shared repository file changed, the PR must be labeled
 the repository-level paths that require maintainer review, following
 §FS-human-intervention-policy.
 
+### FS-library-update-tested-version-split: Library-update tested-version split
+
+For a `library-update-request` publication that changes generated tests for an
+existing metadata entry, Forge must run a Java-only compatibility sweep before
+the branch becomes PR-eligible (§FS-local-ci-equivalent-verification). The sweep
+executes `javaTest` for the changed metadata coordinate with `GVM_TCK_LV` set to
+each tested-version alias in the index entry, in index order, and stops at the
+first failing alias. This is intentionally narrower than full CI: it catches
+generated JVM test code that is incompatible with later aliases without paying
+the native-image matrix cost locally.
+
+If the first alias fails, Forge must fail publication instead of splitting,
+because there is no passing prefix for the current update. If a later alias
+fails, Forge must split the index entry at that first failing alias. The
+generated metadata version keeps only the passing prefix. A successor entry uses
+the failing alias as its `metadata-version`, preserves that alias and all later
+aliases as its `tested-versions`, and receives `latest: true` when the split
+entry previously carried `latest: true`.
+
+The successor entry must preserve the repository's pre-generation support for
+the failing range. Forge must copy the metadata directory and test directory
+from the PR base commit entry that originally covered the failing alias, using
+that original entry's `metadata-version` and `test-version` if present, into
+`metadata/<group>/<artifact>/<failing-version>` and
+`tests/src/<group>/<artifact>/<failing-version>`. The current PR then keeps the
+new generated progress for the passing prefix while retaining baseline support
+for the successor range.
+
+When Forge creates such a split, it must also create a follow-up
+`library-update-request` issue for the successor metadata version and place that
+issue in `In Progress`. The current PR must reference the follow-up issue but
+must not close it. After the current PR merges, Forge releases the follow-up
+issue by clearing assignees and moving its project status to `Todo`, making the
+successor update eligible for normal processing.
+
 ### FS-human-intervention-policy: Human intervention policy
 
 The `human-intervention` label is a maintainer follow-up signal, not a generic

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -319,39 +319,40 @@ the repository-level paths that require maintainer review, following
 
 ### FS-library-update-tested-version-split: Library-update tested-version split
 
-A `library-update-request` entry often covers several tested-version aliases at
-once (for example `["1.1", "1.2", "1.3"]`). When a coverage-improvement run
-regenerates the JVM tests for such an entry, the new tests can pass on the
-entry's own version yet stop compiling or running against a *later* alias. Forge
-must catch that break before the branch becomes PR-eligible and split the entry,
-so the PR keeps the regenerated progress for the aliases that still pass while
-the repository keeps its existing support for the rest.
+A `library-update-request` entry often lists several tested versions of the same
+library at once (for example `["1.1", "1.2", "1.3"]`). When a coverage-improvement
+run regenerates the JVM tests for such an entry, the new tests can pass on the
+entry's own version yet stop compiling or running against a *later* tested
+version. Forge must catch that break before the branch becomes PR-eligible and
+split the entry, so the PR keeps the regenerated progress for the versions that
+still pass while the repository keeps its existing support for the rest.
 
-**Alias sweep.** Before publication (§FS-local-ci-equivalent-verification), Forge
-runs a Java-only sweep. It runs `javaTest` for the changed coordinate once per
-tested-version alias, walking the index entry in order with `GVM_TCK_LV` set to
-each alias, and stops at the first alias that fails. The sweep is deliberately
-narrower than full CI — it skips the native-image matrix — because it only needs
-to catch JVM test code that no longer works on a later alias.
+**Version sweep.** Before publication (§FS-local-ci-equivalent-verification),
+Forge runs a Java-only sweep. It runs `javaTest` for the changed coordinate once
+per tested version, walking the entry's `tested-versions` in order with
+`GVM_TCK_LV` set to each version, and stops at the first version that fails. The
+sweep is deliberately narrower than full CI — it skips the native-image matrix —
+because it only needs to catch JVM test code that no longer works on a later
+version.
 
 **Progress output.** Forge must report the sweep on the CLI: the changed
-coordinate, how many aliases it will check, each alias version as it starts, the
-log path for that alias, and whether the alias passed or failed. When every alias
-passes, the output must say plainly that no split is needed.
+coordinate, how many versions it will check, each version as it starts, the log
+path for that version, and whether the version passed or failed. When every
+version passes, the output must say plainly that no split is needed.
 
-**Outcome.** If the *first* alias fails there is no passing prefix to keep, so
-Forge fails publication instead of splitting. If a *later* alias fails, Forge
-splits the index entry at that first failing alias into two entries:
+**Outcome.** If the *first* version fails there is no passing prefix to keep, so
+Forge fails publication instead of splitting. If a *later* version fails, Forge
+splits the index entry at that first failing version into two entries:
 
 | | `metadata-version` | `tested-versions` | `latest` | contents |
 |---|---|---|---|---|
 | **Current entry** | unchanged | the passing prefix | kept unless it moves to the successor | the regenerated metadata and tests from this PR |
-| **Successor entry** | the first failing alias | the failing alias and every later one | inherited when the split entry had `latest: true` | baseline metadata and tests copied from the PR base commit |
+| **Successor entry** | the first failing version | the failing version and every later one | inherited when the split entry had `latest: true` | baseline metadata and tests copied from the PR base commit |
 
 **Successor contents.** The successor entry must preserve the repository's
 pre-generation support for the failing range. Forge copies the metadata and test
 directories from the PR base commit entry that originally covered the failing
-alias — using that entry's `metadata-version` and `test-version` when present —
+version — using that entry's `metadata-version` and `test-version` when present —
 into `metadata/<group>/<artifact>/<failing-version>` and
 `tests/src/<group>/<artifact>/<failing-version>`. The PR then ships the new
 generated progress for the passing prefix and keeps baseline support for the

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -319,43 +319,50 @@ the repository-level paths that require maintainer review, following
 
 ### FS-library-update-tested-version-split: Library-update tested-version split
 
-For a `library-update-request` publication that changes generated tests for an
-existing metadata entry, Forge must run a Java-only compatibility sweep before
-the branch becomes PR-eligible (§FS-local-ci-equivalent-verification). The sweep
-executes `javaTest` for the changed metadata coordinate with `GVM_TCK_LV` set to
-each tested-version alias in the index entry, in index order, and stops at the
-first failing alias. This is intentionally narrower than full CI: it catches
-generated JVM test code that is incompatible with later aliases without paying
-the native-image matrix cost locally.
+A `library-update-request` entry often covers several tested-version aliases at
+once (for example `["1.1", "1.2", "1.3"]`). When a coverage-improvement run
+regenerates the JVM tests for such an entry, the new tests can pass on the
+entry's own version yet stop compiling or running against a *later* alias. Forge
+must catch that break before the branch becomes PR-eligible and split the entry,
+so the PR keeps the regenerated progress for the aliases that still pass while
+the repository keeps its existing support for the rest.
 
-Forge must print CLI progress for the sweep, including the changed coordinate,
-the number of aliases being checked, each alias version as it starts, the log
-path for that alias, and whether the alias passed or failed. If all aliases
-pass, the CLI output must make clear that no tested-version split is needed.
+**Alias sweep.** Before publication (§FS-local-ci-equivalent-verification), Forge
+runs a Java-only sweep. It runs `javaTest` for the changed coordinate once per
+tested-version alias, walking the index entry in order with `GVM_TCK_LV` set to
+each alias, and stops at the first alias that fails. The sweep is deliberately
+narrower than full CI — it skips the native-image matrix — because it only needs
+to catch JVM test code that no longer works on a later alias.
 
-If the first alias fails, Forge must fail publication instead of splitting,
-because there is no passing prefix for the current update. If a later alias
-fails, Forge must split the index entry at that first failing alias. The
-generated metadata version keeps only the passing prefix. A successor entry uses
-the failing alias as its `metadata-version`, preserves that alias and all later
-aliases as its `tested-versions`, and receives `latest: true` when the split
-entry previously carried `latest: true`.
+**Progress output.** Forge must report the sweep on the CLI: the changed
+coordinate, how many aliases it will check, each alias version as it starts, the
+log path for that alias, and whether the alias passed or failed. When every alias
+passes, the output must say plainly that no split is needed.
 
-The successor entry must preserve the repository's pre-generation support for
-the failing range. Forge must copy the metadata directory and test directory
-from the PR base commit entry that originally covered the failing alias, using
-that original entry's `metadata-version` and `test-version` if present, into
-`metadata/<group>/<artifact>/<failing-version>` and
-`tests/src/<group>/<artifact>/<failing-version>`. The current PR then keeps the
-new generated progress for the passing prefix while retaining baseline support
-for the successor range.
+**Outcome.** If the *first* alias fails there is no passing prefix to keep, so
+Forge fails publication instead of splitting. If a *later* alias fails, Forge
+splits the index entry at that first failing alias into two entries:
 
-When Forge creates such a split, it must also create a follow-up
-`library-update-request` issue for the successor metadata version and place that
-issue in `In Progress`. The current PR must reference the follow-up issue but
-must not close it. After the current PR merges, Forge releases the follow-up
-issue by clearing assignees and moving its project status to `Todo`, making the
-successor update eligible for normal processing.
+| | `metadata-version` | `tested-versions` | `latest` | contents |
+|---|---|---|---|---|
+| **Current entry** | unchanged | the passing prefix | kept unless it moves to the successor | the regenerated metadata and tests from this PR |
+| **Successor entry** | the first failing alias | the failing alias and every later one | inherited when the split entry had `latest: true` | baseline metadata and tests copied from the PR base commit |
+
+**Successor contents.** The successor entry must preserve the repository's
+pre-generation support for the failing range. Forge copies the metadata and test
+directories from the PR base commit entry that originally covered the failing
+alias — using that entry's `metadata-version` and `test-version` when present —
+into `metadata/<group>/<artifact>/<failing-version>` and
+`tests/src/<group>/<artifact>/<failing-version>`. The PR then ships the new
+generated progress for the passing prefix and keeps baseline support for the
+successor range.
+
+**Follow-up issue.** On every split, Forge also opens a `library-update-request`
+issue for the successor metadata version and holds it in `In Progress` so the
+queue cannot claim it early. The PR references this issue but does not close it,
+through the `Refs:` line and `Forge-Unblocks-Issue:` trailer of §GIT-pr-body.
+Once the PR merges, Forge releases the issue — clearing its assignees and moving
+its project status to `Todo` — so the successor update enters normal processing.
 
 ### FS-human-intervention-policy: Human intervention policy
 

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -328,6 +328,11 @@ first failing alias. This is intentionally narrower than full CI: it catches
 generated JVM test code that is incompatible with later aliases without paying
 the native-image matrix cost locally.
 
+Forge must print CLI progress for the sweep, including the changed coordinate,
+the number of aliases being checked, each alias version as it starts, the log
+path for that alias, and whether the alias passed or failed. If all aliases
+pass, the CLI output must make clear that no tested-version split is needed.
+
 If the first alias fails, Forge must fail publication instead of splitting,
 because there is no passing prefix for the current update. If a later alias
 fails, Forge must split the index entry at that first failing alias. The

--- a/forge/docs/git-scripts.md
+++ b/forge/docs/git-scripts.md
@@ -35,8 +35,9 @@ branch namespace, stale remote-branch deletion, workflow-specific staging,
 fork-aware base fetch and rebase, local CI-equivalent verification
 (§FS-local-ci-equivalent-verification), and the final push. Publishers
 contribute only their workflow-specific parts — the staging policy
-(§GIT-expected-paths), optional pre-rebase and post-verification assertions,
-and the PR title/body/label construction (§GIT-pr-body, §GIT-issue-linking) —
+(§GIT-expected-paths), optional pre-rebase, pre-verification, and
+post-verification assertions, and the PR title/body/label construction
+(§GIT-pr-body, §GIT-issue-linking) —
 so there is exactly one code path for how a verified diff becomes a pushed
 branch. Publication bookkeeping needed by several publishers (PR-number
 parsing and the old-vs-new test diff embedded in PR bodies) lives in the same
@@ -135,6 +136,12 @@ references, review text, metrics summaries, and human-intervention visibility.
 It must apply the PR label that corresponds to the successful workflow result,
 not the issue queue label when those differ. A single-PR workflow links the PR
 to its claimed issue with `Fixes: #<issue>`, so merging the PR closes the issue.
+When a library-update publication splits tested-version aliases according to
+§FS-library-update-tested-version-split, the PR body must also include a
+human-visible `Refs: #<follow-up-issue>` line and a machine-readable
+`Forge-Unblocks-Issue: #<follow-up-issue>` trailer. Forge automation must use
+the trailer, not casual issue references, to release the follow-up issue after
+the PR merges.
 
 ## GIT-chunked-linking: Chunked dynamic-access PR linking
 

--- a/forge/docs/git-scripts.md
+++ b/forge/docs/git-scripts.md
@@ -136,7 +136,7 @@ references, review text, metrics summaries, and human-intervention visibility.
 It must apply the PR label that corresponds to the successful workflow result,
 not the issue queue label when those differ. A single-PR workflow links the PR
 to its claimed issue with `Fixes: #<issue>`, so merging the PR closes the issue.
-When a library-update publication splits tested-version aliases according to
+When a library-update publication splits tested versions according to
 §FS-library-update-tested-version-split, the PR body must also include a
 human-visible `Refs: #<follow-up-issue>` line and a machine-readable
 `Forge-Unblocks-Issue: #<follow-up-issue>` trailer. Forge automation must use

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -141,6 +141,7 @@ from utility_scripts.library_preparation_preflight import (
     LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
     run_library_preparation_preflight as run_preflight_decision,
 )
+from utility_scripts.library_update_alias_split import extract_follow_up_issue_numbers
 from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
     get_not_for_native_image_marker,
@@ -2440,6 +2441,29 @@ def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
     )
 
 
+def apply_library_update_alias_split_merge_follow_up(pr: dict) -> None:
+    """Release parked successor issues after their splitting PR merges.
+
+    Library-update alias splits park successor issues in `In Progress`; the PR
+    trailer is the explicit automation signal to move them to `Todo`.
+    §FS-library-update-tested-version-split
+    """
+    for issue_number in extract_follow_up_issue_numbers(pr.get("body")):
+        item_id = get_project_item_id(issue_number)
+        if item_id is None:
+            raise RuntimeError(
+                f"PR #{pr.get('number')} unblocks issue #{issue_number}, "
+                f"but the issue is not linked to project {PROJECT_NUMBER}."
+            )
+        set_item_status(item_id, STATUS_TODO)
+        clear_issue_assignees(issue_number)
+        invalidate_issue_claim_cache_entry(issue_number)
+        log_stage(
+            "library-update-alias-split",
+            f"Released successor issue #{issue_number} after PR #{pr.get('number')} merged.",
+        )
+
+
 def merge_pull_request(pr: dict, reachability_metadata_path: str | None = None) -> None:
     """Merge a pull request using the repository's configured merge method."""
     pr_number = pr.get("number")
@@ -2471,6 +2495,7 @@ def merge_pull_request(pr: dict, reachability_metadata_path: str | None = None) 
     gh(*merge_args)
     if not pr.get("isMergeQueueEnabled"):
         apply_chunked_dynamic_access_merge_follow_up(pr)
+        apply_library_update_alias_split_merge_follow_up(pr)
 
 
 def reconcile_reviewed_pull_request(

--- a/forge/git_scripts/make_pr_improve_coverage.py
+++ b/forge/git_scripts/make_pr_improve_coverage.py
@@ -49,6 +49,12 @@ from utility_scripts.local_ci_verification import (
     format_local_ci_verification_pr_section,
     local_ci_requires_human_intervention,
 )
+from utility_scripts.library_update_alias_split import (
+    ensure_alias_split_follow_up_issue,
+    format_alias_split_pr_section,
+    load_alias_split_metrics,
+    maybe_split_library_update_tested_versions,
+)
 
 BASELINE_STATS_FILENAME = ".baseline-stats.json"
 LIBRARY_UPDATE_TARGET_FILENAME = ".library_update_target.json"
@@ -73,6 +79,7 @@ def build_pull_request_body(
         chunk_final: bool = True,
         dynamic_access_exhaust_report: DynamicAccessExhaustReport | None = None,
         local_ci_verification: dict | None = None,
+        alias_split: dict | None = None,
 ) -> str:
     """Build the PR body with metrics and optional stats."""
     input_tokens_used = metrics.get("input_tokens_used", 0)
@@ -165,6 +172,7 @@ Summary:
         body += f"- Stage: `{post_generation_intervention.get('stage', 'unknown')}`\n\n"
         body += f"- Intervention file: `{post_generation_intervention.get('intervention_file', 'unknown')}`\n\n"
         body += str(post_generation_intervention.get("analysis_markdown", "")).strip() + "\n"
+    body += format_alias_split_pr_section(alias_split)
     body += format_local_ci_verification_pr_section(local_ci_verification)
     return body
 
@@ -300,6 +308,12 @@ def create_pull_request(
         print(f"Pull request already exists for branch {branch}.")
         return
 
+    ensure_alias_split_follow_up_issue(
+        metrics_repo_path=metrics_repo_root,
+        current_issue_number=issue_number,
+        repo=REPO,
+    )
+
     title, body, matched = build_pull_request_preview(
         coordinates=coordinates,
         metrics_repo_root=metrics_repo_root,
@@ -372,6 +386,7 @@ def build_pull_request_preview(
         post_generation_intervention=matched.get("post_generation_intervention"),
         library_update_target=load_library_update_target_sidecar(metrics_repo_root),
         local_ci_verification=matched.get(LOCAL_CI_VERIFICATION_KEY),
+        alias_split=load_alias_split_metrics(metrics_repo_root),
         chunked_dynamic_access=chunked_dynamic_access,
         chunk_final=chunk_final,
         dynamic_access_exhaust_report=load_dynamic_access_exhaust_report(repo_path, coordinates),
@@ -488,12 +503,21 @@ def push_current_branch_to_origin(
         )
         stage_and_commit(group, artifact, library_version, coordinates, repo_path)
 
+    def before_verification(base_ref: str) -> None:
+        maybe_split_library_update_tested_versions(
+            repo_path=repo_path,
+            coordinates=coordinates,
+            base_ref=base_ref,
+            metrics_repo_path=metrics_repo_path,
+        )
+
     new_branch, _ = publish_branch(
         repo_path=repo_path,
         branch_suffix=branch_suffix,
         coordinates=coordinates,
         stage=stage,
         metrics_repo_path=metrics_repo_path,
+        before_verification=before_verification,
     )
 
     return new_branch

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -40,6 +40,7 @@ def publish_branch(
         stage: Callable[[], None],
         metrics_repo_path: str | None = None,
         before_rebase: Callable[[], None] | None = None,
+        before_verification: Callable[[str], None] | None = None,
         after_verification: Callable[[], None] | None = None,
 ) -> tuple[str, LocalCIVerificationResult]:
     """Create, stage, rebase, verify, and push the publication branch.
@@ -58,6 +59,10 @@ def publish_branch(
         before_rebase()
     base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
+    if before_verification is not None:
+        # Library-update publishers may refine alias buckets before local CI
+        # decides PR eligibility. §FS-library-update-tested-version-split
+        before_verification(base_ref)
     local_ci_verification = run_local_ci_verification(
         repo_path=repo_path,
         coordinates=coordinates,

--- a/forge/utility_scripts/library_update_alias_split.py
+++ b/forge/utility_scripts/library_update_alias_split.py
@@ -32,11 +32,13 @@ from utility_scripts.metrics_writer import (
     read_pending_metrics,
     write_pending_metrics,
 )
+from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 
 ALIAS_SPLIT_METRICS_KEY = "library_update_alias_split"
 FOLLOW_UP_TRAILER = "Forge-Unblocks-Issue"
+ALIAS_SWEEP_STAGE = "library-update-alias-sweep"
 PROJECT_NUMBER = 30
 STATUS_FIELD_NAME = "Status"
 STATUS_IN_PROGRESS = "In Progress"
@@ -112,10 +114,19 @@ def maybe_split_library_update_tested_versions(
 
     existing_split = load_alias_split_metrics(metrics_repo_path)
     if existing_split is not None and existing_split.get("successor_metadata_version"):
+        log_stage(
+            ALIAS_SWEEP_STAGE,
+            f"Existing tested-version split already recorded for {target_coordinates}; skipping sweep.",
+        )
         return existing_split
 
     sweep = _run_java_alias_sweep(repo_path, target_coordinates, tested_versions)
     if sweep["failed_version"] is None:
+        log_stage(
+            ALIAS_SWEEP_STAGE,
+            f"All {len(tested_versions)} tested-version alias(es) passed for {target_coordinates}; "
+            "no split needed.",
+        )
         return None
 
     failed_index = int(sweep["failed_index"])
@@ -267,10 +278,16 @@ def _load_index_entries_from_commit(
 
 
 def _run_java_alias_sweep(repo_path: str, coordinates: str, versions: list[str]) -> dict[str, Any]:
+    # Operators need live CLI progress because this sweep can run many Gradle
+    # commands before local CI starts. §FS-library-update-tested-version-split
+    log_stage(
+        ALIAS_SWEEP_STAGE,
+        f"Starting Java compatibility sweep for {coordinates} across {len(versions)} tested-version alias(es).",
+    )
     commands: list[dict[str, Any]] = []
     for index, version in enumerate(versions):
         log_path = build_timestamped_task_log_path(
-            "library-update-alias-sweep",
+            ALIAS_SWEEP_STAGE,
             coordinates,
             f"javaTest-{version}",
         )
@@ -278,6 +295,13 @@ def _run_java_alias_sweep(repo_path: str, coordinates: str, versions: list[str])
         env["GVM_TCK_LV"] = version
         env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
         command = ["./gradlew", "clean", "javaTest", f"-Pcoordinates={coordinates}"]
+        display_path = display_log_path(log_path)
+        log_stage(
+            ALIAS_SWEEP_STAGE,
+            f"Testing alias {index + 1}/{len(versions)}: GVM_TCK_LV={version}",
+            indent_level=1,
+        )
+        log_stage(ALIAS_SWEEP_STAGE, f"Log: {display_path}", indent_level=2)
         with open(log_path, "w", encoding="utf-8") as log_file:
             completed = subprocess.run(
                 command,
@@ -293,15 +317,21 @@ def _run_java_alias_sweep(repo_path: str, coordinates: str, versions: list[str])
             "version": version,
             "command": " ".join(command),
             "returncode": completed.returncode,
-            "log_path": display_log_path(log_path),
+            "log_path": display_path,
         }
         commands.append(command_record)
         if completed.returncode != 0:
+            log_stage(
+                ALIAS_SWEEP_STAGE,
+                f"Alias {version} failed with exit {completed.returncode}; stopping sweep.",
+                indent_level=1,
+            )
             return {
                 "commands": commands,
                 "failed_version": version,
                 "failed_index": index,
             }
+        log_stage(ALIAS_SWEEP_STAGE, f"Alias {version} passed.", indent_level=1)
     return {
         "commands": commands,
         "failed_version": None,

--- a/forge/utility_scripts/library_update_alias_split.py
+++ b/forge/utility_scripts/library_update_alias_split.py
@@ -1,0 +1,633 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Split library-update tested-version aliases when generated JVM tests stop being compatible."""
+
+import copy
+import json
+import os
+import re
+import shutil
+import subprocess
+from typing import Any
+
+from git_scripts.common_git import (
+    get_issue_project_item_status,
+    gh,
+    gh_json,
+    parse_coordinate_parts,
+    stage_and_commit as stage_and_commit_common,
+)
+from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.metadata_index import (
+    index_path,
+    load_index_entries,
+    resolve_metadata_version,
+    resolve_test_version,
+)
+from utility_scripts.metrics_writer import (
+    PENDING_METRICS_FILENAME,
+    read_pending_metrics,
+    write_pending_metrics,
+)
+from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+
+
+ALIAS_SPLIT_METRICS_KEY = "library_update_alias_split"
+FOLLOW_UP_TRAILER = "Forge-Unblocks-Issue"
+PROJECT_NUMBER = 30
+STATUS_FIELD_NAME = "Status"
+STATUS_IN_PROGRESS = "In Progress"
+
+
+def format_follow_up_trailer(issue_number: int) -> str:
+    """Return the machine-readable follow-up issue trailer used by merge follow-up."""
+    return f"{FOLLOW_UP_TRAILER}: #{issue_number}"
+
+
+def extract_follow_up_issue_numbers(body: str | None) -> list[int]:
+    """Return follow-up issues from PR text trailers, ignoring casual references."""
+    if not isinstance(body, str):
+        return []
+    return [
+        int(match.group(1))
+        for match in re.finditer(rf"(?m)^{re.escape(FOLLOW_UP_TRAILER)}:\s*#(\d+)\b", body)
+    ]
+
+
+def load_alias_split_metrics(metrics_repo_path: str | None) -> dict[str, Any] | None:
+    """Load recorded split metadata from pending metrics."""
+    if metrics_repo_path is None:
+        return None
+    pending_path = os.path.join(metrics_repo_path, PENDING_METRICS_FILENAME)
+    if not os.path.isfile(pending_path):
+        return None
+    metrics = read_pending_metrics(metrics_repo_path)
+    split = metrics.get(ALIAS_SPLIT_METRICS_KEY)
+    return split if isinstance(split, dict) else None
+
+
+def write_alias_split_metrics(metrics_repo_path: str | None, split: dict[str, Any]) -> None:
+    """Persist split metadata so PR publication can reference the follow-up issue."""
+    if metrics_repo_path is None:
+        raise RuntimeError("Cannot persist library-update alias split without a metrics repository path.")
+    pending_path = os.path.join(metrics_repo_path, PENDING_METRICS_FILENAME)
+    if not os.path.isfile(pending_path):
+        raise RuntimeError(f"Cannot persist library-update alias split; missing {pending_path}.")
+    metrics = read_pending_metrics(metrics_repo_path)
+    metrics[ALIAS_SPLIT_METRICS_KEY] = split
+    write_pending_metrics(metrics_repo_path, metrics)
+
+
+def maybe_split_library_update_tested_versions(
+        *,
+        repo_path: str,
+        coordinates: str,
+        base_ref: str,
+        metrics_repo_path: str | None,
+) -> dict[str, Any] | None:
+    """Run the JVM alias sweep and split at the first successor failure.
+
+    Library-update generated tests must remain compatible with every alias in
+    the changed index entry. When a later alias fails, the generated prefix and
+    copied baseline successor range are split before PR eligibility.
+    §FS-library-update-tested-version-split
+    """
+    group, artifact, requested_version = parse_coordinate_parts(coordinates)
+    target_metadata_version = resolve_metadata_version(repo_path, group, artifact, requested_version)
+    target_test_version = resolve_test_version(repo_path, group, artifact, requested_version)
+    target_coordinates = f"{group}:{artifact}:{target_metadata_version}"
+    entries = load_index_entries(repo_path, group, artifact) or []
+    target_entry = _find_entry_by_metadata_version(entries, target_metadata_version)
+    if target_entry is None:
+        return None
+    if not _has_changed_tests(repo_path, base_ref, group, artifact, target_test_version):
+        return None
+
+    tested_versions = _entry_tested_versions(target_entry)
+    if len(tested_versions) <= 1:
+        return None
+
+    existing_split = load_alias_split_metrics(metrics_repo_path)
+    if existing_split is not None and existing_split.get("successor_metadata_version"):
+        return existing_split
+
+    sweep = _run_java_alias_sweep(repo_path, target_coordinates, tested_versions)
+    if sweep["failed_version"] is None:
+        return None
+
+    failed_index = int(sweep["failed_index"])
+    if failed_index == 0:
+        raise RuntimeError(
+            f"Library-update JVM alias sweep failed on the first tested version "
+            f"{sweep['failed_version']} for {target_coordinates}; no passing prefix can be split."
+        )
+
+    base_entries = _load_index_entries_from_commit(base_ref, repo_path, group, artifact)
+    original_entry = _find_entry_covering_version(base_entries, str(sweep["failed_version"]))
+    if original_entry is None:
+        raise RuntimeError(
+            f"Could not find base index entry covering {group}:{artifact}:{sweep['failed_version']} "
+            f"in {base_ref}."
+        )
+
+    split = _apply_alias_split(
+        repo_path=repo_path,
+        base_ref=base_ref,
+        group=group,
+        artifact=artifact,
+        requested_coordinates=coordinates,
+        target_metadata_version=target_metadata_version,
+        original_entry=original_entry,
+        tested_versions=tested_versions,
+        failed_index=failed_index,
+        sweep=sweep,
+    )
+    write_alias_split_metrics(metrics_repo_path, split)
+    stage_and_commit_common(
+        [
+            os.path.join("metadata", group, artifact, "index.json"),
+            os.path.join("metadata", group, artifact, split["successor_metadata_version"]),
+            os.path.join("tests", "src", group, artifact, split["successor_metadata_version"]),
+        ],
+        f"Split tested-version aliases for {coordinates}",
+        cwd=repo_path,
+    )
+    return split
+
+
+def ensure_alias_split_follow_up_issue(
+        *,
+        metrics_repo_path: str | None,
+        current_issue_number: int | None,
+        repo: str,
+) -> dict[str, Any] | None:
+    """Create and park the successor library-update issue after local CI passes.
+
+    The issue is kept `In Progress` until the current PR merges, preventing the
+    normal work queue from claiming the successor too early.
+    §FS-library-update-tested-version-split
+    """
+    split = load_alias_split_metrics(metrics_repo_path)
+    if split is None:
+        return None
+    existing_issue = split.get("follow_up_issue_number")
+    if isinstance(existing_issue, int):
+        return split
+
+    coordinates = str(split["successor_coordinates"])
+    issue_number = _find_existing_open_issue_number(repo, coordinates)
+    if issue_number is None:
+        issue_number = _create_follow_up_issue(repo, split, current_issue_number)
+    _ensure_issue_project_status(repo, PROJECT_NUMBER, issue_number, STATUS_IN_PROGRESS)
+
+    updated_split = dict(split)
+    updated_split["follow_up_issue_number"] = issue_number
+    write_alias_split_metrics(metrics_repo_path, updated_split)
+    return updated_split
+
+
+def format_alias_split_pr_section(split: dict[str, Any] | None) -> str:
+    """Return PR body text for a tested-version alias split."""
+    if not isinstance(split, dict):
+        return ""
+    issue_number = split.get("follow_up_issue_number")
+    issue_lines = ""
+    if isinstance(issue_number, int):
+        issue_lines = (
+            f"Refs: #{issue_number}\n"
+            f"{format_follow_up_trailer(issue_number)}\n"
+        )
+    return (
+        "\n### Tested-Version Alias Split\n\n"
+        f"- First failing JVM alias: `{split.get('failed_version')}`\n"
+        f"- Generated prefix retained on `{split.get('current_metadata_version')}`: "
+        f"{_format_version_list(split.get('passing_versions'))}\n"
+        f"- Baseline successor entry: `{split.get('successor_metadata_version')}` with "
+        f"{_format_version_list(split.get('successor_versions'))}\n"
+        f"- Baseline metadata copied from: `{split.get('original_metadata_version')}`\n"
+        f"- Baseline tests copied from: `{split.get('original_test_version')}`\n"
+        f"{issue_lines}"
+    )
+
+
+def _entry_tested_versions(entry: dict[str, Any]) -> list[str]:
+    versions = entry.get("tested-versions")
+    if not isinstance(versions, list):
+        return []
+    return [str(version) for version in versions]
+
+
+def _find_entry_by_metadata_version(entries: list[dict[str, Any]], metadata_version: str) -> dict[str, Any] | None:
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("metadata-version") == metadata_version:
+            return entry
+    return None
+
+
+def _find_entry_covering_version(entries: list[dict[str, Any]], version: str) -> dict[str, Any] | None:
+    for entry in entries:
+        if isinstance(entry, dict) and version in _entry_tested_versions(entry):
+            return entry
+    return None
+
+
+def _has_changed_tests(repo_path: str, base_ref: str, group: str, artifact: str, test_version: str) -> bool:
+    test_prefix = os.path.join("tests", "src", group, artifact, test_version).replace(os.sep, "/")
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", base_ref, "HEAD", "--", test_prefix],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return any(line.strip() for line in result.stdout.splitlines())
+
+
+def _load_index_entries_from_commit(
+        commit: str,
+        repo_path: str,
+        group: str,
+        artifact: str,
+) -> list[dict[str, Any]]:
+    relative_path = os.path.relpath(index_path(repo_path, group, artifact), repo_path).replace(os.sep, "/")
+    result = subprocess.run(
+        ["git", "show", f"{commit}:{relative_path}"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    parsed = json.loads(result.stdout)
+    if not isinstance(parsed, list):
+        raise RuntimeError(f"Base index is not a JSON array: {relative_path}")
+    return [entry for entry in parsed if isinstance(entry, dict)]
+
+
+def _run_java_alias_sweep(repo_path: str, coordinates: str, versions: list[str]) -> dict[str, Any]:
+    commands: list[dict[str, Any]] = []
+    for index, version in enumerate(versions):
+        log_path = build_timestamped_task_log_path(
+            "library-update-alias-sweep",
+            coordinates,
+            f"javaTest-{version}",
+        )
+        env = gradle_command_environment(repo_path, dict(os.environ))
+        env["GVM_TCK_LV"] = version
+        env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
+        command = ["./gradlew", "clean", "javaTest", f"-Pcoordinates={coordinates}"]
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            completed = subprocess.run(
+                command,
+                cwd=repo_path,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+        command_record = {
+            "version": version,
+            "command": " ".join(command),
+            "returncode": completed.returncode,
+            "log_path": display_log_path(log_path),
+        }
+        commands.append(command_record)
+        if completed.returncode != 0:
+            return {
+                "commands": commands,
+                "failed_version": version,
+                "failed_index": index,
+            }
+    return {
+        "commands": commands,
+        "failed_version": None,
+        "failed_index": None,
+    }
+
+
+def _apply_alias_split(
+        *,
+        repo_path: str,
+        base_ref: str,
+        group: str,
+        artifact: str,
+        requested_coordinates: str,
+        target_metadata_version: str,
+        original_entry: dict[str, Any],
+        tested_versions: list[str],
+        failed_index: int,
+        sweep: dict[str, Any],
+) -> dict[str, Any]:
+    failed_version = tested_versions[failed_index]
+    passing_versions = tested_versions[:failed_index]
+    successor_versions = tested_versions[failed_index:]
+    original_metadata_version = str(original_entry.get("metadata-version") or "")
+    original_test_version = str(original_entry.get("test-version") or original_metadata_version)
+    if not original_metadata_version or not original_test_version:
+        raise RuntimeError(f"Base entry covering {failed_version} lacks metadata/test version fields.")
+
+    _copy_tree_from_commit(
+        repo_path,
+        base_ref,
+        os.path.join("metadata", group, artifact, original_metadata_version),
+        os.path.join(repo_path, "metadata", group, artifact, failed_version),
+    )
+    _copy_tree_from_commit(
+        repo_path,
+        base_ref,
+        os.path.join("tests", "src", group, artifact, original_test_version),
+        os.path.join(repo_path, "tests", "src", group, artifact, failed_version),
+    )
+
+    entries = load_index_entries(repo_path, group, artifact) or []
+    target_index = _find_entry_index_by_metadata_version(entries, target_metadata_version)
+    if target_index is None:
+        raise RuntimeError(f"Missing current index entry for metadata-version {target_metadata_version}")
+
+    current_entry = entries[target_index]
+    split_latest = current_entry.get("latest") is True
+    current_entry["tested-versions"] = passing_versions
+    if split_latest:
+        current_entry.pop("latest", None)
+
+    successor_entry = copy.deepcopy(original_entry)
+    successor_entry["metadata-version"] = failed_version
+    successor_entry["tested-versions"] = successor_versions
+    successor_entry.pop("test-version", None)
+    if split_latest:
+        successor_entry["latest"] = True
+    else:
+        successor_entry.pop("latest", None)
+
+    entries.insert(target_index, successor_entry)
+    _write_index_entries(repo_path, group, artifact, entries)
+
+    return {
+        "requested_coordinates": requested_coordinates,
+        "current_coordinates": f"{group}:{artifact}:{target_metadata_version}",
+        "successor_coordinates": f"{group}:{artifact}:{failed_version}",
+        "current_metadata_version": target_metadata_version,
+        "successor_metadata_version": failed_version,
+        "failed_version": failed_version,
+        "passing_versions": passing_versions,
+        "successor_versions": successor_versions,
+        "original_metadata_version": original_metadata_version,
+        "original_test_version": original_test_version,
+        "commands": sweep.get("commands") or [],
+    }
+
+
+def _find_entry_index_by_metadata_version(entries: list[dict[str, Any]], metadata_version: str) -> int | None:
+    for index, entry in enumerate(entries):
+        if isinstance(entry, dict) and entry.get("metadata-version") == metadata_version:
+            return index
+    return None
+
+
+def _copy_tree_from_commit(repo_path: str, commit: str, source_rel: str, destination_abs: str) -> None:
+    source_rel = source_rel.replace(os.sep, "/")
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "-z", "--name-only", commit, "--", source_rel],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    paths = [path.decode("utf-8") for path in result.stdout.split(b"\0") if path]
+    if not paths:
+        raise RuntimeError(f"No files found in {commit}:{source_rel}")
+    if os.path.exists(destination_abs):
+        shutil.rmtree(destination_abs)
+    for path in paths:
+        file_result = subprocess.run(
+            ["git", "show", f"{commit}:{path}"],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        relative_file = os.path.relpath(path, source_rel)
+        destination_file = os.path.join(destination_abs, relative_file)
+        os.makedirs(os.path.dirname(destination_file), exist_ok=True)
+        with open(destination_file, "wb") as output_file:
+            output_file.write(file_result.stdout)
+
+
+def _write_index_entries(repo_path: str, group: str, artifact: str, entries: list[dict[str, Any]]) -> None:
+    path = index_path(repo_path, group, artifact)
+    with open(path, "w", encoding="utf-8") as index_file:
+        json.dump(entries, index_file, indent=2)
+        index_file.write("\n")
+
+
+def _find_existing_open_issue_number(repo: str, coordinates: str) -> int | None:
+    issues = gh_json(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--search",
+        f'"{coordinates}" in:title,body',
+        "--json",
+        "number,title,body",
+        "--limit",
+        "20",
+    )
+    if not isinstance(issues, list):
+        return None
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        text = f"{issue.get('title') or ''}\n{issue.get('body') or ''}"
+        if coordinates in text and isinstance(issue.get("number"), int):
+            return int(issue["number"])
+    return None
+
+
+def _create_follow_up_issue(repo: str, split: dict[str, Any], current_issue_number: int | None) -> int:
+    coordinates = str(split["successor_coordinates"])
+    blocked_by = f"Blocked by the current update issue #{current_issue_number}." if current_issue_number else ""
+    body = f"""This issue tracks the successor library-update split for `{coordinates}`.
+
+Forge split the previous tested-version range because generated JVM tests first failed at `{split['failed_version']}`.
+
+{blocked_by}
+
+Successor tested versions to preserve:
+{_format_issue_version_lines(split.get("successor_versions"))}
+
+The current PR keeps the generated progress for `{split['current_coordinates']}`
+and copies baseline support for this successor range.
+"""
+    result = gh(
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        f"Update existing library: {coordinates}",
+        "--body",
+        body,
+        "--label",
+        "library-update-request",
+    )
+    match = re.search(r"/issues/(\d+)", result.stdout)
+    if match is None:
+        raise RuntimeError(f"Could not parse created follow-up issue number from: {result.stdout.strip()}")
+    return int(match.group(1))
+
+
+def _ensure_issue_project_status(repo: str, project_number: int, issue_number: int, status: str) -> None:
+    item_id, current_status = get_issue_project_item_status(
+        repo,
+        project_number,
+        issue_number,
+        STATUS_FIELD_NAME,
+    )
+    project_id, field_id, option_ids = _project_status_field_info(repo, project_number)
+    if status not in option_ids:
+        raise RuntimeError(f"Missing project status option {status!r}")
+    if item_id is None:
+        issue_id = _issue_node_id(repo, issue_number)
+        item_id = _add_issue_to_project(project_id, issue_id)
+    if current_status != status:
+        _set_project_item_status(project_id, item_id, field_id, option_ids[status])
+
+
+def _project_status_field_info(repo: str, project_number: int) -> tuple[str, str, dict[str, str]]:
+    owner, _ = repo.split("/")
+    query = f"""
+    query {{
+      organization(login: "{owner}") {{
+        projectV2(number: {project_number}) {{
+          id
+          fields(first: 50) {{
+            nodes {{
+              ... on ProjectV2SingleSelectField {{
+                id
+                name
+                options {{
+                  id
+                  name
+                }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    result = gh_json("api", "graphql", "-f", f"query={query}")
+    project = (
+        result.get("data", {})
+        .get("organization", {})
+        .get("projectV2", {})
+    )
+    if not isinstance(project, dict) or not project.get("id"):
+        raise RuntimeError(f"Missing GitHub project {project_number} for {owner}")
+    for field in project.get("fields", {}).get("nodes", []):
+        if not isinstance(field, dict) or field.get("name") != STATUS_FIELD_NAME:
+            continue
+        options = {
+            str(option["name"]): str(option["id"])
+            for option in field.get("options", [])
+            if isinstance(option, dict) and option.get("name") and option.get("id")
+        }
+        return str(project["id"]), str(field["id"]), options
+    raise RuntimeError(f"Missing project status field {STATUS_FIELD_NAME!r}")
+
+
+def _issue_node_id(repo: str, issue_number: int) -> str:
+    data = gh_json(
+        "issue",
+        "view",
+        str(issue_number),
+        "--repo",
+        repo,
+        "--json",
+        "id",
+    )
+    issue_id = data.get("id") if isinstance(data, dict) else None
+    if not isinstance(issue_id, str) or not issue_id:
+        raise RuntimeError(f"Missing GitHub node id for issue #{issue_number}")
+    return issue_id
+
+
+def _add_issue_to_project(project_id: str, issue_id: str) -> str:
+    mutation = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+    """
+    result = gh_json(
+        "api",
+        "graphql",
+        "-f",
+        f"query={mutation}",
+        "-f",
+        f"projectId={project_id}",
+        "-f",
+        f"contentId={issue_id}",
+    )
+    item_id = (
+        result.get("data", {})
+        .get("addProjectV2ItemById", {})
+        .get("item", {})
+        .get("id")
+    )
+    if not isinstance(item_id, str) or not item_id:
+        raise RuntimeError("Missing project item id after adding follow-up issue")
+    return item_id
+
+
+def _set_project_item_status(project_id: str, item_id: str, field_id: str, option_id: str) -> None:
+    mutation = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId,
+        itemId: $itemId,
+        fieldId: $fieldId,
+        value: {singleSelectOptionId: $optionId}
+      }) {
+        projectV2Item {
+          id
+        }
+      }
+    }
+    """
+    gh_json(
+        "api",
+        "graphql",
+        "-f",
+        f"query={mutation}",
+        "-f",
+        f"projectId={project_id}",
+        "-f",
+        f"itemId={item_id}",
+        "-f",
+        f"fieldId={field_id}",
+        "-f",
+        f"optionId={option_id}",
+    )
+
+
+def _format_version_list(value: Any) -> str:
+    if not isinstance(value, list):
+        return "`none`"
+    return ", ".join(f"`{version}`" for version in value) or "`none`"
+
+
+def _format_issue_version_lines(value: Any) -> str:
+    if not isinstance(value, list):
+        return "- none"
+    return "\n".join(f"- `{version}`" for version in value) or "- none"

--- a/forge/utility_scripts/library_update_alias_split.py
+++ b/forge/utility_scripts/library_update_alias_split.py
@@ -450,7 +450,9 @@ def _copy_tree_from_commit(repo_path: str, commit: str, source_rel: str, destina
 def _write_index_entries(repo_path: str, group: str, artifact: str, entries: list[dict[str, Any]]) -> None:
     path = index_path(repo_path, group, artifact)
     with open(path, "w", encoding="utf-8") as index_file:
-        json.dump(entries, index_file, indent=2)
+        # Match the repository's Jackson pretty-printer (space before the colon,
+        # raw UTF-8) so a split only diffs the entries it changes.
+        json.dump(entries, index_file, indent=2, separators=(",", " : "), ensure_ascii=False)
         index_file.write("\n")
 
 


### PR DESCRIPTION
## Motivation

A `library-update` coverage-improvement run regenerates JVM tests for a metadata
entry that often covers **several tested-version aliases** at once (e.g.
`["1.1", "1.2", "1.3"]`). The freshly generated tests can pass on the entry's own
version yet quietly stop compiling or running against a *later* alias — and today
nothing catches that before the PR becomes eligible, so the entry ships claiming
support it no longer has.

This PR teaches Forge to detect that break and **split the entry at the first
alias that fails**, keeping the generated progress for the passing prefix while
preserving the repo's existing baseline support for everything after it.

## What it does

Before a changed-tests library-update branch becomes PR-eligible, Forge runs a
**Java-only alias sweep** — `javaTest` with `GVM_TCK_LV` set to each alias in
index order, stopping at the first failure. This is deliberately narrower than
full CI (no native-image matrix) since it only needs to catch JVM test
incompatibility. On the first later-alias failure it splits the index entry:

| | `metadata-version` | `tested-versions` | `latest` | source |
|---|---|---|---|---|
| **Current entry** | unchanged | passing prefix | dropped if it moves | generated progress (this PR) |
| **Successor entry** | first failing alias | failing alias + all later | inherited if split entry had it | baseline metadata/tests copied from the PR base commit |

It then opens a parked `library-update-request` issue for the successor range,
holds it in **In Progress** so the queue can't claim it early, and references it
from the PR via a machine-readable `Forge-Unblocks-Issue:` trailer. Once this PR
merges, Forge releases that issue to **Todo** for normal processing.

If the *first* alias fails there is no passing prefix to keep, so publication
fails instead of splitting.

## Spec & wiring

- New behavior contract: §FS-library-update-tested-version-split
- PR-body trailer / follow-up linking: §GIT-pr-body
- Hooks into publication through a new `before_verification` step in
  `publish_branch`, so the split lands before local CI decides eligibility —
  one code path for "verified diff → pushed branch" is preserved.

Fixes #8438
