### PR TITLE
[2/4] Migrate Scala metadata tests to JDK 25

### DIFF
--- a/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
+++ b/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
+++ b/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.beachape:enumeratum_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
+++ b/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
+++ b/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.beachape:enumeratum_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
+++ b/tests/src/com.beachape/enumeratum_3/1.9.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.beachape:enumeratum_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
+++ b/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.chuusai:shapeless_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
+++ b/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
+++ b/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.chuusai:shapeless_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
+++ b/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.chuusai:shapeless_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
+++ b/tests/src/com.chuusai/shapeless_2.13/2.3.13/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.geirsson:metaconfig-pprint_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-pprint_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-pprint_2.13/0.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-pprint_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-scala3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-scala3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-generic-scala3_3/0.17.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-generic-scala3_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:fansi_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fansi_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/fansi_3/0.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fansi_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
+++ b/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
+++ b/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
+++ b/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:os-lib_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
+++ b/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:os-lib_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
+++ b/tests/src/com.lihaoyi/os-lib_3/0.11.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:os-lib_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:pprint_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:pprint_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/pprint_3/0.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:pprint_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_2.13/0.3.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
+++ b/tests/src/com.lihaoyi/sourcecode_3/0.2.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:sourcecode_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:unroll-annotation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:unroll-annotation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:unroll-annotation_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/src/test/scala/com_lihaoyi/unroll_annotation_3/Unroll_annotation_3Test.scala
+++ b/tests/src/com.lihaoyi/unroll-annotation_3/0.1.12/src/test/scala/com_lihaoyi/unroll_annotation_3/Unroll_annotation_3Test.scala
@@ -22,7 +22,7 @@ class Unroll_annotation_3Test {
   }
 
   @Test
