### PR TITLE
[3/4] Migrate Scala metadata tests to JDK 25

### DIFF
--- a/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
+++ b/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
+++ b/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
+++ b/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-reactive-streams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
+++ b/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-reactive-streams_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
+++ b/tests/src/co.fs2/fs2-reactive-streams_3/3.13.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "co.fs2:fs2-reactive-streams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.geirsson:metaconfig-typesafe-config_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-typesafe-config_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.geirsson:metaconfig-typesafe-config_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
+++ b/tests/src/com.geirsson/metaconfig-typesafe-config_2.13/0.12.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
+++ b/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
+++ b/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
+++ b/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.fd4s:fs2-kafka_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
+++ b/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.fd4s:fs2-kafka_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
+++ b/tests/src/com.github.fd4s/fs2-kafka_3/3.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.fd4s:fs2-kafka_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13/1.4.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
+++ b/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
+++ b/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
+++ b/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ghostdogpr:caliban_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
+++ b/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.ghostdogpr:caliban_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
+++ b/tests/src/com.github.ghostdogpr/caliban_3/2.10.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.ghostdogpr:caliban_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
+++ b/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
+++ b/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
+++ b/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
+++ b/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
+++ b/tests/src/com.github.plokhotnyuk.jsoniter-scala/jsoniter-scala-core_3/2.33.3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
+++ b/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.takayahilton:sql-formatter_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
+++ b/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
+++ b/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
+++ b/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.takayahilton:sql-formatter_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
+++ b/tests/src/com.github.takayahilton/sql-formatter_2.13/1.2.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.github.takayahilton:sql-formatter_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:requests_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:requests_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
+++ b/tests/src/com.lihaoyi/requests_3/0.9.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:requests_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle-implicits_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:upickle-implicits_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle-implicits_3/4.1.0-test-publish/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle-implicits_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.monovore:decline-effect_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.monovore:decline-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline-effect_3/2.6.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.monovore:decline-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
+++ b/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
+++ b/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
+++ b/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.magnolia1_3:magnolia_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
+++ b/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.magnolia1_3:magnolia_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
+++ b/tests/src/com.softwaremill.magnolia1_3/magnolia_3/1.3.16/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.magnolia1_3:magnolia_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/core_3/4.0.3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:ws_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:ws_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/ws_3/1.5.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:ws_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:zio_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/zio_3/1.5.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.shared:zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-http4s-server_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-http4s-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-http4s-server_3/1.11.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-http4s-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-functional_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-functional_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_2.13/2.10.8/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-functional_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play_2.13/2.9.10/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.6.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
+++ b/tests/src/com.typesafe/ssl-config-core_3/0.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe:ssl-config-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
+++ b/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
+++ b/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
+++ b/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-config-typesafe_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
+++ b/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-config-typesafe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
+++ b/tests/src/dev.zio/zio-config-typesafe_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-config-typesafe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
+++ b/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
+++ b/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-json_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
+++ b/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
+++ b/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
+++ b/tests/src/dev.zio/zio-json_3/0.7.42/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
+++ b/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-logging_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
+++ b/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
+++ b/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-logging_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
+++ b/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
+++ b/tests/src/dev.zio/zio-logging_2.13/2.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-logging_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-prelude-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-prelude-macros_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude-macros_3/1.0.0-RC39/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-prelude-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
+++ b/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-query_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
+++ b/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
+++ b/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
+++ b/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-query_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
+++ b/tests/src/dev.zio/zio-query_3/0.7.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-query_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema-derivation_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema-derivation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-derivation_3/1.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-schema-derivation_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
+++ b/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
+++ b/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
+++ b/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "eu.timepit:refined_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
+++ b/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "eu.timepit:refined_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
+++ b/tests/src/eu.timepit/refined_3/0.11.3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "eu.timepit:refined_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-generic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-generic_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-generic_3/0.14.12/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-generic_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.suzaku:boopickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.suzaku:boopickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
+++ b/tests/src/io.suzaku/boopickle_3/1.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.suzaku:boopickle_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-circe_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-circe_3/0.23.34/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-core_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-native_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-native_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-native_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-native_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.parboiled:parboiled_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.parboiled:parboiled_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_2.13/2.5.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.parboiled:parboiled_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.playframework.twirl:twirl-api_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.playframework.twirl:twirl-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.playframework.twirl:twirl-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/src/test/scala/org_playframework_twirl/twirl_api_3/Twirl_api_3Test.scala
+++ b/tests/src/org.playframework.twirl/twirl-api_3/2.0.1/src/test/scala/org_playframework_twirl/twirl_api_3/Twirl_api_3Test.scala
@@ -104,14 +104,14 @@ class Twirl_api_3Test {
     assertEquals("", template._display_(scala.runtime.BoxedUnit.UNIT).body)
     assertEquals("<b>safe</b>", template._display_(HtmlFormat.raw("<b>safe</b>")).body)
 
-    assertEquals("optional &amp; escaped", template._display_(Some("optional & escaped"))(htmlClassTag).body)
-    assertEquals("", template._display_(None)(htmlClassTag).body)
-    assertEquals("java &lt;optional&gt;", template._display_(Optional.of("java <optional>"))(htmlClassTag).body)
-    assertEquals("", template._display_(Optional.empty[String]())(htmlClassTag).body)
+    assertEquals("optional &amp; escaped", template._display_(Some("optional & escaped"))(using htmlClassTag).body)
+    assertEquals("", template._display_(None)(using htmlClassTag).body)
+    assertEquals("java &lt;optional&gt;", template._display_(Optional.of("java <optional>"))(using htmlClassTag).body)
+    assertEquals("", template._display_(Optional.empty[String]())(using htmlClassTag).body)
 
-    assertEquals("a&amp;<b>b</b>c&lt;", template._display_(Seq("a&", HtmlFormat.raw("<b>b</b>"), "c<"))(htmlClassTag).body)
-    assertEquals("x&lt;y&gt;", template._display_(Array("x<", "y>"))(htmlClassTag).body)
-    assertEquals("j&lt;<em>safe</em>", template._display_(java.util.Arrays.asList[Any]("j<", HtmlFormat.raw("<em>safe</em>")))(htmlClassTag).body)
+    assertEquals("a&amp;<b>b</b>c&lt;", template._display_(Seq("a&", HtmlFormat.raw("<b>b</b>"), "c<"))(using htmlClassTag).body)
+    assertEquals("x&lt;y&gt;", template._display_(Array("x<", "y>"))(using htmlClassTag).body)
+    assertEquals("j&lt;<em>safe</em>", template._display_(java.util.Arrays.asList[Any]("j<", HtmlFormat.raw("<em>safe</em>")))(using htmlClassTag).body)
 
     val copied: BaseScalaTemplate[Html, Format[Html]] = template.copy(HtmlFormat)
     assertEquals(template, copied)
@@ -161,7 +161,7 @@ class Twirl_api_3Test {
       StringContext("Hello ", " and ", "!").interpolate[Markdown](
         Seq("A_B *C*", trustedText),
         MarkdownFormat
-      )(summon[ClassTag[Markdown]])
+      )(using summon[ClassTag[Markdown]])
 
     assertEquals("Hello A\\_B \\*C\\* and **trusted**!", renderedText.body)
   }

