### PR TITLE
Run metadata generation inside throwaway Incus VMs

### DIFF
--- a/forge/.gitignore
+++ b/forge/.gitignore
@@ -7,6 +7,7 @@ logs/
 fixture-e2e-logs/
 .pending_metrics.json
 .continuation-marker.json
+incus/forge.env
 
 ##############################
 ## Agent state

--- a/forge/README.md
+++ b/forge/README.md
@@ -104,18 +104,70 @@ and fails fast if anything is missing. The runner itself is tracked in
 §ROADMAP-forge-incus-vm-runner.
 §FS-forge-vm-isolated-execution §AR-forge-vm-runner-boundary
 
-### Install and initialize Incus (one-time, on the host)
+### Prepare the host (one-time)
+
+Forge never installs or configures Incus; do this once. Each step is a real
+prerequisite — VM support, networking, storage, and Docker coexistence — and
+`--incus` preflights the most important ones and fails fast if they are missing.
+
+**1. Incus with VM support.** `--incus` launches real virtual machines
+(`incus launch --vm`), which require QEMU and KVM (`/dev/kvm` present; the CPU
+must expose `vmx`/`svm`). Install both Incus and QEMU:
 
 ```console
-# Install Incus from your distribution's packages, then:
-sudo incus admin init --minimal          # storage pool + default network
+sudo apt install incus qemu-system-x86       # package names for Debian/Ubuntu
+# If Incus was already running when QEMU was installed, restart it so the daemon
+# detects the VM backend — otherwise launches fail with
+# "QEMU command not available for CPU architecture":
+sudo systemctl restart incus
+```
+
+**2. Initialize Incus and its bridge network.**
+
+```console
+sudo incus admin init --minimal          # storage pool + managed incusbr0 bridge
 sudo usermod -aG incus-admin "$USER"     # drive Incus without sudo; re-login to apply
 incus list                               # should print an empty table
+```
 
-# Apply the checked-in profile the runner launches every VM with:
+The checked-in profile attaches each VM's NIC to `incusbr0` (the bridge
+`init --minimal` creates); if your bridge has another name, edit the `eth0`
+device in `incus/forge.profile.yaml`.
+
+**3. Apply the Forge profile.**
+
+```console
 incus profile create forge
 incus profile edit forge < incus/forge.profile.yaml
 ```
+
+**4. Give the VMs room on disk.** The base image plus per-run VMs (GraalVM
+installs, Gradle caches, Docker images, native-image scratch) need tens of GB.
+If your root filesystem is small, put the Forge VMs on a roomier disk by creating
+a storage pool there and pointing the `forge` profile's root device at it:
+
+```console
+mkdir -p /path/on/big/disk/incus-storage
+incus storage create forge dir source=/path/on/big/disk/incus-storage
+incus profile device set forge root pool forge   # this machine only; the committed profile stays generic
+```
+
+This redirects only the per-run VMs; Incus's image cache and the published
+`forge-base` image still live under `/var/lib/incus` on the root filesystem, so
+keep some headroom there too.
+
+**5. If the host also runs Docker.** Docker sets the iptables `FORWARD` policy to
+`DROP`, which blocks the Incus bridge from reaching the internet — `apt`, the
+repo clone, and Docker pulls inside the VM all time out. Allow `incusbr0` through
+the Docker-managed chain:
+
+```console
+sudo iptables -I DOCKER-USER -i incusbr0 -j ACCEPT
+sudo iptables -I DOCKER-USER -o incusbr0 -j ACCEPT
+```
+
+These are runtime rules; persist them with your firewall manager (e.g.
+`iptables-persistent`) if you want them to survive a reboot.
 
 ### Build the base image (one-time, rebuilt only to refresh tooling)
 

--- a/forge/README.md
+++ b/forge/README.md
@@ -93,6 +93,67 @@ distribution cache under the system temp directory. Set
 `FORGE_GRADLE_USER_HOME` to override the full Gradle user home.
 §AR-forge-workflow-boundary
 
+## Isolated execution with Incus (optional)
+
+`forge_metadata.py --incus` runs each generation inside a fresh, single-use Incus
+VM instead of on the host, so generated tests that open windows, fill `/tmp`,
+write into `$HOME`, or start Docker containers cannot touch the operator's
+machine. Forge never installs or configures Incus: prepare the host once with the
+steps below, then pass `--incus`. With the flag set Forge preflights this setup
+and fails fast if anything is missing. The runner itself is tracked in
+§ROADMAP-forge-incus-vm-runner.
+§FS-forge-vm-isolated-execution §AR-forge-vm-runner-boundary
+
+### Install and initialize Incus (one-time, on the host)
+
+```console
+# Install Incus from your distribution's packages, then:
+sudo incus admin init --minimal          # storage pool + default network
+sudo usermod -aG incus-admin "$USER"     # drive Incus without sudo; re-login to apply
+incus list                               # should print an empty table
+```
+
+### Build the base image (one-time, rebuilt only to refresh tooling)
+
+The base image is a template the per-run VMs are launched from. It bakes in the
+expensive setup so each run reuses it instead of rebuilding it: GraalVM, Docker,
+warmed Gradle caches, and a reachability checkout.
+
+```console
+# Launch a Docker-capable builder VM (Debian 12 shown):
+incus launch images:debian/12 forge-build --vm -c security.secureboot=false
+incus exec forge-build -- bash -lc '
+  set -eux
+  apt-get update && apt-get install -y git curl docker.io
+  systemctl enable --now docker
+  # Install the GraalVM your strategies require and expose it on
+  # GRAALVM_HOME / PATH (see the Setup section above).
+  git clone https://github.com/oracle/graalvm-reachability-metadata.git ~/reachability
+  cd ~/reachability && ./gradlew --no-daemon help    # warm the Gradle caches
+'
+# Snapshot the prepared VM into a reusable base image, then drop the builder:
+incus stop forge-build
+incus publish forge-build --alias forge-base
+incus delete forge-build
+incus image list                         # "forge-base" should be listed
+```
+
+### Credentials and logs
+
+- Authenticate `gh` for the reachability repo on the host (`gh auth login`); the
+  runner injects those credentials into each VM at launch.
+- The runner mounts a per-run host directory into the VM and points the
+  configurable log destination (`FORGE_LOGS_DIR`) at it, so run logs land on the
+  host and survive VM teardown. Metrics and preserved-work branches leave over
+  the network, so they need no shared directory.
+
+### Run
+
+```console
+python3 forge_metadata.py --run-work-queues --incus
+./do-work.sh --incus                     # same flag, forwarded by the loop wrapper
+```
+
 ## Manual Workflows
 
 The top-level worker delegates to these lower-level entry points. Use them

--- a/forge/README.md
+++ b/forge/README.md
@@ -111,41 +111,75 @@ and fails fast if anything is missing. The runner itself is tracked in
 sudo incus admin init --minimal          # storage pool + default network
 sudo usermod -aG incus-admin "$USER"     # drive Incus without sudo; re-login to apply
 incus list                               # should print an empty table
+
+# Apply the checked-in profile the runner launches every VM with:
+incus profile create forge
+incus profile edit forge < incus/forge.profile.yaml
 ```
 
 ### Build the base image (one-time, rebuilt only to refresh tooling)
 
-The base image is a template the per-run VMs are launched from. It bakes in the
-expensive setup so each run reuses it instead of rebuilding it: GraalVM, Docker,
-warmed Gradle caches, and a reachability checkout.
+The base image is a read-only template the per-run VMs are launched from (via
+copy-on-write, so launching is cheap). It bakes in the expensive, generic,
+non-secret setup so each run reuses it instead of rebuilding it: GraalVM, Docker,
+warmed Gradle caches, and a reachability checkout at
+`/root/graalvm-reachability-metadata` (override with `FORGE_INCUS_REPO_PATH`).
+The image is built locally on each host and never shipped.
+
+First record your machine's VM environment. Copy the template and set the
+GraalVM homes generation needs — all of `GRAALVM_HOME`/`JAVA_HOME`,
+`GRAALVM_HOME_25_0`, and `GRAALVM_HOME_LATEST_EA` are required by Forge's
+pre-processing preflight — to your local installs. The build copies each
+referenced installation into the image so the VM matches local generation
+rather than downloading a separate version; `GRAALVM_HOME` and
+`GRAALVM_HOME_25_0` typically share one JDK 25 path, while
+`GRAALVM_HOME_LATEST_EA` is a distinct early-access build:
 
 ```console
-# Launch a Docker-capable builder VM (Debian 12 shown):
-incus launch images:debian/12 forge-build --vm -c security.secureboot=false
-incus exec forge-build -- bash -lc '
-  set -eux
-  apt-get update && apt-get install -y git curl docker.io
-  systemctl enable --now docker
-  # Install the GraalVM your strategies require and expose it on
-  # GRAALVM_HOME / PATH (see the Setup section above).
-  git clone https://github.com/oracle/graalvm-reachability-metadata.git ~/reachability
-  cd ~/reachability && ./gradlew --no-daemon help    # warm the Gradle caches
-'
-# Snapshot the prepared VM into a reusable base image, then drop the builder:
-incus stop forge-build
-incus publish forge-build --alias forge-base
-incus delete forge-build
-incus image list                         # "forge-base" should be listed
+cp incus/forge.env.example incus/forge.env
+$EDITOR incus/forge.env                   # set the GraalVM homes; add any generation vars
 ```
+
+`incus/build-base-image.sh` is the reproducible definition of the image. It
+launches a throwaway builder VM, copies in your local GraalVM, bakes
+`forge.env` into the VM's environment, provisions it, publishes the disk as the
+`forge-base` alias, and deletes the builder:
+
+```console
+./incus/build-base-image.sh
+incus image list forge-base              # "forge-base" should be listed
+```
+
+Everything `forge.env` defines becomes part of the VM's environment, so put any
+other variable a generation run needs there. Override any of `FORGE_INCUS_IMAGE`,
+`FORGE_INCUS_SOURCE_IMAGE`, `FORGE_INCUS_REPO_URL`, or `FORGE_INCUS_REPO_PATH` to
+target a different image alias, base OS, or checkout. Re-run the script to
+refresh the image when GraalVM, the checkout, or `forge.env` change.
 
 ### Credentials and logs
 
-- Authenticate `gh` for the reachability repo on the host (`gh auth login`); the
-  runner injects those credentials into each VM at launch.
-- The runner mounts a per-run host directory into the VM and points the
-  configurable log destination (`FORGE_LOGS_DIR`) at it, so run logs land on the
-  host and survive VM teardown. Metrics and preserved-work branches leave over
-  the network, so they need no shared directory.
+- Authenticate `gh` for the reachability repo on the host (`gh auth login`, or
+  export `GH_TOKEN`/`GITHUB_TOKEN`); the runner reads that token and seeds it
+  into each VM at launch with `gh auth login --with-token`.
+- The runner mounts a per-run host directory into each VM at `/forge-logs` and
+  points the configurable log destination (`FORGE_LOGS_DIR`) at it, so run logs
+  land on the host under `<logs-root>/issue-<number>` and survive VM teardown.
+  Metrics and preserved-work branches leave over the network, so they need no
+  shared directory.
+
+### Settings
+
+The runner reads these optional environment variables; defaults match the setup
+above.
+
+- `FORGE_INCUS_IMAGE` — base image alias (default `forge-base`).
+- `FORGE_INCUS_PROFILE` — profile applied at launch (default `forge`).
+- `FORGE_INCUS_REPO_PATH` — baked checkout path in the VM
+  (default `/root/graalvm-reachability-metadata`).
+- `FORGE_INCUS_LOGS_ROOT` — host directory holding the per-run log mounts
+  (default the Forge `logs/` root).
+- `FORGE_INCUS_LAUNCH_TIMEOUT` — seconds to wait for the VM guest agent
+  (default `300`).
 
 ### Run
 

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -26,6 +26,7 @@ REVIEW_LABEL="${FORGE_REVIEW_LABEL:-}"
 REVIEW_LIMIT="${FORGE_REVIEW_LIMIT:-1}"
 REVIEW_MODEL="${FORGE_REVIEW_MODEL:-gpt-5.4}"
 USER_REQUESTED_ONLY="${FORGE_USER_REQUESTED_ISSUES_ONLY:-0}"
+USE_INCUS="${FORGE_INCUS:-0}"
 WORK_STRATEGY_NAME="${FORGE_STRATEGY_NAME:-dynamic_access_main_sources_pi_gpt-5.5}"
 GITHUB_RATE_LIMIT_EXIT_CODE=75
 MAX_PARALLELISM=4
@@ -113,6 +114,10 @@ Options:
       Fetch only user-requested issue queue items by excluding configured
       automation and maintainer issue authors. Defaults to
       FORGE_USER_REQUESTED_ISSUES_ONLY, then 0.
+  --incus
+      Run each generation inside a fresh, single-use Incus VM instead of on the
+      host. Requires a host prepared per forge/README.md; Forge preflights and
+      fails fast if the setup is incomplete. Defaults to FORGE_INCUS, then off.
 
 Environment:
   DO_WORK_SLEEP_SECONDS
@@ -138,6 +143,9 @@ Environment:
   FORGE_USER_REQUESTED_ISSUES_ONLY
       Set to 1 to fetch only user-requested issue queue items, or 0 to process
       all eligible issue authors. Defaults to 0.
+  FORGE_INCUS
+      Set to 1 to run each generation inside a fresh, single-use Incus VM, or 0
+      to run on the host. Defaults to 0.
   FORGE_LIBRARY_REVIEW_LIMIT, FORGE_JAVAC_REVIEW_LIMIT, FORGE_JAVA_RUN_REVIEW_LIMIT,
   FORGE_NI_RUN_REVIEW_LIMIT, FORGE_BULK_UPDATE_REVIEW_LIMIT
       Override FORGE_REVIEW_LIMIT for one default review queue.
@@ -389,6 +397,7 @@ export_work_configuration() {
     export FORGE_REVIEW_LIMIT="$REVIEW_LIMIT"
     export FORGE_REVIEW_MODEL="$REVIEW_MODEL"
     export FORGE_USER_REQUESTED_ISSUES_ONLY="$USER_REQUESTED_ONLY"
+    export FORGE_INCUS="$USE_INCUS"
 
     if [[ -n "$REVIEW_LABEL" ]]; then
         export FORGE_REVIEW_LABEL="$REVIEW_LABEL"
@@ -403,6 +412,9 @@ process_work_queues() {
         "--parallelism"
         "$PARALLELISM"
     )
+    if [[ "$USE_INCUS" == "1" ]]; then
+        forge_metadata_args+=("--incus")
+    fi
 
     run_step "Processing configured work queues via forge_metadata." \
         "$PYTHON_BIN" "$SCRIPT_DIR/forge_metadata.py" "${forge_metadata_args[@]}"
@@ -543,6 +555,10 @@ while [[ "$#" -gt 0 ]]; do
             USER_REQUESTED_ONLY=1
             shift
             ;;
+        --incus)
+            USE_INCUS=1
+            shift
+            ;;
         --)
             shift
             if [[ "$#" -gt 1 || -n "$BRANCH_ARG" ]]; then
@@ -629,6 +645,11 @@ fi
 
 if [[ "$USER_REQUESTED_ONLY" != "0" && "$USER_REQUESTED_ONLY" != "1" ]]; then
     echo "FORGE_USER_REQUESTED_ISSUES_ONLY must be 0 or 1." >&2
+    exit 1
+fi
+
+if [[ "$USE_INCUS" != "0" && "$USE_INCUS" != "1" ]]; then
+    echo "FORGE_INCUS must be 0 or 1." >&2
     exit 1
 fi
 

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -84,54 +84,94 @@ flowchart LR
 
 ## AR-forge-vm-runner-boundary: VM isolation wraps Forge worker execution
 
-The optional VM mode (§FS-forge-vm-isolated-execution) belongs around the worker
-and orchestration boundary, not in individual workflow engines or generated-test
-prompts. The opt-in flag is `--incus` on the `forge_metadata.py` entry point,
-forwarded unchanged by the `do-work.sh` / `do_up_to_date_work.sh` loop wrappers
-(the loops stay on the host; they do not run inside a VM). `forge_metadata.py`
-keeps claiming work from the GitHub queues on the host; for each claimed run, its
-VM runner launches a fresh single-use Incus VM from a reusable golden base image
-that bakes in the expensive immutable bits — GraalVM installations, Gradle
-caches, Docker layers, and a reachability checkout — refreshes that checkout to
-current `master` at launch, runs that run's existing per-issue workflow inside
-the VM, and tears the VM down afterwards. `--incus` is the only Incus-aware
-surface; the workflow drivers, engines, and agents run the same code they run on
-the host. Because `FORGE_PARALLELISM` allows several concurrent runs, each run
-gets its own VM.
+VM isolation lives at the worker and orchestration boundary
+(§FS-forge-vm-isolated-execution), not in workflow engines or generated-test
+prompts. The opt-in flag is `--incus` on `forge_metadata.py`, forwarded by the
+`do-work.sh` / `do_up_to_date_work.sh` loops (which stay on the host). The
+realization is re-entrant: the *same* script runs twice — on the host to claim
+work, then again inside a fresh VM to do the generation.
 
-Run logs cross the host/VM boundary through a shared directory device, since a
-single-use VM keeps nothing after teardown. The runner mounts a per-run host
-directory at a clean top-level path in the VM (Incus disk device / virtiofs) and
-points Forge's configurable log destination at that path, rather than mounting
-inside the checkout. Logs then land on the host as the run proceeds and outlive
-teardown. Metrics and preserved failed-work branches keep leaving over the
-network, so they need no shared storage; the worktree and other side effects
-stay on the single-use VM's own disk.
+```mermaid
+flowchart TB
+    Base[("base image — a template<br/>GraalVM · caches · Docker · checkout")]
+    GitHub[("GitHub<br/>issues · branches · PRs · metrics")]
 
-Workflow drivers and agents continue to receive ordinary repository paths,
-environment variables, and strategy configuration. They must not shell each
-Gradle command through Incus, choose VM lifecycle policy, or special-case whether
-the current host is bare metal or a VM. Keeping Incus at the runner boundary
-preserves the control-plane and workflow-driver contracts
-(§AR-forge-control-plane, §AR-forge-workflow-boundary) while giving operators a
-machine-level sandbox for tests that may write to `$HOME`, fill `/tmp`, open
-windows, or start Docker-backed services.
+    subgraph Host["HOST"]
+        Loop["do-work.sh → do_up_to_date_work.sh"]
+        Disp["forge_metadata.py --incus<br/>(claim work)"]
+        Runner["VM runner<br/>launch · mount · seed · destroy"]
+        HostLogs[("forge logs<br/>host directory")]
+        Loop --> Disp -->|per claimed run| Runner
+    end
 
-The runner's per-run sequence is:
+    subgraph VM["FRESH SINGLE-USE VM — per run"]
+        Inner["forge_metadata.py --issue-number N<br/>(generate · Gradle · Docker · agent)"]
+    end
 