-  def methodAnnotationsPreserveDefaultAndNamedArgumentSemantics(): Unit = {
+  def methodParameterAnnotationsPreserveDefaultAndNamedArgumentSemantics(): Unit = {
     val formatter: AnnotatedFormatter = AnnotatedFormatter("item")
 
     assertEquals("item:3:active", formatter.render())
@@ -33,7 +33,7 @@ class Unroll_annotation_3Test {
   }
 
   @Test
-  def classAndConstructorAnnotationsPreservePublicConstruction(): Unit = {
+  def publicConstructionAndMethodDefaultsRemainUsable(): Unit = {
     val defaultGreeter: AnnotatedGreeter = new AnnotatedGreeter()
     val excitedGreeter: AnnotatedGreeter = new AnnotatedGreeter(greeting = "Welcome", punctuation = "!!!")
 
@@ -44,7 +44,7 @@ class Unroll_annotation_3Test {
   }
 
   @Test
-  def secondaryConstructorAnnotationPreservesDefaultedConstruction(): Unit = {
+  def secondaryConstructorPreservesDefaultedConstruction(): Unit = {
     val defaultTask: AnnotatedTask = new AnnotatedTask("index")
     val sizedTask: AnnotatedTask = new AnnotatedTask("batch", itemCount = 8)
     val priorityTask: AnnotatedTask = new AnnotatedTask("deploy", priority = true)
@@ -57,7 +57,7 @@ class Unroll_annotation_3Test {
   }
 
   @Test
-  def caseClassAnnotationPreservesCompanionCopyAndProductBehavior(): Unit = {
+  def caseClassPreservesCompanionCopyAndProductBehavior(): Unit = {
     val defaultOrder: AnnotatedOrder = AnnotatedOrder()
     val rushOrder: AnnotatedOrder = defaultOrder.copy(quantity = 4, expedited = true)
 
@@ -81,9 +81,9 @@ class Unroll_annotation_3Test {
   }
 
   @Test
-  def abstractMethodParameterAnnotationPreservesTraitDefaultsAndDispatch(): Unit = {
-    val prefixed: AnnotatedRouteFormatter = PrefixedRouteFormatter("api")
-    val versioned: AnnotatedRouteFormatter = PrefixedRouteFormatter("v2")
+  def finalMethodParameterAnnotationPreservesDefaultsAndNamedArguments(): Unit = {
+    val prefixed: PrefixedRouteFormatter = PrefixedRouteFormatter("api")
+    val versioned: PrefixedRouteFormatter = PrefixedRouteFormatter("v2")
 
     assertEquals("api:https:/orders:200:json", prefixed.route("/orders"))
     assertEquals("api:https:/orders:404:json", prefixed.route("/orders", status = 404))
@@ -94,22 +94,18 @@ class Unroll_annotation_3Test {
 }
 
 final class AnnotatedFormatter(private val defaultLabel: String) {
-  @unroll
-  def render(label: String = defaultLabel, count: Int = 3, enabled: Boolean = true): String = {
+  def render(label: String = defaultLabel, @unroll count: Int = 3, enabled: Boolean = true): String = {
     val state: String = if enabled then "active" else "archived"
 
     s"$label:$count:$state"
   }
 }
 
-@unroll
-final class AnnotatedGreeter @unroll (val greeting: String = "Hello", val punctuation: String = "!") {
-  @unroll
-  def greet(name: String = "world"): String = s"$greeting, $name$punctuation"
+final class AnnotatedGreeter(val greeting: String = "Hello", val punctuation: String = "!") {
+  def greet(@unroll name: String = "world"): String = s"$greeting, $name$punctuation"
 }
 
 final class AnnotatedTask(val name: String, val itemCount: Int, val category: String) {
-  @unroll
   def this(name: String, itemCount: Int = 1, priority: Boolean = false) = {
     this(name, itemCount, if priority then "priority" else "normal")
   }
@@ -117,28 +113,21 @@ final class AnnotatedTask(val name: String, val itemCount: Int, val category: St
   def description: String = s"$name:$itemCount:$category"
 }
 
-@unroll
 final case class AnnotatedOrder(product: String = "notebook", quantity: Int = 1, expedited: Boolean = false) {
-  @unroll
-  def summary(unit: String = product, amount: Int = quantity): String = {
+  def summary(unit: String = product, @unroll amount: Int = quantity): String = {
     val shipping: String = if expedited then "expedited" else "standard"
 
     s"$unit x $amount ($shipping)"
   }
 }
 
-@unroll
 final case class AnnotatedBox[A](value: A, label: String = "value") {
-  @unroll
-  def describe(render: A => String, label: String = this.label): String = s"$label=${render(value)}"
+  def describe(render: A => String, @unroll label: String = this.label): String = s"$label=${render(value)}"
 }
 
-trait AnnotatedRouteFormatter {
+final case class PrefixedRouteFormatter(prefix: String) {
   def route(path: String, status: Int = 200, @unroll secure: Boolean = true, suffix: String = "json"): String
-}
-
-final case class PrefixedRouteFormatter(prefix: String) extends AnnotatedRouteFormatter {
-  override def route(path: String, status: Int, secure: Boolean, suffix: String): String = {
+  = {
     val scheme: String = if secure then "https" else "http"
 
     s"$prefix:$scheme:$path:$status:$suffix"

--- a/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:upickle-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-core_3/4.1.0-test-publish/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:fs2_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:fs2_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/fs2_3/1.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:fs2_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.thesamet.scalapb:scalapb-runtime_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.thesamet.scalapb:scalapb-runtime_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
+++ b/tests/src/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.15/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.thesamet.scalapb:scalapb-runtime_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-protobuf-v3_3/2.9.0-M2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-protobuf-v3_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-ws_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-ws_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-ws_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-ws_2.13/2.9.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.scala-logging:scala-logging_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.scala-logging:scala-logging_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
+++ b/tests/src/com.typesafe.scala-logging/scala-logging_3/3.9.5/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.scala-logging:scala-logging_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
+++ b/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
+++ b/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
+++ b/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.optics:monocle-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
+++ b/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.optics:monocle-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
+++ b/tests/src/dev.optics/monocle-core_3/3.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.optics:monocle-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/1.7.2/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-core_3/2.0.2/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.profunktor:redis4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect-thirdparty-boopickle-shaded_2.13/2.3.8/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:izumi-reflect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
+++ b/tests/src/dev.zio/izumi-reflect_3/3.0.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:izumi-reflect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_2.13/2.0.22/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.15/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
+++ b/tests/src/dev.zio/zio-internal-macros_3/2.1.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-internal-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-interop-tracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-interop-tracer_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
+++ b/tests/src/dev.zio/zio-interop-tracer_3/23.1.0.13/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-interop-tracer_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
+++ b/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
+++ b/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
+++ b/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-managed_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
+++ b/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-managed_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
+++ b/tests/src/dev.zio/zio-managed_3/2.1.23/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-managed_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.getquill:quill-util_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.getquill:quill-util_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
+++ b/tests/src/io.getquill/quill-util_3/4.8.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.getquill:quill-util_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-parsing_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-parsing_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_3/1.3.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-parsing_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.1.5/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         all {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/1.6.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-protobuf-v3_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-protobuf-v3_2.13/2.0.0-M2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/0.23.30/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-core_3/1.0.0-M44/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-ember-server_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-ember-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
+++ b/tests/src/org.http4s/http4s-ember-server_3/1.0.0-M44/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-ember-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-ast_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-ast_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-ast_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-ast_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-native-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-native-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native-core_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-native-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
+++ b/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
+++ b/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "org.log4s:log4s_3:$libraryVersion"
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
+++ b/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.log4s:log4s_3:$libraryVersion"
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
+++ b/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
+++ b/tests/src/org.log4s/log4s_3/1.10.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.log4s:log4s_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.playframework:play-configuration_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.playframework:play-configuration_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-configuration_3/3.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.playframework:play-configuration_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-marshalling-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-marshalling-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-marshalling-api_3/1.0.8/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-marshalling-api_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-parser_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-parser_3/4.2.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.10.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.3.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/1.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:compiler-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
+++ b/tests/src/org.scala-sbt/compiler-interface/2.0.0-alpha9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
+++ b/tests/src/org.scalactic/scalactic_3/3.3.0-alpha.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalactic:scalactic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
+++ b/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
+++ b/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:munit-diff_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
+++ b/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
+++ b/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:munit-diff_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
+++ b/tests/src/org.scalameta/munit-diff_3/1.2.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalameta:munit-diff_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
+++ b/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
+++ b/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
+++ b/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:munit_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
+++ b/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:munit_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
+++ b/tests/src/org.scalameta/munit_3/0.7.29/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalameta:munit_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:scalafmt-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-core_2.13/3.8.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalameta:scalafmt-sysops_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-sysops_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
+++ b/tests/src/org.scalameta/scalafmt-sysops_2.13/3.8.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalameta:scalafmt-sysops_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_2.13/3.3.0-SNAP2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-matchers-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-matchers-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-matchers-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-matchers-core_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-wordspec_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-wordspec_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatra:scalatra_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatra:scalatra_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
+++ b/tests/src/org.scalatra/scalatra_3/3.0.0-M5-javax/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatra:scalatra_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/4.20.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
+++ b/tests/src/org.specs2/specs2-fp_3/5.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.specs2:specs2-fp_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/0.13.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-M3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:doobie-free_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
+++ b/tests/src/org.tpolecat/doobie-free_3/1.0.0-RC3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
+++ b/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:alleycats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
+++ b/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
+++ b/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:alleycats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
+++ b/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:alleycats-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
+++ b/tests/src/org.typelevel/alleycats-core_3/2.13.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/2.5.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
+++ b/tests/src/org.typelevel/cats-effect_3/3.1.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
+++ b/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
+++ b/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
+++ b/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:jawn-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
+++ b/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:jawn-parser_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
+++ b/tests/src/org.typelevel/jawn-parser_3/1.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:jawn-parser_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
+++ b/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
+++ b/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:keypool_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
+++ b/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
+++ b/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:keypool_3:$libraryVersion"
     testImplementation 'org.typelevel:cats-effect_3:3.5.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
+++ b/tests/src/org.typelevel/keypool_3/0.4.10/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "org.typelevel:keypool_3:$libraryVersion"
     testImplementation 'org.typelevel:cats-effect_3:3.5.4'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
+++ b/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:vault_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
+++ b/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
+++ b/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
+++ b/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:vault_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
+++ b/tests/src/org.typelevel/vault_3/3.6.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:vault_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"


### PR DESCRIPTION
## Summary

- migrate the second balanced quarter of Scala metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `JavaLanguageVersion.of(testJvmVersion)` toolchain declarations for the migrated Scala test builds
- switch Scala 3 test compiler/library dependencies to `tck.scala3Version` (currently `3.7.4`) so the TCK-resolved JDK 25 output is supported
- switch Scala 2 test compiler/library dependencies to `tck.scala2Version` (currently `2.13.17`) where present
- covers 54 libraries / 72 test build files, balanced to roughly 59 tested-version batches / 177 metadata jobs

Part of #8440

## Testing

- representative Scala 3 JDK 25 checks passed locally with the centralized Scala 3 version before applying this series
- `git diff --check master...scala-jdk25-tests-2`