### PR TITLE
Fix Forge publication pending metrics resume

### DIFF
--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -67,6 +67,14 @@ classes re-appear in the regenerated report.
   "newVersion": null,
   "libraryUpdateRoute": null,
   "libraryPreparationPreflight": null,
+  "publicationMetrics": {
+    "library": "com.acme:widget:1.4.0",
+    "timestamp": "2026-06-18T14:44:56.782450Z",
+    "extras": {
+      "post_generation_intervention": { "stage": "future-defaults-all" },
+      "local_ci_verification": { "status": "passed" }
+    }
+  },
   "phases": {
     "setup":        { "status": "completed", "preflightDone": true, "setupDone": true },
     "fix":          { "status": "skipped",   "iteration": null },
@@ -105,6 +113,13 @@ because the marker never enters a successful run's publication staging
 - `libraryPreparationPreflight` records dispatcher preflight output so resume
   can skip the preflight agent while still passing the original advisory setup
   context back to the workflow driver.
+- `publicationMetrics` records the committed per-library execution-metrics
+  entry (`library` plus `timestamp`) and only the local-only PR fields needed to
+  reconstruct `.pending_metrics.json` during publication resume. Durable metrics
+  remain the source for normal cost, token, coverage, and status evidence
+  (§FS-forge-run-metrics); the marker carries local extras such as
+  `post_generation_intervention`, `local_ci_verification`, and
+  `library_update_alias_split` when they exist.
 - Improve-coverage runs write the original `.baseline-stats.json` into the
   resolved test directory during setup. Resume treats that as preserved worktree
   state and reuses it instead of recomputing the baseline after generation may
@@ -140,8 +155,15 @@ does the PR making. Opening the pull request is the workflow's
 completion — a marker only exists for a run that failed before that point, so
 continuation never reaches a state with the pull request already open.
 In publication resume mode, Forge creates a clearance commit before it publishes
-the PR branch. The clearance commit deletes resume helper artifacts: the
-continuation marker, pending metrics, and human-intervention logs.
+the PR branch. The clearance commit deletes resume helper artifacts from the
+branch: the continuation marker and human-intervention logs. Pending metrics are
+a local PR-publication input, so they must remain readable until PR creation
+finishes even when the cleanup removes them from the branch index.
+If that transient pending file is missing in a later publication resume, Forge
+reconstructs it from the durable execution-metrics entry referenced by
+`publicationMetrics` and overlays the marker's `extras`. A publication marker
+without `publicationMetrics` is incomplete: Forge does not guess from the latest
+durable execution-metrics entry because that would lose local-only PR fields.
 
 ## 4. Relationship to human intervention
 

--- a/forge/docs/e2e.md
+++ b/forge/docs/e2e.md
@@ -108,6 +108,12 @@ intended to make routing and current-version resolution demonstrable for those
 labels; the primary `9101` fixture remains the default dynamic-access acceptance
 target. §E2E-forge-workflow-testing.5
 
+The `9107` fixture is a publication-continuation smoke test: its marker starts at
+`publication` and points at durable execution metrics plus marker-local PR
+extras, so it verifies `.pending_metrics.json` reconstruction and dry-run PR
+body generation without invoking an agent-backed generation workflow.
+§FS-forge-run-continuation.2
+
 For `library-new-request` fixtures that use an already-supported dynamic-access
 library, fixture setup removes the requested version entry and version-scoped
 metadata, tests, and stats from the isolated worktree before workflow routing.

--- a/forge/fixture_github_issues/library-new-request-publication-continuation.yaml
+++ b/forge/fixture_github_issues/library-new-request-publication-continuation.yaml
@@ -1,0 +1,92 @@
+# Fixture-backed publication continuation scenario. The marker starts at the
+# publication phase and points at durable execution metrics plus local-only
+# extras, so fixture E2E verifies pending metrics reconstruction without running
+# an agent-backed generation workflow.
+number: 9107
+title: "Add support for org.example:publication-resume:1.0.0"
+state: OPEN
+labels:
+  - library-new-request
+assignees: []
+project:
+  number: 30
+  item_id: fixture-project-item-9107
+  status: Todo
+blocked_by: []
+body: |
+  Please resume publication for `org.example:publication-resume:1.0.0`.
+
+comments:
+  - author: fixture-runner
+    created_at: "2026-06-19T10:00:00Z"
+    body: |
+      Fixture preserved work branch for publication resume.
+
+      Branch name: `fixture/preserved-work/issue-9107-library-new-request-publication-resume`
+worktree_files:
+  metadata/org.example/publication-resume/index.json:
+    - metadata-version: "1.0.0"
+      tested-versions:
+        - "1.0.0"
+  stats/org.example/publication-resume/1.0.0/execution-metrics.json:
+    add_new_library_support:2026-06-19T10:00:00.000000Z:
+      timestamp: "2026-06-19T10:00:00.000000Z"
+      library: "org.example:publication-resume:1.0.0"
+      status: "success_with_intervention"
+      strategy_name: "dynamic_access_main_sources_pi_gpt-5.5"
+      metrics:
+        iterations: 1
+        input_tokens_used: 10
+        cached_input_tokens_used: 2
+        output_tokens_used: 3
+        metadata_entries: 1
+        test_only_metadata_entries: 0
+        code_coverage_percent: 0
+        generated_loc: 4
+        tested_library_loc: 8
+continuation_marker:
+  schemaVersion: 1
+  continueFrom: publication
+  preservedBranch: fixture/preserved-work/issue-9107-library-new-request-publication-resume
+  strategyName: dynamic_access_main_sources_pi_gpt-5.5
+  issueNumber: 9107
+  label: library-new-request
+  coordinate: org.example:publication-resume:1.0.0
+  newVersion: null
+  libraryUpdateRoute: null
+  libraryPreparationPreflight: null
+  publicationMetrics:
+    library: org.example:publication-resume:1.0.0
+    timestamp: "2026-06-19T10:00:00.000000Z"
+    extras:
+      post_generation_intervention:
+        stage: current-defaults
+        intervention_file: forge/logs/org.example:publication-resume:1.0.0/fix.log
+        analysis_markdown: "Fixture post-generation intervention details."
+      local_ci_verification:
+        status: success
+        base_commit: fixture-base
+        final_commit: fixture-final
+        commands: []
+        fixups: []
+        repo_fix_paths: []
+        human_intervention_required: false
+        failure_gate: null
+        failure_command: null
+  phases:
+    setup:
+      status: completed
+      preflightDone: true
+      setupDone: true
+    fix:
+      status: skipped
+      iteration: null
+    explore:
+      status: skipped
+      exhaustedClasses: []
+    finalization:
+      status: completed
+    publication:
+      status: pending
+      isPushed: false
+      branch: null

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -160,7 +160,12 @@ from utility_scripts.metadata_index import (
     resolve_metadata_version,
     resolve_test_dir,
 )
-from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME, read_pending_metrics
+from utility_scripts.metrics_writer import (
+    PENDING_METRICS_FILENAME,
+    load_execution_metrics_for_timestamp,
+    read_pending_metrics,
+    write_pending_metrics,
+)
 from utility_scripts.repo_path_resolver import (
     git_env_limited_to_repo_root,
     get_forge_subdir_name,
@@ -292,6 +297,11 @@ HUMAN_INTERVENTION_NON_FAILURE_STATUSES = {
     RUN_STATUS_CHUNK_READY,
     SUCCESS_WITH_INTERVENTION_STATUS,
 }
+PUBLICATION_METRICS_EXTRA_KEYS: tuple[str, ...] = (
+    "post_generation_intervention",
+    "local_ci_verification",
+    "library_update_alias_split",
+)
 # A workflow failure is logical (driver/core/CI-check) and gets `human-intervention`
 # by default. The only exception is an external dependency failure, which surfaces
 # as a typed exception at the Python boundary that issues it: GitHub (`gh`) as
@@ -4317,6 +4327,7 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     marker_path = continuation_marker_path(repo_path)
     marker = load_continuation_marker(marker_path)
     if marker is not None:
+        record_publication_metrics_from_pending(marker, claimed_issue.scratch_metrics_repo_path)
         marker.record_preserved_branch(branch_name)
         marker.save(marker_path)
     subprocess.run(["git", "add", "-A"], cwd=repo_path, env=git_env, check=True)
@@ -6150,6 +6161,92 @@ def _load_library_update_publication_route(claimed_issue: ClaimedIssue) -> Libra
     return load_library_update_route(library_update_route_artifact_root(claimed_issue))
 
 
+def _pending_run_metrics_path(claimed_issue: ClaimedIssue) -> str:
+    """Return the transient metrics file path for this claimed issue."""
+    return os.path.join(
+        claimed_issue.scratch_metrics_repo_path,
+        PENDING_METRICS_FILENAME,
+    )
+
+
+def record_publication_metrics_from_pending(
+        marker: ContinuationMarker,
+        metrics_repo_path: str,
+) -> bool:
+    """Copy local-only pending metrics fields into the continuation marker."""
+    pending_metrics_path = os.path.join(metrics_repo_path, PENDING_METRICS_FILENAME)
+    if not os.path.isfile(pending_metrics_path):
+        return False
+    try:
+        run_metrics = read_pending_metrics(metrics_repo_path)
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        log_stage(
+            "publication",
+            f"Could not snapshot pending metrics into continuation marker: {exc!r}.",
+        )
+        return False
+    marker.record_publication_metrics(run_metrics, PUBLICATION_METRICS_EXTRA_KEYS)
+    return marker.publication_metrics is not None
+
+
+def record_pending_publication_metrics_for_resume(claimed_issue: ClaimedIssue) -> None:
+    """Persist the pending metrics reconstruction inputs in the continuation marker."""
+    marker_path = continuation_marker_path(claimed_issue.worktree_path)
+    marker = load_continuation_marker(marker_path)
+    if marker is None:
+        return
+    if record_publication_metrics_from_pending(marker, claimed_issue.scratch_metrics_repo_path):
+        marker.save(marker_path)
+
+
+def _restore_pending_run_metrics_from_marker(
+        claimed_issue: ClaimedIssue,
+        marker: ContinuationMarker,
+) -> bool:
+    """Restore transient metrics from durable metrics plus marker-local extras."""
+    marker_metrics = marker.publication_metrics
+    if not isinstance(marker_metrics, dict):
+        return False
+    library = marker_metrics.get("library")
+    timestamp = marker_metrics.get("timestamp")
+    if not isinstance(library, str) or not isinstance(timestamp, str):
+        return False
+    run_metrics = load_execution_metrics_for_timestamp(claimed_issue.worktree_path, library, timestamp)
+    if run_metrics is None:
+        log_stage(
+            "publication",
+            (
+                "Could not restore pending metrics from continuation marker because no durable "
+                f"execution metrics entry matched {library} at {timestamp}."
+            ),
+        )
+        return False
+    extras = marker_metrics.get("extras")
+    if isinstance(extras, dict):
+        run_metrics.update(extras)
+    write_pending_metrics(claimed_issue.scratch_metrics_repo_path, run_metrics)
+    log_stage(
+        "publication",
+        (
+            "Restored missing pending metrics from durable execution metrics and "
+            f"continuation marker extras for {library}."
+        ),
+    )
+    return True
+
+
+def restore_pending_run_metrics_from_execution_metrics(claimed_issue: ClaimedIssue) -> None:
+    """Restore or snapshot transient publication metrics for resumable PR creation."""
+    pending_metrics_path = _pending_run_metrics_path(claimed_issue)
+    if os.path.isfile(pending_metrics_path):
+        record_pending_publication_metrics_for_resume(claimed_issue)
+        return
+
+    marker = load_continuation_marker(continuation_marker_path(claimed_issue.worktree_path))
+    if marker is not None:
+        _restore_pending_run_metrics_from_marker(claimed_issue, marker)
+
+
 def build_publication_handoff(claimed_issue: ClaimedIssue) -> PublicationHandoff:
     """Build the live-or-fixture PR publication handoff.
 
@@ -6159,6 +6256,7 @@ def build_publication_handoff(claimed_issue: ClaimedIssue) -> PublicationHandoff
     """
     require_claimed_issue_worktree(claimed_issue, "successful finalization")
     issue_number = claimed_issue.issue["number"]
+    restore_pending_run_metrics_from_execution_metrics(claimed_issue)
     exhaust_report_path = find_dynamic_access_exhaust_report_path(
         claimed_issue.worktree_path,
         claimed_issue.issue_coordinates,

--- a/forge/git_scripts/pr_publication.py
+++ b/forge/git_scripts/pr_publication.py
@@ -41,8 +41,8 @@ BASE_BRANCH: str = "master"
 REVIEWERS: list[str] = get_configured_reviewers()
 PRESERVATION_ONLY_PATHS: set[str] = {
     f"forge/{CONTINUATION_MARKER_FILENAME}",
-    f"forge/{PENDING_METRICS_FILENAME}",
 }
+LOCAL_PUBLICATION_INPUT_PATHS: set[str] = {f"forge/{PENDING_METRICS_FILENAME}"}
 PRESERVATION_ONLY_DIRECTORIES: tuple[str, ...] = ("forge/human-intervention-logs",)
 
 
@@ -88,9 +88,30 @@ def _has_staged_changes(repo_path: str) -> bool:
     return result.returncode != 0
 
 
+def _snapshot_local_publication_inputs(repo_path: str) -> dict[str, bytes]:
+    """Read local-only inputs that PR creation still needs after branch cleanup."""
+    snapshots: dict[str, bytes] = {}
+    for path in sorted(LOCAL_PUBLICATION_INPUT_PATHS):
+        absolute_path = os.path.join(repo_path, path)
+        if os.path.isfile(absolute_path):
+            with open(absolute_path, "rb") as local_input:
+                snapshots[path] = local_input.read()
+    return snapshots
+
+
+def _restore_local_publication_inputs(repo_path: str, snapshots: dict[str, bytes]) -> None:
+    """Restore PR inputs as untracked files after removing them from the branch."""
+    for path, contents in snapshots.items():
+        absolute_path = os.path.join(repo_path, path)
+        os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+        with open(absolute_path, "wb") as local_input:
+            local_input.write(contents)
+
+
 def _remove_preservation_only_files(repo_path: str) -> None:
     """Remove files that are tracked only on failed-run preservation branches."""
-    paths: list[str] = sorted(PRESERVATION_ONLY_PATHS)
+    local_input_snapshots = _snapshot_local_publication_inputs(repo_path)
+    paths: list[str] = sorted(PRESERVATION_ONLY_PATHS | LOCAL_PUBLICATION_INPUT_PATHS)
     pathspecs = [*paths, *PRESERVATION_ONLY_DIRECTORIES]
     tracked_paths = subprocess.check_output(
         ["git", "ls-files", "--", *pathspecs],
@@ -107,6 +128,7 @@ def _remove_preservation_only_files(repo_path: str) -> None:
         absolute_directory = os.path.join(repo_path, directory)
         if os.path.isdir(absolute_directory):
             shutil.rmtree(absolute_directory)
+    _restore_local_publication_inputs(repo_path, local_input_snapshots)
 
 
 def _commit_preservation_artifact_clearance(repo_path: str) -> None:

--- a/forge/schemas/continuation_marker_schema.json
+++ b/forge/schemas/continuation_marker_schema.json
@@ -96,6 +96,34 @@
         "null"
       ]
     },
+    "publicationMetrics": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "extras": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "library": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "library",
+            "timestamp",
+            "extras"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "schemaVersion": {
       "const": 1
     },

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -15,6 +15,7 @@ import forge_metadata
 from git_scripts import common_git
 from utility_scripts.fixture_github import FixtureGitHubState, FixtureIssue
 from utility_scripts.dynamic_access_report import DynamicAccessClass, DynamicAccessCoverageReport
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
 
 
 def _project_item_status_response(status: str) -> dict:
@@ -154,6 +155,111 @@ def _dynamic_access_report(class_names: list[str]) -> DynamicAccessCoverageRepor
 
 
 class FinalizeSuccessfulIssueTests(unittest.TestCase):
+    def test_restores_missing_pending_metrics_from_execution_metrics_and_marker_extras(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            forge_path = os.path.join(repo_path, "forge")
+            metadata_index_dir = os.path.join(repo_path, "metadata", "org.example", "lib")
+            stats_dir = os.path.join(repo_path, "stats", "org.example", "lib", "1.0.0")
+            os.makedirs(forge_path)
+            os.makedirs(metadata_index_dir)
+            os.makedirs(stats_dir)
+            with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "tested-versions": ["1.0.0"],
+                        }
+                    ],
+                    index_file,
+                )
+            run_metrics = {
+                "timestamp": "2026-06-18T14:44:56.782450Z",
+                "library": "org.example:lib:1.0.0",
+                "status": "success",
+                "metrics": {"input_tokens_used": 1},
+            }
+            with open(os.path.join(stats_dir, "execution-metrics.json"), "w", encoding="utf-8") as metrics_file:
+                json.dump({"add_new_library_support:2026-06-18": run_metrics}, metrics_file)
+            marker = forge_metadata.ContinuationMarker.create(
+                strategy_name="dynamic_access_main_sources_pi_gpt-5.5",
+                issue_number=1412,
+                label=forge_metadata.LABEL_LIBRARY_NEW,
+                coordinate="org.example:lib:1.0.0",
+                new_version=None,
+            )
+            pending_metrics = {
+                **run_metrics,
+                "post_generation_intervention": {"stage": "future-defaults-all"},
+                "local_ci_verification": {"status": "passed"},
+            }
+            marker.record_publication_metrics(pending_metrics, forge_metadata.PUBLICATION_METRICS_EXTRA_KEYS)
+            marker.save(forge_metadata.continuation_marker_path(repo_path))
+
+            claimed_issue = forge_metadata.ClaimedIssue(
+                issue={"number": 1412},
+                label=forge_metadata.LABEL_LIBRARY_NEW,
+                item_id="project-item",
+                base_reachability_metadata_path=repo_path,
+                worktree_path=repo_path,
+                scratch_metrics_repo_path=forge_path,
+                issue_coordinates="org.example:lib:1.0.0",
+            )
+
+            forge_metadata.restore_pending_run_metrics_from_execution_metrics(claimed_issue)
+
+            with open(os.path.join(forge_path, PENDING_METRICS_FILENAME), "r", encoding="utf-8") as pending_file:
+                self.assertEqual(json.load(pending_file), pending_metrics)
+
+    def test_records_existing_pending_metrics_in_continuation_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            forge_path = os.path.join(repo_path, "forge")
+            os.makedirs(forge_path)
+            run_metrics = {
+                "timestamp": "2026-06-18T14:44:56.782450Z",
+                "library": "org.example:lib:1.0.0",
+                "status": "success",
+                "metrics": {"input_tokens_used": 1},
+                "post_generation_intervention": {"stage": "current-defaults"},
+                "library_update_alias_split": {"follow_up_issue": 1413},
+            }
+            with open(os.path.join(forge_path, PENDING_METRICS_FILENAME), "w", encoding="utf-8") as pending_file:
+                json.dump(run_metrics, pending_file)
+            marker = forge_metadata.ContinuationMarker.create(
+                strategy_name="dynamic_access_main_sources_pi_gpt-5.5",
+                issue_number=1412,
+                label=forge_metadata.LABEL_LIBRARY_NEW,
+                coordinate="org.example:lib:1.0.0",
+                new_version=None,
+            )
+            marker.save(forge_metadata.continuation_marker_path(repo_path))
+
+            claimed_issue = forge_metadata.ClaimedIssue(
+                issue={"number": 1412},
+                label=forge_metadata.LABEL_LIBRARY_NEW,
+                item_id="project-item",
+                base_reachability_metadata_path=repo_path,
+                worktree_path=repo_path,
+                scratch_metrics_repo_path=forge_path,
+                issue_coordinates="org.example:lib:1.0.0",
+            )
+
+            forge_metadata.restore_pending_run_metrics_from_execution_metrics(claimed_issue)
+
+            saved_marker = forge_metadata.load_continuation_marker(forge_metadata.continuation_marker_path(repo_path))
+            self.assertIsNotNone(saved_marker)
+            self.assertEqual(
+                saved_marker.publication_metrics,
+                {
+                    "library": "org.example:lib:1.0.0",
+                    "timestamp": "2026-06-18T14:44:56.782450Z",
+                    "extras": {
+                        "post_generation_intervention": {"stage": "current-defaults"},
+                        "library_update_alias_split": {"follow_up_issue": 1413},
+                    },
+                },
+            )
+
     def test_not_for_native_image_pr_receives_metrics_repo_path_for_local_ci(self) -> None:
         claimed_issue = _claimed_issue()
 