-1. **Preflight.** With the flag set, verify Incus, the golden base image, the
-   required Incus configuration, and GitHub credentials are present, and stop
-   with an actionable error if anything is missing. The runner never installs or
-   configures Incus itself.
-2. **Launch** a fresh VM by cloning the cached golden base image.
+    Disp -->|scan + claim| GitHub
+    Runner -->|launch fresh VM| VM
+    Base -.->|template for| VM
+    Runner -->|incus exec| Inner
+    Inner -->|logs via mount| HostLogs
+    Inner -->|push: branch · PR · metrics| GitHub
+    Runner -->|destroy after run| VM
+```
+
+For each claimed run, the VM runner executes this per-run sequence:
+
+1. **Preflight** — verify Incus, the base image, configuration, and GitHub
+   credentials; stop with an actionable error if anything is missing. The runner
+   never installs or configures Incus itself.
+2. **Launch** a fresh VM from the cached base image (the image is never modified).
 3. **Mount** a per-run host log directory at a clean top-level path and point the
    configurable log destination (`FORGE_LOGS_DIR`) at it.
-4. **Seed** the run: inject GitHub credentials and refresh the baked checkout to
-   current `master`.
-5. **Run** that run's existing per-issue workflow (the same path as
-   `forge_metadata.py --issue-number N`) inside the VM.
-6. **Publish** as usual — branches, PRs, and metrics leave over the network.
-7. **Destroy** the VM; the mounted logs remain on the host.
+4. **Seed** — inject GitHub credentials and refresh the baked checkout to `master`.
+5. **Run** the run's existing per-issue workflow (`forge_metadata.py
+   --issue-number N`) inside the VM.
+6. **Publish** — branches, PRs, and metrics leave over the network.
+7. **Destroy** the VM; mounted logs remain on the host.
+
+Two invariants hold the boundary. `--incus` is the only Incus-aware surface:
+workflow drivers, engines, and agents run the same code as on the host and never
+shell through Incus or pick VM policy (§AR-forge-control-plane,
+§AR-forge-workflow-boundary). And nothing durable lives on the disposable VM —
+logs cross through the mount, metrics and preserved-work branches leave over the
+network, and `FORGE_PARALLELISM` gives each concurrent run its own VM.
+
+The base image is a template, not a running machine: a saved disk (OS, GraalVM,
+Gradle caches, Docker, and a reachability checkout) plus metadata, built once and
+cached in the local Incus image store. Each run launches a fresh VM *from* that
+image, adds the issue's worktree, and runs `forge_metadata.py --issue-number N`;
+the image itself is never modified, and the VM is deleted afterwards. Building the
+image once is what makes runs cheap — GraalVM, Docker, and caches are installed a
+single time and reused, not rebuilt per run:
+
+```text
+  BUILT ONCE, reused by every run (a template, not a running machine):
+  +---------------------------------------------------+
+  | base image "forge-base"                           |
+  |   OS · GraalVM · Gradle caches · Docker · checkout |
+  +---------------------------------------------------+
+                 |
+                 |  each run launches a fresh VM FROM the image
+                 |  (the image itself is never modified)
+                 v
+  +---------------------------------------------------+
+  | fresh VM for issue 9101   (deleted after the run) |
+  |   = base image  +  this issue's worktree          |
+  |   runs:  forge_metadata.py --issue-number 9101    |
+  +---------------------------------------------------+
+                 |
+                 |  logs -> mounted host directory
+                 v
+  ~/forge-out/9101    (stays on the HOST after the VM is gone)
+
+  Concurrency: each issue gets its own fresh VM (up to FORGE_PARALLELISM).
+  Teardown deletes the VM and its worktree; the base image and host logs remain.
+```
+
+Rebuilding the base image (to refresh GraalVM, caches, or the baked checkout) is
+the only time the expensive setup is paid for again.
 
 ## AR-forge-workflow-boundary: Workflow drivers compose setup, workflow engine, and metrics
 

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -21,6 +21,7 @@ structure chosen to satisfy it, with the workflow catalog in
 | §WF-forge-workflow-drivers | behavioral contract for deterministic workflow drivers |
 | §STRAT-forge-predefined-strategy-contract | behavioral contract for named strategy configuration bundles |
 | §AR-forge-control-plane | how the worker loop, dispatcher, GitHub queues, and worktrees compose |
+| §AR-forge-vm-runner-boundary | how VM isolation wraps Forge without changing workflow semantics |
 | §AR-forge-workflow-boundary | how workflow drivers turn a claimed issue into an isolated workflow run |
 | §AR-forge-strategy-agent-boundary | how strategy configuration, workflow engines, agents, and post-generation interventions are separated |
 | §AR-forge-verification-publication-boundary | why PR creation is a publication step after verification, not part of generation |
@@ -80,6 +81,25 @@ flowchart LR
     PR --> GitHub
     Dispatcher -->|failure / review bookkeeping| GitHub
 ```
+
+## AR-forge-vm-runner-boundary: VM isolation wraps Forge worker execution
+
+Incus VM support belongs around the worker and orchestration boundary, not in
+individual workflow engines or generated-test prompts (§FS-forge-vm-isolated-execution).
+A VM runner should prepare or enter an Incus VM that contains the complete
+reachability checkout, Forge tooling, GraalVM installations, GitHub credentials,
+Docker capability needed by tests, Gradle caches, and durable output locations,
+then invoke the existing `do-work.sh`, `do_up_to_date_work.sh`, or
+`forge_metadata.py` entrypoints inside that VM.
+
+Workflow drivers and agents should continue to receive ordinary repository
+paths, environment variables, and strategy configuration. They should not shell
+each Gradle command through Incus, choose VM lifecycle policy, or special-case
+whether the current host is bare metal or a VM. Keeping Incus at the runner
+boundary preserves the control-plane and workflow-driver contracts
+(§AR-forge-control-plane, §AR-forge-workflow-boundary) while giving operators a
+machine-level sandbox for tests that may write to `$HOME`, fill `/tmp`, open
+windows, or start Docker-backed services.
 
 ## AR-forge-workflow-boundary: Workflow drivers compose setup, workflow engine, and metrics
 

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -86,14 +86,18 @@ flowchart LR
 
 The optional VM mode (§FS-forge-vm-isolated-execution) belongs around the worker
 and orchestration boundary, not in individual workflow engines or generated-test
-prompts. A VM runner, gated by the opt-in flag, launches a fresh single-use
-Incus VM per run from a reusable golden base image that bakes in the expensive
-immutable bits — GraalVM installations, Gradle caches, Docker layers, and a
-reachability checkout — and refreshes that checkout to current `master` at
-launch. The runner then invokes the existing `do-work.sh`,
-`do_up_to_date_work.sh`, or `forge_metadata.py` entrypoints inside that VM and
-tears the VM down afterwards. Because `FORGE_PARALLELISM` allows several
-concurrent runs, each run gets its own VM.
+prompts. The opt-in flag is `--incus` on the `forge_metadata.py` entry point,
+forwarded unchanged by the `do-work.sh` / `do_up_to_date_work.sh` loop wrappers
+(the loops stay on the host; they do not run inside a VM). `forge_metadata.py`
+keeps claiming work from the GitHub queues on the host; for each claimed run, its
+VM runner launches a fresh single-use Incus VM from a reusable golden base image
+that bakes in the expensive immutable bits — GraalVM installations, Gradle
+caches, Docker layers, and a reachability checkout — refreshes that checkout to
+current `master` at launch, runs that run's existing per-issue workflow inside
+the VM, and tears the VM down afterwards. `--incus` is the only Incus-aware
+surface; the workflow drivers, engines, and agents run the same code they run on
+the host. Because `FORGE_PARALLELISM` allows several concurrent runs, each run
+gets its own VM.
 
 Run logs cross the host/VM boundary through a shared directory device, since a
 single-use VM keeps nothing after teardown. The runner mounts a per-run host
@@ -124,7 +128,8 @@ The runner's per-run sequence is:
    configurable log destination (`FORGE_LOGS_DIR`) at it.
 4. **Seed** the run: inject GitHub credentials and refresh the baked checkout to
    current `master`.
-5. **Run** the existing Forge entrypoint inside the VM.
+5. **Run** that run's existing per-issue workflow (the same path as
+   `forge_metadata.py --issue-number N`) inside the VM.
 6. **Publish** as usual — branches, PRs, and metrics leave over the network.
 7. **Destroy** the VM; the mounted logs remain on the host.
 

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -89,7 +89,8 @@ VM isolation lives at the worker and orchestration boundary
 prompts. The opt-in flag is `--incus` on `forge_metadata.py`, forwarded by the
 `do-work.sh` / `do_up_to_date_work.sh` loops (which stay on the host). The
 realization is re-entrant: the *same* script runs twice — on the host to claim
-work, then again inside a fresh VM to do the generation.
+work (the host owns the claim and its queue accounting), then again inside a
+fresh VM to process that already-claimed work without claiming it again.
 
 ```mermaid
 flowchart TB
@@ -123,13 +124,18 @@ For each claimed run, the VM runner executes this per-run sequence:
    credentials; stop with an actionable error if anything is missing. The runner
    never installs or configures Incus itself.
 2. **Launch** a fresh VM from the cached base image (the image is never modified).
-3. **Mount** a per-run host log directory at a clean top-level path and point the
-   configurable log destination (`FORGE_LOGS_DIR`) at it.
-4. **Seed** — inject GitHub credentials and refresh the baked checkout to `master`.
+3. **Mount** a per-run host log directory at a clean top-level path (with
+   `FORGE_LOGS_DIR` pointed at it) and the operator's host checkout read-only.
+4. **Refresh** the VM's Forge checkout by re-cloning it from the mounted host
+   repo, so the run uses the operator's *current* code rather than the snapshot
+   baked into the image (which otherwise drifts between base-image rebuilds);
+   then **seed** GitHub credentials and agent config.
 5. **Run** the run's existing per-issue workflow (`forge_metadata.py
-   --issue-number N`) inside the VM.
+   --issue-number N`) inside the VM, told via `FORGE_ALREADY_CLAIMED` to process
+   the host-claimed issue without claiming again.
 6. **Publish** — branches, PRs, and metrics leave over the network.
-7. **Destroy** the VM; mounted logs remain on the host.
+7. **Destroy** the VM; mounted logs remain on the host. If the run failed, the
+   host reverts its claim so the issue returns to `Todo`.
 
 Two invariants hold the boundary. `--incus` is the only Incus-aware surface:
 workflow drivers, engines, and agents run the same code as on the host and never