--- a/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.playframework:play-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.playframework:play-json_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-json_3/3.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.playframework:play-json_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.playframework:play-server_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.playframework:play-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-server_3/3.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.playframework:play-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-ast_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-ast_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-ast_3/4.2.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-ast_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-streaming-api_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-streaming-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-streaming-api_3/1.0.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-streaming-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_2.13/2.11.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-java8-compat_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-java8-compat_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-java8-compat_3/1.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-java8-compat_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_2.13/1.1.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
+++ b/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
+++ b/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
+++ b/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang:scala3-interfaces:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
+++ b/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang:scala3-interfaces:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
+++ b/tests/src/org.scala-lang/scala3-interfaces/3.3.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang:scala3-interfaces:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
+++ b/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
+++ b/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang:scalap:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
+++ b/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang:scalap:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
+++ b/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
+++ b/tests/src/org.scala-lang/scalap/2.13.13/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang:scalap:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
+++ b/tests/src/org.scalatest/scalatest-diagrams_3/3.3.0-SNAP4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-diagrams_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-freespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-freespec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-freespec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-freespec_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funsuite_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funsuite_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
+++ b/tests/src/org.scodec/scodec-bits_3/1.1.27/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scodec:scodec-bits_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scodec:scodec-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scodec:scodec-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
+++ b/tests/src/org.scodec/scodec-core_3/2.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scodec:scodec-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "org.tpolecat:doobie-hikari_3:$libraryVersion"
     testImplementation 'com.h2database:h2:1.4.200'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-hikari_3:$libraryVersion"
     testImplementation 'com.h2database:h2:1.4.200'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-hikari_3/0.13.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-hikari_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
+++ b/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
+++ b/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
+++ b/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:case-insensitive_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
+++ b/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:case-insensitive_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
+++ b/tests/src/org.typelevel/case-insensitive_3/1.4.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:case-insensitive_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect-kernel_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect-kernel_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-kernel_3/3.3.14/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-effect-kernel_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect-std_3:$libraryVersion"
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-effect-std_3:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
@@ -15,9 +15,16 @@ dependencies {
     testImplementation "org.typelevel:cats-effect-std_3:$libraryVersion"
     testImplementation "org.typelevel:cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
+++ b/tests/src/org.typelevel/cats-effect-std_3/3.5.2/build.gradle
@@ -18,13 +18,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
+++ b/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
+++ b/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-mtl_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
+++ b/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
+++ b/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-mtl_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
+++ b/tests/src/org.typelevel/cats-mtl_3/1.3.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-mtl_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:log4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:log4cats-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-core_3/2.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:log4cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
+++ b/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
+++ b/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
+++ b/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:munit-cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
+++ b/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:munit-cats-effect_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
+++ b/tests/src/org.typelevel/munit-cats-effect_3/2.2.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:munit-cats-effect_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
+++ b/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
+++ b/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
+++ b/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:twiddles-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
+++ b/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:twiddles-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
+++ b/tests/src/org.typelevel/twiddles-core_3/0.7.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:twiddles-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 


### PR DESCRIPTION
## Summary

- migrate the third balanced quarter of Scala metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `JavaLanguageVersion.of(testJvmVersion)` toolchain declarations for the migrated Scala test builds
- switch Scala 3 test compiler/library dependencies to `tck.scala3Version` (currently `3.7.4`) so the TCK-resolved JDK 25 output is supported
- switch Scala 2 test compiler/library dependencies to `tck.scala2Version` (currently `2.13.17`) where present
- covers 55 libraries / 57 test build files, balanced to roughly 59 tested-version batches / 177 metadata jobs

Part of #8440

## Testing

- representative Scala 3 JDK 25 checks passed locally with the centralized Scala 3 version before applying this series
- `git diff --check master...scala-jdk25-tests-3`