### PR TITLE
Forge: resume failed runs from continuation markers

### DIFF
--- a/forge/.gitignore
+++ b/forge/.gitignore
@@ -6,6 +6,7 @@ metadata_forge.egg-info/
 logs/
 fixture-e2e-logs/
 .pending_metrics.json
+.continuation-marker.json
 
 ##############################
 ## Agent state

--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
-from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
+from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.stage_logger import log_stage
 
@@ -244,6 +244,9 @@ class BasicIterativeStrategy(WorkflowStrategy):
 
         save_phase_update(
             self.continuation_marker_path,
-            lambda marker: marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+            lambda marker: (
+                marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+                marker.mark_phase_skipped(PHASE_EXPLORE),
+            ),
         )
         return RUN_STATUS_SUCCESS, global_iterations, unittest_number

--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
+from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.stage_logger import log_stage
 
@@ -149,6 +150,10 @@ class BasicIterativeStrategy(WorkflowStrategy):
             agent,
             checkpoint_commit_hash,
     ):
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_running(PHASE_FIX),
+        )
         global_iterations = 0
         failed_iterations = 0
         unittest_number = 0
@@ -172,6 +177,10 @@ class BasicIterativeStrategy(WorkflowStrategy):
             self._print_detail("agent: complete")
 
             global_iterations += 1
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.record_iteration(PHASE_FIX, global_iterations),
+            )
             reached_native_test = False
             for test_iter in range(self.max_test_iterations):
                 self._print_detail(
@@ -227,6 +236,14 @@ class BasicIterativeStrategy(WorkflowStrategy):
             subprocess.run(["git", "reset", "--hard", checkpoint_commit_hash], check=False)
 
         if unittest_number == 0:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
+            )
             return RUN_STATUS_FAILURE, global_iterations, unittest_number
 
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+        )
         return RUN_STATUS_SUCCESS, global_iterations, unittest_number

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -12,7 +12,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     WorkflowStrategy,
 )
-from utility_scripts.continuation_marker import PHASE_EXPLORE, save_phase_update
+from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.dynamic_access_report import (
     DynamicAccessCoverageReport,
     compute_class_delta,
@@ -221,10 +221,17 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         if current_report is None:
             current_report = self._generate_dynamic_access_report()
         if self._should_fallback_to_basic_flow(current_report):
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_skipped(PHASE_EXPLORE),
+            )
             return True, 0
         save_phase_update(
             self.continuation_marker_path,
-            lambda marker: marker.mark_phase_running(PHASE_EXPLORE),
+            lambda marker: (
+                marker.mark_phase_skipped_if_pending(PHASE_FIX),
+                marker.mark_phase_running(PHASE_EXPLORE),
+            ),
         )
 
         exhausted_classes: set[str] = self._continuation_exhausted_classes()

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -12,6 +12,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     WorkflowStrategy,
 )
+from utility_scripts.continuation_marker import PHASE_EXPLORE, save_phase_update
 from utility_scripts.dynamic_access_report import (
     DynamicAccessCoverageReport,
     compute_class_delta,
@@ -221,8 +222,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             current_report = self._generate_dynamic_access_report()
         if self._should_fallback_to_basic_flow(current_report):
             return True, 0
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_running(PHASE_EXPLORE),
+        )
 
-        exhausted_classes: set[str] = set()
+        exhausted_classes: set[str] = self._continuation_exhausted_classes()
         if self.dynamic_access_exhaust_report is not None:
             exhausted_classes.update(self.dynamic_access_exhaust_report.processed_classes())
         previous_report = None
@@ -280,6 +285,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             active_class = current_report.next_uncovered_class(exhausted_classes)
             if active_class is None:
                 if not flush_native_test_batch("end-of-classes"):
+                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                     return False, prompt_iterations
                 if (
                         successful_classes == 0
@@ -288,7 +294,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         and self._library_test_change_signature() != initial_test_change_signature
                 ):
                     self._print_dynamic_access_message("Coverage not improved. Keeping generated tests by request.")
+                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
                     return True, prompt_iterations
+                if successful_classes > 0:
+                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
+                else:
+                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                 return successful_classes > 0, prompt_iterations
 
             class_name = active_class.class_name
@@ -344,6 +355,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 agent.send_prompt(dynamic_prompt)
                 self._print_dynamic_access_detail("agent: complete", indent_level=2)
                 prompt_iterations += 1
+                save_phase_update(
+                    self.continuation_marker_path,
+                    lambda marker: marker.record_iteration(PHASE_EXPLORE, prompt_iterations),
+                )
                 class_attempts += 1
 
                 reached_native_test = False
@@ -412,6 +427,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         indent_level=2,
                         class_name=class_name,
                     )
+                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                     return False, prompt_iterations
                 record_indirectly_completed_classes(class_name)
 
@@ -515,6 +531,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     indent_level=1,
                     class_name=class_name,
                 )
+                self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                 return False, prompt_iterations
             if class_failed:
                 self._print_dynamic_access_detail(
@@ -542,6 +559,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         terminal_classes_this_part,
                 ):
                     if not flush_native_test_batch("chunked-dynamic-access-boundary"):
+                        self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                         return False, prompt_iterations
                     self._last_phase_status = RUN_STATUS_CHUNK_READY
                     self._print_dynamic_access_message(
@@ -550,6 +568,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         )
                     )
                     self._save_dynamic_access_exhaust_report()
+                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
                     return True, prompt_iterations
                 continue
             updated_class = current_report.get_class(class_name)
@@ -587,6 +606,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     terminal_classes_this_part,
             ):
                 if not flush_native_test_batch("chunked-dynamic-access-boundary"):
+                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
                     return False, prompt_iterations
                 self._last_phase_status = RUN_STATUS_CHUNK_READY
                 self._print_dynamic_access_message(
@@ -595,7 +615,42 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     )
                 )
                 self._save_dynamic_access_exhaust_report()
+                self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
                 return True, prompt_iterations
+
+    def _mark_continuation_explore_completed(self, iteration: int, exhausted_classes: set[str]) -> None:
+        """Persist successful dynamic-access phase completion."""
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: (
+                marker.record_exhausted_classes(sorted(exhausted_classes)),
+                marker.mark_phase_completed(PHASE_EXPLORE, iteration=iteration),
+            ),
+        )
+
+    def _mark_continuation_explore_pending(self, iteration: int, exhausted_classes: set[str]) -> None:
+        """Persist an incomplete dynamic-access phase."""
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: (
+                marker.record_exhausted_classes(sorted(exhausted_classes)),
+                marker.mark_phase_pending(PHASE_EXPLORE, iteration=iteration),
+            ),
+        )
+
+    def _continuation_exhausted_classes(self) -> set[str]:
+        """Return EXPLORE classes that continuation must not retry."""
+        if self.continuation_marker is None:
+            return set()
+        explore_phase: dict[str, object] = self.continuation_marker.phases.get(PHASE_EXPLORE, {})
+        exhausted_classes: object = explore_phase.get("exhaustedClasses", [])
+        if not isinstance(exhausted_classes, list):
+            return set()
+        return {
+            class_name
+            for class_name in exhausted_classes
+            if isinstance(class_name, str) and class_name
+        }
 
     def _queue_native_test_verification_step(
             self,

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -10,6 +10,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     WorkflowStrategy,
 )
+from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
 
 
 @WorkflowStrategy.register("increase_dynamic_access_coverage")
@@ -41,6 +42,10 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
     def run(self, agent, **kwargs):
         if self.primary is None:
             self._print_message("no primary workflow configured, skipping to dynamic-access coverage phase")
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_skipped_if_pending(PHASE_FIX),
+            )
             status = RUN_STATUS_SUCCESS
             iterations = 0
         else:

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -4,6 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
+from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
 from utility_scripts.native_test_verification import (
     STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
     global_output_dir,
@@ -98,6 +99,10 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         print(f"{'  ' * indent_level}{message}")
 
     def run(self, agent):
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_running(PHASE_FIX),
+        )
         workflow_status = RUN_STATUS_FAILURE
 
         self._print_message("running initial gradle test to collect errors")
@@ -108,6 +113,10 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         global_iterations = 1
 
         for test_iter in range(self.max_test_iterations):
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.record_iteration(PHASE_FIX, test_iter + 1),
+            )
             self._print_message(
                 "test {test_iteration}/{max_test_iterations}".format(
                     test_iteration=test_iter + 1,
@@ -152,6 +161,16 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
                 workflow_status = RUN_STATUS_FAILURE
 
         agent.clear_context()
+        if workflow_status == RUN_STATUS_SUCCESS:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+            )
+        else:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
+            )
         return workflow_status, global_iterations
 
     def _run_native_test_verification_gate(self) -> bool:

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -4,7 +4,7 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
-from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
+from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.native_test_verification import (
     STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
     global_output_dir,
@@ -164,7 +164,10 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         if workflow_status == RUN_STATUS_SUCCESS:
             save_phase_update(
                 self.continuation_marker_path,
-                lambda marker: marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+                lambda marker: (
+                    marker.mark_phase_completed(PHASE_FIX, iteration=global_iterations),
+                    marker.mark_phase_skipped(PHASE_EXPLORE),
+                ),
             )
         else:
             save_phase_update(

--- a/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
+from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.dynamic_access_report import format_full_report, load_dynamic_access_coverage_report
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import (
@@ -73,6 +74,13 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             )
             return self._run_basic_iterative_fallback(agent, **kwargs)
 
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: (
+                marker.mark_phase_skipped_if_pending(PHASE_FIX),
+                marker.mark_phase_running(PHASE_EXPLORE),
+            ),
+        )
         checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
         successful_iterations = 0
         prompt_iterations = 0
@@ -173,6 +181,10 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
                     "native_test_verification_gate_failed",
                     issue="nativeTest_did_not_pass_within_verification_budget",
                 )
+                save_phase_update(
+                    self.continuation_marker_path,
+                    lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
+                )
                 return RUN_STATUS_FAILURE, prompt_iterations, 0
 
             if current_report.total_calls == current_report.covered_calls:
@@ -180,7 +192,15 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
                 break
 
         if successful_iterations > 0:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_completed(PHASE_EXPLORE, iteration=prompt_iterations),
+            )
             return RUN_STATUS_SUCCESS, prompt_iterations, successful_iterations
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
+        )
         return RUN_STATUS_FAILURE, prompt_iterations, 0
 
     def _run_native_test_verification_gate(self) -> bool:

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -46,6 +46,15 @@ RUN_STATUS_FAILURE = "failure"
 SUCCESS_WITH_INTERVENTION_STATUS = "success_with_intervention"
 RUN_STATUS_CHUNK_READY = "chunk_ready"
 
+
+def strategy_skips_initial_fix_phase(strategy_obj: dict) -> bool:
+    """Return True when a strategy enters dynamic-access work without a fix phase."""
+    workflow_name = strategy_obj.get("workflow")
+    if workflow_name in {"dynamic_access_iterative", "optimistic_dynamic_access"}:
+        return True
+    return workflow_name == "increase_dynamic_access_coverage" and not strategy_obj.get("primary-workflow")
+
+
 class WorkflowStrategy(ABC):
     """Base class for workflow strategy implementations.
 

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -19,6 +19,12 @@ from ai_workflows.core.fix_post_generation_pi import (
     run_pi_post_generation_fix,
 )
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.continuation_marker import (
+    PHASE_FINALIZATION,
+    PHASE_PUBLICATION,
+    load_continuation_marker,
+    save_phase_update,
+)
 from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
@@ -117,6 +123,8 @@ class WorkflowStrategy(ABC):
         self.parameters = self.strategy_obj.get("parameters", {})
         self.persistent_instructions = load_persistent_instructions(self.strategy_obj, **self.context)
         self.post_generation_intervention: dict | None = None
+        self.continuation_marker_path: str | None = self.context.get("continuation_marker_path")
+        self.continuation_marker = load_continuation_marker(self.continuation_marker_path)
         self._validate_required_prompts()
         self._validate_required_params()
 
@@ -462,8 +470,25 @@ class WorkflowStrategy(ABC):
         a chunk-ready run stays chunk-ready when finalization succeeds, otherwise
         the finalization status becomes the run status.
         """
+        save_phase_update(
+            self.continuation_marker_path,
+            lambda marker: marker.mark_phase_running(PHASE_FINALIZATION),
+        )
         finalize_status, _ = self._finalize_successful_iteration(base_commit=base_commit)
         finalize_succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
+        if finalize_succeeded:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: (
+                    marker.mark_phase_completed(PHASE_FINALIZATION),
+                    marker.mark_phase_pending(PHASE_PUBLICATION),
+                ),
+            )
+        else:
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_pending(PHASE_FINALIZATION),
+            )
         if finalize_succeeded and workflow_status == RUN_STATUS_CHUNK_READY:
             return RUN_STATUS_CHUNK_READY
         return finalize_status

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -42,6 +42,12 @@ from ai_workflows.core.workflow_strategy import (
 from ai_workflows.core.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts import metrics_writer
+from utility_scripts.continuation_marker import (
+    PHASE_FINALIZATION,
+    PHASE_SETUP,
+    load_continuation_marker,
+    save_phase_update,
+)
 from utility_scripts.dynamic_access_exhaust_report import resolve_workflow_exhaust_report
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
@@ -172,6 +178,10 @@ def build_parser():
         "--library-preparation-preflight-path",
         help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
+    parser.add_argument(
+        "--continuation-marker-path",
+        help="Path to the Forge run-continuation marker for this issue run.",
+    )
     return parser
 
 
@@ -207,6 +217,7 @@ def parse_flags(argv_list):
         flags.chunk_class_count,
         flags.issue_number,
         flags.library_preparation_preflight_path,
+        flags.continuation_marker_path,
     )
 
 
@@ -398,9 +409,14 @@ def main(argv=None):
         chunk_class_count,
         issue_number,
         library_preparation_preflight_path,
+        continuation_marker_path,
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
+    continuation_marker = load_continuation_marker(continuation_marker_path)
+    resume_from = None if continuation_marker is None else continuation_marker.continue_from
+    resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
+    resume_finalization = resume_from == PHASE_FINALIZATION
 
     # Resolve repository locations (possibly cloning)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
@@ -416,6 +432,14 @@ def main(argv=None):
             reachability_repo_path,
         )
     )
+    if not resume_existing_tree:
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: (
+                marker.mark_phase_running(PHASE_SETUP),
+                marker.mark_setup_preflight_done(),
+            ),
+        )
     resolve_graalvm_java_home()
 
     log_stage("setup", f"Selected strategy: {strategy_name}")
@@ -428,32 +452,39 @@ def main(argv=None):
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
 
     os.chdir(reachability_repo_path)
-    create_feature_branch_for_library(package, artifact, library_version)
-    if is_not_for_native_image(reachability_repo_path, package, artifact):
-        log_stage("native-image-eligibility", f"{package}:{artifact} is already marked not-for-native-image")
-        return 0
-    try:
-        discover_artifact_metadata(reachability_repo_path, library)
-        eligibility = evaluate_native_image_eligibility(reachability_repo_path, library)
-        if eligibility.not_for_native_image:
-            marker_path = write_not_for_native_image_marker(
-                reachability_repo_path,
-                package,
-                artifact,
-                eligibility.reason or "Artifact is not applicable to GraalVM Native Image metadata.",
-                eligibility.replacement,
-            )
-            log_stage(
-                "native-image-eligibility",
-                f"Marked {package}:{artifact} as not-for-native-image in {os.path.relpath(marker_path, reachability_repo_path)}",
-            )
+    if not resume_existing_tree:
+        create_feature_branch_for_library(package, artifact, library_version)
+        if is_not_for_native_image(reachability_repo_path, package, artifact):
+            log_stage("native-image-eligibility", f"{package}:{artifact} is already marked not-for-native-image")
             return 0
-        run_scaffold(library)
-    except ScaffoldError as exc:
-        print(f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}", file=sys.stderr)
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
-    populate_artifact_urls(reachability_repo_path, library)
+        try:
+            discover_artifact_metadata(reachability_repo_path, library)
+            eligibility = evaluate_native_image_eligibility(reachability_repo_path, library)
+            if eligibility.not_for_native_image:
+                marker_path = write_not_for_native_image_marker(
+                    reachability_repo_path,
+                    package,
+                    artifact,
+                    eligibility.reason or "Artifact is not applicable to GraalVM Native Image metadata.",
+                    eligibility.replacement,
+                )
+                log_stage(
+                    "native-image-eligibility",
+                    f"Marked {package}:{artifact} as not-for-native-image in {os.path.relpath(marker_path, reachability_repo_path)}",
+                )
+                return 0
+            run_scaffold(library)
+        except ScaffoldError as exc:
+            print(f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}", file=sys.stderr)
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
+        populate_artifact_urls(reachability_repo_path, library)
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: marker.mark_setup_done(),
+        )
+    else:
+        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
     source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
     prepared_source_context = prepare_source_contexts(
         repo_root=get_repo_root(),
@@ -485,15 +516,17 @@ def main(argv=None):
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
         library_preparation_preflight_context=library_preparation_preflight_context,
+        continuation_marker_path=continuation_marker_path,
     )
 
