### PR TITLE
Keep Docker sample coordinate runnable

### DIFF
--- a/docs/tck.md
+++ b/docs/tck.md
@@ -23,6 +23,12 @@ Every coordinate-scoped task accepts the single filter `-Pcoordinates=`, which
 takes `all`, `group:artifact`, `group:artifact:version`, or a shard `k/n` so CI
 can parallelize the work (§FS-repository-functional-spec.6). The tasks here
 resolve that filter into concrete coordinates and inspect what they select.
+Fixture coordinates such as `org.example:*` and `samples:*` are selectable by
+the coordinate resolver and runnable through style and test lanes, but they must
+not be counted as public supported-library output. The `testInfra` bundle uses
+the public-library coordinate set and excludes `samples:*`, because the bundle
+includes reporting/public-output tasks that do not operate on fixture-only
+coordinates.
 
 | Task | Purpose |
 | --- | --- |

--- a/tests/src/samples/docker/image-pull/build.gradle
+++ b/tests/src/samples/docker/image-pull/build.gradle
@@ -8,10 +8,6 @@ plugins {
     id "org.graalvm.internal.tck"
 }
 
-tasks.withType(JavaCompile) {
-    options.release = 17
-}
-
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -150,7 +150,6 @@ if (CoordinateUtils.isFractionalBatch(coordinateFilter)) {
 } else {
     matchingCoordinates = tck.getMatchingCoordinates(coordinateFilter)
 }
-matchingCoordinates = matchingCoordinates.findAll { !it.startsWith("samples:") }
 
 
 // gradle checkstyle -Pcoordinates=<maven-coordinates>  §TCK-test-harness.2
@@ -280,7 +279,6 @@ tasks.register("listCoordinates", DefaultTask) { task ->
             } else {
                 coords = tck.getMatchingCoordinatesStrict(coordinateFilter)
             }
-            coords = coords.findAll { !it.startsWith("samples:") }
         } else {
             coords = new ArrayList<>(matchingCoordinates)
         }
@@ -526,7 +524,6 @@ Provider<Task> generateMatrixMatchingCoordinates = tasks.register("generateMatri
             def frac = CoordinateUtils.parseFraction(coordinateFilter)
             List<String> allStrict = tck.getMatchingCoordinatesStrict("all")
             matrixCoordinates = CoordinateUtils.computeBatchedCoordinates(allStrict, frac[0], frac[1])
-                    .findAll { !it.startsWith("samples:") }
         }
         def matrix = [
                 "coordinates": matrixCoordinates

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/CoordinatesAwareTask.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Base task providing unified coordinate resolution from -Pcoordinates and optional overrides.
@@ -26,7 +25,8 @@ import java.util.stream.Collectors;
  *  - filter by group/artifact
  *  - "all"
  *  - fractional batches "k/n"
- * Always filters out "samples:".
+ * Fixture coordinates remain runnable; reporting tasks decide which coordinates
+ * are excluded from supported-library outputs. §TCK-test-harness.1
  */
 public abstract class CoordinatesAwareTask extends DefaultTask {
 
@@ -60,9 +60,7 @@ public abstract class CoordinatesAwareTask extends DefaultTask {
             String coordinateFilter = Objects.toString(getProject().findProperty("coordinates"), "");
             coords = computeMatchingCoordinates(coordinateFilter);
         }
-        return coords.stream()
-                .filter(c -> !c.startsWith("samples:"))
-                .collect(Collectors.toList());
+        return coords;
     }
 
     protected List<String> computeMatchingCoordinates(String filter) {


### PR DESCRIPTION
## Summary
- allow `samples:*` fixture coordinates to stay selectable by the runnable coordinate resolver
- keep sample/library fixtures out of public supported-library output semantics
- align `samples:docker:image-pull` with the current TCK JVM baseline by removing its stale Java 17 override

## Verification
- `./gradlew listCoordinates -Pcoordinates=samples:docker:image-pull --console=plain`
- `./gradlew listCoordinates -Pcoordinates=samples:docker:image-pull -PstrictCoordinates=true --console=plain`
- `./gradlew checkstyle -Pcoordinates=samples:docker:image-pull --console=plain`
- `./gradlew compileTestJava -Pcoordinates=samples:docker:image-pull --console=plain`
- `./gradlew checkMetadataFiles -Pcoordinates=samples:docker:image-pull --console=plain`
- `./gradlew :tck-build-logic:test --console=plain`

`./gradlew javaTest -Pcoordinates=samples:docker:image-pull --console=plain` now reaches the sample JUnit tests locally; it fails without CI Docker network isolation because `hello-world` can be pulled, which is the behavior the sample is meant to reject after allowed images are pre-pulled and networking is disabled.

### Open question
Should `samples:docker:image-pull` remain a runnable fixture coordinate in the generic style/test lanes long term, or should it eventually move to a dedicated Docker-policy CI lane?

Fixes https://github.com/oracle/graalvm-reachability-metadata/issues/8551