### PR TITLE
Migrate remaining Groovy and Java metadata tests to JDK 25

### DIFF
--- a/tests/src/org.apache.groovy/groovy-test-junit5/4.0.24/build.gradle
+++ b/tests/src/org.apache.groovy/groovy-test-junit5/4.0.24/build.gradle
@@ -17,12 +17,6 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-client/6.2.16.Final/build.gradle
@@ -15,10 +15,6 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
-tasks.withType(JavaCompile).configureEach {
-    options.release = 21
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.RELEASE/build.gradle
+++ b/tests/src/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/3.1.0.RELEASE/build.gradle
@@ -10,10 +10,6 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
-tasks.withType(JavaCompile) {
-    options.release = 21
-}
-
 dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")
     testImplementation("org.slf4j:slf4j-simple:1.7.36")

--- a/tests/src/org.thymeleaf/thymeleaf-spring6/3.1.0.RELEASE/build.gradle
+++ b/tests/src/org.thymeleaf/thymeleaf-spring6/3.1.0.RELEASE/build.gradle
@@ -10,10 +10,6 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 
-tasks.withType(JavaCompile) {
-    options.release = 21
-}
-
 dependencies {
     testImplementation("org.slf4j:slf4j-api:1.7.36")
     testImplementation("org.slf4j:slf4j-simple:1.7.36")


### PR DESCRIPTION
## Summary

- remove the remaining non-Scala explicit JDK 21 test overrides so the TCK-resolved test JVM default applies
- covers `org.apache.groovy:groovy-test-junit5`, `org.jboss.resteasy:resteasy-client`, `org.thymeleaf:thymeleaf-spring6`, and `org.thymeleaf.extras:thymeleaf-extras-springsecurity6`
- avoids replacing the old overrides with hardcoded JDK 25 settings

Part of #8441

## Testing

- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew compileTestJava -Pcoordinates=org.jboss.resteasy:resteasy-client:6.2.16.Final --stacktrace`
- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew compileTestJava -Pcoordinates=org.thymeleaf:thymeleaf-spring6:3.1.0.RELEASE --stacktrace`
- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew compileTestJava -Pcoordinates=org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.0.RELEASE --stacktrace`
- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew javaTest -Pcoordinates=org.apache.groovy:groovy-test-junit5:4.0.24 --stacktrace`
- `git diff --check master...remaining-jdk25-tests`