-    # Add generated files to git and commit; record commit hash (do not use it)
     directory_path = module_dir
     index_json_path = os.path.join(reachability_repo_path, "metadata", package, artifact, "index.json")
-    subprocess.run(["git", "add", directory_path, index_json_path], check=False)
-    subprocess.run(["git", "commit", "-m", f"Scaffold {library}"], check=False, capture_output=True, text=True)
+    if not resume_existing_tree:
+        # Add generated files to git and commit; record commit hash (do not use it)
+        subprocess.run(["git", "add", directory_path, index_json_path], check=False)
+        subprocess.run(["git", "commit", "-m", f"Scaffold {library}"], check=False, capture_output=True, text=True)
     checkpoint_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    log_stage("scaffold", f"Committed scaffold at {checkpoint_commit_hash}")
+    log_stage("scaffold", f"Checkpoint at {checkpoint_commit_hash}")
 
     editable_files = list_all_files(test_source_layout.source_root)
     build_gradle_file = os.path.join(
@@ -531,10 +564,15 @@ def main(argv=None):
         ]
         agent.graphify(graphify_dirs)
 
-    workflow_status, global_iterations, unittest_number = strategy_obj.run(
-        agent=agent,
-        checkpoint_commit_hash=checkpoint_commit_hash,
-    )
+    if resume_finalization:
+        workflow_status = RUN_STATUS_SUCCESS
+        global_iterations = 0
+        unittest_number = 1
+    else:
+        workflow_status, global_iterations, unittest_number = strategy_obj.run(
+            agent=agent,
+            checkpoint_commit_hash=checkpoint_commit_hash,
+        )
 
     scaffold_placeholder_quality_gate_failed = False
     generated_test_validity_gate_failed = False

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -38,6 +38,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
+    strategy_skips_initial_fix_phase,
 )
 from ai_workflows.core.workflow_strategy import WorkflowStrategy
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
@@ -481,7 +482,9 @@ def main(argv=None):
         populate_artifact_urls(reachability_repo_path, library)
         save_phase_update(
             continuation_marker_path,
-            lambda marker: marker.mark_setup_done(),
+            lambda marker: marker.mark_setup_done(
+                skip_fix_phase=strategy_skips_initial_fix_phase(strategy),
+            ),
         )
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -23,6 +23,13 @@ from ai_workflows.core.workflow_strategy import (
 from ai_workflows.drivers.improve_library_coverage import prepare_library_update_target
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
 from utility_scripts import metrics_writer
+from utility_scripts.continuation_marker import (
+    PHASE_EXPLORE,
+    PHASE_FINALIZATION,
+    PHASE_SETUP,
+    load_continuation_marker,
+    save_phase_update,
+)
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
@@ -98,6 +105,10 @@ def build_parser():
     parser.add_argument(
         "--library-preparation-preflight-path",
         help="Path to the dispatcher-created library preparation preflight JSON record.",
+    )
+    parser.add_argument(
+        "--continuation-marker-path",
+        help="Path to the Forge run-continuation marker for this issue run.",
     )
     return parser
 
@@ -249,6 +260,7 @@ def build_strategy_and_agent(
         version: str,
         library_preparation_preflight_context,
         explore: bool,
+        continuation_marker_path: str | None = None,
 ):
     """Construct the dynamic-access strategy object and its agent for the new coordinate.
 
@@ -303,6 +315,7 @@ def build_strategy_and_agent(
         test_source_dir_name=test_source_layout.source_dir_name,
         metadata_version=metadata_version,
         library_preparation_preflight_context=library_preparation_preflight_context,
+        continuation_marker_path=continuation_marker_path,
     )
 
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
@@ -342,6 +355,10 @@ def main(argv=None) -> int:
 
     current_coordinates = args.coordinates
     new_version = args.new_version
+    continuation_marker = load_continuation_marker(args.continuation_marker_path)
+    resume_from = None if continuation_marker is None else continuation_marker.continue_from
+    resume_existing_tree = resume_from in {"fix", PHASE_EXPLORE, PHASE_FINALIZATION, "publication"}
+    resume_finalization = resume_from == PHASE_FINALIZATION
     # Apply deterministic preflight setup into the resolved worktree before
     # generation; only advisory guidance reaches the prompt context.
     library_preparation_preflight, library_preparation_preflight_context = (
@@ -350,6 +367,14 @@ def main(argv=None) -> int:
             reachability_metadata_path,
         )
     )
+    if not resume_existing_tree:
+        save_phase_update(
+            args.continuation_marker_path,
+            lambda marker: (
+                marker.mark_phase_running(PHASE_SETUP),
+                marker.mark_setup_preflight_done(),
+            ),
+        )
     if library_preparation_preflight is not None:
         print("[pipeline] Library preparation preflight:")
         print(library_preparation_preflight_context)
@@ -364,57 +389,65 @@ def main(argv=None) -> int:
         f"fix-native-image-run-{group}-{artifact}-{new_version}",
         cwd=reachability_metadata_path,
     )
-    print(f"[pipeline] Creating branch: {branch}")
-    create_or_switch_branch(reachability_metadata_path, branch)
+    if not resume_existing_tree:
+        print(f"[pipeline] Creating branch: {branch}")
+        create_or_switch_branch(reachability_metadata_path, branch)
 
-    print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
-    result = run_fix_test_native_image_run(
-        reachability_metadata_path=reachability_metadata_path,
-        current_coordinates=current_coordinates,
-        new_version=new_version,
-    )
-
-    if result.returncode != 0:
-        generated_metadata_file = os.path.join(
-            reachability_metadata_path,
-            "metadata",
-            group,
-            artifact,
-            new_version,
-            "reachability-metadata.json",
-        )
-        if not os.path.isfile(generated_metadata_file):
-            print(
-                "ERROR: fixTestNativeImageRun failed before generating "
-                f"{generated_metadata_file}. Skipping Codex metadata repair.",
-                file=sys.stderr,
-            )
-            return result.returncode
-        print(f"[pipeline] Detected missing metadata entries for {library}. Running Codex fix.")
-        gradle_env = gradle_command_environment(reachability_metadata_path)
-        codex_rc, _codex_log, _codex_timed_out = run_codex_metadata_fix(
-            reachability_metadata_path,
-            library,
-            graalvm_home=gradle_env.get("GRAALVM_HOME"),
-            library_preparation_preflight_context=library_preparation_preflight_context,
-        )
-        if codex_rc != 0:
-            print(f"ERROR: Codex failed with return code: {codex_rc}", file=sys.stderr)
-            return codex_rc
-        print(f"[pipeline] Codex metadata fix completed. Running Gradle test for {library}.")
-        result = run_gradle_test(
+        print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
+        result = run_fix_test_native_image_run(
             reachability_metadata_path=reachability_metadata_path,
-            coordinates=library,
+            current_coordinates=current_coordinates,
+            new_version=new_version,
         )
-        if result.returncode != 0:
-            print("[pipeline] Gradle test failed after Codex metadata fix. Skipping PR creation.", file=sys.stderr)
-            return result.returncode
 
-    populate_artifact_urls(reachability_metadata_path, library)
-    checkpoint = commit_checkpoint(reachability_metadata_path, library)
+        if result.returncode != 0:
+            generated_metadata_file = os.path.join(
+                reachability_metadata_path,
+                "metadata",
+                group,
+                artifact,
+                new_version,
+                "reachability-metadata.json",
+            )
+            if not os.path.isfile(generated_metadata_file):
+                print(
+                    "ERROR: fixTestNativeImageRun failed before generating "
+                    f"{generated_metadata_file}. Skipping Codex metadata repair.",
+                    file=sys.stderr,
+                )
+                return result.returncode
+            print(f"[pipeline] Detected missing metadata entries for {library}. Running Codex fix.")
+            gradle_env = gradle_command_environment(reachability_metadata_path)
+            codex_rc, _codex_log, _codex_timed_out = run_codex_metadata_fix(
+                reachability_metadata_path,
+                library,
+                graalvm_home=gradle_env.get("GRAALVM_HOME"),
+                library_preparation_preflight_context=library_preparation_preflight_context,
+            )
+            if codex_rc != 0:
+                print(f"ERROR: Codex failed with return code: {codex_rc}", file=sys.stderr)
+                return codex_rc
+            print(f"[pipeline] Codex metadata fix completed. Running Gradle test for {library}.")
+            result = run_gradle_test(
+                reachability_metadata_path=reachability_metadata_path,
+                coordinates=library,
+            )
+            if result.returncode != 0:
+                print("[pipeline] Gradle test failed after Codex metadata fix. Skipping PR creation.", file=sys.stderr)
+                return result.returncode
+
+        populate_artifact_urls(reachability_metadata_path, library)
+        checkpoint = commit_checkpoint(reachability_metadata_path, library)
+        save_phase_update(
+            args.continuation_marker_path,
+            lambda marker: marker.mark_setup_done(),
+        )
+    else:
+        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
+        checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
     # Coverage gate: explore only when the new version has uncovered calls.
-    explore = should_explore_new_version(reachability_metadata_path, group, artifact, new_version)
+    explore = not resume_finalization and should_explore_new_version(reachability_metadata_path, group, artifact, new_version)
     if explore:
         print(f"[pipeline] Preparing version-specific test-suite for {library}")
         prepare_library_update_target(reachability_metadata_path, group, artifact, new_version)
@@ -428,6 +461,7 @@ def main(argv=None) -> int:
         version=new_version,
         library_preparation_preflight_context=library_preparation_preflight_context,
         explore=explore,
+        continuation_marker_path=args.continuation_marker_path,
     )
 
     iterations = 0
@@ -448,6 +482,7 @@ def main(argv=None) -> int:
                 version=new_version,
                 library_preparation_preflight_context=library_preparation_preflight_context,
                 explore=False,
+                continuation_marker_path=args.continuation_marker_path,
             )
 
     finalize_status = strategy_obj.finalize_run(checkpoint)

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -26,6 +26,7 @@ from utility_scripts import metrics_writer
 from utility_scripts.continuation_marker import (
     PHASE_EXPLORE,
     PHASE_FINALIZATION,
+    PHASE_FIX,
     PHASE_SETUP,
     load_continuation_marker,
     save_phase_update,
@@ -440,7 +441,10 @@ def main(argv=None) -> int:
         checkpoint = commit_checkpoint(reachability_metadata_path, library)
         save_phase_update(
             args.continuation_marker_path,
-            lambda marker: marker.mark_setup_done(),
+            lambda marker: (
+                marker.mark_setup_done(),
+                marker.mark_phase_completed(PHASE_FIX),
+            ),
         )
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
@@ -473,6 +477,10 @@ def main(argv=None) -> int:
         # already valid and the finalization gate decides PR eligibility.
         log_stage("explore", f"Dynamic-access exploration completed with status: {explore_status}")
         if explore_status != RUN_STATUS_SUCCESS:
+            save_phase_update(
+                args.continuation_marker_path,
+                lambda marker: marker.mark_phase_completed(PHASE_EXPLORE, iteration=iterations),
+            )
             strategy_obj, _seed_agent, model_name, tests_root = build_strategy_and_agent(
                 strategy_name=args.strategy_name,
                 reachability_metadata_path=reachability_metadata_path,
@@ -484,6 +492,11 @@ def main(argv=None) -> int:
                 explore=False,
                 continuation_marker_path=args.continuation_marker_path,
             )
+    else:
+        save_phase_update(
+            args.continuation_marker_path,
+            lambda marker: marker.mark_phase_skipped(PHASE_EXPLORE),
+        )
 
     finalize_status = strategy_obj.finalize_run(checkpoint)
     succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -42,6 +42,12 @@ from ai_workflows.core.workflow_strategy import (
 )
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated, load_library_stats
 from utility_scripts import metrics_writer
+from utility_scripts.continuation_marker import (
+    PHASE_FINALIZATION,
+    PHASE_SETUP,
+    load_continuation_marker,
+    save_phase_update,
+)
 from utility_scripts.dynamic_access_exhaust_report import resolve_workflow_exhaust_report
 from utility_scripts.issue_requested_metadata import (
     NO_REPORTER_METADATA_CONTEXT,
@@ -162,6 +168,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--library-preparation-preflight-path",
         help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
+    parser.add_argument(
+        "--continuation-marker-path",
+        help="Path to the Forge run-continuation marker for this issue run.",
+    )
     return parser
 
 
@@ -189,6 +199,7 @@ def parse_flags(argv_list: list[str]):
         flags.issue_number,
         flags.issue_requested_metadata_context,
         flags.library_preparation_preflight_path,
+        flags.continuation_marker_path,
     )
 
 
@@ -704,10 +715,15 @@ def main(argv=None) -> int:
         issue_number,
         issue_requested_metadata_context,
         library_preparation_preflight_path,
+        continuation_marker_path,
     ) = parse_flags(argv if argv is not None else sys.argv[1:])
 
     library = f"{group}:{artifact}:{version}"
     strategy = require_strategy_by_name(strategy_name)
+    continuation_marker = load_continuation_marker(continuation_marker_path)
+    resume_from = None if continuation_marker is None else continuation_marker.continue_from
+    resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
+    resume_finalization = resume_from == PHASE_FINALIZATION
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
@@ -720,6 +736,14 @@ def main(argv=None) -> int:
             reachability_repo_path,
         )
     )
+    if not resume_existing_tree:
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: (
+                marker.mark_phase_running(PHASE_SETUP),
+                marker.mark_setup_preflight_done(),
+            ),
+        )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
@@ -743,10 +767,17 @@ def main(argv=None) -> int:
             ),
         )
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
-    # Create feature branch
-    new_branch = build_ai_branch_name(f"improve-coverage-{group}-{artifact}-{version}")
-    delete_remote_branch_if_exists(new_branch)
-    subprocess.run(["git", "switch", "-C", new_branch], check=True)
+    if not resume_existing_tree:
+        # Create feature branch
+        new_branch = build_ai_branch_name(f"improve-coverage-{group}-{artifact}-{version}")
+        delete_remote_branch_if_exists(new_branch)
+        subprocess.run(["git", "switch", "-C", new_branch], check=True)
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: marker.mark_setup_done(),
+        )
+    else:
+        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
 
     # Commit existing state as checkpoint
     test_version = update_target.resolved_test_version
@@ -777,11 +808,12 @@ def main(argv=None) -> int:
             ),
         )
     index_json = os.path.join(reachability_repo_path, "metadata", group, artifact, "index.json")
-    subprocess.run(["git", "add", tests_dir, index_json], check=False)
-    subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", f"Checkpoint for coverage improvement of {library}"],
-        capture_output=True, text=True, check=False,
-    )
+    if not resume_existing_tree:
+        subprocess.run(["git", "add", tests_dir, index_json], check=False)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", f"Checkpoint for coverage improvement of {library}"],
+            capture_output=True, text=True, check=False,
+        )
     checkpoint_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     log_stage("setup", f"Checkpoint commit: {checkpoint_commit}")
 
@@ -841,6 +873,7 @@ def main(argv=None) -> int:
         dynamic_access_exhaust_report=dynamic_access_exhaust_report,
         dynamic_access_exhaust_report_path=dynamic_access_exhaust_report_path,
         chunk_class_count=chunk_class_count,
+        continuation_marker_path=continuation_marker_path,
     )
 
     # Initialize agent
@@ -869,11 +902,15 @@ def main(argv=None) -> int:
         persistent_instructions=strategy_obj.persistent_instructions,
     )
 
-    run_result = strategy_obj.run(
-        agent=agent,
-        checkpoint_commit_hash=checkpoint_commit,
-    )
-    workflow_status, iterations = run_result[0], run_result[1]
+    if resume_finalization:
+        workflow_status = RUN_STATUS_SUCCESS
+        iterations = 0
+    else:
+        run_result = strategy_obj.run(
+            agent=agent,
+            checkpoint_commit_hash=checkpoint_commit,
+        )
+        workflow_status, iterations = run_result[0], run_result[1]
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:
         workflow_status = strategy_obj.finalize_run(checkpoint_commit, workflow_status)

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -39,6 +39,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
     WorkflowStrategy,
+    strategy_skips_initial_fix_phase,
 )
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated, load_library_stats
 from utility_scripts import metrics_writer
@@ -775,7 +776,9 @@ def main(argv=None) -> int:
         subprocess.run(["git", "switch", "-C", new_branch], check=True)
         save_phase_update(
             continuation_marker_path,
-            lambda marker: marker.mark_setup_done(),
+            lambda marker: marker.mark_setup_done(
+                skip_fix_phase=strategy_skips_initial_fix_phase(strategy),
+            ),
         )
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -70,6 +70,7 @@ from utility_scripts.source_context import (
     populate_artifact_urls,
     prepare_source_contexts,
     resolve_test_source_layout,
+    source_context_urls_available,
 )
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import require_strategy_by_name
@@ -817,23 +818,42 @@ def main(argv=None) -> int:
     checkpoint_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     log_stage("setup", f"Checkpoint commit: {checkpoint_commit}")
 
-    # Snapshot baseline stats and metadata entry counts before the workflow modifies them
-    baseline_stats = load_library_stats(reachability_repo_path, library)
-    baseline_metadata_entries = count_metadata_entries(reachability_repo_path, group, artifact, version)
-    baseline_test_only_entries = count_test_only_metadata_entries(reachability_repo_path, group, artifact, version)
-    baseline_snapshot = {
-        "stats": baseline_stats,
-        "metadata_entries": baseline_metadata_entries,
-        "test_only_metadata_entries": baseline_test_only_entries,
-    }
     baseline_stats_path = os.path.join(tests_dir, BASELINE_STATS_FILENAME)
-    with open(baseline_stats_path, "w", encoding="utf-8") as f:
-        json.dump(baseline_snapshot, f, indent=2)
-    log_stage("setup", f"Saved baseline snapshot to {BASELINE_STATS_FILENAME}")
-
-    populate_artifact_urls(reachability_repo_path, library)
+    if resume_existing_tree:
+        if not os.path.isfile(baseline_stats_path):
+            print(
+                f"ERROR: Resumed {library} is missing cached baseline snapshot: "
+                f"{os.path.relpath(baseline_stats_path, reachability_repo_path)}",
+                file=sys.stderr,
+            )
+            return 1
+        log_stage("setup", f"Reusing cached baseline snapshot from {BASELINE_STATS_FILENAME}")
+    else:
+        # Snapshot baseline stats and metadata entry counts before the workflow modifies them.
+        baseline_stats = load_library_stats(reachability_repo_path, library)
+        baseline_metadata_entries = count_metadata_entries(reachability_repo_path, group, artifact, version)
+        baseline_test_only_entries = count_test_only_metadata_entries(reachability_repo_path, group, artifact, version)
+        baseline_snapshot = {
+            "stats": baseline_stats,
+            "metadata_entries": baseline_metadata_entries,
+            "test_only_metadata_entries": baseline_test_only_entries,
+        }
+        with open(baseline_stats_path, "w", encoding="utf-8") as f:
+            json.dump(baseline_snapshot, f, indent=2)
+        log_stage("setup", f"Saved baseline snapshot to {BASELINE_STATS_FILENAME}")
 
     source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
+    if not resume_existing_tree or not source_context_urls_available(
+            reachability_repo_path,
+            library,
+            source_context_types,
+    ):
+        populate_artifact_urls(reachability_repo_path, library)
+    else:
+        log_stage(
+            "populate-artifact-urls",
+            f"Skipping artifact URL population for resumed {library}; index.json already has requested source-context URLs.",
+        )
     prepared_source_context = prepare_source_contexts(
         repo_root=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         reachability_repo_path=reachability_repo_path,

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -25,6 +25,12 @@ from ai_workflows.core.workflow_strategy import (
 )
 from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
 from utility_scripts import metrics_writer
+from utility_scripts.continuation_marker import (
+    PHASE_FINALIZATION,
+    PHASE_SETUP,
+    load_continuation_marker,
+    save_phase_update,
+)
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
@@ -142,6 +148,10 @@ def build_parser(config: JavaFailWorkflowConfig):
         "--library-preparation-preflight-path",
         help="Path to the dispatcher-created library preparation preflight JSON record.",
     )
+    parser.add_argument(
+        "--continuation-marker-path",
+        help="Path to the Forge run-continuation marker for this issue run.",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="enable verbose mode for the configured agent")
     return parser
 
@@ -170,6 +180,7 @@ def parse_flags(config: JavaFailWorkflowConfig, argv_list):
         flags.reachability_metadata_path,
         flags.metrics_repo_path,
         flags.library_preparation_preflight_path,
+        flags.continuation_marker_path,
     )
 
 
@@ -432,9 +443,14 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         explicit_repo_path,
         explicit_metrics_repo_path,
         library_preparation_preflight_path,
+        continuation_marker_path,
     ) = parse_flags(config, argv if argv is not None else sys.argv[1:])
 
     strategy = require_strategy_by_name(strategy_name)
+    continuation_marker = load_continuation_marker(continuation_marker_path)
+    resume_from = None if continuation_marker is None else continuation_marker.continue_from
+    resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
+    resume_finalization = resume_from == PHASE_FINALIZATION
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
@@ -447,6 +463,14 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
             reachability_repo_path,
         )
     )
+    if not resume_existing_tree:
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: (
+                marker.mark_phase_running(PHASE_SETUP),
+                marker.mark_setup_preflight_done(),
+            ),
+        )
     ensure_gh_authenticated()
     resolve_graalvm_java_home()
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
@@ -470,12 +494,21 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     tests_dir_preexisted = os.path.exists(tests_dir)
     metadata_dir_preexisted = os.path.exists(metadata_dir)
 
-    copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
-    update_metadata_index_json(config, group, artifact, updated_library_version)
-    create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
-    commit_checkpoint = create_project_prep_checkpoint(config, group, artifact, updated_library_version)
+    if not resume_existing_tree:
+        copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
+        update_metadata_index_json(config, group, artifact, updated_library_version)
+        create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
+        commit_checkpoint = create_project_prep_checkpoint(config, group, artifact, updated_library_version)
+        save_phase_update(
+            continuation_marker_path,
+            lambda marker: marker.mark_setup_done(),
+        )
+    else:
+        log_stage("continuation", f"Resuming {group}:{artifact}:{updated_library_version} from phase {resume_from}")
+        commit_checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     updated_library = f"{group}:{artifact}:{updated_library_version}"
-    populate_artifact_urls(reachability_repo_path, updated_library)
+    if not resume_existing_tree:
+        populate_artifact_urls(reachability_repo_path, updated_library)
 
     source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
     prepared_source_context = prepare_source_contexts(
@@ -515,6 +548,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         test_language_display_name=test_source_layout.display_language,
         test_source_dir_name=test_source_layout.source_dir_name,
         library_preparation_preflight_context=library_preparation_preflight_context,
+        continuation_marker_path=continuation_marker_path,
     )
 
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
@@ -532,9 +566,13 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         persistent_instructions=strategy_obj.persistent_instructions,
     )
 
-    workflow_status, iterations = strategy_obj.run(
-        agent=agent,
-    )
+    if resume_finalization:
+        workflow_status = RUN_STATUS_SUCCESS
+        iterations = 0
+    else:
+        workflow_status, iterations = strategy_obj.run(
+            agent=agent,
+        )
 
     last_passing_candidate_commit = None
     if workflow_status == RUN_STATUS_SUCCESS:

--- a/forge/ai_workflows/drivers/library_update_router.py
+++ b/forge/ai_workflows/drivers/library_update_router.py
@@ -40,55 +40,25 @@ class LibraryUpdateRoute:
     """Persisted route selected for a `library-update-request` issue."""
 
     selected_driver: str
-    requested_coordinates: str
     baseline_coordinates: str | None
     new_version: str
-    reason: str
-    match_type: str
-    compile_exit_code: int | None = None
-    java_test_exit_code: int | None = None
-    native_test_exit_code: int | None = None
-    compile_log_path: str | None = None
-    java_test_log_path: str | None = None
-    native_test_log_path: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
             "selected_driver": self.selected_driver,
-            "requested_coordinates": self.requested_coordinates,
             "baseline_coordinates": self.baseline_coordinates,
             "new_version": self.new_version,
-            "reason": self.reason,
-            "match_type": self.match_type,
-            "compile_exit_code": self.compile_exit_code,
-            "java_test_exit_code": self.java_test_exit_code,
-            "native_test_exit_code": self.native_test_exit_code,
-            "compile_log_path": self.compile_log_path,
-            "java_test_log_path": self.java_test_log_path,
-            "native_test_log_path": self.native_test_log_path,
         }
 
     @classmethod
     def from_json(cls, payload: dict[str, Any]) -> "LibraryUpdateRoute":
         selected_driver = _required_str(payload, "selected_driver")
-        requested_coordinates = _required_str(payload, "requested_coordinates")
         new_version = _required_str(payload, "new_version")
-        reason = _required_str(payload, "reason")
-        match_type = _required_str(payload, "match_type")
         baseline_coordinates = _optional_str(payload, "baseline_coordinates")
         return cls(
             selected_driver=selected_driver,
-            requested_coordinates=requested_coordinates,
             baseline_coordinates=baseline_coordinates,
             new_version=new_version,
-            reason=reason,
-            match_type=match_type,
-            compile_exit_code=_optional_int(payload, "compile_exit_code"),
-            java_test_exit_code=_optional_int(payload, "java_test_exit_code"),
-            native_test_exit_code=_optional_int(payload, "native_test_exit_code"),
-            compile_log_path=_optional_str(payload, "compile_log_path"),
-            java_test_log_path=_optional_str(payload, "java_test_log_path"),
-            native_test_log_path=_optional_str(payload, "native_test_log_path"),
         )
 
 
@@ -149,7 +119,7 @@ def route_sidecar_path(metrics_repo_root: str) -> str:
 
 
 def write_library_update_route(metrics_repo_root: str, route: LibraryUpdateRoute) -> str:
-    """Persist the selected route for publication handoff and diagnostics."""
+    """Persist the selected route for publication handoff."""
     os.makedirs(metrics_repo_root, exist_ok=True)
     path = route_sidecar_path(metrics_repo_root)
     with open(path, "w", encoding="utf-8") as route_file:
@@ -183,11 +153,12 @@ def select_library_update_route(repo_path: str, metrics_repo_root: str, coordina
     if target.match_type != MATCH_NEW_VERSION or os.path.isdir(target.test_dir):
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_IMPROVE_COVERAGE,
-            requested_coordinates=coordinates,
             baseline_coordinates=None,
             new_version=requested_version,
-            reason=f"requested version is already covered by {target.match_type} target",
-            match_type=target.match_type,
+        )
+        log_stage(
+            "library-update-router",
+            f"Selected {route.selected_driver} for {coordinates}.",
         )
         write_library_update_route(metrics_repo_root, route)
         return route
@@ -212,59 +183,32 @@ def select_library_update_route(repo_path: str, metrics_repo_root: str, coordina
     if compile_result.exit_code != 0:
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_FIX_JAVAC,
-            requested_coordinates=coordinates,
             baseline_coordinates=baseline_coordinates,
             new_version=requested_version,
-            reason="compatibility probe failed during Java compilation",
-            match_type=target.match_type,
-            compile_exit_code=compile_result.exit_code,
-            compile_log_path=compile_result.log_path,
         )
     elif java_test_result is not None and java_test_result.exit_code != 0:
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_FIX_JAVA_RUN,
-            requested_coordinates=coordinates,
             baseline_coordinates=baseline_coordinates,
             new_version=requested_version,
-            reason="compatibility probe compiled but failed JVM tests",
-            match_type=target.match_type,
-            compile_exit_code=compile_result.exit_code,
-            java_test_exit_code=java_test_result.exit_code,
-            compile_log_path=compile_result.log_path,
-            java_test_log_path=java_test_result.log_path,
         )
     elif native_test_result is not None and native_test_result.exit_code != 0:
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_FIX_NI_RUN,
-            requested_coordinates=coordinates,
             baseline_coordinates=baseline_coordinates,
             new_version=requested_version,
-            reason="compatibility probe compiled and passed JVM tests but failed native-image tests",
-            match_type=target.match_type,
-            compile_exit_code=compile_result.exit_code,
-            java_test_exit_code=java_test_result.exit_code if java_test_result is not None else None,
-            native_test_exit_code=native_test_result.exit_code,
-            compile_log_path=compile_result.log_path,
-            java_test_log_path=java_test_result.log_path if java_test_result is not None else None,
-            native_test_log_path=native_test_result.log_path,
         )
     else:
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_IMPROVE_COVERAGE,
-            requested_coordinates=coordinates,
             baseline_coordinates=baseline_coordinates,
             new_version=requested_version,
-            reason="compatibility probe passed Java compilation and JVM tests",
-            match_type=target.match_type,
-            compile_exit_code=compile_result.exit_code,
-            java_test_exit_code=None if java_test_result is None else java_test_result.exit_code,
-            native_test_exit_code=None if native_test_result is None else native_test_result.exit_code,
-            compile_log_path=compile_result.log_path,
-            java_test_log_path=None if java_test_result is None else java_test_result.log_path,
-            native_test_log_path=None if native_test_result is None else native_test_result.log_path,
         )
     write_library_update_route(metrics_repo_root, route)
-    log_stage("library-update-router", f"Selected {route.selected_driver} for {coordinates}: {route.reason}")
+    log_stage(
+        "library-update-router",
+        f"Selected {route.selected_driver} for {coordinates}.",
+    )
     return route
 
 
@@ -407,13 +351,4 @@ def _optional_str(payload: dict[str, Any], key: str) -> str | None:
         return None
     if not isinstance(value, str):
         raise ValueError(f"ERROR: Library-update route field `{key}` must be a string when present.")
-    return value
-
-
-def _optional_int(payload: dict[str, Any], key: str) -> int | None:
-    value = payload.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, int):
-        raise ValueError(f"ERROR: Library-update route field `{key}` must be an integer when present.")
     return value

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -43,6 +43,10 @@ A run is an ordered sequence of phases. Continuation classifies each phase by it
 The unifying invariant: **the preserved branch HEAD is the cursor.** The
 committed tree is the source of truth for where a phase got to, so the marker
 never stores commit hashes — only the logical state a rebuild cannot recover.
+Every phase before the active resume point must be terminal: workflows that do
+not have a primary fix phase mark `fix` as `skipped` when setup completes, and
+workflows that do not run dynamic-access exploration mark `explore` as
+`skipped` before finalization.
 
 ## 2. ContinuationMarker
 
@@ -135,6 +139,9 @@ and `isPushed` records whether the branch is already pushed, so a resumed run on
 does the PR making. Opening the pull request is the workflow's
 completion — a marker only exists for a run that failed before that point, so
 continuation never reaches a state with the pull request already open.
+In publication resume mode, Forge creates a clearance commit before it publishes
+the PR branch. The clearance commit deletes resume helper artifacts: the
+continuation marker, pending metrics, and human-intervention logs.
 
 ## 4. Relationship to human intervention
 

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -117,15 +117,17 @@ because the marker never enters a successful run's publication staging
 
 A resume run reads the marker from the preserved branch and:
 
-1. Re-routes the workflow from `issueNumber`/`label`/`coordinate` and
+1. Requires the issue to carry `resumable`; plain `human-intervention` issues
+   stay manual and do not trigger preserved-branch discovery.
+2. Re-routes the workflow from `issueNumber`/`label`/`coordinate` and
    re-instantiates the engine from `strategyName`.
-2. Derives preserved-work branch prefixes from recent issue comment authors and
+3. Derives preserved-work branch prefixes from recent issue comment authors and
    the deterministic `ai/<login>/human-intervention/issue-...-` branch naming
    convention, then selects a matching remote branch that carries a valid marker.
-3. Checks out the preserved branch and rebases it onto current `master`; if it
+4. Checks out the preserved branch and rebases it onto current `master`; if it
    no longer applies cleanly, it falls back to a clean run rather than resuming a
    stale tree.
-4. Enters the phase named by `continueFrom` and applies that phase's resume
+5. Enters the phase named by `continueFrom` and applies that phase's resume
    action from §1, skipping every earlier completed or skipped phase.
 
 Publication resume hinges on the push: the branch is read from the marker

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -119,10 +119,13 @@ A resume run reads the marker from the preserved branch and:
 
 1. Re-routes the workflow from `issueNumber`/`label`/`coordinate` and
    re-instantiates the engine from `strategyName`.
-2. Checks out the preserved branch and rebases it onto current `master`; if it
+2. Derives preserved-work branch prefixes from recent issue comment authors and
+   the deterministic `ai/<login>/human-intervention/issue-...-` branch naming
+   convention, then selects a matching remote branch that carries a valid marker.
+3. Checks out the preserved branch and rebases it onto current `master`; if it
    no longer applies cleanly, it falls back to a clean run rather than resuming a
    stale tree.
-3. Enters the phase named by `continueFrom` and applies that phase's resume
+4. Enters the phase named by `continueFrom` and applies that phase's resume
    action from §1, skipping every earlier completed or skipped phase.
 
 Publication resume hinges on the push: the branch is read from the marker

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -61,6 +61,8 @@ classes re-appear in the regenerated report.
   "label": "library-new-request",
   "coordinate": "com.acme:widget:1.4.0",
   "newVersion": null,
+  "libraryUpdateRoute": null,
+  "libraryPreparationPreflight": null,
   "phases": {
     "setup":        { "status": "completed", "preflightDone": true, "setupDone": true },
     "fix":          { "status": "skipped",   "iteration": null },
@@ -93,6 +95,16 @@ because the marker never enters a successful run's publication staging
 - `issueNumber`, `label`, `coordinate`, and `newVersion` re-route the workflow;
   they are kept explicit because the coordinate is sanitized inside the branch
   name and cannot be parsed back reliably.
+- `libraryUpdateRoute` records the dispatcher-selected route for
+  `library-update-request` issues so publication-only resume does not depend on
+  a per-run sidecar directory that is absent from the preserved branch.
+- `libraryPreparationPreflight` records dispatcher preflight output so resume
+  can skip the preflight agent while still passing the original advisory setup
+  context back to the workflow driver.
+- Improve-coverage runs write the original `.baseline-stats.json` into the
+  resolved test directory during setup. Resume treats that as preserved worktree
+  state and reuses it instead of recomputing the baseline after generation may
+  already have changed the tree.
 - `explore.exhaustedClasses` is the only EXPLORE state worth keeping: a fresh
   report cannot distinguish an uncovered-but-abandoned class from an
   uncovered-but-untried one.

--- a/forge/docs/e2e.md
+++ b/forge/docs/e2e.md
@@ -199,10 +199,38 @@ body: |
 comments:
   - author: fixture-author
     body: "Please cover reflective field metadata, data models, and I/O helpers."
+worktree_files:
+  tests/src/com.google.http-client/google-http-client/1.42.2/.baseline-stats.json:
+    stats: null
+    metadata_entries: 0
+    test_only_metadata_entries: 0
+continuation_marker:
+  schemaVersion: 1
+  continueFrom: explore
+  preservedBranch: fixture/preserved-work/issue-9101
+  strategyName: dynamic_access_main_sources_pi_gpt-5.5
+  issueNumber: 9101
+  label: library-new-request
+  coordinate: com.google.http-client:google-http-client:1.42.2
+  newVersion: null
+  libraryUpdateRoute: null
+  libraryPreparationPreflight: null
+  phases:
+    setup: {status: completed, preflightDone: true, setupDone: true}
+    fix: {status: skipped, iteration: null}
+    explore: {status: running, iteration: 1, exhaustedClasses: []}
+    finalization: {status: pending}
+    publication: {status: pending, isPushed: false, branch: null}
 ```
 
 Fixture queue scanning is local to the loaded YAML issues. It does not perform
 live GitHub search, live issue claiming, or live project-board mutation.
+The optional `continuation_marker` block is written to the isolated fixture
+worktree as `forge/.continuation-marker.json` before dispatch, allowing fixture
+E2E to exercise run-continuation entry points without a live preserved branch.
+The optional `worktree_files` map writes small fixture-owned files into the
+isolated checkout before dispatch; continuation fixtures use it for preserved
+worktree state such as improve-coverage baseline snapshots.
 
 ## 3. Live GitHub Smoke E2E
 

--- a/forge/fixture_github_issues/library-update-request-continuation.yaml
+++ b/forge/fixture_github_issues/library-update-request-continuation.yaml
@@ -1,0 +1,82 @@
+# Fixture-backed continuation scenario. The marker starts after setup and enters
+# the dynamic-access exploration phase for an already supported library-update
+# request, so fixture E2E exercises marker-backed route restoration and resume.
+number: 9106
+title: "Resume coverage improvement for commons-net:commons-net:3.13.0"
+state: OPEN
+labels:
+  - library-update-request
+assignees: []
+project:
+  number: 30
+  item_id: fixture-project-item-9106
+  status: Todo
+blocked_by: []
+body: |
+  Please resume dynamic-access coverage improvement for
+  `commons-net:commons-net:3.13.0`.
+
+  This fixture uses a continuation marker to start from the exploration phase.
+  The underlying test suite is already present through the shared
+  `commons-net:commons-net:3.1` metadata version and resolves the requested
+  tested version through `metadata/commons-net/commons-net/index.json`.
+
+  Requested coordinate:
+  `commons-net:commons-net:3.13.0`
+comments:
+  - author: fixture-runner
+    created_at: "2026-06-16T16:00:00Z"
+    body: |
+      Fixture preserved work branch for continuation.
+
+      Branch name: `fixture/preserved-work/issue-9106-library-update-request-commons-net`
+worktree_files:
+  tests/src/commons-net/commons-net/3.1/.baseline-stats.json:
+    stats: null
+    metadata_entries: 0
+    test_only_metadata_entries: 0
+continuation_marker:
+  schemaVersion: 1
+  continueFrom: explore
+  preservedBranch: fixture/preserved-work/issue-9106-library-update-request-commons-net
+  strategyName: dynamic_access_main_sources_pi_gpt-5.5
+  issueNumber: 9106
+  label: library-update-request
+  coordinate: commons-net:commons-net:3.13.0
+  newVersion: null
+  libraryUpdateRoute:
+    selected_driver: improve_library_coverage
+    baseline_coordinates: null
+    new_version: 3.13.0
+  libraryPreparationPreflight:
+    status: degraded
+    action: no_action
+    issue_number: 9106
+    issue_label: library-update-request
+    library: commons-net:commons-net:3.13.0
+    summary: Fixture continuation preflight was preserved in the marker.
+    deterministic_setup: []
+    agent_guidance: ""
+    risks: []
+    applied_setup: []
+    input_evidence: []
+    failure_reason: fixture no-op preflight
+  phases:
+    setup:
+      status: completed
+      preflightDone: true
+      setupDone: true
+    fix:
+      status: skipped
+      iteration: null
+    explore:
+      status: running
+      iteration: 1
+      exhaustedClasses:
+        - fixture.AlreadyExplored
+    finalization:
+      status: pending
+    publication:
+      status: pending
+      isPushed: false
+      branch: null

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -77,6 +77,7 @@ from ai_workflows.drivers.library_update_router import (
     LibraryUpdateRoute,
     load_library_update_route,
     select_library_update_route,
+    write_library_update_route,
 )
 from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
@@ -139,6 +140,7 @@ from utility_scripts.continuation_marker import (
     ContinuationMarker,
     continuation_marker_path,
     load_continuation_marker,
+    save_phase_update,
 )
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.fixture_github import FixtureGitHubState, load_fixture_github_state
@@ -146,7 +148,9 @@ from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_stats import resolve_stats_file_path
 from utility_scripts.library_preparation_preflight import (
     LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
+    load_library_preparation_preflight,
     run_library_preparation_preflight as run_preflight_decision,
+    write_library_preparation_preflight,
 )
 from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
@@ -3870,7 +3874,7 @@ def build_origin_branch_url(repo_path: str, branch_name: str) -> str:
 def get_issue_comments(issue_number: int) -> list[dict]:
     """Fetch issue comments used for continuation branch discovery."""
     if is_fixture_testing_enabled():
-        return []
+        return require_fixture_github_state().get_issue_comments(issue_number)
     data = gh_json(
         "issue",
         "view",
@@ -4044,6 +4048,82 @@ def create_or_load_run_continuation_marker(
         )
     marker.save(marker_path)
     return marker_path
+
+
+def library_update_route_from_marker(marker: ContinuationMarker | None) -> LibraryUpdateRoute | None:
+    """Return the marker-backed library-update route when continuation has one."""
+    if marker is None or marker.library_update_route is None:
+        return None
+    return LibraryUpdateRoute.from_json(marker.library_update_route)
+
+
+def restore_library_update_route_from_marker(
+        claimed_issue: ClaimedIssue,
+        marker: ContinuationMarker | None,
+        *,
+        required: bool = False,
+) -> LibraryUpdateRoute | None:
+    """Restore marker-backed library-update route state into the run sidecar."""
+    if claimed_issue.label != LABEL_LIBRARY_UPDATE:
+        return None
+    route = library_update_route_from_marker(marker)
+    if route is None:
+        if required:
+            raise ValueError(
+                f"Issue #{claimed_issue.issue['number']} resumes publication without a library-update route."
+            )
+        return None
+    write_library_update_route(library_update_route_artifact_root(claimed_issue), route)
+    log_stage(
+        "continuation",
+        f"Restored library-update route {route.selected_driver} for issue #{claimed_issue.issue['number']}.",
+    )
+    return route
+
+
+def record_library_update_route_in_marker(marker_path: str | None, route: LibraryUpdateRoute | None) -> None:
+    """Persist the selected library-update route into the continuation marker."""
+    if marker_path is None or route is None:
+        return
+    save_phase_update(
+        marker_path,
+        lambda marker: marker.record_library_update_route(route.to_json()),
+    )
+
+
+def restore_library_preparation_preflight_from_marker(
+        claimed_issue: ClaimedIssue,
+        marker: ContinuationMarker | None,
+) -> str | None:
+    """Restore marker-backed dispatcher preflight state into the run sidecar."""
+    if marker is None or marker.library_preparation_preflight is None:
+        return None
+    preflight_root = claimed_issue.preflight_info_path or claimed_issue.scratch_metrics_repo_path
+    preflight_path = write_library_preparation_preflight(
+        preflight_root,
+        marker.library_preparation_preflight,
+    )
+    log_stage(
+        "continuation",
+        f"Restored library preparation preflight for issue #{claimed_issue.issue['number']}.",
+    )
+    return preflight_path
+
+
+def record_library_preparation_preflight_in_marker(
+        marker_path: str | None,
+        preflight_path: str | None,
+) -> None:
+    """Persist dispatcher preflight output into the continuation marker."""
+    if marker_path is None or preflight_path is None:
+        return
+    preflight = load_library_preparation_preflight(preflight_path)
+    if preflight is None:
+        return
+    save_phase_update(
+        marker_path,
+        lambda marker: marker.record_library_preparation_preflight(preflight),
+    )
 
 
 def require_claimed_issue_worktree(claimed_issue: ClaimedIssue, stage: str) -> str:
@@ -4881,22 +4961,41 @@ def invoke_pipeline(
     )
     marker = load_continuation_marker(continuation_path)
     if marker is not None and marker.continue_from == PHASE_PUBLICATION:
+        restore_library_update_route_from_marker(claimed_issue, marker, required=True)
         log_stage(
             "continuation",
             f"Issue #{claimed_issue.issue['number']} resumes at publication; skipping workflow driver.",
         )
         return True
-    library_preparation_preflight_path = run_library_preparation_preflight(
-        claimed_issue,
-        effective_strategy_name,
-    )
+    setup_phase = {} if marker is None else marker.phases.get("setup", {})
+    if bool(setup_phase.get("preflightDone")):
+        library_preparation_preflight_path = restore_library_preparation_preflight_from_marker(
+            claimed_issue,
+            marker,
+        )
+        log_stage(
+            "continuation",
+            f"Issue #{claimed_issue.issue['number']} skips completed setup preflight.",
+        )
+    else:
+        library_preparation_preflight_path = run_library_preparation_preflight(
+            claimed_issue,
+            effective_strategy_name,
+        )
+        record_library_preparation_preflight_in_marker(
+            continuation_path,
+            library_preparation_preflight_path,
+        )
     library_update_route = None
     if claimed_issue.label == LABEL_LIBRARY_UPDATE:
-        library_update_route = select_library_update_route(
-            claimed_issue.worktree_path,
-            library_update_route_artifact_root(claimed_issue),
-            claimed_issue.issue_coordinates,
-        )
+        library_update_route = restore_library_update_route_from_marker(claimed_issue, marker)
+        if library_update_route is None:
+            library_update_route = select_library_update_route(
+                claimed_issue.worktree_path,
+                library_update_route_artifact_root(claimed_issue),
+                claimed_issue.issue_coordinates,
+            )
+            record_library_update_route_in_marker(continuation_path, library_update_route)
 
     chunk_class_count = None
     if (
@@ -4924,13 +5023,10 @@ def invoke_pipeline(
     print()
     log_stage(invocation.log_stage_name, invocation.log_message)
     if is_fixture_testing_enabled():
-        display_argv, issue_context = list(invocation.argv), None
+        display_argv = list(invocation.argv)
         if "--issue-requested-metadata-context" in display_argv:
             context_flag_index = display_argv.index("--issue-requested-metadata-context")
-            issue_context = display_argv[context_flag_index + 1]
             del display_argv[context_flag_index:context_flag_index + 2]
-        if issue_context:
-            log_stage("workflow-driver", f"Issue body/context passed to workflow:\n{issue_context}")
         log_stage(
             "workflow-driver",
             (
@@ -5749,6 +5845,7 @@ def build_fixture_claimed_issue(
         return None
 
     issue_coordinates, current_coordinates, new_version = claim_metadata
+    continuation_marker = load_continuation_marker(continuation_marker_path(worktree_path))
     return ClaimedIssue(
         issue=issue,
         label=label,
@@ -5760,6 +5857,7 @@ def build_fixture_claimed_issue(
         current_coordinates=current_coordinates,
         new_version=new_version,
         preflight_info_path=preflight_info_path,
+        continuation_marker=continuation_marker,
     )
 
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -45,7 +45,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.drivers.add_new_library_support import (
@@ -132,6 +132,13 @@ from utility_scripts.dynamic_access_exhaust_report import (
     DynamicAccessExhaustReport,
     dynamic_access_exhaust_report_path,
     find_dynamic_access_exhaust_report_path,
+)
+from utility_scripts.continuation_marker import (
+    CONTINUATION_MARKER_FILENAME,
+    PHASE_PUBLICATION,
+    ContinuationMarker,
+    continuation_marker_path,
+    load_continuation_marker,
 )
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.fixture_github import FixtureGitHubState, load_fixture_github_state
@@ -325,6 +332,7 @@ class ClaimedIssue:
     current_coordinates: str | None = None
     new_version: str | None = None
     preflight_info_path: str | None = None
+    continuation_marker: ContinuationMarker | None = None
 
 
 @dataclass(frozen=True)
@@ -3859,6 +3867,185 @@ def build_origin_branch_url(repo_path: str, branch_name: str) -> str:
     return f"https://github.com/{origin_owner}/{repo_name}/tree/{quote(branch_name, safe='')}"
 
 
+def get_issue_comments(issue_number: int) -> list[dict]:
+    """Fetch issue comments used for continuation branch discovery."""
+    if is_fixture_testing_enabled():
+        return []
+    data = gh_json(
+        "issue",
+        "view",
+        str(issue_number),
+        "--repo",
+        REPO,
+        "--json",
+        "comments",
+    )
+    comments = data.get("comments")
+    return comments if isinstance(comments, list) else []
+
+
+def extract_preserved_branch_name(comment_body: str) -> str | None:
+    """Extract the preserved work branch name from a human-intervention comment."""
+    branch_match = re.search(r"Branch name:\s*`([^`]+)`", comment_body)
+    if branch_match:
+        return branch_match.group(1).strip()
+    tree_match = re.search(r"/tree/([A-Za-z0-9%._~!$&'()*+,;=:@/-]+)", comment_body)
+    if tree_match:
+        return unquote(tree_match.group(1)).strip()
+    return None
+
+
+def find_latest_preserved_branch_name(issue_number: int) -> str | None:
+    """Return the latest preserved branch mentioned on the issue, when present."""
+    branch_name = None
+    for comment in get_issue_comments(issue_number):
+        body = comment.get("body")
+        if not isinstance(body, str):
+            continue
+        candidate = extract_preserved_branch_name(body)
+        if candidate:
+            branch_name = candidate
+    return branch_name
+
+
+def fetch_remote_branch(repo_path: str, branch_name: str) -> str:
+    """Fetch a remote branch and return its local remote-tracking ref."""
+    remote_ref = f"refs/remotes/origin/{branch_name}"
+    run_git_transport(
+        ["fetch", "origin", f"+refs/heads/{branch_name}:{remote_ref}"],
+        cwd=repo_path,
+        env=git_env_limited_to_repo_root(repo_path),
+    )
+    return remote_ref
+
+
+def load_continuation_marker_from_branch(
+        repo_path: str,
+        branch_name: str,
+) -> ContinuationMarker | None:
+    """Load the continuation marker stored on a remote preserved branch."""
+    remote_ref = fetch_remote_branch(repo_path, branch_name)
+    marker_relpath = f"forge/{CONTINUATION_MARKER_FILENAME}"
+    result = subprocess.run(
+        ["git", "show", f"{remote_ref}:{marker_relpath}"],
+        cwd=repo_path,
+        env=git_env_limited_to_repo_root(repo_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        log_stage(
+            "continuation",
+            f"Preserved branch {branch_name} has no {marker_relpath}; running issue from scratch.",
+        )
+        return None
+    try:
+        marker = ContinuationMarker.from_dict(json.loads(result.stdout))
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to parse continuation marker on branch {branch_name}: {exc!r}",
+            file=sys.stderr,
+        )
+        return None
+    if marker.preserved_branch is None:
+        marker.record_preserved_branch(branch_name)
+    return marker
+
+
+def resolve_issue_continuation_marker(
+        issue: dict,
+        label: str,
+        base_reachability_metadata_path: str,
+) -> ContinuationMarker | None:
+    """Resolve a previously preserved continuation marker for this claim."""
+    issue_number = int(issue["number"])
+    branch_name = find_latest_preserved_branch_name(issue_number)
+    if not branch_name:
+        return None
+    marker = load_continuation_marker_from_branch(base_reachability_metadata_path, branch_name)
+    if marker is None:
+        return None
+    if marker.issue_number != issue_number or marker.label != label:
+        log_stage(
+            "continuation",
+            (
+                f"Ignoring preserved marker on {branch_name}: "
+                f"marker issue/label #{marker.issue_number} {marker.label} does not match "
+                f"#{issue_number} {label}."
+            ),
+        )
+        return None
+    return marker
+
+
+def checkout_continuation_branch(
+        worktree_path: str,
+        marker: ContinuationMarker,
+) -> bool:
+    """Check out and rebase the preserved branch into the isolated worktree."""
+    branch_name = marker.preserved_branch
+    if not branch_name:
+        return False
+    git_env = git_env_limited_to_repo_root(worktree_path)
+    remote_ref = fetch_remote_branch(worktree_path, branch_name)
+    subprocess.run(
+        ["git", "switch", "-C", branch_name, remote_ref],
+        cwd=worktree_path,
+        env=git_env,
+        check=True,
+    )
+    base_ref = fetch_remote_branch(worktree_path, DEFAULT_WORKTREE_BASE_REF)
+    rebase_result = subprocess.run(
+        ["git", "rebase", base_ref],
+        cwd=worktree_path,
+        env=git_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if rebase_result.returncode == 0:
+        log_stage(
+            "continuation",
+            f"Resuming issue #{marker.issue_number} from {branch_name} at phase {marker.continue_from}.",
+        )
+        return True
+    print(
+        (
+            f"ERROR: Could not rebase preserved branch {branch_name} onto "
+            f"{DEFAULT_WORKTREE_BASE_REF}; falling back to a clean run.\n{rebase_result.stdout}"
+        ),
+        file=sys.stderr,
+    )
+    subprocess.run(["git", "rebase", "--abort"], cwd=worktree_path, env=git_env, check=False)
+    subprocess.run(["git", "switch", "--detach", base_ref], cwd=worktree_path, env=git_env, check=True)
+    marker_path = continuation_marker_path(worktree_path)
+    if os.path.exists(marker_path):
+        os.remove(marker_path)
+    return False
+
+
+def create_or_load_run_continuation_marker(
+        claimed_issue: ClaimedIssue,
+        strategy_name: str,
+) -> str:
+    """Ensure this claimed run has an eager continuation marker."""
+    marker_path = continuation_marker_path(claimed_issue.worktree_path)
+    marker = load_continuation_marker(marker_path)
+    if marker is None:
+        marker = claimed_issue.continuation_marker or ContinuationMarker.create(
+            strategy_name=strategy_name,
+            issue_number=int(claimed_issue.issue["number"]),
+            label=claimed_issue.label,
+            coordinate=claimed_issue.issue_coordinates,
+            new_version=claimed_issue.new_version,
+        )
+    marker.save(marker_path)
+    return marker_path
+
+
 def require_claimed_issue_worktree(claimed_issue: ClaimedIssue, stage: str) -> str:
     """Require the claimed issue path to be the exact isolated reachability worktree."""
     try:
@@ -3921,9 +4108,23 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     log_stage("preserve-failed-work", f"Preserving failed work for issue #{issue_number} on branch {branch_name}")
     subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, env=git_env, check=True)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
+    marker_path = continuation_marker_path(repo_path)
+    marker = load_continuation_marker(marker_path)
+    if marker is not None:
+        marker.record_preserved_branch(branch_name)
+        marker.save(marker_path)
     subprocess.run(["git", "add", "-A"], cwd=repo_path, env=git_env, check=True)
     if logs_destination_relpath is not None:
         subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, env=git_env, check=True)
+    force_add_paths = []
+    marker_relpath = os.path.relpath(marker_path, repo_path)
+    if os.path.exists(marker_path):
+        force_add_paths.append(marker_relpath)
+    pending_metrics_relpath = os.path.join(get_forge_subdir_name(), PENDING_METRICS_FILENAME)
+    if os.path.exists(os.path.join(repo_path, pending_metrics_relpath)):
+        force_add_paths.append(pending_metrics_relpath)
+    if force_add_paths:
+        subprocess.run(["git", "add", "-f", "--", *force_add_paths], cwd=repo_path, env=git_env, check=True)
     diff_result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, env=git_env, check=False)
     committed_changes = diff_result.returncode != 0
     if committed_changes:
@@ -4388,6 +4589,12 @@ def append_library_preparation_preflight_arg(pipeline_argv: list[str], preflight
         pipeline_argv.extend(["--library-preparation-preflight-path", preflight_path])
 
 
+def append_continuation_marker_arg(pipeline_argv: list[str], marker_path: str | None) -> None:
+    """Append the continuation marker path when continuation tracking is active."""
+    if marker_path:
+        pipeline_argv.extend(["--continuation-marker-path", marker_path])
+
+
 def library_update_route_artifact_root(claimed_issue: ClaimedIssue) -> str:
     """Return the non-worktree artifact root for library-update route handoff."""
     return claimed_issue.preflight_info_path or claimed_issue.scratch_metrics_repo_path
@@ -4400,6 +4607,7 @@ def build_workflow_driver_invocation(
         library_preparation_preflight_path: str | None = None,
         chunk_class_count: int | None = None,
         library_update_route: LibraryUpdateRoute | None = None,
+        continuation_marker_path: str | None = None,
 ) -> WorkflowDriverInvocation:
     """Build the routed workflow-driver command for a claimed issue."""
     issue_number = claimed_issue.issue["number"]
@@ -4410,6 +4618,7 @@ def build_workflow_driver_invocation(
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
         append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+        append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         if keep_tests_without_dynamic_access:
@@ -4442,6 +4651,7 @@ def build_workflow_driver_invocation(
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
         append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+        append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         return WorkflowDriverInvocation(
@@ -4471,6 +4681,7 @@ def build_workflow_driver_invocation(
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
         append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+        append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
         if strategy_name:
             pipeline_argv.extend(["--strategy-name", strategy_name])
         return WorkflowDriverInvocation(
@@ -4500,6 +4711,7 @@ def build_workflow_driver_invocation(
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
         append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+        append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
         return WorkflowDriverInvocation(
             driver_name="fix_ni_run",
             script_name="fix_ni_run.py",
@@ -4533,6 +4745,7 @@ def build_workflow_driver_invocation(
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
             append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+            append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
             return WorkflowDriverInvocation(
                 driver_name="fix_javac_fail",
                 script_name="fix_javac_fail.py",
@@ -4561,6 +4774,7 @@ def build_workflow_driver_invocation(
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
             append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+            append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
             return WorkflowDriverInvocation(
                 driver_name="fix_java_run_fail",
                 script_name="fix_java_run_fail.py",
@@ -4589,6 +4803,7 @@ def build_workflow_driver_invocation(
                 "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
             ]
             append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+            append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
             return WorkflowDriverInvocation(
                 driver_name="fix_ni_run",
                 script_name="fix_ni_run.py",
@@ -4615,6 +4830,7 @@ def build_workflow_driver_invocation(
             "--metrics-repo-path", claimed_issue.scratch_metrics_repo_path,
         ]
         append_library_preparation_preflight_arg(pipeline_argv, library_preparation_preflight_path)
+        append_continuation_marker_arg(pipeline_argv, continuation_marker_path)
         issue_requested_metadata_context = extract_issue_requested_metadata_context(get_issue_body(issue_number))
         if issue_requested_metadata_context:
             pipeline_argv.extend(["--issue-requested-metadata-context", issue_requested_metadata_context])
@@ -4656,9 +4872,23 @@ def invoke_pipeline(
     strategy names, and chunk context.
     """
     require_claimed_issue_worktree(claimed_issue, "workflow execution")
+    effective_strategy_name = strategy_name or DEFAULT_WORK_QUEUE_STRATEGY_NAME
+    if claimed_issue.continuation_marker is not None:
+        effective_strategy_name = claimed_issue.continuation_marker.strategy_name
+    continuation_path = create_or_load_run_continuation_marker(
+        claimed_issue,
+        effective_strategy_name,
+    )
+    marker = load_continuation_marker(continuation_path)
+    if marker is not None and marker.continue_from == PHASE_PUBLICATION:
+        log_stage(
+            "continuation",
+            f"Issue #{claimed_issue.issue['number']} resumes at publication; skipping workflow driver.",
+        )
+        return True
     library_preparation_preflight_path = run_library_preparation_preflight(
         claimed_issue,
-        strategy_name,
+        effective_strategy_name,
     )
     library_update_route = None
     if claimed_issue.label == LABEL_LIBRARY_UPDATE:
@@ -4679,16 +4909,17 @@ def invoke_pipeline(
     ):
         chunk_class_count = prepare_dynamic_access_chunking(
             claimed_issue,
-            strategy_name,
+            effective_strategy_name,
         )
     invocation = build_workflow_driver_invocation(
-        claimed_issue,
-        strategy_name,
-        keep_tests_without_dynamic_access,
-        library_preparation_preflight_path,
-        chunk_class_count,
-        library_update_route,
-    )
+            claimed_issue,
+            effective_strategy_name,
+            keep_tests_without_dynamic_access,
+            library_preparation_preflight_path,
+            chunk_class_count,
+            library_update_route,
+            continuation_path,
+        )
 
     print()
     log_stage(invocation.log_stage_name, invocation.log_message)
