### PR TITLE
[4/4] Migrate Scala metadata tests to JDK 25

### DIFF
--- a/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/2.5.6/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
+++ b/tests/src/co.fs2/fs2-core_3/3.0-130-1713a29/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "co.fs2:fs2-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
+++ b/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
+++ b/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
+++ b/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.beachape:enumeratum-circe_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
+++ b/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.beachape:enumeratum-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
+++ b/tests/src/com.beachape/enumeratum-circe_3/1.9.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.beachape:enumeratum-circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
+++ b/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
+++ b/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
+++ b/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.comcast:ip4s-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
+++ b/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.comcast:ip4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
+++ b/tests/src/com.comcast/ip4s-core_3/3.5.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.comcast:ip4s-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_2.13/2.11.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
+++ b/tests/src/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.fasterxml.jackson.module:jackson-module-scala_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
@@ -11,13 +11,14 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.17:$libraryVersion"
     scalaCompilerPlugins "com.github.ghik:silencer-plugin_2.13.17:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
@@ -19,6 +19,12 @@ dependencies {
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 tasks.withType(ScalaCompile).configureEach {
     scalaCompileOptions.additionalParameters = [
             "-Wunused:locals",

--- a/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
@@ -12,11 +12,11 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "com.github.ghik:silencer-lib_2.13.16:$libraryVersion"
-    scalaCompilerPlugins "com.github.ghik:silencer-plugin_2.13.16:$libraryVersion"
+    testImplementation "com.github.ghik:silencer-lib_2.13.17:$libraryVersion"
+    scalaCompilerPlugins "com.github.ghik:silencer-plugin_2.13.17:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 tasks.withType(ScalaCompile).configureEach {
@@ -28,7 +28,7 @@ tasks.withType(ScalaCompile).configureEach {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.17:$libraryVersion"
@@ -21,7 +22,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.16/1.7.19/build.gradle
@@ -25,13 +25,6 @@ tasks.withType(ScalaCompile).configureEach {
             "-Werror"
     ]
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.5:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.5:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.5:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.5/1.7.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     binaries {
         test {

--- a/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     binaries {
         test {

--- a/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
+++ b/tests/src/com.github.pureconfig/pureconfig-core_3/0.17.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.github.pureconfig:pureconfig-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:fastparse_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fastparse_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:fastparse_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/fastparse_3/3.1.1/src/test/scala/com_lihaoyi/fastparse_3/Fastparse_3Test.scala
+++ b/tests/src/com.lihaoyi/fastparse_3/3.1.1/src/test/scala/com_lihaoyi/fastparse_3/Fastparse_3Test.scala
@@ -19,14 +19,14 @@ import org.junit.jupiter.api.Test
 class Fastparse_3Test {
   @Test
   def parsesExpressionLanguageWithCapturesRepetitionAndEndChecking(): Unit = {
-    val parsed: Parsed[Assignment] = parse("answer = 1 + 2 * (3 + 4) - -5", ExpressionGrammar.assignment(_))
+    val parsed: Parsed[Assignment] = parse("answer = 1 + 2 * (3 + 4) - -5", ExpressionGrammar.assignment(using _))
 
     assertThat(parsed).isEqualTo(Parsed.Success(Assignment("answer", 20), 29))
   }
 
   @Test
   def reportsStructuredFailuresAndTraceMessagesForInvalidExpressions(): Unit = {
-    val parsed: Parsed[Assignment] = parse("answer = 1 + * 2", ExpressionGrammar.assignment(_), verboseFailures = true)
+    val parsed: Parsed[Assignment] = parse("answer = 1 + * 2", ExpressionGrammar.assignment(using _), verboseFailures = true)
     val failure: Parsed.Failure = expectFailure(parsed)
     val traced: Parsed.TracedFailure = failure.trace()
 
@@ -43,7 +43,7 @@ class Fastparse_3Test {
   def parsesDelimitedRecordsFromChunkedIteratorInput(): Unit = {
     val inspectedInput: IteratorParserInput = IteratorParserInput(Iterator("alpha,be", "ta,gamma", ",delta"))
     val parsedInput: IteratorParserInput = IteratorParserInput(Iterator("alpha,be", "ta,gamma", ",delta"))
-    val parsed: Parsed[Seq[String]] = parse(parsedInput, CsvGrammar.values(_))
+    val parsed: Parsed[Seq[String]] = parse(parsedInput, CsvGrammar.values(using _))
 
     assertThat(inspectedInput.isReachable(21)).isTrue
     assertThat(inspectedInput.slice(11, 16)).isEqualTo("gamma")
@@ -53,7 +53,7 @@ class Fastparse_3Test {
   @Test
   def exposesIndexedParserInputSlicesPositionsAndFoldedResults(): Unit = {
     val input: IndexedParserInput = IndexedParserInput("first\nsecond\nthird")
-    val parsed: Parsed[SpanToken] = parse(input, SpanGrammar.secondLineToken(_))
+    val parsed: Parsed[SpanToken] = parse(input, SpanGrammar.secondLineToken(using _))
     val folded: String = parsed.fold(
       (label: String, index: Int, extra: Parsed.Extra) => s"failure:$label@$index:${extra.startIndex}",
       (token: SpanToken, index: Int) => s"${token.text}:${token.start}-${token.end}:$index"
@@ -71,10 +71,10 @@ class Fastparse_3Test {
   def handlesWhitespaceModesIncludingNestedAndUnclosedComments(): Unit = {
     val scalaParsed: Parsed[Seq[String]] = parse(
       "alpha /* outer /* nested */ done */ , // line comment\n beta",
-      WhitespaceGrammars.scalaIdentifierList(_)
+      WhitespaceGrammars.scalaIdentifierList(using _)
     )
     val javaFailure: Parsed.Failure = expectFailure(
-      parse("left /* missing close */ right /* unclosed", WhitespaceGrammars.javaIdentifierPair(_), verboseFailures = true)
+      parse("left /* missing close */ right /* unclosed", WhitespaceGrammars.javaIdentifierPair(using _), verboseFailures = true)
     )
 
     assertThat(scalaParsed).isEqualTo(Parsed.Success(Seq("alpha", "beta"), 59))
@@ -84,11 +84,11 @@ class Fastparse_3Test {
 
   @Test
   def usesCaseInsensitiveAlternativesLookaheadPredicatesAndValidation(): Unit = {
-    val command: Parsed[String] = parse("SeLeCt", CommandGrammar.command(_))
-    val identifier: Parsed[String] = parse("customer_42", CommandGrammar.nonKeywordIdentifier(_))
-    val keywordAsIdentifier: Parsed[String] = parse("DELETE", CommandGrammar.nonKeywordIdentifier(_), verboseFailures = true)
-    val evenHalf: Parsed[Int] = parse("42", CommandGrammar.evenHalf(_))
-    val oddHalf: Parsed[Int] = parse("41", CommandGrammar.evenHalf(_), verboseFailures = true)
+    val command: Parsed[String] = parse("SeLeCt", CommandGrammar.command(using _))
+    val identifier: Parsed[String] = parse("customer_42", CommandGrammar.nonKeywordIdentifier(using _))
+    val keywordAsIdentifier: Parsed[String] = parse("DELETE", CommandGrammar.nonKeywordIdentifier(using _), verboseFailures = true)
+    val evenHalf: Parsed[Int] = parse("42", CommandGrammar.evenHalf(using _))
+    val oddHalf: Parsed[Int] = parse("41", CommandGrammar.evenHalf(using _), verboseFailures = true)
 
     assertThat(command).isEqualTo(Parsed.Success("select", 6))
     assertThat(identifier).isEqualTo(Parsed.Success("customer_42", 11))
@@ -99,10 +99,10 @@ class Fastparse_3Test {
 
   @Test
   def synthesizesDefaultValuesAndExplicitFailuresWithPassAndFail(): Unit = {
-    val defaulted: Parsed[Directive] = parse("cache", DirectiveGrammar.directive(_))
-    val enabled: Parsed[Directive] = parse("metrics=true", DirectiveGrammar.directive(_))
+    val defaulted: Parsed[Directive] = parse("cache", DirectiveGrammar.directive(using _))
+    val enabled: Parsed[Directive] = parse("metrics=true", DirectiveGrammar.directive(using _))
     val invalidBoolean: Parsed.Failure = expectFailure(
-      parse("maybe", DirectiveGrammar.booleanValue(_), verboseFailures = true)
+      parse("maybe", DirectiveGrammar.booleanValue(using _), verboseFailures = true)
     )
 
     assertThat(defaulted).isEqualTo(Parsed.Success(Directive("cache", false), 5))
@@ -112,9 +112,9 @@ class Fastparse_3Test {
 
   @Test
   def demonstratesCutBacktrackingAndNoCutRecovery(): Unit = {
-    val noCut: Parsed[Unit] = parse("ac", CutGrammar.withoutCut(_))
-    val cutFailure: Parsed.Failure = expectFailure(parse("ac", CutGrammar.withCut(_), verboseFailures = true))
-    val recovered: Parsed[Unit] = parse("ac", CutGrammar.cutWrappedInNoCut(_))
+    val noCut: Parsed[Unit] = parse("ac", CutGrammar.withoutCut(using _))
+    val cutFailure: Parsed.Failure = expectFailure(parse("ac", CutGrammar.withCut(using _), verboseFailures = true))
+    val recovered: Parsed[Unit] = parse("ac", CutGrammar.cutWrappedInNoCut(using _))
 
     assertThat(noCut).isEqualTo(Parsed.Success((), 2))
     assertThat(cutFailure.index).isEqualTo(1)
@@ -124,16 +124,16 @@ class Fastparse_3Test {
 
   @Test
   def supportsDependentParsingWithFlatMapAndRawSequencing(): Unit = {
-    assertThat(parse("'fastparse'", QuotedGrammar.quoted(_))).isEqualTo(Parsed.Success("fastparse", 11))
-    assertThat(parse("\"Scala 3\"", QuotedGrammar.quoted(_))).isEqualTo(Parsed.Success("Scala 3", 9))
+    assertThat(parse("'fastparse'", QuotedGrammar.quoted(using _))).isEqualTo(Parsed.Success("fastparse", 11))
+    assertThat(parse("\"Scala 3\"", QuotedGrammar.quoted(using _))).isEqualTo(Parsed.Success("Scala 3", 9))
 
-    val failure: Parsed.Failure = expectFailure(parse("'unterminated", QuotedGrammar.quoted(_), verboseFailures = true))
+    val failure: Parsed.Failure = expectFailure(parse("'unterminated", QuotedGrammar.quoted(using _), verboseFailures = true))
     assertThat(failure.msg).contains("Expected")
   }
 
   @Test
   def parsesUsingCharacterPredicatesAndAnyCharacterParsers(): Unit = {
-    val parsed: Parsed[CharacterSummary] = parse("Aλ9!?", CharacterGrammar.summary(_))
+    val parsed: Parsed[CharacterSummary] = parse("Aλ9!?", CharacterGrammar.summary(using _))
 
     assertThat(parsed).isEqualTo(Parsed.Success(CharacterSummary("Aλ", "9", "!?"), 5))
   }
@@ -147,7 +147,7 @@ class Fastparse_3Test {
     try {
       val inspectedInput: ReaderParserInput = ReaderParserInput(inspectedReader, 4)
       val parsedInput: ReaderParserInput = ReaderParserInput(parsedReader, 4)
-      val parsed: Parsed[(String, String)] = parse(parsedInput, ReaderBackedGrammar.assignment(_))
+      val parsed: Parsed[(String, String)] = parse(parsedInput, ReaderBackedGrammar.assignment(using _))
 
       assertThat(inspectedInput.isReachable(16)).isTrue
       assertThat(inspectedInput.slice(0, 4)).isEqualTo("name")

--- a/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.1.0-test-publish/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/ujson_3/4.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:ujson_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.1.0-test-publish/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
@@ -21,12 +21,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
@@ -24,8 +24,14 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 String graalvmHome = System.getenv("GRAALVM_HOME") ?: System.getenv("JAVA_HOME")

--- a/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
@@ -43,7 +43,7 @@ if (project.hasProperty("agent") && graalvmJavaExecutable != null && graalvmJava
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
@@ -20,6 +20,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.lihaoyi:upickle_3:$libraryVersion"
@@ -30,7 +31,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
+++ b/tests/src/com.lihaoyi/upickle_3/4.4.0/build.gradle
@@ -40,13 +40,6 @@ if (project.hasProperty("agent") && graalvmJavaExecutable != null && graalvmJava
         }
     }
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.monovore/decline_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline_3/2.6.2/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.monovore/decline_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline_3/2.6.2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.monovore/decline_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline_3/2.6.2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.monovore:decline_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.monovore/decline_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline_3/2.6.2/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.monovore:decline_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.monovore/decline_3/2.6.2/build.gradle
+++ b/tests/src/com.monovore/decline_3/2.6.2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.monovore:decline_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:circe_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
+++ b/tests/src/com.softwaremill.sttp.client4/circe_3/4.0.23/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.client4:circe_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.model:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.model:core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
+++ b/tests/src/com.softwaremill.sttp.model/core_3/1.7.12/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.model:core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-cats_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-cats_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-cats_3/1.11.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-cats_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-server_3/1.11.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-server_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-zio_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
+++ b/tests/src/com.softwaremill.sttp.tapir/tapir-zio_3/1.13.18/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.softwaremill.sttp.tapir:tapir-zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-parsing_2.13/10.5.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.akka:akka-parsing_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:play-functional_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-functional_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:play-functional_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/play-functional_3/2.10.6/src/test/scala/com_typesafe_play/play_functional_3/Play_functional_3Test.scala
+++ b/tests/src/com.typesafe.play/play-functional_3/2.10.6/src/test/scala/com_typesafe_play/play_functional_3/Play_functional_3Test.scala
@@ -232,9 +232,9 @@ class Play_functional_3Test {
         Codec(input => f1(codec.parse(input)), value => codec.print(f2(value)))
     }
 
-    val readerExtractor: VariantExtractor[Reader] = VariantExtractor.functor(readerFunctor)
-    val printerExtractor: VariantExtractor[Printer] = VariantExtractor.contravariantFunctor(printerContravariant)
-    val codecExtractor: VariantExtractor[Codec] = VariantExtractor.invariantFunctor(codecInvariant)
+    val readerExtractor: VariantExtractor[Reader] = VariantExtractor.functor(using readerFunctor)
+    val printerExtractor: VariantExtractor[Printer] = VariantExtractor.contravariantFunctor(using printerContravariant)
+    val codecExtractor: VariantExtractor[Codec] = VariantExtractor.invariantFunctor(using codecInvariant)
 
     val readerResult: String = readerExtractor match {
       case FunctorExtractor(functor) =>

--- a/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_2.13/1.6.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
+++ b/tests/src/com.typesafe.play/twirl-api_3/1.6.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "com.typesafe.play:twirl-api_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
+++ b/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
+++ b/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-http_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
+++ b/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
+++ b/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-http_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
+++ b/tests/src/dev.zio/zio-http_3/3.3.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-http_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-prelude_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-prelude_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
+++ b/tests/src/dev.zio/zio-prelude_3/1.0.0-RC39/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-prelude_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-schema-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema-macros_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
+++ b/tests/src/dev.zio/zio-schema-macros_3/1.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-schema-macros_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio-test_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio-test_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio-test_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio-test_3/2.1.25/src/test/scala/dev_zio/zio_test_3/Zio_test_3Test.scala
+++ b/tests/src/dev.zio/zio-test_3/2.1.25/src/test/scala/dev_zio/zio_test_3/Zio_test_3Test.scala
@@ -274,7 +274,7 @@ class Zio_test_3Test {
 
     val identical = Diff.stringDiff.diff("zio", "zio")
     val changed = Diff.stringDiff.diff("zio", "zio-test")
-    val listChanged = Diff.listDiff(Diff.stringDiff).diff(List("a", "b"), List("a", "c", "d"))
+    val listChanged = Diff.listDiff(using Diff.stringDiff).diff(List("a", "b"), List("a", "c", "d"))
 
     assertThat(identical.noDiff).isTrue()
     assertThat(changed.hasDiff).isTrue()

--- a/tests/src/dev.zio/zio_3/2.1.6/build.gradle
+++ b/tests/src/dev.zio/zio_3/2.1.6/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "dev.zio:zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/dev.zio/zio_3/2.1.6/build.gradle
+++ b/tests/src/dev.zio/zio_3/2.1.6/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/dev.zio/zio_3/2.1.6/build.gradle
+++ b/tests/src/dev.zio/zio_3/2.1.6/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio_3/2.1.6/build.gradle
+++ b/tests/src/dev.zio/zio_3/2.1.6/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "dev.zio:zio_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/dev.zio/zio_3/2.1.6/build.gradle
+++ b/tests/src/dev.zio/zio_3/2.1.6/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "dev.zio:zio_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.10/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.14.11/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
+++ b/tests/src/io.circe/circe-core_3/0.15.0-M1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.circe:circe-jawn_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.circe:circe-jawn_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
+++ b/tests/src/io.circe/circe-jawn_3/0.14.12/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.circe:circe-jawn_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
+++ b/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.getquill:quill-engine_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
+++ b/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.getquill:quill-engine_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
+++ b/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
+++ b/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "io.getquill:quill-engine_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
+++ b/tests/src/io.getquill/quill-engine_2.13/4.8.5/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
+++ b/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
+++ b/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
+++ b/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "io.scalaland:chimney_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
+++ b/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "io.scalaland:chimney_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
+++ b/tests/src/io.scalaland/chimney_3/2.0.0-M1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "io.scalaland:chimney_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-dsl_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-dsl_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
+++ b/tests/src/org.http4s/http4s-dsl_3/0.23.34/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-dsl_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.http4s:http4s-server_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
+++ b/tests/src/org.http4s/http4s-server_3/0.23.30/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.http4s:http4s-server_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M11/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -21,13 +21,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 configurations.configureEach {
     exclude group: 'org.scala-native'
@@ -24,7 +25,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -21,6 +21,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -11,6 +11,7 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 configurations.configureEach {
     exclude group: 'org.scala-native'
@@ -19,8 +20,8 @@ configurations.configureEach {
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
+++ b/tests/src/org.json4s/json4s-core_2.13/3.7.0-M13/build.gradle
@@ -18,13 +18,13 @@ configurations.configureEach {
 dependencies {
     testImplementation "org.json4s:json4s-core_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-jackson-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-jackson-core_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-jackson-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-scalap_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.json4s:json4s-scalap_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
+++ b/tests/src/org.json4s/json4s-scalap_3/4.0.7/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.json4s:json4s-scalap_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.parboiled:parboiled_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.parboiled:parboiled_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
+++ b/tests/src/org.parboiled/parboiled_3/2.5.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.parboiled:parboiled_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.playframework:play-functional_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.playframework:play-functional_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
+++ b/tests/src/org.playframework/play-functional_3/3.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.playframework:play-functional_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.sangria-graphql:sangria-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
+++ b/tests/src/org.sangria-graphql/sangria-core_3/4.2.9/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.sangria-graphql:sangria-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-collection-compat_3/2.4.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-collection-compat_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_2.13/1.0.3/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parallel-collections_3/1.0.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parallel-collections_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
+++ b/tests/src/org.scala-lang.modules/scala-parser-combinators_3/2.3.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-lang.modules:scala-parser-combinators_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
+++ b/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scala-sbt:test-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
+++ b/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
+++ b/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scala-sbt:test-interface:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
+++ b/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
+++ b/tests/src/org.scala-sbt/test-interface/1.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scala-sbt:test-interface:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-featurespec_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-featurespec_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-funspec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-funspec_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-mustmatchers_3/3.2.19/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-mustmatchers_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.2.19/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scalatest:scalatest-refspec_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
+++ b/tests/src/org.scalatest/scalatest-refspec_2.13/3.3.0-SNAP2/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
+++ b/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "org.scoverage:scalac-scoverage-runtime_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
+++ b/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
@@ -17,6 +17,13 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
+++ b/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.scoverage:scalac-scoverage-runtime_2.13:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
+++ b/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala-library:2.13.17'
     testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
+++ b/tests/src/org.scoverage/scalac-scoverage-runtime_2.13/1.4.1/build.gradle
@@ -14,13 +14,13 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.scoverage:scalac-scoverage-runtime_2.13:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.16'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.16'
+    testImplementation 'org.scala-lang:scala-library:2.13.17'
+    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-postgres_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:doobie-postgres_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
+++ b/tests/src/org.tpolecat/doobie-postgres_3/0.13.4/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:doobie-postgres_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.tpolecat:skunk-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.tpolecat:skunk-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
+++ b/tests/src/org.tpolecat/skunk-core_3/1.1.0-M3/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.tpolecat:skunk-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-core_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
+++ b/tests/src/org.typelevel/cats-core_3/2.6.1/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-core_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
+++ b/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
+++ b/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
+++ b/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:cats-parse_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
+++ b/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-parse_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
+++ b/tests/src/org.typelevel/cats-parse_3/1.0.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:cats-parse_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:log4cats-slf4j_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:log4cats-slf4j_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
+++ b/tests/src/org.typelevel/log4cats-slf4j_3/2.7.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:log4cats-slf4j_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.13.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.4.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-common_3/0.5.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:otel4s-core-common_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
@@ -17,13 +17,6 @@ dependencies {
     testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
     testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
 }
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
-    }
-}
-
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
@@ -14,9 +14,16 @@ String libraryVersion = tck.testedLibraryVersion.get()
 dependencies {
     testImplementation "org.typelevel:otel4s-core-trace_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.3.6'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.3.6'
+    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
+    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
 graalvmNative {
     agent {
         defaultMode = "conditional"

--- a/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
@@ -10,6 +10,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-trace_3:$libraryVersion"
@@ -20,7 +21,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 

--- a/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
+++ b/tests/src/org.typelevel/otel4s-core-trace_3/0.4.0/build.gradle
@@ -11,12 +11,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "org.typelevel:otel4s-core-trace_3:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {


### PR DESCRIPTION
## Summary

- migrate the final balanced quarter of Scala metadata tests from explicit JDK 21 targets to the TCK-resolved JDK 25 test target
- restore local `JavaLanguageVersion.of(testJvmVersion)` toolchain declarations for the migrated Scala test builds
- switch Scala 3 test compiler/library dependencies to `tck.scala3Version` (currently `3.7.4`) so the TCK-resolved JDK 25 output is supported
- switch Scala 2 test compiler/library dependencies to `tck.scala2Version` (currently `2.13.17`) where present
- covers 56 libraries / 66 test build files, balanced to roughly 59 tested-version batches / 177 metadata jobs

Part of #8440

## Testing

- `JAVA_HOME=/home/jovan/ol/bb/master/graal/sdk/mxbuild/linux-amd64/GRAALVM_JAVA25/graalvm-25.1.0-dev+10.1 GRAALVM_HOME=$JAVA_HOME ./gradlew javaTest -Pcoordinates=com.fasterxml.jackson.module:jackson-module-scala_2.13:2.11.4 --stacktrace`
- representative Scala 3 JDK 25 checks passed locally with the centralized Scala 3 version before applying this series
- `git diff --check master...scala-jdk25-tests-4`