--- a/forge/tests/test_local_ci_verification.py
+++ b/forge/tests/test_local_ci_verification.py
@@ -55,8 +55,9 @@ class LocalCIVerificationTests(unittest.TestCase):
                 stderr=None,
                 text: bool | None = None,
                 check: bool | None = None,
+                **kwargs,
         ) -> subprocess.CompletedProcess[str]:
-            del cwd, stdout, stderr, text, check
+            del cwd, stdout, stderr, text, check, kwargs
             commands.append(command)
             if command == ["git", "remote", "get-url", "upstream"]:
                 return subprocess.CompletedProcess(command, 1, stdout="")
@@ -85,8 +86,9 @@ class LocalCIVerificationTests(unittest.TestCase):
                 stderr=None,
                 text: bool | None = None,
                 check: bool | None = None,
+                **kwargs,
         ) -> subprocess.CompletedProcess[str]:
-            del cwd, stdout, stderr, text, check
+            del cwd, stdout, stderr, text, check, kwargs
             commands.append(command)
             if command == ["git", "remote", "get-url", "upstream"]:
                 return subprocess.CompletedProcess(command, 1, stdout="")

--- a/forge/tests/test_make_pr_not_for_native_image.py
+++ b/forge/tests/test_make_pr_not_for_native_image.py
@@ -16,8 +16,10 @@ class MakePrNotForNativeImageTests(unittest.TestCase):
         result = LocalCIVerificationResult(status="success", base_commit="FETCH_HEAD")
         events: list[str] = []
 
