### PR TITLE
[1/4] Migrate Scala metadata tests to JDK 25

### DIFF
--- a/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
+++ b/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
+++ b/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
+++ b/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-io_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
+++ b/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-io_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
+++ b/tests/src/co.fs2/fs2-io_3/3.9.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "co.fs2:fs2-io_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.geirsson:metaconfig-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-core_2.13/0.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-base_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-base_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-base_3/0.17.10/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-base_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
+++ b/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
+++ b/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.scopt:scopt_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
+++ b/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
+++ b/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.scopt:scopt_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
+++ b/tests/src/com.github.scopt/scopt_3/4.1.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.scopt:scopt_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fansi_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fansi_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:fansi_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_2.13/0.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:geny_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:geny_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
+++ b/tests/src/com.lihaoyi/geny_3/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:geny_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
+++ b/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
+++ b/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
+++ b/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:scalatags_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
+++ b/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:scalatags_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
+++ b/tests/src/com.lihaoyi/scalatags_3/0.13.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:scalatags_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:upack_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upack_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upack_3/4.1.0-test-publish/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upack_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/core_3/1.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-json-circe_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-json-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-json-circe_3/1.11.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-json-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.thesamet.scalapb:lenses_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.thesamet.scalapb:lenses_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.thesamet.scalapb:lenses_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/lenses_2.13/0.11.15/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_3/10.6.0-M1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.6.21/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.8.8/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_2.13/2.9.0-M1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_2.13/2.9.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
+++ b/tests/src/com.typesafe.play/play-configuration_3/2.9.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-configuration_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-json_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-json_3/2.10.6/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.slick:slick-hikaricp_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.slick:slick-hikaricp_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.slick:slick-hikaricp_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick-hikaricp_2.13/3.6.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
@@ -18,6 +18,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.slick:slick_2.13:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.slick:slick_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.postgresql:postgresql:42.7.7'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
+++ b/tests/src/com.typesafe.slick/slick_2.13/3.6.1/build.gradle
@@ -15,13 +15,13 @@ dependencies {
     testImplementation "com.typesafe.slick:slick_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.postgresql:postgresql:42.7.7'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.4.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_2.13/0.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3:$libraryVersion"
     testImplementation "dev.zio:izumi-reflect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_3/3.0.1/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3:$libraryVersion"
     testImplementation "dev.zio:izumi-reflect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
+++ b/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
+++ b/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
+++ b/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-config_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
+++ b/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-config_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
+++ b/tests/src/dev.zio/zio-config_3/4.0.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-config_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-interop-cats_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-interop-cats_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-cats_3/23.1.0.13/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-interop-cats_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema_3/1.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-schema_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.15/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-stacktracer_3/2.1.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-stacktracer_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.14.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-numbers_3/0.15.0-M1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-numbers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-parser_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-parser_3/0.14.12/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.getquill:quill-engine_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.getquill:quill-engine_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-engine_3/4.8.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.getquill:quill-engine_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.suzaku:boopickle_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.suzaku:boopickle_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "io.suzaku:boopickle_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_2.13/1.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.0.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/1.2.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_3/2.0.0-M2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-ember-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-ember-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-core_3/1.0.0-M44/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-ember-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-ast_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-ast_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_2.13/3.7.0-M11/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-ast_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M11/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-jackson_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -16,13 +16,13 @@ dependencies {
         exclude group: 'org.scala-native'
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation("org.json4s:json4s-jackson_2.13:$libraryVersion") {
@@ -22,7 +23,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -11,14 +11,15 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation("org.json4s:json4s-jackson_2.13:$libraryVersion") {
         exclude group: 'org.scala-native'
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -19,6 +19,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_2.13/3.7.0-M13/build.gradle
@@ -19,13 +19,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-jackson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-scalap_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-scalap_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_2.13/3.7.0-M11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-scalap_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
+++ b/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
+++ b/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:macro-visit_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
+++ b/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
+++ b/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:macro-visit_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
+++ b/tests/src/org.sangria-graphql/macro-visit_3/0.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:macro-visit_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-derivation_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-derivation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-derivation_3/4.2.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-derivation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/1.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_2.13/2.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-xml_3/2.1.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-xml_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
+++ b/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:util-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
+++ b/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
+++ b/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:util-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
+++ b/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
+++ b/tests/src/org.scala-sbt/util-interface/1.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:util-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.18.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
+++ b/tests/src/org.scalacheck/scalacheck_2.13/1.19.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalacheck:scalacheck_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
+++ b/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalameta:mdoc-parser_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
+++ b/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:mdoc-parser_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
+++ b/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
+++ b/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
+++ b/tests/src/org.scalameta/mdoc-parser_2.13/2.5.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:mdoc-parser_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-config_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:scalafmt-config_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-config_2.13/3.8.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-config_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
+++ b/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
+++ b/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:scalameta_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
+++ b/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:scalameta_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
+++ b/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
+++ b/tests/src/org.scalameta/scalameta_2.13/4.9.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalameta:scalameta_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-flatspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-flatspec_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-flatspec_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-flatspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-shouldmatchers_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-shouldmatchers_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "org.scalatra:scalatra-common_3:$libraryVersion"
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatra:scalatra-common_3:$libraryVersion"
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra-common_3/3.0.0-M5-javax/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatra:scalatra-common_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/4.20.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-core_3/5.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
+++ b/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
+++ b/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
+++ b/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:sourcepos_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
+++ b/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:sourcepos_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
+++ b/tests/src/org.tpolecat/sourcepos_3/1.1.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:sourcepos_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
+++ b/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
+++ b/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
+++ b/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:typename_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
+++ b/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:typename_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
+++ b/tests/src/org.tpolecat/typename_3/1.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:typename_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-kernel_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-kernel_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-kernel_3/2.6.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-kernel_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
+++ b/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:paiges-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
+++ b/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.typelevel:paiges-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
+++ b/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
+++ b/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
+++ b/tests/src/org.typelevel/paiges-core_2.13/0.4.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:paiges-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_2.13/0.1.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
+++ b/tests/src/org.typelevel/scalac-compat-annotation_3/0.1.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:scalac-compat-annotation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {


### PR DESCRIPTION
## Summary

- migrate the first balanced quarter of Scala metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `JavaLanguageVersion.of(testJvmVersion)` toolchain declarations for the migrated Scala test builds
- switch Scala 3 test compiler/library dependencies to `tck.scala3Version` (currently `3.7.4`) so the TCK-resolved JDK 25 output is supported
- switch Scala 2 test compiler/library dependencies to `tck.scala2Version` (currently `2.13.17`) where present
- covers 55 libraries / 67 test build files, balanced to roughly 60 tested-version batches / 180 metadata jobs

Part of #8440

## Testing

- representative Scala 3 JDK 25 checks passed locally with the centralized Scala 3 version before applying this series
- `git diff --check master...scala-jdk25-tests-1`