### PR TITLE
Raise generated HTTP test timeouts

### DIFF
--- a/forge/prompt_templates/persistent/basic_iterative_rules.md
+++ b/forge/prompt_templates/persistent/basic_iterative_rules.md
@@ -11,6 +11,7 @@ Rules:
 - Keep tests version-agnostic. Do not hardcode the artifact version in normal test inputs or assertions.
 - Exception assertions are acceptable only for documented, supported negative-path APIs. Do not write tests whose method name, comments, or assertions describe a known broken behavior path such as "fails before", "regression", "broken", or "version-specific" failure.
 - Every individual test must complete in under 60 seconds. Use bounded waits and close all clients, servers, executors, and other background resources.
+- When tests use connection, request, read, socket, server, client, process, database, messaging, or HTTP timeouts, set each explicit timeout to at least 10 seconds. Shorter timeouts are flaky under native-image-agent metadata generation and Native Image startup, while unbounded waits are still not allowed.
 - Never generate, write, or modify reachability metadata or Native Image config entries. Do not create or edit `reachability-metadata.json`, `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, `predefined-classes-config.json`, or any other file under `src/test/resources/META-INF/native-image`; Forge handles metadata generation and merging externally.
 
 Native Image execution contract (non-negotiable):

--- a/forge/prompt_templates/persistent/default_agent_rules.md
+++ b/forge/prompt_templates/persistent/default_agent_rules.md
@@ -5,6 +5,7 @@ Workflow rules:
 - Keep tests compatible with Native Image by default.
 - Never generate, write, or modify reachability metadata or Native Image config entries. Do not create or edit `reachability-metadata.json`, `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, `predefined-classes-config.json`, or any other file under `src/test/resources/META-INF/native-image`; Forge handles metadata generation and merging externally.
 - Do not add test JVM toolchain, target, or release overrides that move the test away from the TCK-resolved test JVM version. If a language plugin needs an explicit setting such as `JavaLanguageVersion.of(...)`, `jvmToolchain(...)`, `kotlinOptions.jvmTarget = ...`, or `options.release = ...`, wire it to the resolved test JVM version instead of hardcoding a number. Do not add old-JDK compatibility flags such as `-Djava.security.manager=allow`. If a path only works on a different JDK, leave that path untested.
+- When tests use connection, request, read, socket, server, client, process, database, messaging, or HTTP timeouts, set each explicit timeout to at least 10 seconds. Shorter timeouts are flaky under native-image-agent metadata generation and Native Image startup, while unbounded waits are still not allowed.
 - Do not skip Native Image execution with runtime guards or native-image-specific disables.
 - Do not compile, run, or verify tests yourself; the workflow runs validation externally.
 - Keep edits focused on the active library and requested workflow task.

--- a/forge/prompt_templates/persistent/dynamic_access_rules.md
+++ b/forge/prompt_templates/persistent/dynamic_access_rules.md
@@ -16,6 +16,7 @@ Rules:
 - Keep tests version-agnostic. Do not hardcode the artifact version in normal test inputs or assertions.
 - Exception assertions are acceptable only for documented, supported negative-path APIs. Do not write tests whose method name, comments, or assertions describe a known broken behavior path such as "fails before", "regression", "broken", or "version-specific" failure.
 - Every individual test must complete in under 60 seconds. Use bounded waits and close all clients, servers, executors, and other background resources.
+- When tests use connection, request, read, socket, server, client, process, database, messaging, or HTTP timeouts, set each explicit timeout to at least 10 seconds. Shorter timeouts are flaky under native-image-agent metadata generation and Native Image startup, while unbounded waits are still not allowed.
 - Never generate, write, or modify reachability metadata or Native Image config entries. Do not create or edit `reachability-metadata.json`, `reflect-config.json`, `resource-config.json`, `proxy-config.json`, `serialization-config.json`, `jni-config.json`, `predefined-classes-config.json`, or any other file under `src/test/resources/META-INF/native-image`; Forge handles metadata generation and merging externally.
 
 Native Image execution contract (non-negotiable):