@@ -5384,6 +5615,11 @@ def claim_issue_for_processing(
     if claim_metadata is None:
         return None
     issue_coordinates, current_coordinates, new_version = claim_metadata
+    continuation_marker = resolve_issue_continuation_marker(
+        issue,
+        label,
+        base_reachability_metadata_path,
+    )
     try:
         chunked_exhaust_report = resolve_chunked_dynamic_access_exhaust_report(
             issue,
@@ -5408,6 +5644,8 @@ def claim_issue_for_processing(
             issue["number"],
         )
         preflight_info_path = create_preflight_info_dir(worktree_path)
+        if continuation_marker is not None and not checkout_continuation_branch(worktree_path, continuation_marker):
+            continuation_marker = None
         if chunked_exhaust_report is not None:
             verify_chunked_dynamic_access_base_contains_published_commit(
                 chunked_exhaust_report,
@@ -5435,6 +5673,7 @@ def claim_issue_for_processing(
         current_coordinates=current_coordinates,
         new_version=new_version,
         preflight_info_path=preflight_info_path,
+        continuation_marker=continuation_marker,
     )
 
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -45,7 +45,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
-from urllib.parse import quote, unquote
+from urllib.parse import quote
 
 import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.drivers.add_new_library_support import (
@@ -3850,12 +3850,29 @@ def _sanitize_branch_segment(value: str) -> str:
 
 def build_failure_preservation_branch_name(claimed_issue: ClaimedIssue) -> str:
     """Build a unique branch name for preserving a failed issue run."""
-    authenticated_login = _sanitize_branch_segment(get_authenticated_user())
-    coordinate = _sanitize_branch_segment(claimed_issue.issue_coordinates)
-    label = _sanitize_branch_segment(claimed_issue.label)
+    branch_prefix = build_failure_preservation_branch_prefix(
+        issue_number=int(claimed_issue.issue["number"]),
+        label=claimed_issue.label,
+        coordinate=claimed_issue.issue_coordinates,
+        github_login=get_authenticated_user(),
+    )
+    return f"{branch_prefix}{uuid.uuid4().hex[:8]}"
+
+
+def build_failure_preservation_branch_prefix(
+        *,
+        issue_number: int,
+        label: str,
+        coordinate: str,
+        github_login: str,
+) -> str:
+    """Build the deterministic prefix for failed-work preservation branches."""
+    authenticated_login = _sanitize_branch_segment(github_login)
+    coordinate_segment = _sanitize_branch_segment(coordinate)
+    label_segment = _sanitize_branch_segment(label)
     return (
         f"ai/{authenticated_login}/human-intervention/"
-        f"issue-{claimed_issue.issue['number']}-{label}-{coordinate}-{uuid.uuid4().hex[:8]}"
+        f"issue-{issue_number}-{label_segment}-{coordinate_segment}-"
     )
 
 
@@ -3888,28 +3905,95 @@ def get_issue_comments(issue_number: int) -> list[dict]:
     return comments if isinstance(comments, list) else []
 
 
-def extract_preserved_branch_name(comment_body: str) -> str | None:
-    """Extract the preserved work branch name from a human-intervention comment."""
-    branch_match = re.search(r"Branch name:\s*`([^`]+)`", comment_body)
-    if branch_match:
-        return branch_match.group(1).strip()
-    tree_match = re.search(r"/tree/([A-Za-z0-9%._~!$&'()*+,;=:@/-]+)", comment_body)
-    if tree_match:
-        return unquote(tree_match.group(1)).strip()
+def comment_author_login(comment: dict) -> str | None:
+    """Return the GitHub login that posted an issue comment."""
+    author = comment.get("author")
+    if isinstance(author, dict):
+        login = author.get("login")
+        return login if isinstance(login, str) and login else None
+    if isinstance(author, str) and author:
+        return author
     return None
 
 
-def find_latest_preserved_branch_name(issue_number: int) -> str | None:
-    """Return the latest preserved branch mentioned on the issue, when present."""
-    branch_name = None
-    for comment in get_issue_comments(issue_number):
-        body = comment.get("body")
-        if not isinstance(body, str):
+def list_remote_branches_by_prefix(repo_path: str, branch_prefix: str) -> list[str]:
+    """Return remote branch names whose heads match the given prefix."""
+    result = run_git_transport(
+        ["ls-remote", "--heads", "origin", f"{branch_prefix}*"],
+        cwd=repo_path,
+        env=git_env_limited_to_repo_root(repo_path),
+    )
+    branch_names = []
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
             continue
-        candidate = extract_preserved_branch_name(body)
-        if candidate:
-            branch_name = candidate
-    return branch_name
+        ref_name = parts[1]
+        if not ref_name.startswith("refs/heads/"):
+            continue
+        branch_name = ref_name[len("refs/heads/"):]
+        if branch_name.startswith(branch_prefix):
+            branch_names.append(branch_name)
+    return sorted(set(branch_names))
+
+
+def remote_branch_commit_timestamp(repo_path: str, branch_name: str) -> int:
+    """Fetch a remote branch and return its tip commit timestamp."""
+    remote_ref = fetch_remote_branch(repo_path, branch_name)
+    result = subprocess.run(
+        ["git", "show", "-s", "--format=%ct", remote_ref],
+        cwd=repo_path,
+        env=git_env_limited_to_repo_root(repo_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    return int(result.stdout.strip())
+
+
+def sort_remote_branches_by_commit_time(repo_path: str, branch_names: list[str]) -> list[str]:
+    """Return remote branch names newest-first by tip commit time."""
+    return sorted(
+        branch_names,
+        key=lambda branch_name: remote_branch_commit_timestamp(repo_path, branch_name),
+        reverse=True,
+    )
+
+
+def find_preserved_branch_candidates(
+        issue: dict,
+        label: str,
+        coordinate: str,
+        repo_path: str,
+) -> list[str]:
+    """Return likely preserved-work branches derived from recent comment authors."""
+    issue_number = int(issue["number"])
+    candidates = []
+    seen_branches = set()
+    seen_prefixes = set()
+    for comment in reversed(get_issue_comments(issue_number)):
+        author_login = comment_author_login(comment)
+        if author_login is None:
+            continue
+        branch_prefix = build_failure_preservation_branch_prefix(
+            issue_number=issue_number,
+            label=label,
+            coordinate=coordinate,
+            github_login=author_login,
+        )
+        if branch_prefix in seen_prefixes:
+            continue
+        seen_prefixes.add(branch_prefix)
+        for branch_name in sort_remote_branches_by_commit_time(
+                repo_path,
+                list_remote_branches_by_prefix(repo_path, branch_prefix),
+        ):
+            if branch_name in seen_branches:
+                continue
+            candidates.append(branch_name)
+            seen_branches.add(branch_name)
+    return candidates
 
 
 def fetch_remote_branch(repo_path: str, branch_name: str) -> str:
@@ -3953,7 +4037,7 @@ def load_continuation_marker_from_branch(
             file=sys.stderr,
         )
         return None
-    if marker.preserved_branch is None:
+    if marker.preserved_branch != branch_name:
         marker.record_preserved_branch(branch_name)
     return marker
 
@@ -3961,17 +4045,22 @@ def load_continuation_marker_from_branch(
 def resolve_issue_continuation_marker(
         issue: dict,
         label: str,
+        coordinate: str,
         base_reachability_metadata_path: str,
 ) -> ContinuationMarker | None:
     """Resolve a previously preserved continuation marker for this claim."""
     issue_number = int(issue["number"])
-    branch_name = find_latest_preserved_branch_name(issue_number)
-    if not branch_name:
-        return None
-    marker = load_continuation_marker_from_branch(base_reachability_metadata_path, branch_name)
-    if marker is None:
-        return None
-    if marker.issue_number != issue_number or marker.label != label:
+    for branch_name in find_preserved_branch_candidates(
+            issue,
+            label,
+            coordinate,
+            base_reachability_metadata_path,
+    ):
+        marker = load_continuation_marker_from_branch(base_reachability_metadata_path, branch_name)
+        if marker is None:
+            continue
+        if marker.issue_number == issue_number and marker.label == label:
+            return marker
         log_stage(
             "continuation",
             (
@@ -3980,8 +4069,7 @@ def resolve_issue_continuation_marker(
                 f"#{issue_number} {label}."
             ),
         )
-        return None
-    return marker
+    return None
 
 
 def checkout_continuation_branch(
@@ -5714,6 +5802,7 @@ def claim_issue_for_processing(
     continuation_marker = resolve_issue_continuation_marker(
         issue,
         label,
+        issue_coordinates,
         base_reachability_metadata_path,
     )
     try:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -241,6 +241,7 @@ LABEL_HUMAN_INTERVENTION = "human-intervention"
 LABEL_HUMAN_INTERVENTION_FIXED = "human-intervention-fixed"
 LABEL_NOT_FOR_NATIVE_IMAGE = "not-for-native-image"
 LABEL_CHUNKED_DYNAMIC_ACCESS = "chunked-dynamic-access"
+LABEL_RESUMABLE = "resumable"
 FIXTURE_AUTHENTICATED_USER = "fixture-runner"
 NON_USER_REQUESTED_ISSUE_AUTHORS: tuple[str, ...] = (
     "graalvmbot",
@@ -305,6 +306,8 @@ PRIORITY_LABEL_COLOR = "FBCA04"
 PRIORITY_LABEL_DESCRIPTION = "Automation should process this issue before regular queue items"
 CHUNKED_DYNAMIC_ACCESS_LABEL_COLOR = "C5DEF5"
 CHUNKED_DYNAMIC_ACCESS_LABEL_DESCRIPTION = "Issue uses chunked dynamic-access processing"
+RESUMABLE_LABEL_COLOR = "0E8A16"
+RESUMABLE_LABEL_DESCRIPTION = "Issue has preserved automation work that Forge can resume"
 DEFAULT_DYNAMIC_ACCESS_CHUNK_CLASS_THRESHOLD = 15
 
 
@@ -939,6 +942,11 @@ def issue_has_label(issue: dict, label_name: str) -> bool:
         if isinstance(label, dict) and label.get("name") == label_name:
             return True
     return False
+
+
+def issue_is_resumable(issue: dict) -> bool:
+    """Return True when an issue is explicitly eligible for run continuation."""
+    return issue_has_label(issue, LABEL_RESUMABLE)
 
 
 def add_issue_label_to_payload(issue: dict, label_name: str) -> None:
@@ -3788,6 +3796,9 @@ def add_issue_label(issue_number: int, label_name: str) -> None:
     elif label_name == LABEL_CHUNKED_DYNAMIC_ACCESS:
         label_color = CHUNKED_DYNAMIC_ACCESS_LABEL_COLOR
         label_description = CHUNKED_DYNAMIC_ACCESS_LABEL_DESCRIPTION
+    elif label_name == LABEL_RESUMABLE:
+        label_color = RESUMABLE_LABEL_COLOR
+        label_description = RESUMABLE_LABEL_DESCRIPTION
     ensure_repo_label_exists(
         label_name,
         label_color,
@@ -4049,6 +4060,8 @@ def resolve_issue_continuation_marker(
         base_reachability_metadata_path: str,
 ) -> ContinuationMarker | None:
     """Resolve a previously preserved continuation marker for this claim."""
+    if not issue_is_resumable(issue):
+        return None
     issue_number = int(issue["number"])
     for branch_name in find_preserved_branch_candidates(
             issue,
@@ -4410,7 +4423,12 @@ def ensure_preserved_branch_link_in_comment(
     )
 
 
-def post_human_intervention_comment_and_label(issue_number: int, comment_body: str | None) -> None:
+def post_human_intervention_comment_and_label(
+        issue_number: int,
+        comment_body: str | None,
+        *,
+        resumable: bool = False,
+) -> None:
     """Post the human-intervention comment and always attempt to apply the label."""
     if is_user_interrupt_requested():
         return
@@ -4433,6 +4451,23 @@ def post_human_intervention_comment_and_label(issue_number: int, comment_body: s
             file=sys.stderr,
         )
         traceback.print_exc()
+
+    if resumable:
+        try:
+            add_issue_label(issue_number, LABEL_RESUMABLE)
+        except Exception as exc:
+            print(
+                f"ERROR: Failed to add '{LABEL_RESUMABLE}' label to issue #{issue_number}: {exc!r}",
+                file=sys.stderr,
+            )
+            traceback.print_exc()
+
+
+def preservation_result_has_continuation_marker(preservation_result: FailurePreservationResult | None) -> bool:
+    """Return True when preserved work carries a continuation marker."""
+    if preservation_result is None:
+        return False
+    return os.path.isfile(continuation_marker_path(preservation_result.reviewable_worktree_path))
 
 
 def maybe_apply_human_intervention_follow_up(
@@ -4466,7 +4501,11 @@ def maybe_apply_human_intervention_follow_up(
         comment_body = None
     if is_user_interrupt_requested():
         return False
-    post_human_intervention_comment_and_label(claimed_issue.issue["number"], comment_body)
+    post_human_intervention_comment_and_label(
+        claimed_issue.issue["number"],
+        comment_body,
+        resumable=preservation_result_has_continuation_marker(preservation_result),
+    )
     return True
 
 
@@ -4507,7 +4546,11 @@ def apply_failed_run_follow_up(
         comment_body = None
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
-    post_human_intervention_comment_and_label(claimed_issue.issue["number"], comment_body)
+    post_human_intervention_comment_and_label(
+        claimed_issue.issue["number"],
+        comment_body,
+        resumable=preservation_result_has_continuation_marker(preservation_result),
+    )
 
 
 def dynamic_access_chunk_class_threshold() -> int:
@@ -5805,6 +5848,15 @@ def claim_issue_for_processing(
         issue_coordinates,
         base_reachability_metadata_path,
     )
+    if issue_is_resumable(issue) and continuation_marker is None:
+        log_stage(
+            "continuation",
+            (
+                f"Skipping issue #{issue['number']}: label '{LABEL_RESUMABLE}' is present, "
+                "but no valid continuation marker was found on a preserved branch."
+            ),
+        )
+        return None
     try:
         chunked_exhaust_report = resolve_chunked_dynamic_access_exhaust_report(
             issue,
@@ -6878,7 +6930,7 @@ def get_issue_claim_cache_observation_from_payload(
     issue_number = issue.get("number")
     if not isinstance(issue_number, int):
         return None
-    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
+    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION) and not issue_is_resumable(issue):
         return IssueClaimCacheObservation(
             issue_number=issue_number,
             reason=ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION,
@@ -7071,7 +7123,7 @@ def get_issue_claim_preflights(
 
 def issue_needs_claim_preflight(issue: dict, authenticated_user: str | None = None) -> bool:
     """Return True when an issue needs GraphQL preflight before claim attempts."""
-    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION):
+    if issue_has_label(issue, LABEL_HUMAN_INTERVENTION) and not issue_is_resumable(issue):
         return False
     if issue_has_label(issue, LABEL_NOT_FOR_NATIVE_IMAGE):
         return False
@@ -7120,9 +7172,15 @@ def should_skip_issue_from_preflight(
         and cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_IN_PROGRESS
         and issue_has_label(issue, LABEL_CHUNKED_DYNAMIC_ACCESS)
     )
+    cached_human_intervention_now_resumable = (
+        cached_skip is not None
+        and cached_skip.reason == ISSUE_CLAIM_CACHE_REASON_HUMAN_INTERVENTION
+        and issue_is_resumable(issue)
+    )
     if (
             cached_skip is not None
             and not cached_chunked_issue_in_progress
+            and not cached_human_intervention_now_resumable
             and cached_skip_blocks_authenticated_user(cached_skip, authenticated_user, take_blocked_issues)
     ):
         return True

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -69,6 +69,20 @@ def _record_publication_pushed(
     active_marker.save(marker_path)
 
 
+def _record_publication_branch(
+        repo_path: str,
+        branch: str,
+        marker: ContinuationMarker | None = None,
+) -> None:
+    """Record the branch namespace before publication reaches the push."""
+    marker_path = continuation_marker_path(repo_path)
+    active_marker = marker or load_continuation_marker(marker_path)
+    if active_marker is None:
+        return
+    active_marker.record_publication_branch(branch)
+    active_marker.save(marker_path)
+
+
 def _is_preservation_only_path(path: str) -> bool:
     """Return True for files that belong only on failed-run preservation branches."""
     normalized_path = path.replace(os.sep, "/")
@@ -125,14 +139,21 @@ def _remove_preservation_only_files(repo_path: str) -> None:
             shutil.rmtree(absolute_directory)
 
 
-def _prepare_unpushed_publication_resume_branch(repo_path: str, branch: str, base_ref: str) -> None:
+def _prepare_unpushed_publication_resume_branch(
+        repo_path: str,
+        branch: str,
+        base_ref: str,
+        marker: ContinuationMarker,
+) -> None:
     """Create a PR branch from base and replay only non-preservation run commits."""
     preserved_head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
     commits = _non_preservation_commits(repo_path, base_ref, preserved_head)
     subprocess.run(["git", "switch", "-C", branch, base_ref], check=True, cwd=repo_path)
+    _record_publication_branch(repo_path, branch, marker)
     for commit in commits:
         subprocess.run(["git", "cherry-pick", commit], check=True, cwd=repo_path)
     _remove_preservation_only_files(repo_path)
+    _record_publication_branch(repo_path, branch, marker)
 
 
 def publish_branch(
@@ -163,13 +184,16 @@ def publish_branch(
         )
 
     base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
-    branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
+    branch = None if resume_marker is None else resume_marker.publication_branch()
+    if branch is None:
+        branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
+    _record_publication_branch(repo_path, branch, resume_marker)
     delete_remote_branch_if_exists(branch, cwd=repo_path)
     if resume_marker is None:
         subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
         _remove_preservation_only_files(repo_path)
     else:
-        _prepare_unpushed_publication_resume_branch(repo_path, branch, base_ref)
+        _prepare_unpushed_publication_resume_branch(repo_path, branch, base_ref, resume_marker)
     stage()
     if before_rebase is not None:
         before_rebase()

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -27,10 +27,112 @@ from utility_scripts.local_ci_verification import (
     fetch_pr_base_ref,
     run_local_ci_verification,
 )
+from utility_scripts.continuation_marker import (
+    CONTINUATION_MARKER_FILENAME,
+    PHASE_PUBLICATION,
+    ContinuationMarker,
+    continuation_marker_path,
+    load_continuation_marker,
+)
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
 
 REPO: str = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH: str = "master"
 REVIEWERS: list[str] = get_configured_reviewers()
+PRESERVATION_ONLY_PATHS: set[str] = {
+    f"forge/{CONTINUATION_MARKER_FILENAME}",
+    f"forge/{PENDING_METRICS_FILENAME}",
+}
+PRESERVATION_ONLY_DIRECTORIES: tuple[str, ...] = ("forge/human-intervention-logs",)
+PRESERVATION_ONLY_PREFIXES: tuple[str, ...] = ("forge/human-intervention-logs/",)
+
+
+def _publication_resume_marker(repo_path: str) -> ContinuationMarker | None:
+    """Return the publication continuation marker when this run resumes publication."""
+    marker = load_continuation_marker(continuation_marker_path(repo_path))
+    if marker is None or marker.continue_from != PHASE_PUBLICATION:
+        return None
+    return marker
+
+
+def _record_publication_pushed(
+        repo_path: str,
+        branch: str,
+        marker: ContinuationMarker | None = None,
+) -> None:
+    """Record the push boundary in the continuation marker if one exists."""
+    marker_path = continuation_marker_path(repo_path)
+    active_marker = marker or load_continuation_marker(marker_path)
+    if active_marker is None:
+        return
+    active_marker.record_publication_pushed(branch)
+    active_marker.save(marker_path)
+
+
+def _is_preservation_only_path(path: str) -> bool:
+    """Return True for files that belong only on failed-run preservation branches."""
+    normalized_path = path.replace(os.sep, "/")
+    return (
+        normalized_path in PRESERVATION_ONLY_PATHS
+        or any(normalized_path.startswith(prefix) for prefix in PRESERVATION_ONLY_PREFIXES)
+    )
+
+
+def _commit_touched_paths(repo_path: str, commit: str) -> set[str]:
+    """Return paths touched by one commit."""
+    output = subprocess.check_output(
+        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", commit],
+        cwd=repo_path,
+        text=True,
+    )
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def _non_preservation_commits(repo_path: str, base_ref: str, head_ref: str) -> list[str]:
+    """Return commits to replay while excluding preservation-only wrapper commits."""
+    output = subprocess.check_output(
+        ["git", "rev-list", "--reverse", f"{base_ref}..{head_ref}"],
+        cwd=repo_path,
+        text=True,
+    )
+    commits: list[str] = []
+    for commit in [line.strip() for line in output.splitlines() if line.strip()]:
+        touched_paths = _commit_touched_paths(repo_path, commit)
+        if touched_paths and all(_is_preservation_only_path(path) for path in touched_paths):
+            continue
+        commits.append(commit)
+    return commits
+
+
+def _remove_preservation_only_files(repo_path: str) -> None:
+    """Remove files that are tracked only on failed-run preservation branches."""
+    paths: list[str] = sorted(PRESERVATION_ONLY_PATHS)
+    pathspecs = [*paths, *PRESERVATION_ONLY_DIRECTORIES]
+    tracked_paths = subprocess.check_output(
+        ["git", "ls-files", "--", *pathspecs],
+        cwd=repo_path,
+        text=True,
+    ).splitlines()
+    if tracked_paths:
+        subprocess.run(["git", "rm", "-f", "-q", "--", *tracked_paths], cwd=repo_path, check=True)
+    for path in paths:
+        absolute_path = os.path.join(repo_path, path)
+        if os.path.isfile(absolute_path):
+            os.remove(absolute_path)
+    for directory in PRESERVATION_ONLY_DIRECTORIES:
+        absolute_directory = os.path.join(repo_path, directory)
+        if os.path.isdir(absolute_directory):
+            shutil.rmtree(absolute_directory)
+
+
+def _prepare_unpushed_publication_resume_branch(repo_path: str, branch: str, base_ref: str) -> None:
+    """Create a PR branch from base and replay only non-preservation run commits."""
+    preserved_head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+    commits = _non_preservation_commits(repo_path, base_ref, preserved_head)
+    subprocess.run(["git", "switch", "-C", branch, base_ref], check=True, cwd=repo_path)
+    for commit in commits:
+        subprocess.run(["git", "cherry-pick", commit], check=True, cwd=repo_path)
+    _remove_preservation_only_files(repo_path)
 
 
 def publish_branch(
@@ -50,13 +152,27 @@ def publish_branch(
     assertions. Local CI-equivalent verification always runs before the push
     that makes the branch PR-eligible (§GIT-pr-eligibility).
     """
+    resume_marker = _publication_resume_marker(repo_path)
+    resume_branch = None if resume_marker is None or not resume_marker.publication_is_pushed() else resume_marker.publication_branch()
+    if resume_branch is not None:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
+        return resume_branch, LocalCIVerificationResult(
+            status="skipped-publication-resume",
+            base_commit=commit,
+            final_commit=commit,
+        )
+
+    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
     branch = build_ai_branch_name(branch_suffix, cwd=repo_path)
     delete_remote_branch_if_exists(branch, cwd=repo_path)
-    subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
+    if resume_marker is None:
+        subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
+        _remove_preservation_only_files(repo_path)
+    else:
+        _prepare_unpushed_publication_resume_branch(repo_path, branch, base_ref)
     stage()
     if before_rebase is not None:
         before_rebase()
-    base_ref = fetch_pr_base_ref(repo_path, REPO, BASE_BRANCH)
     subprocess.run(["git", "rebase", base_ref], check=True, cwd=repo_path)
     local_ci_verification = run_local_ci_verification(
         repo_path=repo_path,
@@ -67,6 +183,7 @@ def publish_branch(
     if after_verification is not None:
         after_verification()
     run_git_transport(["push", "origin", branch], cwd=repo_path)
+    _record_publication_pushed(repo_path, branch, resume_marker)
     return branch, local_ci_verification
 
 

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -118,6 +118,12 @@ def _non_preservation_commits(repo_path: str, base_ref: str, head_ref: str) -> l
     return commits
 
 
+def _has_staged_changes(repo_path: str) -> bool:
+    """Return True when the index contains changes ready to commit."""
+    result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, check=False)
+    return result.returncode != 0
+
+
 def _remove_preservation_only_files(repo_path: str) -> None:
     """Remove files that are tracked only on failed-run preservation branches."""
     paths: list[str] = sorted(PRESERVATION_ONLY_PATHS)
@@ -139,6 +145,13 @@ def _remove_preservation_only_files(repo_path: str) -> None:
             shutil.rmtree(absolute_directory)
 
 
+def _commit_preservation_artifact_clearance(repo_path: str) -> None:
+    """Commit removal of resume helper artifacts when publication resumes."""
+    _remove_preservation_only_files(repo_path)
+    if _has_staged_changes(repo_path):
+        subprocess.run(["git", "commit", "-m", "Clear resume helper artifacts"], check=True, cwd=repo_path)
+
+
 def _prepare_unpushed_publication_resume_branch(
         repo_path: str,
         branch: str,
@@ -152,7 +165,7 @@ def _prepare_unpushed_publication_resume_branch(
     _record_publication_branch(repo_path, branch, marker)
     for commit in commits:
         subprocess.run(["git", "cherry-pick", commit], check=True, cwd=repo_path)
-    _remove_preservation_only_files(repo_path)
+    _commit_preservation_artifact_clearance(repo_path)
     _record_publication_branch(repo_path, branch, marker)
 
 

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -44,7 +44,6 @@ PRESERVATION_ONLY_PATHS: set[str] = {
     f"forge/{PENDING_METRICS_FILENAME}",
 }
 PRESERVATION_ONLY_DIRECTORIES: tuple[str, ...] = ("forge/human-intervention-logs",)
-PRESERVATION_ONLY_PREFIXES: tuple[str, ...] = ("forge/human-intervention-logs/",)
 
 
 def _publication_resume_marker(repo_path: str) -> ContinuationMarker | None:
@@ -81,41 +80,6 @@ def _record_publication_branch(
         return
     active_marker.record_publication_branch(branch)
     active_marker.save(marker_path)
-
-
-def _is_preservation_only_path(path: str) -> bool:
-    """Return True for files that belong only on failed-run preservation branches."""
-    normalized_path = path.replace(os.sep, "/")
-    return (
-        normalized_path in PRESERVATION_ONLY_PATHS
-        or any(normalized_path.startswith(prefix) for prefix in PRESERVATION_ONLY_PREFIXES)
-    )
-
-
-def _commit_touched_paths(repo_path: str, commit: str) -> set[str]:
-    """Return paths touched by one commit."""
-    output = subprocess.check_output(
-        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", commit],
-        cwd=repo_path,
-        text=True,
-    )
-    return {line.strip() for line in output.splitlines() if line.strip()}
-
-
-def _non_preservation_commits(repo_path: str, base_ref: str, head_ref: str) -> list[str]:
-    """Return commits to replay while excluding preservation-only wrapper commits."""
-    output = subprocess.check_output(
-        ["git", "rev-list", "--reverse", f"{base_ref}..{head_ref}"],
-        cwd=repo_path,
-        text=True,
-    )
-    commits: list[str] = []
-    for commit in [line.strip() for line in output.splitlines() if line.strip()]:
-        touched_paths = _commit_touched_paths(repo_path, commit)
-        if touched_paths and all(_is_preservation_only_path(path) for path in touched_paths):
-            continue
-        commits.append(commit)
-    return commits
 
 
 def _has_staged_changes(repo_path: str) -> bool:
@@ -155,16 +119,11 @@ def _commit_preservation_artifact_clearance(repo_path: str) -> None:
 def _prepare_unpushed_publication_resume_branch(
         repo_path: str,
         branch: str,
-        base_ref: str,
         marker: ContinuationMarker,
 ) -> None:
-    """Create a PR branch from base and replay only non-preservation run commits."""
-    preserved_head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_path, text=True).strip()
-    commits = _non_preservation_commits(repo_path, base_ref, preserved_head)
-    subprocess.run(["git", "switch", "-C", branch, base_ref], check=True, cwd=repo_path)
+    """Create the PR branch from the resumed preserved branch and clear helpers."""
+    subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
     _record_publication_branch(repo_path, branch, marker)
-    for commit in commits:
-        subprocess.run(["git", "cherry-pick", commit], check=True, cwd=repo_path)
     _commit_preservation_artifact_clearance(repo_path)
     _record_publication_branch(repo_path, branch, marker)
 
@@ -206,7 +165,7 @@ def publish_branch(
         subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
         _remove_preservation_only_files(repo_path)
     else:
-        _prepare_unpushed_publication_resume_branch(repo_path, branch, base_ref, resume_marker)
+        _prepare_unpushed_publication_resume_branch(repo_path, branch, resume_marker)
     stage()
     if before_rebase is not None:
         before_rebase()

--- a/forge/schemas/continuation_marker_schema.json
+++ b/forge/schemas/continuation_marker_schema.json
@@ -26,6 +26,42 @@
         "null"
       ]
     },
+    "libraryUpdateRoute": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "baseline_coordinates": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "new_version": {
+              "type": "string"
+            },
+            "selected_driver": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "selected_driver",
+            "baseline_coordinates",
+            "new_version"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "libraryPreparationPreflight": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "phases": {
       "additionalProperties": false,
       "properties": {

--- a/forge/schemas/continuation_marker_schema.json
+++ b/forge/schemas/continuation_marker_schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "continueFrom": {
+      "enum": [
+        "setup",
+        "fix",
+        "explore",
+        "finalization",
+        "publication"
+      ]
+    },
+    "coordinate": {
+      "type": "string"
+    },
+    "issueNumber": {
+      "type": "integer"
+    },
+    "label": {
+      "type": "string"
+    },
+    "newVersion": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "phases": {
+      "additionalProperties": false,
+      "properties": {
+        "explore": {
+          "$ref": "#/$defs/phase"
+        },
+        "finalization": {
+          "$ref": "#/$defs/phase"
+        },
+        "fix": {
+          "$ref": "#/$defs/phase"
+        },
+        "publication": {
+          "$ref": "#/$defs/phase"
+        },
+        "setup": {
+          "$ref": "#/$defs/phase"
+        }
+      },
+      "required": [
+        "setup",
+        "fix",
+        "explore",
+        "finalization",
+        "publication"
+      ],
+      "type": "object"
+    },
+    "preservedBranch": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "strategyName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "continueFrom",
+    "preservedBranch",
+    "strategyName",
+    "issueNumber",
+    "label",
+    "coordinate",
+    "newVersion",
+    "phases"
+  ],
+  "type": "object",
+  "$defs": {
+    "phase": {
+      "additionalProperties": true,
+      "properties": {
+        "status": {
+          "enum": [
+            "pending",
+            "running",
+            "completed",
+            "skipped"
+          ]
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -193,14 +193,24 @@ class ContinuationMarker:
         phase.update(fields)
         self.recompute_continue_from()
 
+    def mark_phase_skipped_if_pending(self, phase_name: str, **fields: Any) -> None:
+        """Mark a phase skipped only when no workflow has already claimed it."""
+        phase = self._phase(phase_name)
+        if phase.get("status") == STATUS_PENDING:
+            phase["status"] = STATUS_SKIPPED
+        phase.update(fields)
+        self.recompute_continue_from()
+
     def mark_setup_preflight_done(self) -> None:
         """Record the setup preflight sub-step."""
         self._phase(PHASE_SETUP)["preflightDone"] = True
         self.recompute_continue_from()
 
-    def mark_setup_done(self) -> None:
+    def mark_setup_done(self, skip_fix_phase: bool = False) -> None:
         """Record completed deterministic setup."""
         self.mark_phase_completed(PHASE_SETUP, preflightDone=True, setupDone=True)
+        if skip_fix_phase:
+            self.mark_phase_skipped_if_pending(PHASE_FIX)
 
     def record_iteration(self, phase_name: str, iteration: int | None) -> None:
         """Record the latest logical iteration for a continuous phase."""

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -1,0 +1,258 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Durable run-continuation marker for failed Forge issue runs."""
+
+import json
+import os
+from dataclasses import dataclass, field
+from collections.abc import Callable
+from typing import Any
+
+CONTINUATION_MARKER_FILENAME = ".continuation-marker.json"
+SCHEMA_VERSION = 1
+
+PHASE_SETUP = "setup"
+PHASE_FIX = "fix"
+PHASE_EXPLORE = "explore"
+PHASE_FINALIZATION = "finalization"
+PHASE_PUBLICATION = "publication"
+ORDERED_PHASES = [PHASE_SETUP, PHASE_FIX, PHASE_EXPLORE, PHASE_FINALIZATION, PHASE_PUBLICATION]
+
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_COMPLETED = "completed"
+STATUS_SKIPPED = "skipped"
+TERMINAL_PHASE_STATUSES = {STATUS_COMPLETED, STATUS_SKIPPED}
+
+
+def continuation_marker_path(repo_path: str) -> str:
+    """Return the Forge-local continuation marker path for a reachability checkout."""
+    return os.path.join(repo_path, "forge", CONTINUATION_MARKER_FILENAME)
+
+
+def find_continuation_marker_path(repo_path: str) -> str | None:
+    """Return the Forge-local continuation marker path when it exists."""
+    path = continuation_marker_path(repo_path)
+    return path if os.path.isfile(path) else None
+
+
+def load_continuation_marker(path: str | None) -> "ContinuationMarker | None":
+    """Load a marker if the path exists."""
+    if not path or not os.path.isfile(path):
+        return None
+    return ContinuationMarker.load(path)
+
+
+def _default_phases() -> dict[str, dict[str, Any]]:
+    return {
+        PHASE_SETUP: {"status": STATUS_PENDING, "preflightDone": False, "setupDone": False},
+        PHASE_FIX: {"status": STATUS_PENDING, "iteration": None},
+        PHASE_EXPLORE: {"status": STATUS_PENDING, "exhaustedClasses": []},
+        PHASE_FINALIZATION: {"status": STATUS_PENDING},
+        PHASE_PUBLICATION: {"status": STATUS_PENDING, "isPushed": False, "branch": None},
+    }
+
+
+@dataclass
+class ContinuationMarker:
+    """Machine-readable state needed to resume a failed Forge run.
+
+    The marker stores only logical state that cannot be reconstructed from the
+    preserved branch HEAD, following the continuation contract
+    (§FS-forge-run-continuation.2).
+    """
+
+    continue_from: str
+    preserved_branch: str | None
+    strategy_name: str
+    issue_number: int
+    label: str
+    coordinate: str
+    new_version: str | None
+    phases: dict[str, dict[str, Any]] = field(default_factory=_default_phases)
+    schema_version: int = SCHEMA_VERSION
+
+    @classmethod
+    def create(
+            cls,
+            *,
+            strategy_name: str,
+            issue_number: int,
+            label: str,
+            coordinate: str,
+            new_version: str | None,
+    ) -> "ContinuationMarker":
+        """Create a fresh marker for a claimed issue run."""
+        marker = cls(
+            continue_from=PHASE_SETUP,
+            preserved_branch=None,
+            strategy_name=strategy_name,
+            issue_number=issue_number,
+            label=label,
+            coordinate=coordinate,
+            new_version=new_version,
+        )
+        marker.recompute_continue_from()
+        return marker
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ContinuationMarker":
+        """Build a marker from its JSON payload."""
+        if int(payload.get("schemaVersion", 0)) != SCHEMA_VERSION:
+            raise ValueError(f"Unsupported continuation marker schemaVersion: {payload.get('schemaVersion')}")
+        phases = _default_phases()
+        for phase_name, phase_payload in dict(payload.get("phases", {})).items():
+            if phase_name in phases and isinstance(phase_payload, dict):
+                phases[phase_name].update(phase_payload)
+        marker = cls(
+            continue_from=str(payload["continueFrom"]),
+            preserved_branch=payload.get("preservedBranch"),
+            strategy_name=str(payload["strategyName"]),
+            issue_number=int(payload["issueNumber"]),
+            label=str(payload["label"]),
+            coordinate=str(payload["coordinate"]),
+            new_version=payload.get("newVersion"),
+            phases=phases,
+            schema_version=SCHEMA_VERSION,
+        )
+        marker.recompute_continue_from()
+        return marker
+
+    @classmethod
+    def load(cls, path: str) -> "ContinuationMarker":
+        """Load a marker from JSON."""
+        with open(path, "r", encoding="utf-8") as marker_file:
+            return cls.from_dict(json.load(marker_file))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable marker payload."""
+        self.recompute_continue_from()
+        return {
+            "schemaVersion": self.schema_version,
+            "continueFrom": self.continue_from,
+            "preservedBranch": self.preserved_branch,
+            "strategyName": self.strategy_name,
+            "issueNumber": self.issue_number,
+            "label": self.label,
+            "coordinate": self.coordinate,
+            "newVersion": self.new_version,
+            "phases": self.phases,
+        }
+
+    def save(self, path: str) -> None:
+        """Write the marker to JSON."""
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as marker_file:
+            json.dump(self.to_dict(), marker_file, indent=2, sort_keys=True)
+            marker_file.write("\n")
+
+    def recompute_continue_from(self) -> str:
+        """Refresh and return the first non-terminal phase."""
+        for phase_name in ORDERED_PHASES:
+            status = str(self.phases.get(phase_name, {}).get("status") or STATUS_PENDING)
+            if status not in TERMINAL_PHASE_STATUSES:
+                self.continue_from = phase_name
+                return self.continue_from
+        self.continue_from = PHASE_PUBLICATION
+        return self.continue_from
+
+    def mark_phase_running(self, phase_name: str, **fields: Any) -> None:
+        """Mark a phase as entered and update phase-local fields."""
+        phase = self._phase(phase_name)
+        phase["status"] = STATUS_RUNNING
+        phase.update(fields)
+        self.recompute_continue_from()
+
+    def mark_phase_completed(self, phase_name: str, **fields: Any) -> None:
+        """Mark a phase complete and update phase-local fields."""
+        phase = self._phase(phase_name)
+        phase["status"] = STATUS_COMPLETED
+        phase.update(fields)
+        self.recompute_continue_from()
+
+    def mark_phase_pending(self, phase_name: str, **fields: Any) -> None:
+        """Mark a phase as pending after an incomplete transition."""
+        phase = self._phase(phase_name)
+        phase["status"] = STATUS_PENDING
+        phase.update(fields)
+        self.recompute_continue_from()
+
+    def mark_phase_skipped(self, phase_name: str, **fields: Any) -> None:
+        """Mark a phase as intentionally skipped."""
+        phase = self._phase(phase_name)
+        phase["status"] = STATUS_SKIPPED
+        phase.update(fields)
+        self.recompute_continue_from()
+
+    def mark_setup_preflight_done(self) -> None:
+        """Record the setup preflight sub-step."""
+        self._phase(PHASE_SETUP)["preflightDone"] = True
+        self.recompute_continue_from()
+
+    def mark_setup_done(self) -> None:
+        """Record completed deterministic setup."""
+        self.mark_phase_completed(PHASE_SETUP, preflightDone=True, setupDone=True)
+
+    def record_iteration(self, phase_name: str, iteration: int | None) -> None:
+        """Record the latest logical iteration for a continuous phase."""
+        if phase_name not in {PHASE_FIX, PHASE_EXPLORE}:
+            return
+        self._phase(phase_name)["iteration"] = iteration
+        self.recompute_continue_from()
+
+    def record_exhausted_classes(self, exhausted_classes: list[str]) -> None:
+        """Record dynamic-access classes that a fresh report cannot reconstruct."""
+        self._phase(PHASE_EXPLORE)["exhaustedClasses"] = sorted(set(exhausted_classes))
+        self.recompute_continue_from()
+
+    def record_preserved_branch(self, branch_name: str) -> None:
+        """Record the preservation branch that carries this marker."""
+        self.preserved_branch = branch_name
+
+    def record_publication_branch(self, branch_name: str) -> None:
+        """Record the branch that publication should use."""
+        self._phase(PHASE_PUBLICATION)["branch"] = branch_name
+        self.recompute_continue_from()
+
+    def record_publication_pushed(self, branch_name: str) -> None:
+        """Record that publication pushed the PR branch."""
+        self._phase(PHASE_PUBLICATION).update({
+            "status": STATUS_PENDING,
+            "isPushed": True,
+            "branch": branch_name,
+        })
+        self.recompute_continue_from()
+
+    def mark_publication_completed(self, branch_name: str | None = None) -> None:
+        """Record that PR creation reached the terminal publication point."""
+        fields: dict[str, Any] = {}
+        if branch_name:
+            fields["branch"] = branch_name
+        self.mark_phase_completed(PHASE_PUBLICATION, **fields)
+
+    def publication_is_pushed(self) -> bool:
+        """Return True when resume should skip the push and only find-or-create the PR."""
+        phase = self._phase(PHASE_PUBLICATION)
+        return bool(phase.get("isPushed")) and bool(phase.get("branch"))
+
+    def publication_branch(self) -> str | None:
+        """Return the recorded publication branch."""
+        branch = self._phase(PHASE_PUBLICATION).get("branch")
+        return str(branch) if branch else None
+
+    def _phase(self, phase_name: str) -> dict[str, Any]:
+        if phase_name not in self.phases:
+            raise ValueError(f"Unknown continuation phase: {phase_name}")
+        return self.phases[phase_name]
+
+
+def save_phase_update(path: str | None, update: Callable[[ContinuationMarker], None]) -> None:
+    """Load, mutate, and save a marker when continuation is active."""
+    marker = load_continuation_marker(path)
+    if marker is None:
+        return
+    update(marker)
+    marker.save(path)

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -72,6 +72,8 @@ class ContinuationMarker:
     label: str
     coordinate: str
     new_version: str | None
+    library_update_route: dict[str, Any] | None = None
+    library_preparation_preflight: dict[str, Any] | None = None
     phases: dict[str, dict[str, Any]] = field(default_factory=_default_phases)
     schema_version: int = SCHEMA_VERSION
 
@@ -115,6 +117,8 @@ class ContinuationMarker:
             label=str(payload["label"]),
             coordinate=str(payload["coordinate"]),
             new_version=payload.get("newVersion"),
+            library_update_route=_optional_dict(payload.get("libraryUpdateRoute")),
+            library_preparation_preflight=_optional_dict(payload.get("libraryPreparationPreflight")),
             phases=phases,
             schema_version=SCHEMA_VERSION,
         )
@@ -139,6 +143,8 @@ class ContinuationMarker:
             "label": self.label,
             "coordinate": self.coordinate,
             "newVersion": self.new_version,
+            "libraryUpdateRoute": self.library_update_route,
+            "libraryPreparationPreflight": self.library_preparation_preflight,
             "phases": self.phases,
         }
 
@@ -212,6 +218,16 @@ class ContinuationMarker:
         """Record the preservation branch that carries this marker."""
         self.preserved_branch = branch_name
 
+    def record_library_update_route(self, route_payload: dict[str, Any]) -> None:
+        """Record the selected library-update route for publication resume."""
+        self.library_update_route = dict(route_payload)
+        self.recompute_continue_from()
+
+    def record_library_preparation_preflight(self, preflight_payload: dict[str, Any]) -> None:
+        """Record dispatcher preflight output for continuation resume."""
+        self.library_preparation_preflight = dict(preflight_payload)
+        self.recompute_continue_from()
+
     def record_publication_branch(self, branch_name: str) -> None:
         """Record the branch that publication should use."""
         self._phase(PHASE_PUBLICATION)["branch"] = branch_name
@@ -256,3 +272,9 @@ def save_phase_update(path: str | None, update: Callable[[ContinuationMarker], N
         return
     update(marker)
     marker.save(path)
+
+
+def _optional_dict(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    return None

--- a/forge/utility_scripts/fixture_github.py
+++ b/forge/utility_scripts/fixture_github.py
@@ -83,6 +83,8 @@ class FixtureIssue:
     project_status: str
     blockers: list[int]
     comments: list[FixtureComment]
+    continuation_marker: JsonObject | None
+    worktree_files: dict[str, str]
     fixture_path: str
     url: str
 
@@ -130,6 +132,10 @@ class FixtureIssue:
             "comments": [comment.to_json() for comment in self.comments],
             "fixture_path": self.fixture_path,
         }
+        if self.continuation_marker is not None:
+            payload["continuation_marker"] = dict(self.continuation_marker)
+        if self.worktree_files:
+            payload["worktree_files"] = dict(self.worktree_files)
         return payload
 
 
@@ -314,6 +320,8 @@ class FixtureGitHubState:
             _log_fixture_setup(
                 f"Fixture issue #{issue.number}: no issue-specific workspace cleanup requested."
             )
+        self._prepare_worktree_files(issue, worktree_path)
+        self._prepare_continuation_marker(issue, worktree_path)
 
     def _iter_open_issues(self) -> list[FixtureIssue]:
         return [
@@ -451,6 +459,37 @@ class FixtureGitHubState:
             f"Index={_repo_relative_path(index_json_path, worktree_path)}, "
             f"version paths={_format_cleaned_path_summary(cleaned_paths)}."
         )
+
+    def _prepare_continuation_marker(self, issue: FixtureIssue, worktree_path: str) -> None:
+        """Write the fixture-provided run-continuation marker into the worktree."""
+        if issue.continuation_marker is None:
+            return
+        marker_path = os.path.join(worktree_path, "forge", ".continuation-marker.json")
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w", encoding="utf-8") as marker_file:
+            json.dump(issue.continuation_marker, marker_file, indent=2, sort_keys=True)
+            marker_file.write("\n")
+        _log_fixture_setup(
+            f"Fixture issue #{issue.number}: wrote continuation marker "
+            f"{_repo_relative_path(marker_path, worktree_path)}."
+        )
+
+    def _prepare_worktree_files(self, issue: FixtureIssue, worktree_path: str) -> None:
+        """Write fixture-declared files into the isolated issue worktree."""
+        for relative_path, content in issue.worktree_files.items():
+            normalized_path = os.path.normpath(relative_path)
+            if os.path.isabs(normalized_path) or normalized_path == ".." or normalized_path.startswith("../"):
+                raise FixtureValidationError(
+                    f"Fixture issue #{issue.number}: invalid worktree file path: {relative_path}"
+                )
+            target_path = os.path.join(worktree_path, normalized_path)
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+            with open(target_path, "w", encoding="utf-8") as worktree_file:
+                worktree_file.write(content)
+            _log_fixture_setup(
+                f"Fixture issue #{issue.number}: wrote worktree file "
+                f"{_repo_relative_path(target_path, worktree_path)}."
+            )
 
 
 def load_fixture_github_state(fixture_paths: list[str] | None = None) -> FixtureGitHubState:
@@ -623,6 +662,10 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
     project_number, project_item_id, project_status = _normalize_project(issue, context)
     blockers = _normalize_blockers(issue, context)
     comments = _normalize_comments(_optional_list(issue, "comments", context, default=[]), context)
+    continuation_marker = _optional_mapping(issue, "continuation_marker", context)
+    if continuation_marker is None:
+        continuation_marker = _optional_mapping(issue, "continuationMarker", context)
+    worktree_files = _normalize_worktree_files(issue, context)
     url = _optional_str(issue, "url", context, default=f"fixture://fixture_github_issues/{number}")
     return FixtureIssue(
         number=number,
@@ -637,6 +680,8 @@ def normalize_fixture_issue(raw_issue: JsonObject, fixture_path: str) -> Fixture
         project_status=project_status,
         blockers=blockers,
         comments=comments,
+        continuation_marker=continuation_marker,
+        worktree_files=worktree_files,
         fixture_path=os.path.abspath(fixture_path),
         url=url,
     )
@@ -734,6 +779,33 @@ def _normalize_comments(raw_comments: list[Any], context: str) -> list[FixtureCo
     return comments
 
 
+def _normalize_worktree_files(issue: JsonObject, context: str) -> dict[str, str]:
+    raw_files = _optional_mapping(issue, "worktree_files", context)
+    if raw_files is None:
+        raw_files = _optional_mapping(issue, "worktreeFiles", context)
+    if raw_files is None:
+        return {}
+    files: dict[str, str] = {}
+    for raw_path, raw_content in raw_files.items():
+        if not isinstance(raw_path, str) or not raw_path:
+            raise FixtureValidationError(f"{context}: worktree file paths must be non-empty strings")
+        normalized_path = _normalize_worktree_file_path(raw_path, context)
+        if isinstance(raw_content, str):
+            content = raw_content
+        else:
+            content = json.dumps(raw_content, indent=2, sort_keys=True)
+            content += "\n"
+        files[normalized_path] = content
+    return files
+
+
+def _normalize_worktree_file_path(path: str, context: str) -> str:
+    normalized_path = os.path.normpath(path)
+    if os.path.isabs(normalized_path) or normalized_path == ".." or normalized_path.startswith("../"):
+        raise FixtureValidationError(f"{context}: invalid worktree file path: {path}")
+    return normalized_path
+
+
 def _issue_has_all_labels(issue: FixtureIssue, labels: list[str]) -> bool:
     return all(label in issue.labels for label in labels)
 
@@ -805,6 +877,15 @@ def _optional_list(mapping: JsonObject, key: str, context: str, default: list[An
     if not isinstance(value, list):
         raise FixtureValidationError(f"{context}: `{key}` must be a list")
     return value
+
+
+def _optional_mapping(mapping: JsonObject, key: str, context: str) -> JsonObject | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise FixtureValidationError(f"{context}: `{key}` must be an object")
+    return dict(value)
 
 
 def _is_int(value: Any) -> bool:

--- a/forge/utility_scripts/schema_validator.py
+++ b/forge/utility_scripts/schema_validator.py
@@ -20,6 +20,7 @@ SCHEMA_NAME_MAP = {
     "run_metrics_output": "run-metrics-output-schema-v1.0.1.json",
     "benchmark_run_metrics": "benchmark_run_metrics_schema.json",
     "benchmark_suite": "benchmark_suite_schema.json",
+    "continuation_marker": "continuation_marker_schema.json",
     "strategy": "strategy_schema.json",
 }
 
@@ -91,7 +92,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "schema_name",
-        choices=["run_metrics_output", "benchmark_run_metrics", "benchmark_suite", "strategy"],
+        choices=[
+            "run_metrics_output",
+            "benchmark_run_metrics",
+            "benchmark_suite",
+            "continuation_marker",
+            "strategy",
+        ],
         help="Schema alias to validate against.",
     )
     parser.add_argument("file_path", help="Path to the JSON file to validate.")

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -185,6 +185,24 @@ def populate_artifact_urls(reachability_repo_path: str, coordinate: str, agent_c
     log_stage("populate-artifact-urls", f"Artifact URLs populated for {coordinate}")
 
 
+def source_context_urls_available(
+        reachability_repo_path: str,
+        coordinate: str,
+        source_context_types: list[str],
+) -> bool:
+    """Return True when all requested source-context URL fields are already present."""
+    if not source_context_types:
+        return True
+    index_entry = load_index_entry(reachability_repo_path, coordinate)
+    _, _, requested_version = _coordinate_parts(coordinate)
+    for source_type in source_context_types:
+        field_name = SOURCE_CONTEXT_FIELD_BY_TYPE[source_type]
+        url = render_url_template(normalize_url_value(index_entry.get(field_name)), requested_version)
+        if url is None:
+            return False
+    return True
+
+
 def discover_artifact_metadata(
         reachability_repo_path: str,
         coordinate: str,


### PR DESCRIPTION
Closes #8486

## What this does

Forge could preserve a failed worktree for human intervention, but a later automated run still had to rediscover what had already happened. The decision here is to make preservation resumable only when Forge has explicit machine-readable state: the preserved branch carries `forge/.continuation-marker.json`, and the issue carries `resumable` as the scheduling gate. Plain `human-intervention` stays manual. That keeps old human-intervention issues from being accidentally retried while giving new preserved runs a precise resume path (§FS-forge-run-continuation, §FS-human-intervention-policy).

## Resume contract

The marker records the issue, strategy, coordinate, preserved branch, first non-terminal phase, and phase-local state. Drivers and strategies receive `--continuation-marker-path` and update the marker as setup, fix, explore, finalization, and publication progress.

| Phase | Resume behavior |
| --- | --- |
| `setup` | skips completed preflight/setup substeps and restores cached dispatcher state |
| `fix` | resumes from preserved worktree state and recorded iteration |
| `explore` | reruns exploration from the preserved tree while keeping exhausted classes from being retried |
| `finalization` | reruns finalization from preserved generated work |
| `publication` | skips the workflow driver and publishes from the preserved result; if the branch was already pushed, it resumes PR creation from that branch |

The marker and pending metrics are force-added only on failed-run preservation branches, so successful publication does not stage continuation internals (§GIT-pr-eligibility).

## Resumable issue selection

Resume activation now has a cheap label gate before any branch lookup:

- `human-intervention` alone remains blocked for manual follow-up.
- `human-intervention` + `resumable` may be claimed for continuation.
- If `resumable` is present but no valid marker can be found, Forge skips the issue instead of falling back to a clean run.

Forge no longer depends on parsing branch names from issue comment text. It derives the preserved branch prefix from recent comment authors and the deterministic branch shape:

```text
ai/<login>/human-intervention/issue-<issue>-<label>-<coordinate>-<8hex>
```

Matching remote branches are checked newest-first, and only a marker with the same issue number and pipeline label is accepted.

## Library-update resume state

`library-update-request` needed extra durable state because publication may run without invoking the workflow driver. The marker now stores the selected route and dispatcher preflight payload, while keeping the route schema intentionally small:

```yaml
libraryUpdateRoute:
  selected_driver: improve_library_coverage
  baseline_coordinates: null
  new_version: 3.13.0
```

`requested_coordinates` already lives in the marker coordinate, and probe diagnostics stay out of the persisted route. On improve-coverage resume, the driver reuses the preserved `.baseline-stats.json` instead of recomputing the baseline after generated work may already have changed the tree. It also skips artifact URL population when `index.json` already has the requested source-context URLs, while still preparing local source context for the current workspace.

## Fixture coverage

Fixture testing can now seed both a continuation marker and small preserved worktree files. The new `commons-net:commons-net:3.13.0` fixture starts from `explore`, restores the library-update route and preflight payload, and carries the cached baseline snapshot needed by improve-coverage resume.