### PR TITLE
Centralize language scaffold versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,12 @@ nativeBuildTools = "1.0.0"
 junitPlatform = "1.9.2"
 junitJupiter = "5.9.2"
 groovy = "3.0.14"
+kotlin = "2.3.20"
+scala213 = "2.13.17"
+scala3 = "3.7.4"
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 
 [libraries]
 nativeGradlePlugin = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "nativeBuildTools" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junitPlatform = "1.9.2"
 junitJupiter = "5.9.2"
 groovy = "3.0.14"
 kotlin = "2.3.20"
-scala213 = "2.13.17"
+scala2 = "2.13.17"
 scala3 = "3.7.4"
 
 [plugins]

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -57,8 +57,8 @@ Integer explicitTestJvmVersion(File buildFile) {
 int testJvmVersion = explicitTestJvmVersion(project.buildFile) ?: 25
 tck.testJvmVersion.set(testJvmVersion)
 tck.testJvmVersion.finalizeValueOnRead()
-tck.scala213Version.set(libs.versions.scala213)
-tck.scala213Version.finalizeValueOnRead()
+tck.scala2Version.set(libs.versions.scala2)
+tck.scala2Version.finalizeValueOnRead()
 tck.scala3Version.set(libs.versions.scala3)
 tck.scala3Version.finalizeValueOnRead()
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -57,6 +57,10 @@ Integer explicitTestJvmVersion(File buildFile) {
 int testJvmVersion = explicitTestJvmVersion(project.buildFile) ?: 25
 tck.testJvmVersion.set(testJvmVersion)
 tck.testJvmVersion.finalizeValueOnRead()
+tck.scala213Version.set(libs.versions.scala213)
+tck.scala213Version.finalizeValueOnRead()
+tck.scala3Version.set(libs.versions.scala3)
+tck.scala3Version.finalizeValueOnRead()
 
 tasks.withType(JavaCompile).configureEach {
     options.release = testJvmVersion

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
@@ -45,7 +45,7 @@ public abstract class TckExtension {
 
     public abstract Property<Integer> getTestJvmVersion();
 
-    public abstract Property<@NotNull String> getScala213Version();
+    public abstract Property<@NotNull String> getScala2Version();
 
     public abstract Property<@NotNull String> getScala3Version();
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/TckExtension.java
@@ -45,6 +45,10 @@ public abstract class TckExtension {
 
     public abstract Property<Integer> getTestJvmVersion();
 
+    public abstract Property<@NotNull String> getScala213Version();
+
+    public abstract Property<@NotNull String> getScala3Version();
+
     @Inject
     public abstract ExecOperations getExecOperations();
 

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.kotlin.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.kotlin.template
@@ -7,7 +7,7 @@
 
 plugins {
     id "org.graalvm.internal.tck"
-    id "org.jetbrains.kotlin.jvm" version "2.3.20"
+    alias(libs.plugins.kotlin.jvm)
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
@@ -12,12 +12,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala213Version = tck.scala213Version.get()
 
 dependencies {
     testImplementation "$group$:$artifact$:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala-library:2.13.17'
-    testImplementation 'org.scala-lang:scala-compiler:2.13.17'
+    testImplementation "org.scala-lang:scala-library:$scala213Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala213Version"
 }
 
 java {

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala2.template
@@ -12,13 +12,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
-String scala213Version = tck.scala213Version.get()
+String scala2Version = tck.scala2Version.get()
 
 dependencies {
     testImplementation "$group$:$artifact$:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation "org.scala-lang:scala-library:$scala213Version"
-    testImplementation "org.scala-lang:scala-compiler:$scala213Version"
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
 }
 
 java {

--- a/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala3.template
+++ b/tests/tck-build-logic/src/main/resources/scaffold/build.gradle.scala3.template
@@ -12,12 +12,13 @@ plugins {
 
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
 
 dependencies {
     testImplementation "$group$:$artifact$:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.scala-lang:scala3-library_3:3.7.4'
-    testImplementation 'org.scala-lang:scala3-compiler_3:3.7.4'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
 }
 
 java {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -369,10 +369,10 @@ class ScaffoldTaskTests {
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/org.typelevel/cats-core_2.13/2.12.0/build.gradle"), StandardCharsets.UTF_8))
                 .contains("int testJvmVersion = tck.testJvmVersion.get()")
-                .contains("String scala213Version = tck.scala213Version.get()")
+                .contains("String scala2Version = tck.scala2Version.get()")
                 .contains("JavaLanguageVersion.of(testJvmVersion)")
-                .contains("org.scala-lang:scala-library:$scala213Version")
-                .contains("org.scala-lang:scala-compiler:$scala213Version")
+                .contains("org.scala-lang:scala-library:$scala2Version")
+                .contains("org.scala-lang:scala-compiler:$scala2Version")
                 .doesNotContain("JavaLanguageVersion.of(21)")
                 .doesNotContain("JavaLanguageVersion.of(25)")
                 .doesNotContain("org.scala-lang:scala-library:2.13.16")

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -218,6 +218,8 @@ class ScaffoldTaskTests {
                 "/scaffold/build.gradle.kotlin.template"
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/io.ktor/ktor-server-core-jvm/3.1.0/build.gradle"), StandardCharsets.UTF_8))
+                .contains("alias(libs.plugins.kotlin.jvm)")
+                .doesNotContain("id \"org.jetbrains.kotlin.jvm\" version")
                 .contains("int testJvmVersion = tck.testJvmVersion.get()")
                 .contains("jvmToolchain(testJvmVersion)")
                 .contains("kotlinOptions.jvmTarget = testJvmVersion.toString()")
@@ -322,9 +324,16 @@ class ScaffoldTaskTests {
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/org.typelevel/cats-core_3/2.12.0/build.gradle"), StandardCharsets.UTF_8))
                 .contains("int testJvmVersion = tck.testJvmVersion.get()")
+                .contains("String scala3Version = tck.scala3Version.get()")
+                .contains("org.scala-lang:scala3-library_3:$scala3Version")
+                .contains("org.scala-lang:scala3-compiler_3:$scala3Version")
                 .contains("JavaLanguageVersion.of(testJvmVersion)")
                 .doesNotContain("JavaLanguageVersion.of(21)")
-                .doesNotContain("JavaLanguageVersion.of(25)");
+                .doesNotContain("JavaLanguageVersion.of(25)")
+                .doesNotContain("org.scala-lang:scala3-library_3:3.3.6")
+                .doesNotContain("org.scala-lang:scala3-compiler_3:3.3.6")
+                .doesNotContain("org.scala-lang:scala3-library_3:3.7.4")
+                .doesNotContain("org.scala-lang:scala3-compiler_3:3.7.4");
     }
 
     @Test
@@ -360,13 +369,16 @@ class ScaffoldTaskTests {
         );
         assertThat(Files.readString(tempDir.resolve("tests/src/org.typelevel/cats-core_2.13/2.12.0/build.gradle"), StandardCharsets.UTF_8))
                 .contains("int testJvmVersion = tck.testJvmVersion.get()")
+                .contains("String scala213Version = tck.scala213Version.get()")
                 .contains("JavaLanguageVersion.of(testJvmVersion)")
-                .contains("org.scala-lang:scala-library:2.13.17")
-                .contains("org.scala-lang:scala-compiler:2.13.17")
+                .contains("org.scala-lang:scala-library:$scala213Version")
+                .contains("org.scala-lang:scala-compiler:$scala213Version")
                 .doesNotContain("JavaLanguageVersion.of(21)")
                 .doesNotContain("JavaLanguageVersion.of(25)")
                 .doesNotContain("org.scala-lang:scala-library:2.13.16")
-                .doesNotContain("org.scala-lang:scala-compiler:2.13.16");
+                .doesNotContain("org.scala-lang:scala-compiler:2.13.16")
+                .doesNotContain("org.scala-lang:scala-library:2.13.17")
+                .doesNotContain("org.scala-lang:scala-compiler:2.13.17");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add catalog entries for the Kotlin Gradle plugin, Scala 2, and Scala 3 default scaffold versions
- switch the Kotlin scaffold to the `libs.plugins.kotlin.jvm` plugin alias
- expose Scala default versions through `tck.scala2Version` and `tck.scala3Version`
- switch Scala scaffolds to use the TCK-exposed Scala versions instead of hardcoded compiler/library versions

## Why

This keeps language tool versions in one place before the JDK 25 migration PRs are rebased again. Future JDK or language-tool updates should not require another broad scaffold/version sweep unless a specific library needs an exception.

## Testing

- `./gradlew -p tests/tck-build-logic test --tests org.graalvm.internal.tck.ScaffoldTaskTests --stacktrace`
- temporary standalone checks with Kotlin build files using `alias(libs.plugins.kotlin.jvm)`:
  - `./gradlew javaTest -Pcoordinates=io.github.oshai:kotlin-logging-jvm:8.0.01 --stacktrace`
  - `./gradlew javaTest -Pcoordinates=app.cash.turbine:turbine-jvm:1.2.1 --stacktrace`
- temporary standalone checks with Scala build files using TCK-exposed Scala versions:
  - `./gradlew javaTest -Pcoordinates=org.scalacheck:scalacheck_2.13:1.19.0 --stacktrace` with `tck.scala2Version`
  - `./gradlew javaTest -Pcoordinates=com.typesafe.scala-logging:scala-logging_3:3.9.5 --stacktrace` with `tck.scala3Version`
- `git diff --check`

Fixes #8490