-        def fake_subprocess_run(command: list[str], check: bool = False, cwd: str | None = None):
-            del check, cwd
+        def fake_subprocess_run(command: list[str], check: bool = False, cwd: str | None = None, **kwargs):
+            del check, cwd, kwargs
+            if command[:2] == ["git", "ls-files"]:
+                return subprocess.CompletedProcess(command, 0, stdout="")
             if command[:2] == ["git", "rebase"]:
                 events.append("rebase")
             return subprocess.CompletedProcess(command, 0)

--- a/forge/tests/test_pr_publication.py
+++ b/forge/tests/test_pr_publication.py
@@ -1,0 +1,69 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+from git_scripts import pr_publication
+from utility_scripts.continuation_marker import CONTINUATION_MARKER_FILENAME
+from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
+
+
+def _git(repo_path: str, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+class PrPublicationTests(unittest.TestCase):
+    def test_preservation_cleanup_keeps_pending_metrics_as_local_input(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            _git(repo_path, "init")
+            forge_path = os.path.join(repo_path, "forge")
+            logs_path = os.path.join(forge_path, "human-intervention-logs")
+            os.makedirs(logs_path)
+
+            pending_path = os.path.join(forge_path, PENDING_METRICS_FILENAME)
+            marker_path = os.path.join(forge_path, CONTINUATION_MARKER_FILENAME)
+            log_path = os.path.join(logs_path, "run.log")
+            with open(pending_path, "w", encoding="utf-8") as pending_file:
+                pending_file.write('{"status":"success"}\n')
+            with open(marker_path, "w", encoding="utf-8") as marker_file:
+                marker_file.write("{}\n")
+            with open(log_path, "w", encoding="utf-8") as log_file:
+                log_file.write("log\n")
+
+            _git(
+                repo_path,
+                "add",
+                "-f",
+                f"forge/{PENDING_METRICS_FILENAME}",
+                f"forge/{CONTINUATION_MARKER_FILENAME}",
+                "forge/human-intervention-logs/run.log",
+            )
+
+            pr_publication._remove_preservation_only_files(repo_path)
+
+            self.assertTrue(os.path.isfile(pending_path))
+            with open(pending_path, "r", encoding="utf-8") as pending_file:
+                self.assertEqual(pending_file.read(), '{"status":"success"}\n')
+            self.assertFalse(os.path.exists(marker_path))
+            self.assertFalse(os.path.exists(logs_path))
+            tracked_paths = _git(repo_path, "ls-files").splitlines()
+            self.assertNotIn(f"forge/{PENDING_METRICS_FILENAME}", tracked_paths)
+            self.assertNotIn(f"forge/{CONTINUATION_MARKER_FILENAME}", tracked_paths)
+            self.assertNotIn("forge/human-intervention-logs/run.log", tracked_paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -5,10 +5,11 @@
 
 """Durable run-continuation marker for failed Forge issue runs."""
 
+import copy
 import json
 import os
 from dataclasses import dataclass, field
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 CONTINUATION_MARKER_FILENAME = ".continuation-marker.json"
@@ -74,6 +75,7 @@ class ContinuationMarker:
     new_version: str | None
     library_update_route: dict[str, Any] | None = None
     library_preparation_preflight: dict[str, Any] | None = None
+    publication_metrics: dict[str, Any] | None = None
     phases: dict[str, dict[str, Any]] = field(default_factory=_default_phases)
     schema_version: int = SCHEMA_VERSION
 
@@ -119,6 +121,7 @@ class ContinuationMarker:
             new_version=payload.get("newVersion"),
             library_update_route=_optional_dict(payload.get("libraryUpdateRoute")),
             library_preparation_preflight=_optional_dict(payload.get("libraryPreparationPreflight")),
+            publication_metrics=_optional_dict(payload.get("publicationMetrics")),
             phases=phases,
             schema_version=SCHEMA_VERSION,
         )
@@ -145,6 +148,7 @@ class ContinuationMarker:
             "newVersion": self.new_version,
             "libraryUpdateRoute": self.library_update_route,
             "libraryPreparationPreflight": self.library_preparation_preflight,
+            "publicationMetrics": self.publication_metrics,
             "phases": self.phases,
         }
 
@@ -236,6 +240,26 @@ class ContinuationMarker:
     def record_library_preparation_preflight(self, preflight_payload: dict[str, Any]) -> None:
         """Record dispatcher preflight output for continuation resume."""
         self.library_preparation_preflight = dict(preflight_payload)
+        self.recompute_continue_from()
+
+    def record_publication_metrics(self, run_metrics: dict[str, Any], extra_keys: Iterable[str]) -> None:
+        """Record the durable metrics pointer and local-only PR fields for publication resume."""
+        library = run_metrics.get("library")
+        timestamp = run_metrics.get("timestamp")
+        if not isinstance(library, str) or not library:
+            return
+        if not isinstance(timestamp, str) or not timestamp:
+            return
+        extras = {
+            key: copy.deepcopy(run_metrics[key])
+            for key in extra_keys
+            if key in run_metrics
+        }
+        self.publication_metrics = {
+            "library": library,
+            "timestamp": timestamp,
+            "extras": extras,
+        }
         self.recompute_continue_from()
 
     def record_publication_branch(self, branch_name: str) -> None:

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -754,6 +754,17 @@ def execution_metrics_path(repo_path: str, run_metrics: dict) -> str:
     return os.path.join(repo_path, "stats", group, artifact, metadata_version, "execution-metrics.json")
 
 
+def execution_metrics_path_for_library(repo_path: str, library: str) -> str:
+    """Return the per-library execution metrics path for a coordinate."""
+    parts = library.split(":")
+    if len(parts) != 3 or any(not part for part in parts):
+        raise ValueError(f"ERROR: library must be group:artifact:version: {library}")
+
+    group, artifact, version = parts
+    metadata_version = resolve_metadata_version(repo_path, group, artifact, version)
+    return os.path.join(repo_path, "stats", group, artifact, metadata_version, "execution-metrics.json")
+
+
 def _load_execution_metrics_entries(path: str) -> dict:
     """Load an execution-metrics object from disk."""
     if not os.path.isfile(path):
@@ -765,6 +776,29 @@ def _load_execution_metrics_entries(path: str) -> dict:
     if not isinstance(data, dict):
         raise TypeError(f"ERROR: Expected execution metrics object in {path}")
     return data
+
+
+def load_execution_metrics_for_timestamp(
+        repo_path: str,
+        library: str,
+        timestamp: str,
+        task_type: str | None = None,
+) -> dict | None:
+    """Load the committed execution metrics entry for a library and timestamp."""
+    metrics_path = execution_metrics_path_for_library(repo_path, library)
+    entries = _load_execution_metrics_entries(metrics_path)
+    if task_type is not None:
+        entries = {
+            key: entry
+            for key, entry in entries.items()
+            if key.startswith(f"{task_type}:")
+        }
+    for entry in entries.values():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("library") == library and entry.get("timestamp") == timestamp:
+            return dict(entry)
+    return None
 
 
 def _public_execution_metrics_entry(run_metrics: dict) -> dict:


### PR DESCRIPTION
### Summary

- keep `forge/.pending_metrics.json` available as a local publication input while removing it from PR branch contents
- add `ContinuationMarker.publicationMetrics`, which stores the exact durable execution-metrics pointer plus local-only PR extras
- reconstruct missing pending metrics during publication resume from `execution-metrics.json` plus marker extras, without falling back to lossy latest-metrics guessing
- snapshot pending-metrics extras into the marker before failed work is preserved, including post-generation intervention, local CI verification, and library-update alias split data
- document the pending-metrics/continuation lifecycle and add a fixture-backed publication-continuation E2E scenario

### Testing

- `./.venv/bin/python -m unittest tests.test_forge_metadata.FinalizeSuccessfulIssueTests tests.test_metrics_paths tests.test_pr_publication tests.test_schema_validator tests.test_make_pr_new_library_support tests.test_make_pr_improve_coverage tests.test_make_pr_not_for_native_image tests.test_make_pr_ni_run_fix tests.test_local_ci_verification`
- `GRAALVM_HOME="$JAVA_HOME" GRAALVM_HOME_25_0="$JAVA_HOME" GRAALVM_HOME_LATEST_EA="$JAVA_HOME" .venv/bin/python forge_metadata.py --fixture-testing --issue-number 9107 --reachability-metadata-path ..`
- continuation marker schema validation for fixture issue `9107`
- `git diff --check`

`grund check` still reports the pre-existing AGENTS.md v2 init-block warnings in root and `forge/AGENTS.md`.

Fixes #8555