### PR TITLE
Forge: add run-continuation spec (WF-forge-run-continuation)

### DIFF
--- a/forge/docs/README.md
+++ b/forge/docs/README.md
@@ -41,6 +41,7 @@ its IDs in that one file.
 - [grund.md](grund.md) — `GRUND-forge-motivation`: why Forge exists.
 - [goals.md](goals.md) — `GOAL-forge-direction` and the outcome goals beneath it.
 - [functional-spec.md](functional-spec.md) — `FS-forge-functional-spec`: top-level functional spec and the workflow-spec catalog.
+- [continuation.md](continuation.md) — `FS-forge-run-continuation`: resuming a failed run at the phase that failed, and the continuation marker contract.
 - [architecture.md](architecture.md) — `AR-forge-architecture`: control plane, workflow boundaries, and extension points.
 - [agent.md](agent.md) — `AR-agent-api`: the agent API and its Pi implementation.
 - [do-work.md](do-work.md) — `DW-do-work-loop`: the long-running worker loop.

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -1,0 +1,130 @@
+# FS-forge-run-continuation: Run continuation and resume
+
+Run continuation lets a later Forge run re-enter a failed issue run at the phase
+that failed, instead of regenerating the whole result from scratch. It is a
+cross-cutting capability across the Forge workflow system
+(§WF-forge-workflow-system) and builds on the workflow engine's ownership of run
+state (§WF-forge-workflow-engine): the engine
+already advances per-iteration progress as commits and reverts to the last good
+checkpoint on a failed iteration (§WF-dynamic-access-iterative-strategy).
+Continuation makes that checkpoint state survive process exit and become
+re-entrant on a new run.
+
+Continuation serves §GOAL-shorten-issue-to-shipped-metadata — which already
+requires Forge to "preserve enough evidence for maintainers or later Forge runs
+to continue without rediscovering the same problem" — and
+§GOAL-minimize-generation-cost, by not re-spending tokens and compute on phases
+that already succeeded.
+
+Continuation is **additive** to human intervention, not a replacement. A logical
+failure still preserves the work branch and labels the issue `human-intervention`
+exactly as before (§FS-human-intervention-policy); continuation only adds a
+machine-readable way for a later run, or a maintainer, to resume from that
+preserved branch.
+
+## 1. Phase model
+
+A run is an ordered sequence of phases. Continuation classifies each phase by its
+*shape*, because shape decides how it resumes:
+
+- **Continuous phases** iterate internally and commit many checkpoints. Resume
+  *continues* from the last checkpoint.
+- **Discrete phases** are one short step. Resume *redoes* the step from the
+  preserved branch; a completed discrete phase is skipped.
+
+| Phase | Shape | Resume action |
+| --- | --- | --- |
+| `setup` | discrete | Skip the sub-steps already marked done (`preflightDone`, `setupDone`); otherwise rerun. |
+| `fix` | continuous | Continue from the preserved branch at the recorded `iteration`. |
+| `explore` | continuous | Rerun the phase; the regenerated dynamic-access report self-prunes to uncovered classes, and the recorded `exhaustedClasses` keep already-abandoned classes from being retried. |
+| `finalization` | discrete | If entered but not completed, redo from the preserved branch. |
+| `publication` | discrete (remote) | If `isPushed`, the branch already landed on the recorded `branch` and resume finishes publication from there; otherwise run the full publication pipeline (§GIT-shared-publication-pipeline). |
+
+The unifying invariant: **the preserved branch HEAD is the cursor.** The
+committed tree is the source of truth for where a phase got to, so the marker
+never stores commit hashes — only the logical state a rebuild cannot recover.
+
+## 2. ContinuationMarker
+
+The continuation marker is one JSON object that records only non-reconstructable
+state. Anything a rebuild can regenerate is omitted and recomputed on resume: the
+dynamic-access coverage report is regenerated from the rebuilt tree, and covered
+classes re-appear in the regenerated report.
+
+```json
+{
+  "schemaVersion": 1,
+  "continueFrom": "publication",
+  "preservedBranch": "ai/<login>/human-intervention/issue-9102-library-new-request-com.acme.widget-3f9a2c11",
+  "strategyName": "dynamic_access_main_sources_pi_gpt-5.5",
+  "issueNumber": 9102,
+  "label": "library-new-request",
+  "coordinate": "com.acme:widget:1.4.0",
+  "newVersion": null,
+  "phases": {
+    "setup":        { "status": "completed", "preflightDone": true, "setupDone": true },
+    "fix":          { "status": "skipped",   "iteration": null },
+    "explore":      { "status": "completed", "exhaustedClasses": ["com.acme.Foo"] },
+    "finalization": { "status": "completed" },
+    "publication":  { "status": "pending",   "isPushed": false,
+                      "branch": "ai/<login>/add-lib-support-com.acme-widget-1.4.0" }
+  }
+}
+```
+
+### 2.1 Lifecycle
+
+The marker is **gitignored in the worktree during the run** and written eagerly
+on each phase transition, so it survives a hard kill or agent timeout. It is
+**force-added onto the preservation branch only** when a logical failure
+preserves the work. This is the same mechanic the chunked dynamic-access exhaust
+report already uses to carry resume state (§WF-dynamic-access-exhaust-report);
+because the marker never enters a successful run's publication staging
+(§GIT-expected-paths), a completed PR stays clean with no cleanup step.
+
+### 2.2 Field rules
+
+- `continueFrom` is the authoritative resume entry point; it equals the first
+  phase whose `status` is not `completed` or `skipped`.
+- `preservedBranch` is the remote branch that holds the preserved tree and the
+  marker.
+- `strategyName` re-instantiates the workflow engine and its exploration variant
+  (§STRAT-forge-predefined-strategy-contract).
+- `issueNumber`, `label`, `coordinate`, and `newVersion` re-route the workflow;
+  they are kept explicit because the coordinate is sanitized inside the branch
+  name and cannot be parsed back reliably.
+- `explore.exhaustedClasses` is the only EXPLORE state worth keeping: a fresh
+  report cannot distinguish an uncovered-but-abandoned class from an
+  uncovered-but-untried one.
+- `publication.isPushed` is stored rather than derived so a stale remote branch
+  from an earlier aborted attempt cannot be mistaken for this run's push;
+  `publication.branch` is stored so resume targets the original branch namespace
+  regardless of which identity runs the resume.
+
+## 3. Resume flow
+
+A resume run reads the marker from the preserved branch and:
+
+1. Re-routes the workflow from `issueNumber`/`label`/`coordinate` and
+   re-instantiates the engine from `strategyName`.
+2. Checks out the preserved branch and rebases it onto current `master`; if it
+   no longer applies cleanly, it falls back to a clean run rather than resuming a
+   stale tree.
+3. Enters the phase named by `continueFrom` and applies that phase's resume
+   action from §1, skipping every earlier completed or skipped phase.
+
+Publication resume hinges on the push: the branch is read from the marker
+and `isPushed` records whether the branch is already pushed, so a resumed run only
+does the PR making. Opening the pull request is the workflow's
+completion — a marker only exists for a run that failed before that point, so
+continuation never reaches a state with the pull request already open.
+
+## 4. Relationship to human intervention
+
+Continuation does not change the human-intervention contract
+(§FS-human-intervention-policy). A logical failure still preserves the work
+branch and labels the issue `human-intervention`, so a maintainer always retains
+the existing safety signal and diagnostics. The marker rides that same preserved
+branch, giving a later automated run — or the maintainer — a precise place to
+continue. External or transient failures take no issue action and write no
+marker, exactly as today.

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -371,7 +371,10 @@ normal review automation may treat it as safe. The companion
 `human-intervention-fixed` PR label means a maintainer has addressed the manual
 follow-up and review automation may resume after normal merge gates pass. The
 resulting labeled backlog is drained by automated resolution, not per-item