@@ -170,8 +176,11 @@ single time and reused, not rebuilt per run:
   Teardown deletes the VM and its worktree; the base image and host logs remain.
 ```
 
-Rebuilding the base image (to refresh GraalVM, caches, or the baked checkout) is
-the only time the expensive setup is paid for again.
+Rebuilding the base image (to refresh GraalVM, Gradle caches, or other baked
+dependencies) is the only time the expensive setup is paid for again. The Forge
+checkout is *not* a reason to rebuild: each run re-clones it from the operator's
+host repo (step 4), so Forge code changes take effect on the next run without a
+rebuild.
 
 ## AR-forge-workflow-boundary: Workflow drivers compose setup, workflow engine, and metrics
 

--- a/forge/docs/architecture.md
+++ b/forge/docs/architecture.md
@@ -84,22 +84,49 @@ flowchart LR
 
 ## AR-forge-vm-runner-boundary: VM isolation wraps Forge worker execution
 
-Incus VM support belongs around the worker and orchestration boundary, not in
-individual workflow engines or generated-test prompts (§FS-forge-vm-isolated-execution).
-A VM runner should prepare or enter an Incus VM that contains the complete
-reachability checkout, Forge tooling, GraalVM installations, GitHub credentials,
-Docker capability needed by tests, Gradle caches, and durable output locations,
-then invoke the existing `do-work.sh`, `do_up_to_date_work.sh`, or
-`forge_metadata.py` entrypoints inside that VM.
+The optional VM mode (§FS-forge-vm-isolated-execution) belongs around the worker
+and orchestration boundary, not in individual workflow engines or generated-test
+prompts. A VM runner, gated by the opt-in flag, launches a fresh single-use
+Incus VM per run from a reusable golden base image that bakes in the expensive
+immutable bits — GraalVM installations, Gradle caches, Docker layers, and a
+reachability checkout — and refreshes that checkout to current `master` at
+launch. The runner then invokes the existing `do-work.sh`,
+`do_up_to_date_work.sh`, or `forge_metadata.py` entrypoints inside that VM and
+tears the VM down afterwards. Because `FORGE_PARALLELISM` allows several
+concurrent runs, each run gets its own VM.
 
-Workflow drivers and agents should continue to receive ordinary repository
-paths, environment variables, and strategy configuration. They should not shell
-each Gradle command through Incus, choose VM lifecycle policy, or special-case
-whether the current host is bare metal or a VM. Keeping Incus at the runner
-boundary preserves the control-plane and workflow-driver contracts
+Run logs cross the host/VM boundary through a shared directory device, since a
+single-use VM keeps nothing after teardown. The runner mounts a per-run host
+directory at a clean top-level path in the VM (Incus disk device / virtiofs) and
+points Forge's configurable log destination at that path, rather than mounting
+inside the checkout. Logs then land on the host as the run proceeds and outlive
+teardown. Metrics and preserved failed-work branches keep leaving over the
+network, so they need no shared storage; the worktree and other side effects
+stay on the single-use VM's own disk.
+
+Workflow drivers and agents continue to receive ordinary repository paths,
+environment variables, and strategy configuration. They must not shell each
+Gradle command through Incus, choose VM lifecycle policy, or special-case whether
+the current host is bare metal or a VM. Keeping Incus at the runner boundary
+preserves the control-plane and workflow-driver contracts
 (§AR-forge-control-plane, §AR-forge-workflow-boundary) while giving operators a
 machine-level sandbox for tests that may write to `$HOME`, fill `/tmp`, open
 windows, or start Docker-backed services.
+
+The runner's per-run sequence is:
+
+1. **Preflight.** With the flag set, verify Incus, the golden base image, the
+   required Incus configuration, and GitHub credentials are present, and stop
+   with an actionable error if anything is missing. The runner never installs or
+   configures Incus itself.
+2. **Launch** a fresh VM by cloning the cached golden base image.
+3. **Mount** a per-run host log directory at a clean top-level path and point the
+   configurable log destination (`FORGE_LOGS_DIR`) at it.
+4. **Seed** the run: inject GitHub credentials and refresh the baked checkout to
+   current `master`.
+5. **Run** the existing Forge entrypoint inside the VM.
+6. **Publish** as usual — branches, PRs, and metrics leave over the network.
+7. **Destroy** the VM; the mounted logs remain on the host.
 
 ## AR-forge-workflow-boundary: Workflow drivers compose setup, workflow engine, and metrics
 

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -179,9 +179,11 @@ this functional spec.
 ### FS-forge-vm-isolated-execution: Optional VM-isolated Forge execution
 
 Forge must offer an optional, opt-in mode that runs a whole generation inside a
-dedicated Incus virtual machine. The mode is selected by a single flag; when the
-flag is absent, Forge runs exactly as it does today, directly on the host. The
-flag changes only *where* a generation runs, never *what* it does.
+dedicated Incus virtual machine. The mode is selected by a single opt-in flag,
+`--incus`, on the `forge_metadata.py` entry point — forwarded unchanged by the
+`do-work.sh` / `do_up_to_date_work.sh` loop wrappers, the same way `--parallelism`
+is today. When the flag is absent, Forge runs exactly as it does now, directly on
+the host. The flag changes only *where* a generation runs, never *what* it does.
 
 The reason for the VM is host isolation. Generated tests and agent commands can
 open windows, write into `$HOME`, fill `/tmp`, delete files, and start
@@ -197,7 +199,7 @@ no run state carries into the next run. Each VM must contain a complete
 reachability-repo checkout (§FS-forge-functional-spec) at current `master`,
 Forge tooling, the required GraalVM installation(s), `gh` authentication for the
 reachability repo, the Docker capability tests need, and Gradle caches. Forge
-then runs its existing entrypoints inside that VM.
+then runs that run's existing per-issue workflow inside that VM.
 
 Everything else about a generation stays identical to a host run. Workflow
 selection, strategy configuration, logging, metrics, stop-file handling, worktree

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -176,28 +176,51 @@ this functional spec.
   generic workflow policy; `forge_metadata.py` computes the concrete chunk size
   for each run.
 
-### FS-forge-vm-isolated-execution: VM-isolated Forge execution
-§GOAL-shorten-issue-to-shipped-metadata
+### FS-forge-vm-isolated-execution: Optional VM-isolated Forge execution
 
-Forge should support running unattended issue-resolution and review automation
-inside an Incus virtual machine when operators need host isolation for generated
-tests, agent commands, temporary files, home-directory writes, and Docker-backed
-test resources. Docker containers are workload resources inside that VM, not the
-outer Forge isolation mechanism, because Forge workflows may run third-party
-tools or tests that start Docker containers themselves.
+Forge must offer an optional, opt-in mode that runs a whole generation inside a
+dedicated Incus virtual machine. The mode is selected by a single flag; when the
+flag is absent, Forge runs exactly as it does today, directly on the host. The
+flag changes only *where* a generation runs, never *what* it does.
 
-The VM execution environment must preserve Forge's existing local contracts:
-the runnable artifact is a complete reachability-repo checkout or worktree
-(§FS-forge-functional-spec), local Forge automation remains non-privileged
-inside the run (§FS-local-ci-equivalent-verification), Gradle state remains
-scoped per reachability worktree, durable logs and metrics are still written,
-and stop-file, cleanup, and failed-work preservation behavior remain visible to
-the operator.
+The reason for the VM is host isolation. Generated tests and agent commands can
+open windows, write into `$HOME`, fill `/tmp`, delete files, and start
+Docker-backed services. Running a generation inside an Incus VM keeps every such
+side effect on the VM's disposable disk instead of the operator's machine.
+Docker is deliberately not the isolation boundary: Forge workflows themselves
+start Docker containers for third-party test resources, so Docker stays a
+workload *inside* the VM while the VM is the outer sandbox the operator wants.
 
-Incus lifecycle setup may require operator-approved host configuration before a
-run starts, but ordinary Forge issue and review workflows must not request
-interactive privilege escalation or mutate the host outside that explicit VM
-setup boundary.
+When the flag is set, Forge runs the generation in a fresh, single-use VM
+provisioned for that run, not just a worktree, and discards the VM afterwards so
+no run state carries into the next run. Each VM must contain a complete
+reachability-repo checkout (§FS-forge-functional-spec) at current `master`,
+Forge tooling, the required GraalVM installation(s), `gh` authentication for the
+reachability repo, the Docker capability tests need, and Gradle caches. Forge
+then runs its existing entrypoints inside that VM.
+
+Everything else about a generation stays identical to a host run. Workflow
+selection, strategy configuration, logging, metrics, stop-file handling, worktree
+cleanup, and failed-work preservation behave the same and produce the same
+artifacts; local Forge automation stays non-privileged inside the run
+(§FS-local-ci-equivalent-verification).
+
+Because each run uses a fresh VM, run logs cannot stay inside it. Forge must
+therefore support directing its run logs to an operator-provided location, so
+that location can be a host directory mounted into the VM: every log the run
+produces then lands on the operator's machine as it is written and remains after
+the VM is discarded. Metrics and preserved failed-work branches already leave
+over the network and need no shared storage. The generation worktree and all
+other test side effects stay inside the single-use VM and are discarded with it.
+
+Preparing the host for Incus is an operator/agent prerequisite, not something a
+run does: Forge must not install or configure Incus itself, and ordinary runs
+must not request interactive privilege escalation or mutate the host outside that
+explicit, documented one-time setup. When the flag is passed, Forge must first
+verify the isolated environment is fully prepared — Incus available, the base
+image built, and the required configuration and credentials present — and stop
+with a clear, actionable error rather than running partially or silently falling
+back to the host.
 
 ### 4.4 Repository availability for test and metadata artifacts
 

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -176,6 +176,29 @@ this functional spec.
   generic workflow policy; `forge_metadata.py` computes the concrete chunk size
   for each run.
 
+### FS-forge-vm-isolated-execution: VM-isolated Forge execution
+§GOAL-shorten-issue-to-shipped-metadata
+
+Forge should support running unattended issue-resolution and review automation
+inside an Incus virtual machine when operators need host isolation for generated
+tests, agent commands, temporary files, home-directory writes, and Docker-backed
+test resources. Docker containers are workload resources inside that VM, not the
+outer Forge isolation mechanism, because Forge workflows may run third-party
+tools or tests that start Docker containers themselves.
+
+The VM execution environment must preserve Forge's existing local contracts:
+the runnable artifact is a complete reachability-repo checkout or worktree
+(§FS-forge-functional-spec), local Forge automation remains non-privileged
+inside the run (§FS-local-ci-equivalent-verification), Gradle state remains
+scoped per reachability worktree, durable logs and metrics are still written,
+and stop-file, cleanup, and failed-work preservation behavior remain visible to
+the operator.
+
+Incus lifecycle setup may require operator-approved host configuration before a
+run starts, but ordinary Forge issue and review workflows must not request
+interactive privilege escalation or mutate the host outside that explicit VM
+setup boundary.
+
 ### 4.4 Repository availability for test and metadata artifacts
 
 - Every Forge workflow artifact that runs reachability-repo Gradle tasks for

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -178,51 +178,38 @@ this functional spec.
 
 ### FS-forge-vm-isolated-execution: Optional VM-isolated Forge execution
 
-Forge must offer an optional, opt-in mode that runs a whole generation inside a
-dedicated Incus virtual machine. The mode is selected by a single opt-in flag,
-`--incus`, on the `forge_metadata.py` entry point — forwarded unchanged by the
-`do-work.sh` / `do_up_to_date_work.sh` loop wrappers, the same way `--parallelism`
-is today. When the flag is absent, Forge runs exactly as it does now, directly on
-the host. The flag changes only *where* a generation runs, never *what* it does.
+Forge must offer an optional `--incus` mode that runs a whole generation inside a
+fresh, single-use Incus VM, so generated tests and agent commands that open
+windows, write into `$HOME`, fill `/tmp`, delete files, or start Docker-backed
+services hit a disposable VM instead of the operator's machine. Docker is not the
+isolation boundary — Forge workflows start their own Docker containers for test
+resources, so Docker is a workload *inside* the VM. The flag changes only *where*
+a generation runs, never *what* it does.
 
-The reason for the VM is host isolation. Generated tests and agent commands can
-open windows, write into `$HOME`, fill `/tmp`, delete files, and start
-Docker-backed services. Running a generation inside an Incus VM keeps every such
-side effect on the VM's disposable disk instead of the operator's machine.
-Docker is deliberately not the isolation boundary: Forge workflows themselves
-start Docker containers for third-party test resources, so Docker stays a
-workload *inside* the VM while the VM is the outer sandbox the operator wants.
-
-When the flag is set, Forge runs the generation in a fresh, single-use VM
-provisioned for that run, not just a worktree, and discards the VM afterwards so
-no run state carries into the next run. Each VM must contain a complete
-reachability-repo checkout (§FS-forge-functional-spec) at current `master`,
-Forge tooling, the required GraalVM installation(s), `gh` authentication for the
-reachability repo, the Docker capability tests need, and Gradle caches. Forge
-then runs that run's existing per-issue workflow inside that VM.
-
-Everything else about a generation stays identical to a host run. Workflow
-selection, strategy configuration, logging, metrics, stop-file handling, worktree
-cleanup, and failed-work preservation behave the same and produce the same
-artifacts; local Forge automation stays non-privileged inside the run
-(§FS-local-ci-equivalent-verification).
-
-Because each run uses a fresh VM, run logs cannot stay inside it. Forge must
-therefore support directing its run logs to an operator-provided location, so
-that location can be a host directory mounted into the VM: every log the run
-produces then lands on the operator's machine as it is written and remains after
-the VM is discarded. Metrics and preserved failed-work branches already leave
-over the network and need no shared storage. The generation worktree and all
-other test side effects stay inside the single-use VM and are discarded with it.
-
-Preparing the host for Incus is an operator/agent prerequisite, not something a
-run does: Forge must not install or configure Incus itself, and ordinary runs
-must not request interactive privilege escalation or mutate the host outside that
-explicit, documented one-time setup. When the flag is passed, Forge must first
-verify the isolated environment is fully prepared — Incus available, the base
-image built, and the required configuration and credentials present — and stop
-with a clear, actionable error rather than running partially or silently falling
-back to the host.
+- **Opt-in flag.** `--incus` lives on the `forge_metadata.py` entry point,
+  forwarded by the `do-work.sh` / `do_up_to_date_work.sh` loops like
+  `--parallelism`. When it is absent, Forge runs on the host exactly as today.
+- **Fresh VM per run.** Each claimed run gets its own single-use VM, discarded
+  afterwards so no state carries over. The VM must hold a complete
+  reachability-repo checkout (§FS-forge-functional-spec) at current `master`,
+  Forge tooling, the required GraalVM installation(s), `gh` authentication, the
+  Docker capability tests need, and Gradle caches; Forge runs that run's existing
+  per-issue workflow inside it.
+- **Behavior unchanged.** Workflow selection, strategy configuration, logging,
+  metrics, stop-file handling, worktree cleanup, and failed-work preservation
+  behave the same and produce the same artifacts, and local Forge automation
+  stays non-privileged inside the run (§FS-local-ci-equivalent-verification).
+- **Logs survive the VM.** Forge must support directing run logs to an
+  operator-provided location so it can be a host directory mounted into the VM;
+  logs then land on the host as they are written and remain after teardown.
+  Metrics and preserved failed-work branches already leave over the network; the
+  worktree and other side effects stay in the VM and are discarded with it.
+- **Setup is a prerequisite, not a run action.** Forge must not install or
+  configure Incus, or otherwise mutate the host outside the documented one-time
+  setup. When the flag is passed, Forge must verify the environment is ready —
+  Incus available, base image built, configuration and credentials present — and
+  stop with a clear, actionable error rather than running partially or falling
+  back to the host.
 
 ### 4.4 Repository availability for test and metadata artifacts
 

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -48,8 +48,9 @@ This item of §ROADMAP-forge-implementation adds the operator-facing Incus VM
 runner and setup instructions required by §FS-forge-vm-isolated-execution and
 §AR-forge-vm-runner-boundary.
 
-The implementation should add the opt-in flag, a reusable golden base image, a
-checked-in Incus configuration, and step-by-step setup documentation in
+The implementation should add the opt-in `--incus` flag on `forge_metadata.py`
+(forwarded by the loop wrappers), a reusable golden base image, a checked-in
+Incus configuration, and step-by-step setup documentation in
 README.md and AGENTS.md — written so a human or agent can install Incus and build
 the base image on any machine — for running a whole Forge generation in a fresh,
 single-use VM that can safely absorb generated-test side effects. The base image

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -58,8 +58,8 @@ is a template that bakes in the expensive setup — GraalVM installations, Gradl
 caches, Docker layers, and a reachability checkout — is built once and cached in
 the host's local Incus image store for reuse across runs, and is rebuilt only to
 refresh tooling. Each run launches a fresh VM from the image without modifying it,
-refreshes the baked checkout to current `master`, and injects GitHub
-authentication at launch.
+re-clones the Forge checkout from the operator's host repo so it runs current
+code, and injects GitHub authentication at launch.
 It must also add a configurable log destination (for example a `FORGE_LOGS_DIR`
 setting routed through `resolve_logs_root()`) so a per-run host directory mounted
 at a clean top-level path in the VM captures logs that land on the host as the

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -48,19 +48,30 @@ This item of §ROADMAP-forge-implementation adds the operator-facing Incus VM
 runner and setup instructions required by §FS-forge-vm-isolated-execution and
 §AR-forge-vm-runner-boundary.
 
-The implementation should provide a checked-in Incus configuration and
-step-by-step setup documentation for running Forge issue-resolution and review
-automation in a VM that can safely absorb generated-test side effects. The VM
-environment must contain the complete reachability checkout, Forge tooling,
-GraalVM installations, GitHub authentication, Docker capability required by
-library tests, and durable output paths for logs, metrics, preserved worktrees,
-and publication artifacts.
+The implementation should add the opt-in flag, a reusable golden base image, a
+checked-in Incus configuration, and step-by-step setup documentation in
+README.md and AGENTS.md — written so a human or agent can install Incus and build
+the base image on any machine — for running a whole Forge generation in a fresh,
+single-use VM that can safely absorb generated-test side effects. The base image
+bakes in the expensive immutable bits — GraalVM installations, Gradle caches,
+Docker layers, and a reachability checkout — is built once and cached in the
+host's local Incus image store for reuse across runs, and is rebuilt only to
+refresh tooling; each run clones it copy-on-write, and the runner refreshes the
+baked checkout to current `master` and injects GitHub authentication at launch.
+It must also add a configurable log destination (for example a `FORGE_LOGS_DIR`
+setting routed through `resolve_logs_root()`) so a per-run host directory mounted
+at a clean top-level path in the VM captures logs that land on the host as the
+run proceeds and survive teardown; metrics and preserved failed-work branches
+keep leaving over the network.
 
-The runner should enter the VM and invoke the existing Forge entrypoints rather
-than teaching workflow drivers or agents about Incus. Acceptance should include
-a documented smoke run that proves stop files, Gradle commands, Docker-backed
-tests, durable logs, metrics, worktree cleanup, and failed-work preservation are
-observable from the operator's expected host/VM boundary.
+The runner should preflight the environment when the flag is set — failing
+clearly if Incus, the base image, configuration, or credentials are missing
+rather than installing anything — then launch the VM per run, invoke the existing
+Forge entrypoints, and tear the VM down afterwards rather than teaching workflow
+drivers or agents about Incus. Acceptance should include a documented smoke run
+that proves stop files, Gradle commands, Docker-backed tests, worktree cleanup,
+and failed-work preservation behave as on the host, and that run logs are
+observable on the host through the mounted log directory.
 
 # ROADMAP-forge-fixture-backed-e2e: Fixture-backed E2E mode
 

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -6,11 +6,12 @@ Completed roadmap points stay in this file for citation history. It serves the
 overall Forge direction in §GOAL-forge-direction.
 
 1. Better structure of `ai_workflows/` (§ROADMAP-forge-ai-workflows-structure).
-2. Library-specific preparation preflight (§ROADMAP-forge-library-preflight).
-3. Missing-version library-update router (§ROADMAP-forge-missing-version-router).
-4. Native metadata exploration finalization path (§ROADMAP-forge-native-finalization).
-5. Human-intervention strictness (§ROADMAP-forge-human-intervention-strictness).
-6. Planned code coverage improvement workflow (§ROADMAP-forge-code-coverage-workflow).
+2. Incus VM runner and setup docs (§ROADMAP-forge-incus-vm-runner).
+3. Library-specific preparation preflight (§ROADMAP-forge-library-preflight).
+4. Missing-version library-update router (§ROADMAP-forge-missing-version-router).
+5. Native metadata exploration finalization path (§ROADMAP-forge-native-finalization).
+6. Human-intervention strictness (§ROADMAP-forge-human-intervention-strictness).
+7. Planned code coverage improvement workflow (§ROADMAP-forge-code-coverage-workflow).
 
 Completed roadmap points:
 
@@ -40,6 +41,26 @@ and the workflow-engine registration in `__init__.py`, and updates the path
 references in code and in the remaining docs (README.md, AGENTS.md,
 DEVELOPING.md, and workflow specs) to match the canonical layout already
 described by §WF-forge-workflow-drivers and §WF-forge-workflow-engine.
+
+# ROADMAP-forge-incus-vm-runner: Incus VM runner and setup docs
+
+This item of §ROADMAP-forge-implementation adds the operator-facing Incus VM
+runner and setup instructions required by §FS-forge-vm-isolated-execution and
+§AR-forge-vm-runner-boundary.
+
+The implementation should provide a checked-in Incus configuration and
+step-by-step setup documentation for running Forge issue-resolution and review
+automation in a VM that can safely absorb generated-test side effects. The VM
+environment must contain the complete reachability checkout, Forge tooling,
+GraalVM installations, GitHub authentication, Docker capability required by
+library tests, and durable output paths for logs, metrics, preserved worktrees,
+and publication artifacts.
+
+The runner should enter the VM and invoke the existing Forge entrypoints rather
+than teaching workflow drivers or agents about Incus. Acceptance should include
+a documented smoke run that proves stop files, Gradle commands, Docker-backed
+tests, durable logs, metrics, worktree cleanup, and failed-work preservation are
+observable from the operator's expected host/VM boundary.
 
 # ROADMAP-forge-fixture-backed-e2e: Fixture-backed E2E mode
 

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -49,16 +49,17 @@ runner and setup instructions required by §FS-forge-vm-isolated-execution and
 §AR-forge-vm-runner-boundary.
 
 The implementation should add the opt-in `--incus` flag on `forge_metadata.py`
-(forwarded by the loop wrappers), a reusable golden base image, a checked-in
+(forwarded by the loop wrappers), a reusable base image, a checked-in
 Incus configuration, and step-by-step setup documentation in
 README.md and AGENTS.md — written so a human or agent can install Incus and build
 the base image on any machine — for running a whole Forge generation in a fresh,
 single-use VM that can safely absorb generated-test side effects. The base image
-bakes in the expensive immutable bits — GraalVM installations, Gradle caches,
-Docker layers, and a reachability checkout — is built once and cached in the
-host's local Incus image store for reuse across runs, and is rebuilt only to
-refresh tooling; each run clones it copy-on-write, and the runner refreshes the
-baked checkout to current `master` and injects GitHub authentication at launch.
+is a template that bakes in the expensive setup — GraalVM installations, Gradle
+caches, Docker layers, and a reachability checkout — is built once and cached in
+the host's local Incus image store for reuse across runs, and is rebuilt only to
+refresh tooling. Each run launches a fresh VM from the image without modifying it,
+refreshes the baked checkout to current `master`, and injects GitHub
+authentication at launch.
 It must also add a configurable log destination (for example a `FORGE_LOGS_DIR`
 setting routed through `resolve_logs_root()`) so a per-run host directory mounted
 at a clean top-level path in the VM captures logs that land on the host as the

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -146,6 +146,12 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.fixture_github import FixtureGitHubState, load_fixture_github_state
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.incus_runner import (
+    IncusError,
+    IncusPreflightError,
+    preflight as incus_preflight,
+    run_issue_in_vm,
+)
 from utility_scripts.library_stats import resolve_stats_file_path
 from utility_scripts.library_preparation_preflight import (
     LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
@@ -7769,6 +7775,35 @@ def process_fixture_issues_for_label(
     return processed_count
 
 
+def dispatch_issue_to_vm(
+        issue_number: int,
+        strategy_name: str | None,
+        keep_tests_without_dynamic_access: bool,
+) -> bool:
+    """Run one selected issue inside a fresh Incus VM.
+
+    The host scans and selects work; the VM claims the issue, builds its
+    worktree, runs the per-issue workflow, and publishes over the network
+    (§AR-forge-vm-runner-boundary). A failed VM run is reported as a failed
+    issue; a setup failure (`IncusPreflightError`) propagates to abort the run
+    rather than falling back to the host (§FS-forge-vm-isolated-execution).
+    """
+    try:
+        return run_issue_in_vm(
+            issue_number,
+            strategy_name=strategy_name,
+            keep_tests_without_dynamic_access=keep_tests_without_dynamic_access,
+        )
+    except IncusPreflightError:
+        raise
+    except IncusError as exc:
+        log_failure_banner(
+            f"Incus VM run for issue #{issue_number} failed: {exc}",
+            file=sys.stderr,
+        )
+        return False
+
+
 def process_issues_with_label(
         label: str,
         limit: int,
@@ -7782,6 +7817,7 @@ def process_issues_with_label(
         take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
         environment_already_validated: bool = False,
         user_requested_only: bool = False,
+        use_incus: bool = False,
 ) -> int:
     """
     Process up to `limit` claimable issues, skipping over unclaimed candidates.
@@ -7811,7 +7847,7 @@ def process_issues_with_label(
     priority_exhausted = False
     unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
-    active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue] = {}
+    active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue | None] = {}
 
     log_issue_scan_start(label, offset)
 
@@ -7907,6 +7943,20 @@ def process_issues_with_label(
                     ):
                         continue
 
+                    if use_incus:
+                        # In Incus mode the host only selects work; the VM claims
+                        # the issue and runs it, so there is no host claim to
+                        # track for revert (§AR-forge-vm-runner-boundary).
+                        future = executor.submit(
+                            dispatch_issue_to_vm,
+                            issue["number"],
+                            strategy_name,
+                            keep_tests_without_dynamic_access,
+                        )
+                        active_futures[future] = None
+                        processed_count += 1
+                        continue
+
                     claim_kwargs: dict[str, bool] = {}
                     if not take_blocked_issues:
                         claim_kwargs["take_blocked_issues"] = False
@@ -7962,6 +8012,11 @@ def process_issues_with_label(
             file=sys.stderr,
         )
         for future, claimed_issue in list(active_futures.items()):
+            if claimed_issue is None:
+                # Incus run: the VM owns the claim and is torn down by the
+                # runner; there is no host claim to revert.
+                future.cancel()
+                continue
             if future.cancel():
                 print(
                     f"[Cancelled queued issue #{claimed_issue.issue['number']} future before revert.]",
@@ -7986,6 +8041,7 @@ def process_work_queues(
         parallelism_default: int = DEFAULT_PARALLELISM,
         random_offset_override: bool | None = None,
         user_requested_only_override: bool | None = None,
+        use_incus: bool = False,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
     queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
@@ -8064,6 +8120,7 @@ def process_work_queues(
             parallelism,
             user_requested_only=user_requested_only,
             environment_already_validated=True,
+            use_incus=use_incus,
         )
 
     for review_queue_config in review_queue_configs:
@@ -8213,6 +8270,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_TAKE_BLOCKED_ISSUES,
         help="Claim issues even when GitHub shows open blocking issues. Defaults to enabled.",
     )
+    parser.add_argument(
+        "--incus",
+        dest="incus",
+        action="store_true",
+        default=False,
+        help=(
+            "Run each generation inside a fresh, single-use Incus VM instead of on the host. "
+            "Requires a host prepared per forge/README.md; Forge preflights and fails fast if the "
+            "setup is incomplete rather than installing anything."
+        ),
+    )
 
     args = parser.parse_args(argv)
     if args.period is not None and args.review_pr is None:
@@ -8224,6 +8292,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             parser.error("--fixture-testing cannot be combined with --offset")
         if args.random_offset is not None:
             parser.error("--fixture-testing cannot be combined with --random-offset/--no-random-offset")
+    if args.incus:
+        if args.review_pr is not None or args.clear_issue_caches:
+            parser.error("--incus only applies to issue generation (--label, --issue-number, or --run-work-queues)")
+        if args.fixture_testing:
+            parser.error("--incus cannot be combined with --fixture-testing")
     if args.random_offset is not None and args.label is None and not args.run_work_queues:
         parser.error("--random-offset/--no-random-offset can only be used with --label or --run-work-queues")
     if args.random_offset is True and args.offset != 0:
@@ -8256,8 +8329,17 @@ def process_single_issue(
         keep_tests_without_dynamic_access: bool,
         authenticated_user: str,
         take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
+        use_incus: bool = False,
 ) -> bool:
     """Fetch and process a single issue by number, claiming only in live GitHub mode."""
+    if use_incus:
+        # The VM claims and runs the issue; the host only dispatches
+        # (§AR-forge-vm-runner-boundary).
+        return dispatch_issue_to_vm(
+            issue_number,
+            strategy_name,
+            keep_tests_without_dynamic_access,
+        )
     validate_issue_processing_environment()
 
     issue, label = get_issue_by_number(issue_number)
@@ -8347,6 +8429,11 @@ def main() -> None:
         if not PROJECT_NUMBER:
             print("ERROR: GITHUB_PROJECT_NUMBER env var is not set.", file=sys.stderr)
             sys.exit(1)
+        if args.incus:
+            # Fail fast before any scanning if the host is not set up for Incus,
+            # rather than running partially or falling back to the host
+            # (§FS-forge-vm-isolated-execution).
+            incus_preflight()
         if args.run_work_queues:
             process_work_queues(
                 reachability_metadata_path,
@@ -8357,6 +8444,7 @@ def main() -> None:
                 args.parallelism,
                 random_offset_override=args.random_offset,
                 user_requested_only_override=args.user_requested_only,
+                use_incus=args.incus,
             )
         elif args.review_pr is not None:
             authenticated_user = resolve_authenticated_user()
@@ -8378,6 +8466,7 @@ def main() -> None:
                 args.keep_tests_without_dynamic_access,
                 authenticated_user,
                 args.take_blocked_issues,
+                use_incus=args.incus,
             )
         elif is_fixture_testing_enabled():
             process_fixture_issues_for_label(
@@ -8412,6 +8501,7 @@ def main() -> None:
                 args.parallelism,
                 take_blocked_issues=args.take_blocked_issues,
                 user_requested_only=user_requested_only,
+                use_incus=args.incus,
             )
         normal_exit = True
     except KeyboardInterrupt:
@@ -8430,6 +8520,12 @@ def main() -> None:
     except GitHubRateLimitExceeded as exc:
         log_failure_banner(f"{exc}. Stop current run and retry after reset.", file=sys.stderr)
         sys.exit(GITHUB_RATE_LIMIT_EXIT_CODE)
+    except IncusPreflightError as exc:
+        log_failure_banner(
+            f"Incus setup is incomplete; cannot run with --incus.\n{exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     finally:
         if normal_exit:
             log_success_banner("Run complete.")

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -147,6 +147,8 @@ from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_r
 from utility_scripts.fixture_github import FixtureGitHubState, load_fixture_github_state
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.incus_runner import (
+    FORGE_ALREADY_CLAIMED_ENV,
+    FORGE_CLAIMED_ITEM_ID_ENV,
     IncusError,
     IncusPreflightError,
     preflight as incus_preflight,
@@ -5968,27 +5970,18 @@ def maybe_handle_not_for_native_image_issue(issue: dict, base_reachability_metad
     return True
 
 
-def claim_issue_for_processing(
+def _resolve_claim_metadata(
         issue: dict,
         label: str,
         base_reachability_metadata_path: str,
-        canonical_metrics_repo_path: str,
-        authenticated_user: str,
-        take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
-) -> Optional[ClaimedIssue]:
-    """Claim an issue and prepare its isolated execution workspace.
+):
+    """Resolve coordinates, continuation, and chunked state for a claimable issue.
 
-    Claiming, assignment validation, and worktree creation are orchestration
-    responsibilities, not strategy logic (§AR-forge-control-plane). Chunked
-    dynamic-access continuation derives its exhaust report from the coordinate
-    in the checked-out repository (§WF-dynamic-access-exhaust-report).
+    Shared by the host claim path and the Incus already-claimed path. Returns
+    `(issue_coordinates, current_coordinates, new_version, continuation_marker,
+    chunked_exhaust_report)`, or None when the issue is not processable
+    (§AR-forge-control-plane, §WF-dynamic-access-exhaust-report).
     """
-    if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
-        return None
-
-    if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
-        return None
-
     claim_metadata = build_claim_metadata(issue, label, base_reachability_metadata_path)
     if claim_metadata is None:
         return None
@@ -6021,11 +6014,27 @@ def claim_issue_for_processing(
             file=sys.stderr,
         )
         return None
+    return issue_coordinates, current_coordinates, new_version, continuation_marker, chunked_exhaust_report
 
-    item_id = try_claim_issue(issue, authenticated_user, label, take_blocked_issues)
-    if not item_id:
-        return None
 
+def _build_workspace_for_claimed_issue(
+        issue: dict,
+        label: str,
+        base_reachability_metadata_path: str,
+        canonical_metrics_repo_path: str,
+        item_id: str,
+        resolved,
+        *,
+        revert_claim_on_failure: bool,
+) -> Optional[ClaimedIssue]:
+    """Build the isolated worktree and ClaimedIssue for an already-claimed issue.
+
+    `revert_claim_on_failure` reverts the GitHub claim if setup fails in host mode
+    (where this process owns the claim); the Incus VM passes False because the
+    host owns the claim and reverts it on a failed VM run
+    (§AR-forge-vm-runner-boundary).
+    """
+    issue_coordinates, current_coordinates, new_version, continuation_marker, chunked_exhaust_report = resolved
     try:
         worktree_path, scratch_metrics_repo_path = create_issue_workspace(
             base_reachability_metadata_path,
@@ -6041,12 +6050,13 @@ def claim_issue_for_processing(
                 worktree_path,
             )
     except BaseException as exc:
-        revert_issue_claim(
-            item_id,
-            issue["number"],
-            "claim setup interrupted by Ctrl+C" if is_interrupt_exception(exc)
-            else f"claim setup failure ({type(exc).__name__})",
-        )
+        if revert_claim_on_failure:
+            revert_issue_claim(
+                item_id,
+                issue["number"],
+                "claim setup interrupted by Ctrl+C" if is_interrupt_exception(exc)
+                else f"claim setup failure ({type(exc).__name__})",
+            )
         if isinstance(exc, Exception):
             return None
         raise
@@ -6063,6 +6073,100 @@ def claim_issue_for_processing(
         new_version=new_version,
         preflight_info_path=preflight_info_path,
         continuation_marker=continuation_marker,
+    )
+
+
+def claim_issue_on_github_only(
+        issue: dict,
+        label: str,
+        base_reachability_metadata_path: str,
+        authenticated_user: str,
+        take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
+):
+    """Run claim gating and claim the issue on GitHub, without building a workspace.
+
+    Returns `(item_id, resolved_metadata)` on a successful claim, else None. The
+    control plane claims here (§AR-forge-control-plane): host mode then builds a
+    worktree locally, while Incus mode hands the claimed issue to a VM that builds
+    its own (§AR-forge-vm-runner-boundary).
+    """
+    if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
+        return None
+
+    if maybe_handle_not_for_native_image_issue(issue, base_reachability_metadata_path):
+        return None
+
+    resolved = _resolve_claim_metadata(issue, label, base_reachability_metadata_path)
+    if resolved is None:
+        return None
+
+    item_id = try_claim_issue(issue, authenticated_user, label, take_blocked_issues)
+    if not item_id:
+        return None
+    return item_id, resolved
+
+
+def claim_issue_for_processing(
+        issue: dict,
+        label: str,
+        base_reachability_metadata_path: str,
+        canonical_metrics_repo_path: str,
+        authenticated_user: str,
+        take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
+) -> Optional[ClaimedIssue]:
+    """Claim an issue and prepare its isolated execution workspace.
+
+    Claiming, assignment validation, and worktree creation are orchestration
+    responsibilities, not strategy logic (§AR-forge-control-plane). Chunked
+    dynamic-access continuation derives its exhaust report from the coordinate
+    in the checked-out repository (§WF-dynamic-access-exhaust-report).
+    """
+    claimed = claim_issue_on_github_only(
+        issue,
+        label,
+        base_reachability_metadata_path,
+        authenticated_user,
+        take_blocked_issues,
+    )
+    if claimed is None:
+        return None
+    item_id, resolved = claimed
+    return _build_workspace_for_claimed_issue(
+        issue,
+        label,
+        base_reachability_metadata_path,
+        canonical_metrics_repo_path,
+        item_id,
+        resolved,
+        revert_claim_on_failure=True,
+    )
+
+
+def build_already_claimed_issue(
+        issue: dict,
+        label: str,
+        base_reachability_metadata_path: str,
+        canonical_metrics_repo_path: str,
+        item_id: str,
+) -> Optional[ClaimedIssue]:
+    """Build a ClaimedIssue for an issue the host already claimed, without re-claiming.
+
+    Incus mode claims on the host (§AR-forge-control-plane) and hands the claimed
+    issue to the VM, which only builds its own workspace and processes the work
+    (§AR-forge-vm-runner-boundary). A setup failure here is not reverted: the host
+    owns the claim and reverts it when the VM run reports failure.
+    """
+    resolved = _resolve_claim_metadata(issue, label, base_reachability_metadata_path)
+    if resolved is None:
+        return None
+    return _build_workspace_for_claimed_issue(
+        issue,
+        label,
+        base_reachability_metadata_path,
+        canonical_metrics_repo_path,
+        item_id,
+        resolved,
+        revert_claim_on_failure=False,
     )
 
 
@@ -7779,20 +7883,23 @@ def dispatch_issue_to_vm(
         issue_number: int,
         strategy_name: str | None,
         keep_tests_without_dynamic_access: bool,
+        claimed_item_id: str,
 ) -> bool:
-    """Run one selected issue inside a fresh Incus VM.
+    """Run one already-claimed issue inside a fresh Incus VM.
 
-    The host scans and selects work; the VM claims the issue, builds its
-    worktree, runs the per-issue workflow, and publishes over the network
-    (§AR-forge-vm-runner-boundary). A failed VM run is reported as a failed
-    issue; a setup failure (`IncusPreflightError`) propagates to abort the run
-    rather than falling back to the host (§FS-forge-vm-isolated-execution).
+    The host scans, selects, and claims the issue (§AR-forge-control-plane); the
+    VM builds its own worktree, processes the already-claimed work without
+    claiming again, and publishes over the network (§AR-forge-vm-runner-boundary).
+    A failed VM run is reported as a failed issue so the host reverts its claim; a
+    setup failure (`IncusPreflightError`) propagates to abort the run rather than
+    falling back to the host (§FS-forge-vm-isolated-execution).
     """
     try:
         return run_issue_in_vm(
             issue_number,
             strategy_name=strategy_name,
             keep_tests_without_dynamic_access=keep_tests_without_dynamic_access,
+            claimed_item_id=claimed_item_id,
         )
     except IncusPreflightError:
         raise
@@ -7848,6 +7955,10 @@ def process_issues_with_label(
     unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
     active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue | None] = {}
+    # Incus runs claim on the host (§AR-forge-control-plane) but build no host
+    # worktree, so they cannot be reverted via a ClaimedIssue. Track their GitHub
+    # claim (item_id, issue_number) here to revert on VM failure or interrupt.
+    incus_claims: dict[concurrent.futures.Future[bool], tuple[str, int]] = {}
 
     log_issue_scan_start(label, offset)
 
@@ -7943,23 +8054,38 @@ def process_issues_with_label(
                     ):
                         continue
 
+                    claim_kwargs: dict[str, bool] = {}
+                    if not take_blocked_issues:
+                        claim_kwargs["take_blocked_issues"] = False
+
                     if use_incus:
-                        # In Incus mode the host only selects work; the VM claims
-                        # the issue and runs it, so there is no host claim to
-                        # track for revert (§AR-forge-vm-runner-boundary).
+                        # The host claims the issue (same race check and queue
+                        # accounting as host mode); only after we own it does the
+                        # VM process the already-claimed work without claiming
+                        # again. On VM failure the host reverts the claim
+                        # (§AR-forge-control-plane, §AR-forge-vm-runner-boundary).
+                        claimed = claim_issue_on_github_only(
+                            issue,
+                            label,
+                            base_reachability_metadata_path,
+                            authenticated_user,
+                            **claim_kwargs,
+                        )
+                        if claimed is None:
+                            continue
+                        item_id, _resolved = claimed
                         future = executor.submit(
                             dispatch_issue_to_vm,
                             issue["number"],
                             strategy_name,
                             keep_tests_without_dynamic_access,
+                            item_id,
                         )
                         active_futures[future] = None
+                        incus_claims[future] = (item_id, issue["number"])
                         processed_count += 1
                         continue
 
-                    claim_kwargs: dict[str, bool] = {}
-                    if not take_blocked_issues:
-                        claim_kwargs["take_blocked_issues"] = False
                     claimed_issue = claim_issue_for_processing(
                         issue,
                         label,
@@ -7995,7 +8121,13 @@ def process_issues_with_label(
                 continue
             for future in done_futures:
                 active_futures.pop(future, None)
-                future.result()
+                incus_claim = incus_claims.pop(future, None)
+                succeeded = future.result()
+                if incus_claim is not None and not succeeded:
+                    # The host owns this claim; the VM reported failure, so reset
+                    # the issue to Todo for another worker (§AR-forge-control-plane).
+                    item_id, claim_issue_number = incus_claim
+                    revert_issue_claim(item_id, claim_issue_number, "Incus VM run reported failure")
     except KeyboardInterrupt:
         if is_shutdown_requested():
             mark_shutdown_requested()
@@ -8013,9 +8145,19 @@ def process_issues_with_label(
         )
         for future, claimed_issue in list(active_futures.items()):
             if claimed_issue is None:
-                # Incus run: the VM owns the claim and is torn down by the
-                # runner; there is no host claim to revert.
-                future.cancel()
+                # Incus run: the host owns the claim (§AR-forge-control-plane).
+                # Cancel the dispatch and revert the claim so the issue returns to
+                # Todo; the runner tears down any launched VM.
+                cancelled = future.cancel()
+                incus_claim = incus_claims.pop(future, None)
+                if incus_claim is not None:
+                    item_id, claim_issue_number = incus_claim
+                    if cancelled:
+                        print(
+                            f"[Cancelled queued issue #{claim_issue_number} future before revert.]",
+                            file=sys.stderr,
+                        )
+                    revert_issue_claim(item_id, claim_issue_number, f"{interrupt_reason} in main loop")
                 continue
             if future.cancel():
                 print(
@@ -8333,13 +8475,41 @@ def process_single_issue(
 ) -> bool:
     """Fetch and process a single issue by number, claiming only in live GitHub mode."""
     if use_incus:
-        # The VM claims and runs the issue; the host only dispatches
-        # (§AR-forge-vm-runner-boundary).
-        return dispatch_issue_to_vm(
-            issue_number,
-            strategy_name,
-            keep_tests_without_dynamic_access,
+        # The host claims the issue (race check), then the VM processes the
+        # already-claimed work without claiming again; on VM failure or dispatch
+        # abort the host reverts the claim (§AR-forge-control-plane,
+        # §AR-forge-vm-runner-boundary).
+        validate_issue_processing_environment()
+        issue, label = get_issue_by_number(issue_number)
+        print()
+        log_stage("issue-scan", f"Issue #{issue_number} matched pipeline label: {label}")
+        claim_kwargs: dict[str, bool] = {}
+        if not take_blocked_issues:
+            claim_kwargs["take_blocked_issues"] = False
+        claimed = claim_issue_on_github_only(
+            issue,
+            label,
+            base_reachability_metadata_path,
+            authenticated_user,
+            **claim_kwargs,
         )
+        if claimed is None:
+            log_failure_banner(f"Could not claim issue #{issue_number}.", file=sys.stderr)
+            sys.exit(1)
+        item_id, _resolved = claimed
+        try:
+            succeeded = dispatch_issue_to_vm(
+                issue_number,
+                strategy_name,
+                keep_tests_without_dynamic_access,
+                item_id,
+            )
+        except BaseException:
+            revert_issue_claim(item_id, issue_number, "Incus VM dispatch aborted")
+            raise
+        if not succeeded:
+            revert_issue_claim(item_id, issue_number, "Incus VM run reported failure")
+        return succeeded
     validate_issue_processing_environment()
 
     issue, label = get_issue_by_number(issue_number)
@@ -8364,6 +8534,27 @@ def process_single_issue(
                 keep_tests_without_dynamic_access,
                 canonical_metrics_repo_path,
             )
+
+    if os.environ.get(FORGE_ALREADY_CLAIMED_ENV) == "1":
+        # Launched by the Incus host, which already owns the GitHub claim
+        # (§AR-forge-vm-runner-boundary): build the workspace for the claimed
+        # issue without claiming again. The host reverts on a failed run.
+        claimed_issue = build_already_claimed_issue(
+            issue,
+            label,
+            base_reachability_metadata_path,
+            canonical_metrics_repo_path,
+            os.environ.get(FORGE_CLAIMED_ITEM_ID_ENV, ""),
+        )
+        if not claimed_issue:
+            log_failure_banner(f"Could not prepare already-claimed issue #{issue_number}.", file=sys.stderr)
+            sys.exit(1)
+        return process_claimed_issue_lifecycle(
+            claimed_issue,
+            strategy_name,
+            keep_tests_without_dynamic_access,
+            canonical_metrics_repo_path,
+        )
 
     claim_kwargs: dict[str, bool] = {}
     if not take_blocked_issues:

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -48,6 +48,15 @@ REPO_URL="${FORGE_INCUS_REPO_URL:-https://github.com/oracle/graalvm-reachability
 REPO_PATH="${FORGE_INCUS_REPO_PATH:-/root/graalvm-reachability-metadata}"
 AGENT_TIMEOUT="${FORGE_INCUS_LAUNCH_TIMEOUT:-300}"
 
+# The image bakes a shallow copy of the operator's LOCAL repository (this
+# checkout), so the VM runs the local forge code under development rather than
+# upstream master. HOST_REPO is mounted read-only into the builder and its
+# BASE_REF tip is cloned in; origin is then repointed at REPO_URL so generated
+# branches/PRs push to the real remote. Override HOST_REPO when building from a
+# linked worktree (whose objects live in the main checkout).
+HOST_REPO="${FORGE_INCUS_HOST_REPO:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)}"
+HOST_REPO_BASE_REF="${FORGE_INCUS_BASE_REF:-master}"
+
 log() { printf '[build-base-image] %s\n' "$*"; }
 
 # GraalVM homes the build copies into the VM and generation requires inside it.
@@ -183,12 +192,17 @@ wait_for_agent
 copy_local_graalvm
 write_vm_environment
 
+log "Mounting local repository '$HOST_REPO' into the builder VM (read-only)"
+incus config device add "$BUILDER_VM" forge-host-repo disk \
+    source="$HOST_REPO" path=/forge-host-repo readonly=true
+
 log "Provisioning the builder VM (Docker, repo checkout, warmed Gradle caches)"
 incus exec "$BUILDER_VM" \
     --env GRAALVM_HOME="$GRAALVM_HOME" \
     --env JAVA_HOME="$GRAALVM_HOME" \
     --env REPO_URL="$REPO_URL" \
     --env REPO_PATH="$REPO_PATH" \
+    --env BASE_REF="$HOST_REPO_BASE_REF" \
     -- bash -seuo pipefail <<'PROVISION'
 export DEBIAN_FRONTEND=noninteractive
 
@@ -226,10 +240,13 @@ curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 apt-get install -y --no-install-recommends nodejs
 npm install -g @openai/codex@0.133.0 @mariozechner/pi-coding-agent@0.72.1
 
-# 4. Reachability checkout: the expensive state every run reuses. GraalVM is
-#    already in place (copied from the host) and exposed via /etc/environment.
-#    Each run later refreshes this checkout to current master.
-git clone "$REPO_URL" "$REPO_PATH"
+# 4. Reachability checkout: a shallow copy of the operator's LOCAL repository
+#    (mounted read-only at /forge-host-repo), so the VM runs the local forge code
+#    rather than upstream master. Only the base ref tip is cloned (--depth 1, via
+#    file:// so git honors the depth on a local path). origin is repointed at the
+#    real remote so generated branches/PRs push to the right place.
+git clone --depth 1 --branch "$BASE_REF" "file:///forge-host-repo" "$REPO_PATH"
+git -C "$REPO_PATH" remote set-url origin "$REPO_URL"
 
 # 5. Forge Python package + dependencies (jsonschema, PyYAML, ...), installed
 #    editable so it tracks the refreshed checkout. Debian marks its system Python
@@ -242,6 +259,9 @@ python3 -m pip install --break-system-packages -e "$REPO_PATH/forge"
 cd "$REPO_PATH"
 PATH="$GRAALVM_HOME/bin:$PATH" GRAALVM_HOME="$GRAALVM_HOME" JAVA_HOME="$GRAALVM_HOME" ./gradlew --no-daemon help
 PROVISION
+
+log "Unmounting the local repository from the builder VM"
+incus config device remove "$BUILDER_VM" forge-host-repo
 
 log "Stopping the builder VM before publishing"
 incus stop "$BUILDER_VM"

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -199,7 +199,7 @@ printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99force-ipv4
 # 1. Base tooling + Docker. Test resources run as Docker containers INSIDE this
 #    VM, so the VM needs a working Docker engine.
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl git docker.io
+apt-get install -y --no-install-recommends ca-certificates curl gnupg git docker.io
 systemctl enable --now docker
 
 # 2. GitHub CLI. The runner authenticates with `gh auth login --with-token`
@@ -214,19 +214,27 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubc
 apt-get update
 apt-get install -y --no-install-recommends gh
 
-# 3. Reachability checkout: the expensive state every run reuses. GraalVM is
+# 3. Node.js + the AI agent CLIs generation drives: `codex` (failure analysis)
+#    and `pi` (the *_pi_* strategies). Both are public npm packages; pin to the
+#    versions used on the host. Their credentials are seeded per run by the
+#    runner, never baked into this image.
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y --no-install-recommends nodejs
+npm install -g @openai/codex@0.133.0 @mariozechner/pi-coding-agent@0.72.1
+
+# 4. Reachability checkout: the expensive state every run reuses. GraalVM is
 #    already in place (copied from the host) and exposed via /etc/environment.
 #    Each run later refreshes this checkout to current master.
 git clone "$REPO_URL" "$REPO_PATH"
 
-# 4. Forge Python package + dependencies (jsonschema, PyYAML, ...), installed
+# 5. Forge Python package + dependencies (jsonschema, PyYAML, ...), installed
 #    editable so it tracks the refreshed checkout. Debian marks its system Python
 #    as externally managed (PEP 668); the VM is single-use and root-only, so
 #    install into the system interpreter with --break-system-packages.
 apt-get install -y --no-install-recommends python3-pip
 python3 -m pip install --break-system-packages -e "$REPO_PATH/forge"
 
-# 5. Warm the Gradle caches.
+# 6. Warm the Gradle caches.
 cd "$REPO_PATH"
 PATH="$GRAALVM_HOME/bin:$PATH" GRAALVM_HOME="$GRAALVM_HOME" JAVA_HOME="$GRAALVM_HOME" ./gradlew --no-daemon help
 PROVISION

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -9,7 +9,7 @@
 #
 # This is the reproducible definition of the base image's contents. It runs on
 # the HOST and drives Incus to:
-#   1. launch a throwaway builder VM from a stock Debian image,
+#   1. launch a throwaway builder VM from a stock Ubuntu image,
 #   2. install Docker, copy the LOCAL GraalVM into the VM, bake the per-user VM
 #      environment (incus/forge.env) into /etc/environment, clone the
 #      reachability repo, and warm the Gradle caches,
@@ -43,7 +43,13 @@ FORGE_ENV_FILE="${FORGE_INCUS_ENV_FILE:-$SCRIPT_DIR/forge.env}"
 IMAGE_ALIAS="${FORGE_INCUS_IMAGE:-forge-base}"
 PROFILE="${FORGE_INCUS_PROFILE:-forge}"
 BUILDER_VM="${FORGE_INCUS_BUILDER_VM:-forge-build}"
-SOURCE_IMAGE="${FORGE_INCUS_SOURCE_IMAGE:-images:debian/12}"
+# Ubuntu 24.04 (glibc 2.39), NOT Debian 12 (glibc 2.36): a from-source GRAALVM_HOME
+# is compiled on the operator's host and its static libsvm_container.a references
+# C23 glibc symbols (e.g. __isoc23_sscanf, __isoc23_strtol) that only exist in
+# glibc >= 2.38. Linking nativeTestCompile against an older base glibc then fails
+# with "undefined reference to __isoc23_*". The base glibc must be >= the glibc the
+# GraalVM was built against; 24.04 matches a current Ubuntu host build.
+SOURCE_IMAGE="${FORGE_INCUS_SOURCE_IMAGE:-images:ubuntu/24.04}"
 REPO_URL="${FORGE_INCUS_REPO_URL:-https://github.com/oracle/graalvm-reachability-metadata.git}"
 REPO_PATH="${FORGE_INCUS_REPO_PATH:-/root/graalvm-reachability-metadata}"
 AGENT_TIMEOUT="${FORGE_INCUS_LAUNCH_TIMEOUT:-300}"
@@ -223,7 +229,7 @@ systemctl enable --now docker
 
 # 2. GitHub CLI. The runner authenticates with `gh auth login --with-token`
 #    inside the VM, and generation uses `gh` for issue/PR/project operations.
-#    `gh` is not in Debian's repos, so add the official GitHub CLI apt source.
+#    add the official GitHub CLI apt source (distro-agnostic) for a current `gh`.
 mkdir -p -m 755 /etc/apt/keyrings
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     -o /etc/apt/keyrings/githubcli-archive-keyring.gpg

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -245,6 +245,9 @@ npm install -g @openai/codex@0.133.0 @mariozechner/pi-coding-agent@0.72.1
 #    rather than upstream master. Only the base ref tip is cloned (--depth 1, via
 #    file:// so git honors the depth on a local path). origin is repointed at the
 #    real remote so generated branches/PRs push to the right place.
+# The mounted host repo is owned by the host user (uid 1000), not the VM's root,
+# so git's ownership guard would refuse it; trust it for this throwaway builder.
+git config --global --add safe.directory '*'
 git clone --depth 1 --branch "$BASE_REF" "file:///forge-host-repo" "$REPO_PATH"
 git -C "$REPO_PATH" remote set-url origin "$REPO_URL"
 

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -196,10 +196,14 @@ export DEBIAN_FRONTEND=noninteractive
 # IPv6 and fails with "Network is unreachable".
 printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99force-ipv4
 
-# 1. Base tooling + Docker. Test resources run as Docker containers INSIDE this
-#    VM, so the VM needs a working Docker engine.
+# 1. Base tooling + Docker + native-image toolchain. Test resources run as
+#    Docker containers INSIDE this VM, so it needs a working Docker engine; and
+#    GraalVM native-image needs a C toolchain (gcc/make/libc) and zlib headers
+#    to compile, otherwise `nativeTestCompile` fails with "executable 'gcc' not
+#    found".
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl gnupg git docker.io
+apt-get install -y --no-install-recommends \
+    ca-certificates curl gnupg git docker.io build-essential zlib1g-dev
 systemctl enable --now docker
 
 # 2. GitHub CLI. The runner authenticates with `gh auth login --with-token`

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -192,6 +192,10 @@ incus exec "$BUILDER_VM" \
     -- bash -seuo pipefail <<'PROVISION'
 export DEBIAN_FRONTEND=noninteractive
 
+# The managed incusbr0 bridge is IPv4-only; without this apt resolves mirrors to
+# IPv6 and fails with "Network is unreachable".
+printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99force-ipv4
+
 # 1. Base tooling + Docker. Test resources run as Docker containers INSIDE this
 #    VM, so the VM needs a working Docker engine.
 apt-get update

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -202,7 +202,19 @@ apt-get update
 apt-get install -y --no-install-recommends ca-certificates curl git docker.io
 systemctl enable --now docker
 
-# 2. Reachability checkout + warmed Gradle caches: the expensive state every run
+# 2. GitHub CLI. The runner authenticates with `gh auth login --with-token`
+#    inside the VM, and generation uses `gh` for issue/PR/project operations.
+#    `gh` is not in Debian's repos, so add the official GitHub CLI apt source.
+mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    -o /etc/apt/keyrings/githubcli-archive-keyring.gpg
+chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+apt-get update
+apt-get install -y --no-install-recommends gh
+
+# 3. Reachability checkout + warmed Gradle caches: the expensive state every run
 #    reuses. GraalVM is already in place (copied from the host) and exposed via
 #    /etc/environment. Each run later refreshes this checkout to current master.
 git clone "$REPO_URL" "$REPO_PATH"

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -214,10 +214,19 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubc
 apt-get update
 apt-get install -y --no-install-recommends gh
 
-# 3. Reachability checkout + warmed Gradle caches: the expensive state every run
-#    reuses. GraalVM is already in place (copied from the host) and exposed via
-#    /etc/environment. Each run later refreshes this checkout to current master.
+# 3. Reachability checkout: the expensive state every run reuses. GraalVM is
+#    already in place (copied from the host) and exposed via /etc/environment.
+#    Each run later refreshes this checkout to current master.
 git clone "$REPO_URL" "$REPO_PATH"
+
+# 4. Forge Python package + dependencies (jsonschema, PyYAML, ...), installed
+#    editable so it tracks the refreshed checkout. Debian marks its system Python
+#    as externally managed (PEP 668); the VM is single-use and root-only, so
+#    install into the system interpreter with --break-system-packages.
+apt-get install -y --no-install-recommends python3-pip
+python3 -m pip install --break-system-packages -e "$REPO_PATH/forge"
+
+# 5. Warm the Gradle caches.
 cd "$REPO_PATH"
 PATH="$GRAALVM_HOME/bin:$PATH" GRAALVM_HOME="$GRAALVM_HOME" JAVA_HOME="$GRAALVM_HOME" ./gradlew --no-daemon help
 PROVISION

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+# Build the Forge base image used by `forge_metadata.py --incus`.
+# §AR-forge-vm-runner-boundary §FS-forge-vm-isolated-execution
+#
+# This is the reproducible definition of the base image's contents. It runs on
+# the HOST and drives Incus to:
+#   1. launch a throwaway builder VM from a stock Debian image,
+#   2. install Docker, copy the LOCAL GraalVM into the VM, bake the per-user VM
+#      environment (incus/forge.env) into /etc/environment, clone the
+#      reachability repo, and warm the Gradle caches,
+#   3. publish the prepared disk as the reusable base image alias (forge-base),
+#   4. delete the builder VM.
+#
+# GraalVM is not downloaded here: the VM uses the same GraalVM installation as
+# your local machine, copied from the path you set in incus/forge.env
+# (GRAALVM_HOME / JAVA_HOME), so generation inside the VM matches local. Keep
+# that local install at GraalVM 25 (latest).
+#
+# The base image is built locally on each host and is never shipped: it is large
+# and tooling-versioned, so the repository ships this script, the profile
+# (forge.profile.yaml), and the environment template (forge.env.example), not
+# the image bytes. Re-run this script to refresh the image when GraalVM, the
+# checkout, the caches, or forge.env change.
+#
+# Per-run, secret, and run-specific state (the GitHub token, the issue number,
+# the strategy, the log destination) is NOT baked in here; the runner injects it
+# into each fresh VM at launch.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Per-user VM environment (GraalVM paths + any generation variables). Copied
+# from forge.env.example; see that file for the format.
+FORGE_ENV_FILE="${FORGE_INCUS_ENV_FILE:-$SCRIPT_DIR/forge.env}"
+
+# Everything is overridable so the same script serves different machines.
+IMAGE_ALIAS="${FORGE_INCUS_IMAGE:-forge-base}"
+PROFILE="${FORGE_INCUS_PROFILE:-forge}"
+BUILDER_VM="${FORGE_INCUS_BUILDER_VM:-forge-build}"
+SOURCE_IMAGE="${FORGE_INCUS_SOURCE_IMAGE:-images:debian/12}"
+REPO_URL="${FORGE_INCUS_REPO_URL:-https://github.com/oracle/graalvm-reachability-metadata.git}"
+REPO_PATH="${FORGE_INCUS_REPO_PATH:-/root/graalvm-reachability-metadata}"
+AGENT_TIMEOUT="${FORGE_INCUS_LAUNCH_TIMEOUT:-300}"
+
+log() { printf '[build-base-image] %s\n' "$*"; }
+
+# GraalVM homes the build copies into the VM and generation requires inside it.
+# All three are preflighted by forge_metadata.validate_issue_processing_environment
+# before any issue is processed, so each must resolve to a GraalVM with
+# bin/native-image inside the VM:
+#   GRAALVM_HOME          - primary GraalVM used for generation
+#   GRAALVM_HOME_25_0     - GraalVM 25 post-generation validation lane
+#   GRAALVM_HOME_LATEST_EA - latest early-access validation lane
+GRAALVM_VARS=(GRAALVM_HOME GRAALVM_HOME_25_0 GRAALVM_HOME_LATEST_EA)
+
+validate_graalvm() {
+    local var="$1" home="${!1:-}"
+    if [[ ! -f "$home/bin/native-image" ]]; then
+        echo "ERROR: $var=$home does not look like a GraalVM install ($home/bin/native-image is missing)." >&2
+        exit 1
+    fi
+}
+
+load_forge_env() {
+    if [[ ! -f "$FORGE_ENV_FILE" ]]; then
+        echo "ERROR: $FORGE_ENV_FILE not found. Copy forge.env.example to forge.env and set the GraalVM homes for your machine; see forge/README.md." >&2
+        exit 1
+    fi
+    # Export every assignment so the GraalVM homes are visible to the steps below.
+    set -a
+    # shellcheck disable=SC1090
+    source "$FORGE_ENV_FILE"
+    set +a
+    local var home
+    for var in "${GRAALVM_VARS[@]}"; do
+        home="${!var:-}"
+        if [[ -z "$home" ]]; then
+            echo "ERROR: $var is not set in $FORGE_ENV_FILE. All of ${GRAALVM_VARS[*]} are required by Forge's pre-processing preflight; set it to a local GraalVM install with bin/native-image. See forge/README.md." >&2
+            exit 1
+        fi
+        # Strip trailing slashes so `incus file push -r` copies the directory
+        # itself, not just its contents.
+        while [[ "$home" == */ && "$home" != "/" ]]; do home="${home%/}"; done
+        printf -v "$var" '%s' "$home"
+        validate_graalvm "$var"
+    done
+}
+
+require_incus() {
+    if ! command -v incus >/dev/null 2>&1; then
+        echo "ERROR: 'incus' not found on PATH. Install and initialize Incus first; see forge/README.md." >&2
+        exit 1
+    fi
+    if ! incus info >/dev/null 2>&1; then
+        echo "ERROR: Incus daemon not reachable. Run 'incus admin init --minimal' and add your user to 'incus-admin'." >&2
+        exit 1
+    fi
+}
+
+ensure_profile() {
+    if ! incus profile show "$PROFILE" >/dev/null 2>&1; then
+        log "Creating Incus profile '$PROFILE' from forge.profile.yaml"
+        incus profile create "$PROFILE"
+        incus profile edit "$PROFILE" < "$SCRIPT_DIR/forge.profile.yaml"
+    fi
+}
+
+remove_builder() {
+    if incus info "$BUILDER_VM" >/dev/null 2>&1; then
+        log "Removing builder VM '$BUILDER_VM'"
+        incus delete "$BUILDER_VM" --force
+    fi
+}
+
+wait_for_agent() {
+    local deadline=$(( $(date +%s) + AGENT_TIMEOUT ))
+    log "Waiting for the builder VM guest agent to accept commands..."
+    until incus exec "$BUILDER_VM" -- true >/dev/null 2>&1; do
+        if (( $(date +%s) >= deadline )); then
+            echo "ERROR: builder VM '$BUILDER_VM' did not become ready within ${AGENT_TIMEOUT}s." >&2
+            exit 1
+        fi
+        sleep 2
+    done
+}
+
+# Copy each configured local GraalVM into the builder at the same path it has on
+# the host, so every GraalVM home generation resolves (GRAALVM_HOME,
+# GRAALVM_HOME_25_0, GRAALVM_HOME_LATEST_EA) matches local. Paths shared across
+# vars (e.g. when GRAALVM_HOME and GRAALVM_HOME_25_0 use the same JDK 25) are
+# copied once.
+copy_local_graalvm() {
+    local copied=() var home parent
+    for var in "${GRAALVM_VARS[@]}"; do
+        home="${!var:-}"
+        if [[ " ${copied[*]-} " == *" $home "* ]]; then
+            log "GraalVM for $var already copied ('$home'); skipping"
+            continue
+        fi
+        copied+=("$home")
+        parent="$(dirname "$home")"
+        log "Copying local GraalVM for $var from '$home' into the builder VM"
+        incus exec "$BUILDER_VM" -- mkdir -p "$parent"
+        incus file push -r "$home" "$BUILDER_VM$parent/"
+    done
+}
+
+# Bake the per-user environment into the VM's /etc/environment. `incus exec`
+# uses non-login shells that ignore ~/.profile, so /etc/environment is how every
+# later run sees GRAALVM_HOME, JAVA_HOME, PATH, and any extra generation vars.
+write_vm_environment() {
+    local env_tmp
+    env_tmp="$(mktemp)"
+    # forge.env assignments, minus comments, blank lines, and any leading export.
+    grep -vE '^[[:space:]]*(#|$)' "$FORGE_ENV_FILE" \
+        | sed -E 's/^[[:space:]]*export[[:space:]]+//' > "$env_tmp"
+    # Ensure GraalVM bin is on PATH unless forge.env already sets PATH itself.
+    if ! grep -q '^PATH=' "$env_tmp"; then
+        echo "PATH=$GRAALVM_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$env_tmp"
+    fi
+    log "Baking forge.env into the builder VM's /etc/environment"
+    incus file push "$env_tmp" "$BUILDER_VM/etc/environment"
+    rm -f "$env_tmp"
+}
+
+load_forge_env
+require_incus
+ensure_profile
+remove_builder   # start clean if a previous build left a builder behind
+
+log "Launching builder VM '$BUILDER_VM' from '$SOURCE_IMAGE' with profile '$PROFILE'"
+incus launch "$SOURCE_IMAGE" "$BUILDER_VM" --vm --profile "$PROFILE"
+# Tear the builder down on any failure from here on.
+trap remove_builder EXIT
+wait_for_agent
+
+copy_local_graalvm
+write_vm_environment
+
+log "Provisioning the builder VM (Docker, repo checkout, warmed Gradle caches)"
+incus exec "$BUILDER_VM" \
+    --env GRAALVM_HOME="$GRAALVM_HOME" \
+    --env JAVA_HOME="$GRAALVM_HOME" \
+    --env REPO_URL="$REPO_URL" \
+    --env REPO_PATH="$REPO_PATH" \
+    -- bash -seuo pipefail <<'PROVISION'
+export DEBIAN_FRONTEND=noninteractive
+
+# 1. Base tooling + Docker. Test resources run as Docker containers INSIDE this
+#    VM, so the VM needs a working Docker engine.
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates curl git docker.io
+systemctl enable --now docker
+
+# 2. Reachability checkout + warmed Gradle caches: the expensive state every run
+#    reuses. GraalVM is already in place (copied from the host) and exposed via
+#    /etc/environment. Each run later refreshes this checkout to current master.
+git clone "$REPO_URL" "$REPO_PATH"
+cd "$REPO_PATH"
+PATH="$GRAALVM_HOME/bin:$PATH" GRAALVM_HOME="$GRAALVM_HOME" JAVA_HOME="$GRAALVM_HOME" ./gradlew --no-daemon help
+PROVISION
+
+log "Stopping the builder VM before publishing"
+incus stop "$BUILDER_VM"
+
+log "Publishing the prepared disk as base image alias '$IMAGE_ALIAS'"
+if incus image info "$IMAGE_ALIAS" >/dev/null 2>&1; then
+    log "Replacing existing image '$IMAGE_ALIAS'"
+    incus image delete "$IMAGE_ALIAS"
+fi
+incus publish "$BUILDER_VM" --alias "$IMAGE_ALIAS"
+
+remove_builder
+trap - EXIT
+
+log "Done. Base image '$IMAGE_ALIAS' is in the local image store:"
+incus image list "$IMAGE_ALIAS"

--- a/forge/incus/build-base-image.sh
+++ b/forge/incus/build-base-image.sh
@@ -48,12 +48,13 @@ REPO_URL="${FORGE_INCUS_REPO_URL:-https://github.com/oracle/graalvm-reachability
 REPO_PATH="${FORGE_INCUS_REPO_PATH:-/root/graalvm-reachability-metadata}"
 AGENT_TIMEOUT="${FORGE_INCUS_LAUNCH_TIMEOUT:-300}"
 
-# The image bakes a shallow copy of the operator's LOCAL repository (this
+# The image bakes a full-history copy of the operator's LOCAL repository (this
 # checkout), so the VM runs the local forge code under development rather than
 # upstream master. HOST_REPO is mounted read-only into the builder and its
-# BASE_REF tip is cloned in; origin is then repointed at REPO_URL so generated
-# branches/PRs push to the real remote. Override HOST_REPO when building from a
-# linked worktree (whose objects live in the main checkout).
+# BASE_REF history is cloned in full (see step 4: a shallow clone cannot push a
+# branch rooted on the diverged local base); origin is then repointed at REPO_URL
+# so generated branches/PRs push to the real remote. Override HOST_REPO when
+# building from a linked worktree (whose objects live in the main checkout).
 HOST_REPO="${FORGE_INCUS_HOST_REPO:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)}"
 HOST_REPO_BASE_REF="${FORGE_INCUS_BASE_REF:-master}"
 
@@ -240,15 +241,22 @@ curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 apt-get install -y --no-install-recommends nodejs
 npm install -g @openai/codex@0.133.0 @mariozechner/pi-coding-agent@0.72.1
 
-# 4. Reachability checkout: a shallow copy of the operator's LOCAL repository
+# 4. Reachability checkout: a full clone of the operator's LOCAL repository
 #    (mounted read-only at /forge-host-repo), so the VM runs the local forge code
-#    rather than upstream master. Only the base ref tip is cloned (--depth 1, via
-#    file:// so git honors the depth on a local path). origin is repointed at the
-#    real remote so generated branches/PRs push to the right place.
+#    rather than upstream master. The clone keeps full history (NOT --depth 1): the
+#    base ref is the operator's local master, which has diverged from upstream with
+#    unmerged commits, so a generated branch built on it can only push to origin
+#    when its complete ancestry is present. A shallow clone makes git emit a thin
+#    pack that assumes the remote already has the local base commit, so the push is
+#    rejected with "did not receive expected object / index-pack failed". Full
+#    history makes the VM push exactly what a local run would: the branch plus the
+#    local commits underneath it. Cloning via file:// keeps objects copied (no
+#    hardlinks into the mounted host repo); origin is repointed at the real remote
+#    so generated branches/PRs push to the right place.
 # The mounted host repo is owned by the host user (uid 1000), not the VM's root,
 # so git's ownership guard would refuse it; trust it for this throwaway builder.
 git config --global --add safe.directory '*'
-git clone --depth 1 --branch "$BASE_REF" "file:///forge-host-repo" "$REPO_PATH"
+git clone --branch "$BASE_REF" "file:///forge-host-repo" "$REPO_PATH"
 git -C "$REPO_PATH" remote set-url origin "$REPO_URL"
 
 # 5. Forge Python package + dependencies (jsonschema, PyYAML, ...), installed

--- a/forge/incus/forge.env.example
+++ b/forge/incus/forge.env.example
@@ -1,0 +1,35 @@
+# Per-user Forge VM environment.
+# §AR-forge-vm-runner-boundary §FS-forge-vm-isolated-execution
+#
+# Copy this file to `forge.env` (gitignored) and set the values for YOUR
+# machine. `incus/build-base-image.sh` copies each GraalVM install referenced
+# below into the base image and bakes these variables into the VM's
+# /etc/environment, so a generation run inside the VM uses the same toolchain
+# and settings as your local machine. Re-run build-base-image.sh after changing
+# this file.
+#
+# Format rules:
+#   - plain `KEY=VALUE` lines only (no `export`, no `$VAR` expansion, no spaces
+#     around `=`): the file is both sourced on the host and written verbatim
+#     into the VM's /etc/environment.
+#   - secrets such as GitHub tokens do NOT belong here; the runner injects the
+#     `gh` token into each VM at launch instead.
+
+# Primary GraalVM used for generation (must contain bin/native-image). Forge
+# resolves GRAALVM_HOME/JAVA_HOME from this. Keep it at GraalVM 25 (latest).
+GRAALVM_HOME=/opt/graalvm-25
+JAVA_HOME=/opt/graalvm-25
+
+# GraalVM 25 used by the post-generation validation lane. REQUIRED: Forge's
+# pre-processing preflight exits if it is unset or lacks native-image. With
+# everything on JDK 25 this points at the same install as GRAALVM_HOME.
+GRAALVM_HOME_25_0=/opt/graalvm-25
+
+# GraalVM for the latest early-access validation lane. REQUIRED: the same
+# preflight (validate_issue_processing_environment) also demands this one. It is
+# a distinct early-access build, so point it at your local latest-EA install.
+GRAALVM_HOME_LATEST_EA=/opt/graalvm-latest-ea
+
+# Any other environment variables a generation run needs inside the VM. Add as
+# many as you require; each becomes part of the VM's environment.
+# EXAMPLE_SETTING=value

--- a/forge/incus/forge.profile.yaml
+++ b/forge/incus/forge.profile.yaml
@@ -1,0 +1,23 @@
+# Incus profile for Forge single-use metadata-generation VMs.
+# §AR-forge-vm-runner-boundary §FS-forge-vm-isolated-execution
+#
+# Apply once on the host, then the runner launches every VM with it
+# (FORGE_INCUS_PROFILE defaults to "forge"):
+#
+#   incus profile create forge
+#   incus profile edit forge < forge/incus/forge.profile.yaml
+#
+# The defaults size a VM for a full generation: several copied-in GraalVM
+# installs, Gradle caches, Docker-backed test resources, native-image scratch,
+# and the reachability checkout. Tune limits to the host.
+config:
+  limits.cpu: "4"
+  limits.memory: 16GiB
+  security.secureboot: "false"
+description: Forge single-use metadata-generation VM
+devices:
+  root:
+    path: /
+    pool: default
+    size: 20GiB
+    type: disk

--- a/forge/incus/forge.profile.yaml
+++ b/forge/incus/forge.profile.yaml
@@ -16,6 +16,11 @@ config:
   security.secureboot: "false"
 description: Forge single-use metadata-generation VM
 devices:
+  # Managed bridge created by `incus admin init --minimal`; the VM needs network
+  # for apt, the repo clone, Docker pulls, and gh/metrics over the network.
+  eth0:
+    network: incusbr0
+    type: nic
   root:
     path: /
     pool: default

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1695,6 +1695,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             forge_metadata.DEFAULT_PARALLELISM,
             user_requested_only=False,
             environment_already_validated=True,
+            use_incus=False,
         )
         process_reviews.assert_not_called()
 
@@ -1741,6 +1742,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             forge_metadata.DEFAULT_PARALLELISM,
             user_requested_only=False,
             environment_already_validated=True,
+            use_incus=False,
         )
         process_reviews.assert_not_called()
 
@@ -1784,6 +1786,7 @@ class WorkQueueSchedulerTests(unittest.TestCase):
             forge_metadata.DEFAULT_PARALLELISM,
             user_requested_only=True,
             environment_already_validated=True,
+            use_incus=False,
         )
 
     def test_process_work_queues_resolves_auth_for_review_only_queue(self) -> None:

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -49,6 +49,19 @@ class AgentConfigFilesTests(unittest.TestCase):
         self.assertTrue(any(p.endswith("/.pi/agent/models.json") for p in host_paths))
 
 
+class HostRepoBaseRefTests(unittest.TestCase):
+    def test_defaults(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(incus_runner.base_ref(), "master")
+            # Defaults to the repo containing the forge package (…/<repo>).
+            self.assertTrue(os.path.isabs(incus_runner.host_repo_root()))
+
+    def test_overrides(self) -> None:
+        with patch.dict(os.environ, {"FORGE_INCUS_BASE_REF": "feature/x", "FORGE_INCUS_HOST_REPO": "/h/repo"}, clear=True):
+            self.assertEqual(incus_runner.base_ref(), "feature/x")
+            self.assertEqual(incus_runner.host_repo_root(), "/h/repo")
+
+
 class LogsRootOverrideTests(unittest.TestCase):
     def test_logs_root_defaults_under_repo(self) -> None:
         with patch.dict(os.environ, {}, clear=True):

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -1,0 +1,173 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from utility_scripts import incus_runner
+from utility_scripts.incus_runner import (
+    DEFAULT_INCUS_IMAGE,
+    DEFAULT_INCUS_PROFILE,
+    DEFAULT_VM_REPO_PATH,
+    VM_LOGS_MOUNT_PATH,
+    IncusPreflightError,
+    build_incus_exec_command,
+    build_inner_forge_command,
+    incus_image_name,
+    incus_profile_name,
+    preflight,
+    vm_repo_path,
+)
+from utility_scripts.task_logs import FORGE_LOGS_DIR_ENV, resolve_logs_root
+
+
+class LogsRootOverrideTests(unittest.TestCase):
+    def test_logs_root_defaults_under_repo(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(resolve_logs_root().endswith(os.path.join("forge", "logs")))
+
+    def test_logs_root_honors_override(self) -> None:
+        with patch.dict(os.environ, {FORGE_LOGS_DIR_ENV: "~/forge-out"}, clear=True):
+            resolved = resolve_logs_root()
+        self.assertTrue(os.path.isabs(resolved))
+        self.assertEqual(resolved, os.path.abspath(os.path.expanduser("~/forge-out")))
+
+
+class SettingsResolutionTests(unittest.TestCase):
+    def test_defaults(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(incus_image_name(), DEFAULT_INCUS_IMAGE)
+            self.assertEqual(incus_profile_name(), DEFAULT_INCUS_PROFILE)
+            self.assertEqual(vm_repo_path(), DEFAULT_VM_REPO_PATH)
+
+    def test_overrides(self) -> None:
+        env = {
+            "FORGE_INCUS_IMAGE": "custom-base",
+            "FORGE_INCUS_PROFILE": "custom-profile",
+            "FORGE_INCUS_REPO_PATH": "/srv/reachability",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(incus_image_name(), "custom-base")
+            self.assertEqual(incus_profile_name(), "custom-profile")
+            self.assertEqual(vm_repo_path(), "/srv/reachability")
+
+
+class InnerCommandTests(unittest.TestCase):
+    def test_minimal_inner_command(self) -> None:
+        command = build_inner_forge_command(
+            9101,
+            strategy_name=None,
+            keep_tests_without_dynamic_access=False,
+        )
+        self.assertEqual(command, ["python3", "forge_metadata.py", "--issue-number", "9101"])
+
+    def test_inner_command_forwards_strategy_and_keep_flag(self) -> None:
+        command = build_inner_forge_command(
+            42,
+            strategy_name="dynamic_access_main_sources_pi_gpt-5.5",
+            keep_tests_without_dynamic_access=True,
+        )
+        self.assertEqual(
+            command,
+            [
+                "python3",
+                "forge_metadata.py",
+                "--issue-number",
+                "42",
+                "--strategy-name",
+                "dynamic_access_main_sources_pi_gpt-5.5",
+                "--keep-tests-without-dynamic-access",
+            ],
+        )
+
+    def test_inner_command_never_carries_incus(self) -> None:
+        command = build_inner_forge_command(
+            7,
+            strategy_name="s",
+            keep_tests_without_dynamic_access=True,
+        )
+        self.assertNotIn("--incus", command)
+
+
+class ExecCommandTests(unittest.TestCase):
+    def test_exec_command_sets_cwd_env_and_inner_command(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            exec_command = build_incus_exec_command(
+                "forge-run-7-abcd",
+                ["python3", "forge_metadata.py", "--issue-number", "7"],
+                {"FORGE_LOGS_DIR": VM_LOGS_MOUNT_PATH, "FORGE_STRATEGY_NAME": "s"},
+            )
+
+        self.assertEqual(exec_command[0], "exec")
+        self.assertEqual(exec_command[1], "forge-run-7-abcd")
+        self.assertIn("--cwd", exec_command)
+        self.assertEqual(
+            exec_command[exec_command.index("--cwd") + 1],
+            f"{DEFAULT_VM_REPO_PATH}/forge",
+        )
+        self.assertIn("--env", exec_command)
+        self.assertIn(f"FORGE_LOGS_DIR={VM_LOGS_MOUNT_PATH}", exec_command)
+        self.assertIn("FORGE_STRATEGY_NAME=s", exec_command)
+        separator_index = exec_command.index("--")
+        self.assertEqual(
+            exec_command[separator_index + 1:],
+            ["python3", "forge_metadata.py", "--issue-number", "7"],
+        )
+
+
+class ForwardedEnvironmentTests(unittest.TestCase):
+    def test_forwards_forge_settings_and_pins_logs_dir(self) -> None:
+        env = {
+            "FORGE_STRATEGY_NAME": "s",
+            "FORGE_PARALLELISM": "3",
+            "FORGE_INCUS_IMAGE": "custom-base",
+            "FORGE_LOGS_DIR": "/host/logs",
+            "PATH": "/usr/bin",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            forwarded = incus_runner._forwarded_run_environment()
+
+        self.assertEqual(forwarded["FORGE_STRATEGY_NAME"], "s")
+        self.assertEqual(forwarded["FORGE_PARALLELISM"], "3")
+        # Incus-runner-only and non-FORGE settings are not forwarded.
+        self.assertNotIn("FORGE_INCUS_IMAGE", forwarded)
+        self.assertNotIn("PATH", forwarded)
+        # Logs are always pinned to the in-VM mount target.
+        self.assertEqual(forwarded["FORGE_LOGS_DIR"], VM_LOGS_MOUNT_PATH)
+
+
+class PreflightTests(unittest.TestCase):
+    def test_preflight_fails_when_incus_missing(self) -> None:
+        with patch.object(incus_runner.shutil, "which", return_value=None):
+            with self.assertRaises(IncusPreflightError) as caught:
+                preflight()
+        self.assertIn("incus", str(caught.exception).lower())
+
+    def test_preflight_fails_when_daemon_unreachable(self) -> None:
+        with patch.object(incus_runner.shutil, "which", return_value="/usr/bin/incus"), \
+                patch.object(incus_runner, "_incus_daemon_reachable", return_value=False):
+            with self.assertRaises(IncusPreflightError) as caught:
+                preflight()
+        self.assertIn("daemon", str(caught.exception).lower())
+
+    def test_preflight_fails_when_image_missing(self) -> None:
+        with patch.object(incus_runner.shutil, "which", return_value="/usr/bin/incus"), \
+                patch.object(incus_runner, "_incus_daemon_reachable", return_value=True), \
+                patch.object(incus_runner, "_image_exists", return_value=False):
+            with self.assertRaises(IncusPreflightError) as caught:
+                preflight()
+        self.assertIn("base image", str(caught.exception).lower())
+
+    def test_preflight_passes_when_ready(self) -> None:
+        with patch.object(incus_runner.shutil, "which", return_value="/usr/bin/incus"), \
+                patch.object(incus_runner, "_incus_daemon_reachable", return_value=True), \
+                patch.object(incus_runner, "_image_exists", return_value=True), \
+                patch.object(incus_runner, "_resolve_github_token", return_value="t"):
+            preflight()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -12,16 +12,41 @@ from utility_scripts.incus_runner import (
     DEFAULT_INCUS_IMAGE,
     DEFAULT_INCUS_PROFILE,
     DEFAULT_VM_REPO_PATH,
+    VM_CODEX_DIR,
     VM_LOGS_MOUNT_PATH,
-    IncusPreflightError,
+    VM_PI_AGENT_DIR,
+    agent_config_files,
     build_incus_exec_command,
     build_inner_forge_command,
     incus_image_name,
     incus_profile_name,
+    IncusPreflightError,
     preflight,
     vm_repo_path,
 )
 from utility_scripts.task_logs import FORGE_LOGS_DIR_ENV, resolve_logs_root
+
+
+class AgentConfigFilesTests(unittest.TestCase):
+    def test_maps_small_codex_and_pi_files_to_vm_paths(self) -> None:
+        with patch.dict(os.environ, {"FORGE_INCUS_CODEX_DIR": "/h/cx", "FORGE_INCUS_PI_DIR": "/h/pi"}, clear=True):
+            pairs = agent_config_files()
+        self.assertEqual(
+            pairs,
+            [
+                ("/h/cx/auth.json", f"{VM_CODEX_DIR}/auth.json"),
+                ("/h/cx/config.toml", f"{VM_CODEX_DIR}/config.toml"),
+                ("/h/pi/agent/models.json", f"{VM_PI_AGENT_DIR}/models.json"),
+                ("/h/pi/agent/settings.json", f"{VM_PI_AGENT_DIR}/settings.json"),
+            ],
+        )
+
+    def test_defaults_expand_user_home(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            host_paths = [host for host, _ in agent_config_files()]
+        self.assertTrue(all(os.path.isabs(p) for p in host_paths))
+        self.assertTrue(any(p.endswith("/.codex/auth.json") for p in host_paths))
+        self.assertTrue(any(p.endswith("/.pi/agent/models.json") for p in host_paths))
 
 
 class LogsRootOverrideTests(unittest.TestCase):

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -93,7 +93,7 @@ class InnerCommandTests(unittest.TestCase):
 
 
 class ExecCommandTests(unittest.TestCase):
-    def test_exec_command_sets_cwd_env_and_inner_command(self) -> None:
+    def test_exec_command_sources_env_then_runs_inner_command(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             exec_command = build_incus_exec_command(
                 "forge-run-7-abcd",
@@ -108,12 +108,20 @@ class ExecCommandTests(unittest.TestCase):
             exec_command[exec_command.index("--cwd") + 1],
             f"{DEFAULT_VM_REPO_PATH}/forge",
         )
-        self.assertIn("--env", exec_command)
-        self.assertIn(f"FORGE_LOGS_DIR={VM_LOGS_MOUNT_PATH}", exec_command)
-        self.assertIn("FORGE_STRATEGY_NAME=s", exec_command)
+        # The inner run is wrapped in bash that sources the baked /etc/environment
+        # (GraalVM homes + PATH), then applies the forwarded settings after so they
+        # win over anything forge.env baked in.
         separator_index = exec_command.index("--")
+        self.assertEqual(exec_command[separator_index + 1], "bash")
+        self.assertEqual(exec_command[separator_index + 2], "-c")
+        script = exec_command[separator_index + 3]
+        self.assertIn(". /etc/environment", script)
+        self.assertIn(f"FORGE_LOGS_DIR={VM_LOGS_MOUNT_PATH}", script)
+        self.assertIn("FORGE_STRATEGY_NAME=s", script)
+        self.assertLess(script.index(". /etc/environment"), script.index("FORGE_LOGS_DIR="))
+        # Inner command follows the bash arg0 sentinel as positional args.
         self.assertEqual(
-            exec_command[separator_index + 1:],
+            exec_command[separator_index + 5:],
             ["python3", "forge_metadata.py", "--issue-number", "7"],
         )
 

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -49,19 +49,6 @@ class AgentConfigFilesTests(unittest.TestCase):
         self.assertTrue(any(p.endswith("/.pi/agent/models.json") for p in host_paths))
 
 
-class HostRepoBaseRefTests(unittest.TestCase):
-    def test_defaults(self) -> None:
-        with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(incus_runner.base_ref(), "master")
-            # Defaults to the repo containing the forge package (…/<repo>).
-            self.assertTrue(os.path.isabs(incus_runner.host_repo_root()))
-
-    def test_overrides(self) -> None:
-        with patch.dict(os.environ, {"FORGE_INCUS_BASE_REF": "feature/x", "FORGE_INCUS_HOST_REPO": "/h/repo"}, clear=True):
-            self.assertEqual(incus_runner.base_ref(), "feature/x")
-            self.assertEqual(incus_runner.host_repo_root(), "/h/repo")
-
-
 class LogsRootOverrideTests(unittest.TestCase):
     def test_logs_root_defaults_under_repo(self) -> None:
         with patch.dict(os.environ, {}, clear=True):

--- a/forge/tests/test_incus_runner.py
+++ b/forge/tests/test_incus_runner.py
@@ -38,6 +38,7 @@ class AgentConfigFilesTests(unittest.TestCase):
                 ("/h/cx/config.toml", f"{VM_CODEX_DIR}/config.toml"),
                 ("/h/pi/agent/models.json", f"{VM_PI_AGENT_DIR}/models.json"),
                 ("/h/pi/agent/settings.json", f"{VM_PI_AGENT_DIR}/settings.json"),
+                ("/h/pi/agent/.oca-key", f"{VM_PI_AGENT_DIR}/.oca-key"),
             ],
         )
 

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -135,6 +135,11 @@ def agent_config_files() -> list[tuple[str, str]]:
 
     Only the small auth/provider files are seeded — never the gigabytes of
     session and sqlite state under the agent dirs (§FS-forge-vm-isolated-execution).
+
+    `.oca-key` holds the OCA gateway JWT that pi's `models.json` resolves at
+    runtime via `"apiKey": "!cat $HOME/.pi/agent/.oca-key"`. Without it the VM's
+    pi reads an empty key and every model call returns nothing (0 tokens), so it
+    must be seeded to the exact path `models.json` shells out to.
     """
     codex = _codex_host_dir()
     pi_agent = os.path.join(_pi_host_dir(), "agent")
@@ -143,6 +148,7 @@ def agent_config_files() -> list[tuple[str, str]]:
         (os.path.join(codex, "config.toml"), f"{VM_CODEX_DIR}/config.toml"),
         (os.path.join(pi_agent, "models.json"), f"{VM_PI_AGENT_DIR}/models.json"),
         (os.path.join(pi_agent, "settings.json"), f"{VM_PI_AGENT_DIR}/settings.json"),
+        (os.path.join(pi_agent, ".oca-key"), f"{VM_PI_AGENT_DIR}/.oca-key"),
     ]
 
 

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -1,0 +1,430 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Run a whole Forge generation inside a fresh, single-use Incus VM.
+
+This module is the only Incus-aware surface in Forge. The opt-in `--incus` flag
+on `forge_metadata.py` routes each claimed run through `run_issue_in_vm`, which
+preflights the host, launches a fresh VM from the cached base image, mounts a
+per-run host log directory, seeds GitHub credentials, refreshes the baked
+checkout to `master`, runs `forge_metadata.py --issue-number N` inside the VM,
+and destroys the VM afterwards. Workflow drivers, engines, and agents never see
+Incus; they run the same code inside the VM as on the host.
+§AR-forge-vm-runner-boundary §FS-forge-vm-isolated-execution
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Iterator, Sequence
+
+from utility_scripts.stage_logger import log_stage
+from utility_scripts.task_logs import FORGE_LOGS_DIR_ENV, resolve_logs_root
+
+# Name of the cached base image the per-run VMs are launched from. Built once by
+# the operator (see forge/README.md) and never modified by Forge.
+FORGE_INCUS_IMAGE_ENV = "FORGE_INCUS_IMAGE"
+DEFAULT_INCUS_IMAGE = "forge-base"
+
+# Optional Incus profile applied at launch (Docker nesting, resource limits).
+FORGE_INCUS_PROFILE_ENV = "FORGE_INCUS_PROFILE"
+DEFAULT_INCUS_PROFILE = "forge"
+
+# Path of the baked reachability checkout inside the VM. The per-issue run is
+# invoked from `<repo>/forge`.
+FORGE_INCUS_REPO_PATH_ENV = "FORGE_INCUS_REPO_PATH"
+DEFAULT_VM_REPO_PATH = "/root/graalvm-reachability-metadata"
+
+# Host directory that holds each run's mounted log directory. Per-run logs land
+# in `<root>/issue-<number>` and survive VM teardown.
+FORGE_INCUS_LOGS_ROOT_ENV = "FORGE_INCUS_LOGS_ROOT"
+
+# Clean top-level mount target inside the VM, pointed at by FORGE_LOGS_DIR so the
+# run writes its durable logs straight onto the host.
+VM_LOGS_MOUNT_PATH = "/forge-logs"
+LOGS_DEVICE_NAME = "forge-logs"
+
+# Seconds to wait for the VM guest agent to accept commands after launch.
+FORGE_INCUS_LAUNCH_TIMEOUT_ENV = "FORGE_INCUS_LAUNCH_TIMEOUT"
+DEFAULT_LAUNCH_TIMEOUT_SECONDS = 300
+
+# Environment variables forwarded into the VM run. The behavior-shaping FORGE_*
+# settings are forwarded dynamically; these are the credentials and fixed names.
+FORWARDED_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
+# Incus-runner-only settings that must not leak into the inner host-style run.
+_INCUS_ONLY_ENV_NAMES = frozenset(
+    {
+        FORGE_INCUS_IMAGE_ENV,
+        FORGE_INCUS_PROFILE_ENV,
+        FORGE_INCUS_REPO_PATH_ENV,
+        FORGE_INCUS_LOGS_ROOT_ENV,
+        FORGE_INCUS_LAUNCH_TIMEOUT_ENV,
+        FORGE_LOGS_DIR_ENV,
+    }
+)
+
+
+class IncusError(RuntimeError):
+    """A recoverable failure while driving Incus for a run."""
+
+
+class IncusPreflightError(IncusError):
+    """The host is not ready to run with `--incus`; setup is incomplete.
+
+    Raised with an actionable message instead of installing anything or falling
+    back to the host (§FS-forge-vm-isolated-execution).
+    """
+
+
+def incus_image_name() -> str:
+    """Return the configured base image alias."""
+    return os.environ.get(FORGE_INCUS_IMAGE_ENV) or DEFAULT_INCUS_IMAGE
+
+
+def incus_profile_name() -> str:
+    """Return the configured Incus profile, or empty when none is set."""
+    return os.environ.get(FORGE_INCUS_PROFILE_ENV, DEFAULT_INCUS_PROFILE)
+
+
+def vm_repo_path() -> str:
+    """Return the baked reachability checkout path inside the VM."""
+    return os.environ.get(FORGE_INCUS_REPO_PATH_ENV) or DEFAULT_VM_REPO_PATH
+
+
+def host_logs_root() -> str:
+    """Return the host directory that holds per-run mounted log directories."""
+    override = os.environ.get(FORGE_INCUS_LOGS_ROOT_ENV)
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+    return resolve_logs_root()
+
+
+def launch_timeout_seconds() -> int:
+    """Return how long to wait for the VM guest agent after launch."""
+    raw_value = os.environ.get(FORGE_INCUS_LAUNCH_TIMEOUT_ENV)
+    if not raw_value:
+        return DEFAULT_LAUNCH_TIMEOUT_SECONDS
+    try:
+        parsed = int(raw_value)
+    except ValueError as exc:
+        raise IncusError(
+            f"{FORGE_INCUS_LAUNCH_TIMEOUT_ENV} must be an integer number of seconds, got {raw_value!r}"
+        ) from exc
+    if parsed <= 0:
+        raise IncusError(f"{FORGE_INCUS_LAUNCH_TIMEOUT_ENV} must be a positive integer, got {raw_value!r}")
+    return parsed
+
+
+def _run_incus(
+        args: Sequence[str],
+        *,
+        capture: bool = False,
+        check: bool = True,
+        input_text: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Run an `incus` subcommand, raising `IncusError` on unexpected failure."""
+    command = ["incus", *args]
+    try:
+        return subprocess.run(
+            command,
+            check=check,
+            text=True,
+            input=input_text,
+            capture_output=capture,
+        )
+    except FileNotFoundError as exc:
+        raise IncusPreflightError(
+            "The `incus` command was not found on PATH. Install and initialize Incus on the host "
+            "before using --incus; see forge/README.md (Isolated execution with Incus)."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        raise IncusError(f"`{' '.join(command)}` failed with exit code {exc.returncode}{suffix}") from exc
+
+
+def _resolve_github_token() -> str:
+    """Return a GitHub token to seed into the VM, or raise if none is available."""
+    for env_name in FORWARDED_TOKEN_ENV_NAMES:
+        token = os.environ.get(env_name)
+        if token:
+            return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise IncusPreflightError(
+            "Neither GH_TOKEN/GITHUB_TOKEN nor the `gh` CLI is available to obtain a GitHub token. "
+            "Authenticate `gh` on the host (`gh auth login`) before using --incus."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise IncusPreflightError(
+            "Could not read a GitHub token from `gh auth token`. Authenticate `gh` on the host "
+            "(`gh auth login`) before using --incus."
+        ) from exc
+    token = result.stdout.strip()
+    if not token:
+        raise IncusPreflightError(
+            "`gh auth token` returned no token. Authenticate `gh` on the host (`gh auth login`) "
+            "before using --incus."
+        )
+    return token
+
+
+def _incus_daemon_reachable() -> bool:
+    """Return whether the local Incus daemon is reachable for this user."""
+    result = subprocess.run(
+        ["incus", "info"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _image_exists(image: str) -> bool:
+    """Return whether an image with the given alias is in the local store."""
+    result = subprocess.run(
+        ["incus", "image", "info", image],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def preflight() -> None:
+    """Verify the host is ready to run with `--incus`, or raise `IncusPreflightError`.
+
+    Checks Incus availability, the base image, and GitHub credentials; never
+    installs or configures anything (§FS-forge-vm-isolated-execution, step 1 of
+    §AR-forge-vm-runner-boundary).
+    """
+    if shutil.which("incus") is None:
+        raise IncusPreflightError(
+            "The `incus` command was not found on PATH. Install and initialize Incus on the host "
+            "before using --incus; see forge/README.md (Isolated execution with Incus)."
+        )
+    if not _incus_daemon_reachable():
+        raise IncusPreflightError(
+            "The Incus daemon is not reachable (`incus info` failed). Initialize Incus "
+            "(`incus admin init --minimal`) and ensure your user is in the `incus-admin` group; "
+            "see forge/README.md (Isolated execution with Incus)."
+        )
+    image = incus_image_name()
+    if not _image_exists(image):
+        raise IncusPreflightError(
+            f"The base image '{image}' is not in the local Incus image store. Build it once with the "
+            "steps in forge/README.md (Build the base image), or set FORGE_INCUS_IMAGE to an existing "
+            "image alias."
+        )
+    # Surfaces a missing-credentials failure now rather than mid-run.
+    _resolve_github_token()
+
+
+def _forwarded_run_environment() -> dict[str, str]:
+    """Return the behavior-shaping environment forwarded into the inner run.
+
+    Forwards the operator's `FORGE_*` settings unchanged so workflow selection,
+    strategy configuration, and limits behave the same inside the VM, but drops
+    the Incus-runner-only settings and forces logs onto the mounted host
+    directory (§FS-forge-vm-isolated-execution, "Behavior unchanged").
+    """
+    forwarded: dict[str, str] = {
+        name: value
+        for name, value in os.environ.items()
+        if name.startswith("FORGE_") and name not in _INCUS_ONLY_ENV_NAMES
+    }
+    forwarded[FORGE_LOGS_DIR_ENV] = VM_LOGS_MOUNT_PATH
+    return forwarded
+
+
+def build_inner_forge_command(
+        issue_number: int,
+        *,
+        strategy_name: str | None,
+        keep_tests_without_dynamic_access: bool,
+) -> list[str]:
+    """Build the host-style `forge_metadata.py` invocation that runs inside the VM.
+
+    The inner run never carries `--incus`; it is the ordinary per-issue run
+    (§AR-forge-vm-runner-boundary, step 5).
+    """
+    command = ["python3", "forge_metadata.py", "--issue-number", str(issue_number)]
+    if strategy_name:
+        command += ["--strategy-name", strategy_name]
+    if keep_tests_without_dynamic_access:
+        command.append("--keep-tests-without-dynamic-access")
+    return command
+
+
+def build_incus_exec_command(
+        vm_name: str,
+        inner_command: Sequence[str],
+        forwarded_env: dict[str, str],
+) -> list[str]:
+    """Build the `incus exec` command that runs the inner run inside the VM."""
+    command = ["exec", vm_name, "--cwd", f"{vm_repo_path()}/forge"]
+    for name in sorted(forwarded_env):
+        command += ["--env", f"{name}={forwarded_env[name]}"]
+    command.append("--")
+    command += list(inner_command)
+    return command
+
+
+def _wait_for_guest_agent(vm_name: str, timeout_seconds: int) -> None:
+    """Block until the VM accepts commands, or raise `IncusError` on timeout."""
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        probe = subprocess.run(
+            ["incus", "exec", vm_name, "--", "true"],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if probe.returncode == 0:
+            return
+        if time.monotonic() >= deadline:
+            raise IncusError(
+                f"VM '{vm_name}' did not become ready within {timeout_seconds}s "
+                "(guest agent unreachable)."
+            )
+        time.sleep(2)
+
+
+@contextmanager
+def _launched_vm(vm_name: str) -> Iterator[None]:
+    """Launch a fresh VM from the base image and always destroy it afterwards."""
+    launch_args = ["launch", incus_image_name(), vm_name, "--vm"]
+    profile = incus_profile_name()
+    if profile:
+        launch_args += ["--profile", profile]
+    log_stage("incus", f"Launching fresh VM '{vm_name}' from image '{incus_image_name()}'")
+    _run_incus(launch_args, capture=True)
+    try:
+        _wait_for_guest_agent(vm_name, launch_timeout_seconds())
+        yield
+    finally:
+        log_stage("incus", f"Destroying VM '{vm_name}'")
+        _run_incus(["delete", vm_name, "--force"], capture=True, check=False)
+
+
+def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
+    """Mount the per-run host log directory into the VM at the logs mount path."""
+    os.makedirs(host_log_dir, exist_ok=True)
+    _run_incus(
+        [
+            "config",
+            "device",
+            "add",
+            vm_name,
+            LOGS_DEVICE_NAME,
+            "disk",
+            f"source={host_log_dir}",
+            f"path={VM_LOGS_MOUNT_PATH}",
+        ],
+        capture=True,
+    )
+
+
+def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> None:
+    """Inject GitHub credentials and refresh the baked checkout to `master`."""
+    log_stage("incus", f"Seeding credentials and refreshing checkout in '{vm_name}'")
+    _run_incus(
+        ["exec", vm_name, "--", "gh", "auth", "login", "--with-token"],
+        input_text=github_token + "\n",
+        capture=True,
+    )
+    _run_incus(
+        ["exec", vm_name, "--", "gh", "auth", "setup-git"],
+        capture=True,
+    )
+    repo_path = vm_repo_path()
+    _run_incus(
+        [
+            "exec",
+            vm_name,
+            "--cwd",
+            repo_path,
+            "--",
+            "git",
+            "fetch",
+            "origin",
+            "master",
+        ],
+        capture=True,
+    )
+    _run_incus(
+        [
+            "exec",
+            vm_name,
+            "--cwd",
+            repo_path,
+            "--",
+            "git",
+            "reset",
+            "--hard",
+            "origin/master",
+        ],
+        capture=True,
+    )
+
+
+def run_issue_in_vm(
+        issue_number: int,
+        *,
+        strategy_name: str | None = None,
+        keep_tests_without_dynamic_access: bool = False,
+) -> bool:
+    """Run one issue's generation inside a fresh, single-use Incus VM.
+
+    Implements the per-run sequence of §AR-forge-vm-runner-boundary: preflight,
+    launch, mount logs, seed credentials, run the per-issue workflow, then
+    destroy the VM. Branches, PRs, and metrics leave the VM over the network;
+    only logs cross through the mounted host directory. Returns whether the
+    inner run reported success.
+    """
+    preflight()
+    github_token = _resolve_github_token()
+
+    vm_name = f"forge-run-{issue_number}-{uuid.uuid4().hex[:8]}"
+    host_log_dir = os.path.join(host_logs_root(), f"issue-{issue_number}")
+    inner_command = build_inner_forge_command(
+        issue_number,
+        strategy_name=strategy_name,
+        keep_tests_without_dynamic_access=keep_tests_without_dynamic_access,
+    )
+
+    with _launched_vm(vm_name):
+        _mount_host_logs(vm_name, host_log_dir)
+        _seed_credentials_and_refresh_checkout(vm_name, github_token)
+        exec_command = build_incus_exec_command(
+            vm_name,
+            inner_command,
+            _forwarded_run_environment(),
+        )
+        log_stage(
+            "incus",
+            f"Running issue #{issue_number} in VM '{vm_name}'; logs on host at {host_log_dir}",
+        )
+        result = subprocess.run(["incus", *exec_command], check=False)
+    succeeded = result.returncode == 0
+    if not succeeded:
+        print(
+            f"ERROR: Forge run for issue #{issue_number} inside VM exited with code {result.returncode}; "
+            f"see logs on the host at {host_log_dir}.",
+            file=sys.stderr,
+        )
+    return succeeded

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -18,6 +18,7 @@ Incus; they run the same code inside the VM as on the host.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -275,13 +276,37 @@ def build_incus_exec_command(
         inner_command: Sequence[str],
         forwarded_env: dict[str, str],
 ) -> list[str]:
-    """Build the `incus exec` command that runs the inner run inside the VM."""
-    command = ["exec", vm_name, "--cwd", f"{vm_repo_path()}/forge"]
-    for name in sorted(forwarded_env):
-        command += ["--env", f"{name}={forwarded_env[name]}"]
-    command.append("--")
-    command += list(inner_command)
-    return command
+    """Build the `incus exec` command that runs the inner run inside the VM.
+
+    `incus exec` does not go through PAM, so the GraalVM homes and PATH baked
+    into the VM's `/etc/environment` are not loaded for the run (neither a plain
+    nor a login shell sources that file). Wrap the inner command in a shell that
+    sources `/etc/environment` first, then applies the forwarded `FORGE_*`
+    settings so they win over anything `forge.env` baked in — notably the
+    host-mounted `FORGE_LOGS_DIR`. §FS-forge-vm-isolated-execution
+    """
+    assignments = "".join(
+        f"{name}={shlex.quote(forwarded_env[name])}\n" for name in sorted(forwarded_env)
+    )
+    script = (
+        "set -a\n"
+        ". /etc/environment 2>/dev/null || true\n"
+        f"{assignments}"
+        "set +a\n"
+        'exec "$@"\n'
+    )
+    return [
+        "exec",
+        vm_name,
+        "--cwd",
+        f"{vm_repo_path()}/forge",
+        "--",
+        "bash",
+        "-c",
+        script,
+        "forge-inner",
+        *inner_command,
+    ]
 
 
 def _wait_for_guest_agent(vm_name: str, timeout_seconds: int) -> None:

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -69,6 +69,25 @@ DEFAULT_PI_DIR = "~/.pi"
 VM_CODEX_DIR = "/root/.codex"
 VM_PI_AGENT_DIR = "/root/.pi/agent"
 
+# The operator's host checkout is mounted read-only into each run VM and the
+# baked checkout is re-cloned from it per run, so a run uses the CURRENT Forge
+# code instead of the snapshot baked into the image (which otherwise goes stale
+# between base-image rebuilds). §FS-forge-vm-isolated-execution
+FORGE_INCUS_HOST_REPO_ENV = "FORGE_INCUS_HOST_REPO"
+VM_HOST_REPO_MOUNT_PATH = "/forge-host-repo"
+HOST_REPO_DEVICE_NAME = "forge-host-repo-src"
+# Remote that generated branches/PRs push to. The per-run clone comes from the
+# read-only host mount, whose origin is just a local path, so origin is repointed
+# here afterwards (mirrors build-base-image.sh).
+FORGE_INCUS_REPO_URL_ENV = "FORGE_INCUS_REPO_URL"
+DEFAULT_REPO_URL = "https://github.com/oracle/graalvm-reachability-metadata.git"
+
+# Signals passed to the inner VM run telling it the host already owns the issue
+# claim, so it processes the already-claimed work without claiming again
+# (§AR-forge-vm-runner-boundary, §AR-forge-control-plane).
+FORGE_ALREADY_CLAIMED_ENV = "FORGE_ALREADY_CLAIMED"
+FORGE_CLAIMED_ITEM_ID_ENV = "FORGE_CLAIMED_ITEM_ID"
+
 # Environment variables forwarded into the VM run. The behavior-shaping FORGE_*
 # settings are forwarded dynamically; these are the credentials and fixed names.
 FORWARDED_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
@@ -80,6 +99,8 @@ _INCUS_ONLY_ENV_NAMES = frozenset(
         FORGE_INCUS_REPO_PATH_ENV,
         FORGE_INCUS_LOGS_ROOT_ENV,
         FORGE_INCUS_LAUNCH_TIMEOUT_ENV,
+        FORGE_INCUS_HOST_REPO_ENV,
+        FORGE_INCUS_REPO_URL_ENV,
         FORGE_LOGS_DIR_ENV,
     }
 )
@@ -110,6 +131,37 @@ def incus_profile_name() -> str:
 def vm_repo_path() -> str:
     """Return the baked reachability checkout path inside the VM."""
     return os.environ.get(FORGE_INCUS_REPO_PATH_ENV) or DEFAULT_VM_REPO_PATH
+
+
+def host_repo_path() -> str:
+    """Return the operator's host checkout to mount into each run VM.
+
+    Defaults to the git toplevel of the running Forge code, so a run uses the
+    operator's current checkout rather than the image's baked snapshot; override
+    with FORGE_INCUS_HOST_REPO (§FS-forge-vm-isolated-execution).
+    """
+    override = os.environ.get(FORGE_INCUS_HOST_REPO_ENV)
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+    here = os.path.dirname(os.path.abspath(__file__))
+    result = subprocess.run(
+        ["git", "-C", here, "rev-parse", "--show-toplevel"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    toplevel = (result.stdout or "").strip()
+    if not toplevel:
+        raise IncusPreflightError(
+            "Could not resolve the host repository to mount into the VM. Run --incus from inside "
+            "the Forge git checkout, or set FORGE_INCUS_HOST_REPO to the repository root."
+        )
+    return toplevel
+
+
+def repo_url() -> str:
+    """Return the remote the VM's `origin` is repointed to for branch/PR pushes."""
+    return os.environ.get(FORGE_INCUS_REPO_URL_ENV) or DEFAULT_REPO_URL
 
 
 def host_logs_root() -> str:
@@ -390,6 +442,51 @@ def _launched_vm(vm_name: str) -> Iterator[None]:
         _run_incus(["delete", vm_name, "--force"], capture=True, check=False)
 
 
+def _mount_host_repo_source(vm_name: str) -> None:
+    """Mount the operator's host checkout read-only into the VM as the refresh source."""
+    host_repo = host_repo_path()
+    log_stage("incus", f"Mounting host repo '{host_repo}' into '{vm_name}' (read-only)")
+    _run_incus(
+        [
+            "config",
+            "device",
+            "add",
+            vm_name,
+            HOST_REPO_DEVICE_NAME,
+            "disk",
+            f"source={host_repo}",
+            f"path={VM_HOST_REPO_MOUNT_PATH}",
+            "readonly=true",
+        ],
+        capture=True,
+    )
+
+
+def _refresh_vm_checkout(vm_name: str) -> None:
+    """Re-clone the VM's Forge checkout from the mounted host repo before running.
+
+    The base image bakes a checkout only so its Python package install and Gradle
+    caches are warmed; that snapshot drifts from the operator's checkout between
+    base-image rebuilds. Re-cloning from the read-only host mount per run makes
+    every run use the operator's current Forge code, pinned to that commit. The
+    clone's origin is the local mount path, so it is repointed at the real remote
+    afterwards (mirrors build-base-image.sh). `file://` forces an object copy
+    rather than hardlinks into the read-only mount (§FS-forge-vm-isolated-execution).
+    """
+    repo = vm_repo_path()
+    log_stage("incus", f"Refreshing VM Forge checkout at {repo} from the host mount")
+    script = (
+        "set -euo pipefail\n"
+        f"rm -rf {shlex.quote(repo)}\n"
+        f"git clone --quiet file://{VM_HOST_REPO_MOUNT_PATH} {shlex.quote(repo)}\n"
+        f"git -C {shlex.quote(repo)} remote set-url origin {shlex.quote(repo_url())}\n"
+        f"git -C {shlex.quote(repo)} rev-parse --short HEAD\n"
+    )
+    result = _run_incus(["exec", vm_name, "--", "bash", "-c", script], capture=True)
+    commit = (result.stdout or "").strip().splitlines()[-1] if result.stdout else "?"
+    log_stage("incus", f"VM Forge checkout now at host commit {commit}")
+
+
 def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
     """Mount the per-run host log directory into the VM at the logs mount path."""
     os.makedirs(host_log_dir, exist_ok=True)
@@ -411,9 +508,9 @@ def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
 def _seed_credentials(vm_name: str, github_token: str) -> None:
     """Inject GitHub credentials and author identity into the VM.
 