--- a/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.2.19.Final/src/test/java/undertow/UndertowTests.java
@@ -62,9 +62,9 @@ public class UndertowTests {
         server.start();
         try {
             // Make request
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World");
@@ -110,9 +110,9 @@ public class UndertowTests {
         server.start();
         try {
             // Make request
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/myapp/hello", PORT)))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello world");

--- a/tests/src/io.undertow/undertow-core/2.3.0.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.3.0.Final/src/test/java/undertow/UndertowTests.java
@@ -62,9 +62,9 @@ public class UndertowTests {
         server.start();
         try {
             // Make request
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World");
@@ -110,9 +110,9 @@ public class UndertowTests {
         server.start();
         try {
             // Make request
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/myapp/hello", PORT)))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello world");

--- a/tests/src/io.undertow/undertow-core/2.4.0.Final/src/test/java/undertow/UndertowTests.java
+++ b/tests/src/io.undertow/undertow-core/2.4.0.Final/src/test/java/undertow/UndertowTests.java
@@ -53,9 +53,9 @@ public class UndertowTests {
         server.start();
         try {
             // Make request
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World");

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/src/test/java/tomcat/TomcatTests.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/10.0.20/src/test/java/tomcat/TomcatTests.java
@@ -40,9 +40,9 @@ public class TomcatTests {
         addServlet(context);
         tomcat.start();
         try {
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:8080/hello"))
-                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1)).build();
+                    .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World\n");

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/TomcatTests.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/TomcatTests.java
@@ -43,10 +43,10 @@ public class TomcatTests {
         tomcat.start();
         try {
             assertProtocolIntrospection(connector);
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
             URI uri = URI.create("http://localhost:" + connector.getLocalPort() + "/hello");
             HttpRequest request = HttpRequest.newBuilder(uri).GET().header("Accept", "text/plain")
-                    .timeout(Duration.ofSeconds(1)).build();
+                    .timeout(Duration.ofSeconds(10)).build();
             HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isEqualTo("Hello World\n");

--- a/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/11.0.12/src/test/java/jetty/JettyTests.java
@@ -213,9 +213,9 @@ public class JettyTests {
     }
 
     private static HttpResponse<String> doHttpRequest(String... headers) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", PORT)))
-                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1));
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10));
         if (headers.length > 0) {
             request.headers(headers);
         }

--- a/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.0.1/src/test/java/jetty/JettyTests.java
@@ -157,9 +157,9 @@ public class JettyTests {
     }
 
     private static HttpResponse<String> doHttpRequest(String... headers) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", port)))
-                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1));
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10));
         if (headers.length > 0) {
             request.headers(headers);
         }

--- a/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/CustomRequestLogTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/CustomRequestLogTest.java
@@ -147,13 +147,13 @@ public class CustomRequestLogTest {
     }
 
     private static HttpResponse<String> sendRequest(int port) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/logged?name=value"))
                 .GET()
                 .header("Accept", "text/plain")
                 .header("Cookie", "test=cookie-value")
                 .header("X-Request", "request-value")
-                .timeout(Duration.ofSeconds(2))
+                .timeout(Duration.ofSeconds(10))
                 .build();
         return client.send(request, HttpResponse.BodyHandlers.ofString());
     }

--- a/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/ForwardedRequestCustomizerTest.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/ForwardedRequestCustomizerTest.java
@@ -69,11 +69,11 @@ public class ForwardedRequestCustomizerTest {
 
     private static HttpResponse<String> doHttpRequest(int port, String... headers)
             throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", port)))
                 .GET()
                 .header("Accept", "text/plain")
-                .timeout(Duration.ofSeconds(2))
+                .timeout(Duration.ofSeconds(10))
                 .headers(headers)
                 .build();
         return client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.1.10/src/test/java/jetty/JettyTests.java
@@ -161,9 +161,9 @@ public class JettyTests {
     }
 
     private static HttpResponse<String> doHttpRequest(String... headers) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", port)))
-                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1));
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10));
         if (headers.length > 0) {
             request.headers(headers);
         }

--- a/tests/src/org.eclipse.jetty/jetty-server/12.1.3/src/test/java/jetty/JettyTests.java
+++ b/tests/src/org.eclipse.jetty/jetty-server/12.1.3/src/test/java/jetty/JettyTests.java
@@ -197,9 +197,9 @@ public class JettyTests {
     }
 
     private static HttpResponse<String> doHttpRequest(String... headers) throws IOException, InterruptedException {
-        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build();
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(String.format("http://localhost:%d/", port)))
-                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(1));
+                .GET().header("Accept", "text/plain").timeout(Duration.ofSeconds(10));
         if (headers.length > 0) {
             request.headers(headers);
         }


### PR DESCRIPTION
## What this does

`generateMetadata` runs the test suite under the native-image agent, and we reproduced that a `1s` `java.net.http` request timeout can pass as a normal JVM test but fail during agent-instrumented metadata generation. This raises Forge's persistent generated-test guidance so new tests keep explicit connection/request/read/socket-style timeouts at `10s` or higher, while keeping waits bounded through the existing prompt-template strategy surface (§forge/WF-forge-workflow-strategy-config).

## Existing HTTP server tests

The checked-in `tests/` suite (§TESTS-suite) already had the same operational pattern in Tomcat, Undertow, and Jetty server tests. This raises those `HttpClient` connect timeouts and paired `HttpRequest` timeouts from `1s`/`2s` to `10s`, without changing the request behavior being asserted.