-manual triage (§FS-human-intervention-resolution).
+manual triage (§FS-human-intervention-resolution). The preserved work branch
+additionally carries a continuation marker, so a later run can resume the issue
+from the phase that failed instead of regenerating from scratch
+(§FS-forge-run-continuation).
 
 Post-generation intervention is different: it is an automated recovery step
 inside a workflow. `SUCCESS_WITH_INTERVENTION_STATUS` is PR-eligible when the


### PR DESCRIPTION
## What

Spec-first, docs-only PR that adds `WF-forge-run-continuation` — the contract for
**resuming a failed Forge run at the phase that failed** instead of regenerating the
whole result from scratch — and documents the `ContinuationMarker` it relies on.

No behavior change yet. This is step 1 of the plan in
oracle/graalvm-reachability-metadata#8486; writing the spec before the code so the
implementation has a stable ID to cite.

## Why

A logical failure already preserves the work branch and labels the issue
`human-intervention` (`§FS-human-intervention-policy`), but a retry today
regenerates everything — re-spending tokens and compute on phases that already
succeeded. Continuation lets a later run re-enter at the failed phase, which is
exactly what `§GOAL-shorten-issue-to-shipped-metadata` ("later Forge runs continue
without rediscovering the same problem") and `§GOAL-minimize-generation-cost`
already ask for. It is **additive** to human intervention, not a replacement.

## Contents

- `forge/docs/workflows/continuation.md` — new `WF-forge-run-continuation`: the phase
  model (continuous `fix`/`explore` vs discrete `finalization`/`publication`), the
  marker lifecycle (gitignored during the run, force-added onto the preserved branch
  only — the same mechanic as the chunked exhaust report), and the resume flow.
- `forge/docs/functional-spec.md` — one sentence in `§FS-human-intervention-policy`
  linking the preserved branch to the continuation marker.
- `forge/docs/README.md` — index entry for the new workflow doc.

Scope: docs only, three files, no code touched. `grund check` passes.

### Open question

- Separate from the marker, the PR branch today carries the many per-class
  exploration checkpoint commits (publication carries the working `HEAD`, no squash).
  Do we also want a squash step for a single clean PR commit? Orthogonal to
  continuation — flagging for visibility.
- The driver/engine unification (one config-driven driver shell + a composite
  `fix → explore` engine) would make resume cleaner but is a larger refactor; tracked
  separately, not in this spec.