-    The forge code is already baked into the image (a full-history copy of the
-    operator's local repository), so there is no checkout to refresh here
-    (§FS-forge-vm-isolated-execution).
+    Runs after `_refresh_vm_checkout`, which re-clones the Forge checkout from the
+    operator's host repo so the run uses current code rather than the image's
+    baked snapshot (§FS-forge-vm-isolated-execution).
     """
     log_stage("incus", f"Seeding credentials in '{vm_name}'")
     _run_incus(
@@ -494,14 +591,18 @@ def run_issue_in_vm(
         *,
         strategy_name: str | None = None,
         keep_tests_without_dynamic_access: bool = False,
+        claimed_item_id: str,
 ) -> bool:
-    """Run one issue's generation inside a fresh, single-use Incus VM.
+    """Run one already-claimed issue's generation inside a fresh, single-use Incus VM.
 
     Implements the per-run sequence of §AR-forge-vm-runner-boundary: preflight,
-    launch, mount logs, seed credentials, run the per-issue workflow, then
-    destroy the VM. Branches, PRs, and metrics leave the VM over the network;
-    only logs cross through the mounted host directory. Returns whether the
-    inner run reported success.
+    launch, mount logs + the host repo, re-clone the Forge checkout from the host
+    mount, seed credentials, run the per-issue workflow, then destroy the VM. The
+    host has already claimed the issue (§AR-forge-control-plane), so the inner run
+    is told to process the claimed work without claiming again via
+    `FORGE_ALREADY_CLAIMED`/`FORGE_CLAIMED_ITEM_ID`. Branches, PRs, and metrics
+    leave the VM over the network; only logs cross through the mounted host
+    directory. Returns whether the inner run reported success.
     """
     preflight()
     github_token = _resolve_github_token()
@@ -514,14 +615,20 @@ def run_issue_in_vm(
         keep_tests_without_dynamic_access=keep_tests_without_dynamic_access,
     )
 
+    forwarded_env = _forwarded_run_environment()
+    forwarded_env[FORGE_ALREADY_CLAIMED_ENV] = "1"
+    forwarded_env[FORGE_CLAIMED_ITEM_ID_ENV] = claimed_item_id
+
     with _launched_vm(vm_name):
         _mount_host_logs(vm_name, host_log_dir)
+        _mount_host_repo_source(vm_name)
+        _refresh_vm_checkout(vm_name)
         _seed_credentials(vm_name, github_token)
         _seed_agent_config(vm_name)
         exec_command = build_incus_exec_command(
             vm_name,
             inner_command,
-            _forwarded_run_environment(),
+            forwarded_env,
         )
         log_stage(
             "incus",

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -44,18 +44,6 @@ DEFAULT_INCUS_PROFILE = "forge"
 FORGE_INCUS_REPO_PATH_ENV = "FORGE_INCUS_REPO_PATH"
 DEFAULT_VM_REPO_PATH = "/root/graalvm-reachability-metadata"
 
-# The VM clones upstream at build time, but the forge tooling under test lives in
-# the operator's local checkout (e.g. the in-development branch merged to local
-# master). Before each run the runner mounts that host repo read-only and resets
-# the VM checkout to its `<base ref>`, so the VM runs the local code rather than
-# stale upstream master (§FS-forge-vm-isolated-execution). Only the missing
-# objects transfer over the local fetch.
-FORGE_INCUS_HOST_REPO_ENV = "FORGE_INCUS_HOST_REPO"
-FORGE_INCUS_BASE_REF_ENV = "FORGE_INCUS_BASE_REF"
-DEFAULT_BASE_REF = "master"
-HOST_REPO_MOUNT_PATH = "/forge-host-repo"
-HOST_REPO_DEVICE_NAME = "forge-host-repo"
-
 # Host directory that holds each run's mounted log directory. Per-run logs land
 # in `<root>/issue-<number>` and survive VM teardown.
 FORGE_INCUS_LOGS_ROOT_ENV = "FORGE_INCUS_LOGS_ROOT"
@@ -122,23 +110,6 @@ def incus_profile_name() -> str:
 def vm_repo_path() -> str:
     """Return the baked reachability checkout path inside the VM."""
     return os.environ.get(FORGE_INCUS_REPO_PATH_ENV) or DEFAULT_VM_REPO_PATH
-
-
-def host_repo_root() -> str:
-    """Return the host repo whose local `<base ref>` seeds the VM checkout.
-
-    Defaults to this forge package's own repository (`<repo>/forge/utility_scripts`
-    → `<repo>`), overridable via `FORGE_INCUS_HOST_REPO`.
-    """
-    override = os.environ.get(FORGE_INCUS_HOST_REPO_ENV)
-    if override:
-        return os.path.abspath(os.path.expanduser(override))
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-
-def base_ref() -> str:
-    """Return the git ref the VM checkout is reset to (default `master`)."""
-    return os.environ.get(FORGE_INCUS_BASE_REF_ENV) or DEFAULT_BASE_REF
 
 
 def host_logs_root() -> str:
@@ -431,9 +402,14 @@ def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
     )
 
 
-def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> None:
-    """Inject GitHub credentials and reset the VM checkout to the host's base ref."""
-    log_stage("incus", f"Seeding credentials and refreshing checkout in '{vm_name}'")
+def _seed_credentials(vm_name: str, github_token: str) -> None:
+    """Inject GitHub credentials and author identity into the VM.
+
+    The forge code is already baked into the image (a shallow copy of the
+    operator's local repository), so there is no checkout to refresh here
+    (§FS-forge-vm-isolated-execution).
+    """
+    log_stage("incus", f"Seeding credentials in '{vm_name}'")
     _run_incus(
         ["exec", vm_name, "--", "gh", "auth", "login", "--with-token"],
         input_text=github_token + "\n",
@@ -444,41 +420,6 @@ def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> N
         capture=True,
     )
     _seed_git_identity(vm_name)
-    _reset_checkout_to_host_ref(vm_name)
-
-
-def _reset_checkout_to_host_ref(vm_name: str) -> None:
-    """Reset the VM checkout to the host repo's base ref (local `master`).
-
-    Mounts the host repo read-only and fetches from it so the VM runs the local
-    forge code under development rather than stale upstream master; only the
-    missing objects transfer (§FS-forge-vm-isolated-execution). The mount is
-    removed before generation runs so the VM cannot reach the host repo.
-    """
-    repo_path = vm_repo_path()
-    ref = base_ref()
-    _run_incus(
-        [
-            "config", "device", "add", vm_name, HOST_REPO_DEVICE_NAME, "disk",
-            f"source={host_repo_root()}", f"path={HOST_REPO_MOUNT_PATH}", "readonly=true",
-        ],
-        capture=True,
-    )
-    try:
-        _run_incus(
-            ["exec", vm_name, "--cwd", repo_path, "--", "git", "fetch", HOST_REPO_MOUNT_PATH, ref],
-            capture=True,
-        )
-        _run_incus(
-            ["exec", vm_name, "--cwd", repo_path, "--", "git", "reset", "--hard", "FETCH_HEAD"],
-            capture=True,
-        )
-    finally:
-        _run_incus(
-            ["config", "device", "remove", vm_name, HOST_REPO_DEVICE_NAME],
-            capture=True,
-            check=False,
-        )
 
 
 def _host_git_config(key: str) -> str | None:
@@ -569,7 +510,7 @@ def run_issue_in_vm(
 
     with _launched_vm(vm_name):
         _mount_host_logs(vm_name, host_log_dir)
-        _seed_credentials_and_refresh_checkout(vm_name, github_token)
+        _seed_credentials(vm_name, github_token)
         _seed_agent_config(vm_name)
         exec_command = build_incus_exec_command(
             vm_name,

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -57,6 +57,18 @@ LOGS_DEVICE_NAME = "forge-logs"
 FORGE_INCUS_LAUNCH_TIMEOUT_ENV = "FORGE_INCUS_LAUNCH_TIMEOUT"
 DEFAULT_LAUNCH_TIMEOUT_SECONDS = 300
 
+# Minimal codex/pi config seeded into each VM at launch. Generation drives the
+# codex and pi CLIs, which authenticate against an internal gateway using small
+# config files (a few KB); the rest of ~/.codex and ~/.pi (sessions, sqlite
+# state, logs — gigabytes) is never needed. Seeding these at runtime keeps the
+# secrets out of the published base image (§FS-forge-vm-isolated-execution).
+FORGE_INCUS_CODEX_DIR_ENV = "FORGE_INCUS_CODEX_DIR"
+FORGE_INCUS_PI_DIR_ENV = "FORGE_INCUS_PI_DIR"
+DEFAULT_CODEX_DIR = "~/.codex"
+DEFAULT_PI_DIR = "~/.pi"
+VM_CODEX_DIR = "/root/.codex"
+VM_PI_AGENT_DIR = "/root/.pi/agent"
+
 # Environment variables forwarded into the VM run. The behavior-shaping FORGE_*
 # settings are forwarded dynamically; these are the credentials and fixed names.
 FORWARDED_TOKEN_ENV_NAMES = ("GH_TOKEN", "GITHUB_TOKEN")
@@ -106,6 +118,32 @@ def host_logs_root() -> str:
     if override:
         return os.path.abspath(os.path.expanduser(override))
     return resolve_logs_root()
+
+
+def _codex_host_dir() -> str:
+    """Return the host codex config dir whose key/provider files are seeded."""
+    return os.path.expanduser(os.environ.get(FORGE_INCUS_CODEX_DIR_ENV) or DEFAULT_CODEX_DIR)
+
+
+def _pi_host_dir() -> str:
+    """Return the host pi config dir whose key/provider files are seeded."""
+    return os.path.expanduser(os.environ.get(FORGE_INCUS_PI_DIR_ENV) or DEFAULT_PI_DIR)
+
+
+def agent_config_files() -> list[tuple[str, str]]:
+    """Return `(host_path, vm_path)` pairs for the minimal codex/pi config.
+
+    Only the small auth/provider files are seeded — never the gigabytes of
+    session and sqlite state under the agent dirs (§FS-forge-vm-isolated-execution).
+    """
+    codex = _codex_host_dir()
+    pi_agent = os.path.join(_pi_host_dir(), "agent")
+    return [
+        (os.path.join(codex, "auth.json"), f"{VM_CODEX_DIR}/auth.json"),
+        (os.path.join(codex, "config.toml"), f"{VM_CODEX_DIR}/config.toml"),
+        (os.path.join(pi_agent, "models.json"), f"{VM_PI_AGENT_DIR}/models.json"),
+        (os.path.join(pi_agent, "settings.json"), f"{VM_PI_AGENT_DIR}/settings.json"),
+    ]
 
 
 def launch_timeout_seconds() -> int:
@@ -376,6 +414,7 @@ def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> N
         ["exec", vm_name, "--", "gh", "auth", "setup-git"],
         capture=True,
     )
+    _seed_git_identity(vm_name)
     repo_path = vm_repo_path()
     _run_incus(
         [
@@ -407,6 +446,67 @@ def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> N
     )
 
 
+def _host_git_config(key: str) -> str | None:
+    """Return the host's git config value for `key`, or None if unset."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", key],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def _seed_git_identity(vm_name: str) -> None:
+    """Mirror the host git author identity into the VM.
+
+    `incus exec` runs as a bare `root@<vm>` with no identity, so preserve-work
+    and generation commits fail with "Author identity unknown". Copy the host's
+    `user.name`/`user.email` so commits made in the VM are attributed normally.
+    """
+    for key in ("user.name", "user.email"):
+        value = _host_git_config(key)
+        if value:
+            _run_incus(
+                ["exec", vm_name, "--", "git", "config", "--global", key, value],
+                capture=True,
+            )
+
+
+def _seed_agent_config(vm_name: str) -> None:
+    """Seed the minimal codex/pi auth + provider config into the VM.
+
+    Pushes only the small key/provider files (a few KB total), never the
+    gigabytes of session state, so secrets stay out of the published image
+    (§FS-forge-vm-isolated-execution). Files absent on the host are skipped; if
+    none are found the run continues but agent strategies will fail to
+    authenticate, so warn.
+    """
+    seeded = 0
+    for host_path, vm_path in agent_config_files():
+        if not os.path.isfile(host_path):
+            continue
+        _run_incus(
+            ["exec", vm_name, "--", "mkdir", "-p", os.path.dirname(vm_path)],
+            capture=True,
+        )
+        _run_incus(
+            ["file", "push", host_path, f"{vm_name}{vm_path}", "--mode=0600"],
+            capture=True,
+        )
+        seeded += 1
+    if seeded == 0:
+        print(
+            "WARNING: no codex/pi config found on the host (looked under "
+            f"{_codex_host_dir()} and {_pi_host_dir()}); agent strategies may fail to authenticate.",
+            file=sys.stderr,
+        )
+
+
 def run_issue_in_vm(
         issue_number: int,
         *,
@@ -435,6 +535,7 @@ def run_issue_in_vm(
     with _launched_vm(vm_name):
         _mount_host_logs(vm_name, host_log_dir)
         _seed_credentials_and_refresh_checkout(vm_name, github_token)
+        _seed_agent_config(vm_name)
         exec_command = build_incus_exec_command(
             vm_name,
             inner_command,

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -44,6 +44,18 @@ DEFAULT_INCUS_PROFILE = "forge"
 FORGE_INCUS_REPO_PATH_ENV = "FORGE_INCUS_REPO_PATH"
 DEFAULT_VM_REPO_PATH = "/root/graalvm-reachability-metadata"
 
+# The VM clones upstream at build time, but the forge tooling under test lives in
+# the operator's local checkout (e.g. the in-development branch merged to local
+# master). Before each run the runner mounts that host repo read-only and resets
+# the VM checkout to its `<base ref>`, so the VM runs the local code rather than
+# stale upstream master (§FS-forge-vm-isolated-execution). Only the missing
+# objects transfer over the local fetch.
+FORGE_INCUS_HOST_REPO_ENV = "FORGE_INCUS_HOST_REPO"
+FORGE_INCUS_BASE_REF_ENV = "FORGE_INCUS_BASE_REF"
+DEFAULT_BASE_REF = "master"
+HOST_REPO_MOUNT_PATH = "/forge-host-repo"
+HOST_REPO_DEVICE_NAME = "forge-host-repo"
+
 # Host directory that holds each run's mounted log directory. Per-run logs land
 # in `<root>/issue-<number>` and survive VM teardown.
 FORGE_INCUS_LOGS_ROOT_ENV = "FORGE_INCUS_LOGS_ROOT"
@@ -110,6 +122,23 @@ def incus_profile_name() -> str:
 def vm_repo_path() -> str:
     """Return the baked reachability checkout path inside the VM."""
     return os.environ.get(FORGE_INCUS_REPO_PATH_ENV) or DEFAULT_VM_REPO_PATH
+
+
+def host_repo_root() -> str:
+    """Return the host repo whose local `<base ref>` seeds the VM checkout.
+
+    Defaults to this forge package's own repository (`<repo>/forge/utility_scripts`
+    → `<repo>`), overridable via `FORGE_INCUS_HOST_REPO`.
+    """
+    override = os.environ.get(FORGE_INCUS_HOST_REPO_ENV)
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def base_ref() -> str:
+    """Return the git ref the VM checkout is reset to (default `master`)."""
+    return os.environ.get(FORGE_INCUS_BASE_REF_ENV) or DEFAULT_BASE_REF
 
 
 def host_logs_root() -> str:
@@ -403,7 +432,7 @@ def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
 
 
 def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> None:
-    """Inject GitHub credentials and refresh the baked checkout to `master`."""
+    """Inject GitHub credentials and reset the VM checkout to the host's base ref."""
     log_stage("incus", f"Seeding credentials and refreshing checkout in '{vm_name}'")
     _run_incus(
         ["exec", vm_name, "--", "gh", "auth", "login", "--with-token"],
@@ -415,35 +444,41 @@ def _seed_credentials_and_refresh_checkout(vm_name: str, github_token: str) -> N
         capture=True,
     )
     _seed_git_identity(vm_name)
+    _reset_checkout_to_host_ref(vm_name)
+
+
+def _reset_checkout_to_host_ref(vm_name: str) -> None:
+    """Reset the VM checkout to the host repo's base ref (local `master`).
+
+    Mounts the host repo read-only and fetches from it so the VM runs the local
+    forge code under development rather than stale upstream master; only the
+    missing objects transfer (§FS-forge-vm-isolated-execution). The mount is
+    removed before generation runs so the VM cannot reach the host repo.
+    """
     repo_path = vm_repo_path()
+    ref = base_ref()
     _run_incus(
         [
-            "exec",
-            vm_name,
-            "--cwd",
-            repo_path,
-            "--",
-            "git",
-            "fetch",
-            "origin",
-            "master",
+            "config", "device", "add", vm_name, HOST_REPO_DEVICE_NAME, "disk",
+            f"source={host_repo_root()}", f"path={HOST_REPO_MOUNT_PATH}", "readonly=true",
         ],
         capture=True,
     )
-    _run_incus(
-        [
-            "exec",
-            vm_name,
-            "--cwd",
-            repo_path,
-            "--",
-            "git",
-            "reset",
-            "--hard",
-            "origin/master",
-        ],
-        capture=True,
-    )
+    try:
+        _run_incus(
+            ["exec", vm_name, "--cwd", repo_path, "--", "git", "fetch", HOST_REPO_MOUNT_PATH, ref],
+            capture=True,
+        )
+        _run_incus(
+            ["exec", vm_name, "--cwd", repo_path, "--", "git", "reset", "--hard", "FETCH_HEAD"],
+            capture=True,
+        )
+    finally:
+        _run_incus(
+            ["config", "device", "remove", vm_name, HOST_REPO_DEVICE_NAME],
+            capture=True,
+            check=False,
+        )
 
 
 def _host_git_config(key: str) -> str | None:

--- a/forge/utility_scripts/incus_runner.py
+++ b/forge/utility_scripts/incus_runner.py
@@ -411,7 +411,7 @@ def _mount_host_logs(vm_name: str, host_log_dir: str) -> None:
 def _seed_credentials(vm_name: str, github_token: str) -> None:
     """Inject GitHub credentials and author identity into the VM.
 
-    The forge code is already baked into the image (a shallow copy of the
+    The forge code is already baked into the image (a full-history copy of the
     operator's local repository), so there is no checkout to refresh here
     (§FS-forge-vm-isolated-execution).
     """

--- a/forge/utility_scripts/task_logs.py
+++ b/forge/utility_scripts/task_logs.py
@@ -6,6 +6,12 @@
 import os
 from datetime import datetime, timezone
 
+# Operator-provided log destination. When set, logs land here instead of
+# `<forge-repo-root>/logs`, letting the Incus runner point them at a host
+# directory mounted into the VM so they survive teardown.
+# §FS-forge-vm-isolated-execution
+FORGE_LOGS_DIR_ENV = "FORGE_LOGS_DIR"
+
 
 def sanitize_log_segment(value: str | None) -> str:
     """Return a filesystem-safe directory or file name segment."""
@@ -32,7 +38,16 @@ def _repo_root() -> str:
 
 
 def resolve_logs_root() -> str:
-    """Return the metadata-forge log root."""
+    """Return the metadata-forge log root.
+
+    Honors the `FORGE_LOGS_DIR` override so a run can write its durable logs to
+    an operator-provided location, such as a host directory mounted into an
+    Incus VM (§FS-forge-vm-isolated-execution); otherwise logs stay under
+    `<forge-repo-root>/logs`.
+    """
+    override = os.environ.get(FORGE_LOGS_DIR_ENV)
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
     return os.path.join(_repo_root(), "logs")
 
 


### PR DESCRIPTION
Closes #8247

## What this does

Forge generates and **runs** tests for arbitrary third-party libraries, and that generated code is untrusted — it can open windows, fill `/tmp`, write into `$HOME`, and start its own Docker containers. Running it straight on the operator's machine is risky and messy. This adds an opt-in **`--incus`** mode that runs each issue inside a fresh, single-use virtual machine and destroys it afterward, so nothing a run does can reach the host; behaviour, branches, and outputs are otherwise identical to a normal run. §FS-forge-vm-isolated-execution §AR-forge-vm-runner-boundary §ROADMAP-forge-incus-vm-runner

## How a run works

A base image bakes the expensive, generic setup once; each issue gets a throwaway VM cloned from it copy-on-write, so launches stay cheap and every run starts from an identical clean state:

```
forge-base image  ────►  fresh VM per issue
                                           ├─ seed: gh token, git identity, codex/pi creds
                                           ├─ run the normal per-issue workflow
                                           ├─ stream logs ──► host: forge/logs/issue-<n>/
                                           └─ destroy VM
```

## What's baked vs injected

| Baked into `forge-base` (generic, non-secret) | Injected per run (secret / run-specific) |
|---|---|
| GraalVM, Docker, GitHub CLI, Node + codex/pi, native-image toolchain (gcc), Python package, shallow clone of the local repo | GitHub token, git identity, codex/pi credential files, issue number, strategy, log destination |

The published image stays secret-free; the runner pushes credentials and run-specific state into each VM at launch (§AR-forge-vm-runner-boundary).

## Decisions made during implementation

| Decision | Why it fits |
|---|---|
| **VM, not container** | Untrusted generated code plus nested Docker; a separate guest kernel is a real boundary, not a shared-kernel costume |
| **Fresh, single-use VM per run** | Reproducible, no state bleed between issues; copy-on-write keeps launches cheap |
| **Bake generic tooling, inject secrets at launch** | Published image stays secret-free; credentials rotate without rebuilding it |
| **Bake a shallow copy of the *local* repo** | The VM runs the code under development, not upstream `master`; `--depth 1` avoids copying ~1.2 GB of git history (started as a runtime mount+fetch, simplified to a build-time clone) |
| **Seed only the small codex/pi config files** | The real `~/.codex` / `~/.pi` dirs are ~2.2 GB of session state; only a few KB of auth/provider config is actually needed |
| **Source `/etc/environment` in the exec wrapper** | `incus exec` skips PAM, so the baked GraalVM env vars weren't loaded otherwise |

## Host prerequisites

The operator prepares the host once; `--incus` preflights the essentials and fails fast rather than installing anything. Bringing this up on a real machine surfaced what's needed, now documented in the README:

| Requirement | Why |
|---|---|
| QEMU + KVM, then restart Incus | VMs need a hypervisor and the daemon must detect it |
| `incusbr0` bridge | VM networking (NAT, outbound) |
| Storage pool on a roomy disk | VM disks need tens of GB |
| `DOCKER-USER` accept rules for `incusbr0` | Docker's `FORWARD` default-DROP otherwise blocks the VM's internet |

## Networking (outbound + iptables)

The VMs need only **outbound** traffic — `apt`, `git`, Docker pulls, the LLM gateway — NAT'd through `incusbr0`; no **inbound** is exposed, which is also good for isolation. On a host that also runs Docker, Docker sets the iptables `FORWARD` chain to default-DROP and only allows its own bridge, so the Incus bridge's forwarded packets are silently dropped (DNS resolves, every connection times out). Allowing `incusbr0` through the `DOCKER-USER` chain (`-i`/`-o incusbr0 -j ACCEPT`) fixes it.

## Running it

```bash
./incus/build-base-image.sh           # one-time, per host
python3 forge_metadata.py --run-work-queues --incus
```
