### PR TITLE
Fix Forge chunked continuation resume

### DIFF
--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -230,6 +230,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             self.continuation_marker_path,
             lambda marker: (
                 marker.mark_phase_skipped_if_pending(PHASE_FIX),
+                marker.record_chunk_progress(self.chunk_class_count, 0),
                 marker.mark_phase_running(PHASE_EXPLORE),
             ),
         )
@@ -292,7 +293,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             active_class = current_report.next_uncovered_class(exhausted_classes)
             if active_class is None:
                 if not flush_native_test_batch("end-of-classes"):
-                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_pending(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                     return False, prompt_iterations
                 if (
                         successful_classes == 0
@@ -301,12 +306,24 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         and self._library_test_change_signature() != initial_test_change_signature
                 ):
                     self._print_dynamic_access_message("Coverage not improved. Keeping generated tests by request.")
-                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_completed(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                     return True, prompt_iterations
                 if successful_classes > 0:
-                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_completed(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                 else:
-                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_pending(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                 return successful_classes > 0, prompt_iterations
 
             class_name = active_class.class_name
@@ -434,7 +451,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         indent_level=2,
                         class_name=class_name,
                     )
-                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_pending(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                     return False, prompt_iterations
                 record_indirectly_completed_classes(class_name)
 
@@ -538,7 +559,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     indent_level=1,
                     class_name=class_name,
                 )
-                self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                self._mark_continuation_explore_pending(
+                    prompt_iterations,
+                    exhausted_classes,
+                    len(terminal_classes_this_part),
+                )
                 return False, prompt_iterations
             if class_failed:
                 self._print_dynamic_access_detail(
@@ -566,7 +591,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         terminal_classes_this_part,
                 ):
                     if not flush_native_test_batch("chunked-dynamic-access-boundary"):
-                        self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                        self._mark_continuation_explore_pending(
+                            prompt_iterations,
+                            exhausted_classes,
+                            len(terminal_classes_this_part),
+                        )
                         return False, prompt_iterations
                     self._last_phase_status = RUN_STATUS_CHUNK_READY
                     self._print_dynamic_access_message(
@@ -575,7 +604,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         )
                     )
                     self._save_dynamic_access_exhaust_report()
-                    self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_completed(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                     return True, prompt_iterations
                 continue
             updated_class = current_report.get_class(class_name)
@@ -613,7 +646,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     terminal_classes_this_part,
             ):
                 if not flush_native_test_batch("chunked-dynamic-access-boundary"):
-                    self._mark_continuation_explore_pending(prompt_iterations, exhausted_classes)
+                    self._mark_continuation_explore_pending(
+                        prompt_iterations,
+                        exhausted_classes,
+                        len(terminal_classes_this_part),
+                    )
                     return False, prompt_iterations
                 self._last_phase_status = RUN_STATUS_CHUNK_READY
                 self._print_dynamic_access_message(
@@ -622,25 +659,41 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     )
                 )
                 self._save_dynamic_access_exhaust_report()
-                self._mark_continuation_explore_completed(prompt_iterations, exhausted_classes)
+                self._mark_continuation_explore_completed(
+                    prompt_iterations,
+                    exhausted_classes,
+                    len(terminal_classes_this_part),
+                )
                 return True, prompt_iterations
 
-    def _mark_continuation_explore_completed(self, iteration: int, exhausted_classes: set[str]) -> None:
+    def _mark_continuation_explore_completed(
+            self,
+            iteration: int,
+            exhausted_classes: set[str],
+            chunk_processed_class_count: int | None = None,
+    ) -> None:
         """Persist successful dynamic-access phase completion."""
         save_phase_update(
             self.continuation_marker_path,
             lambda marker: (
                 marker.record_exhausted_classes(sorted(exhausted_classes)),
+                marker.record_chunk_progress(self.chunk_class_count, chunk_processed_class_count),
                 marker.mark_phase_completed(PHASE_EXPLORE, iteration=iteration),
             ),
         )
 
-    def _mark_continuation_explore_pending(self, iteration: int, exhausted_classes: set[str]) -> None:
+    def _mark_continuation_explore_pending(
+            self,
+            iteration: int,
+            exhausted_classes: set[str],
+            chunk_processed_class_count: int | None = None,
+    ) -> None:
         """Persist an incomplete dynamic-access phase."""
         save_phase_update(
             self.continuation_marker_path,
             lambda marker: (
                 marker.record_exhausted_classes(sorted(exhausted_classes)),
+                marker.record_chunk_progress(self.chunk_class_count, chunk_processed_class_count),
                 marker.mark_phase_pending(PHASE_EXPLORE, iteration=iteration),
             ),
         )

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -70,7 +70,8 @@ classes re-appear in the regenerated report.
   "phases": {
     "setup":        { "status": "completed", "preflightDone": true, "setupDone": true },
     "fix":          { "status": "skipped",   "iteration": null },
-    "explore":      { "status": "completed", "exhaustedClasses": ["com.acme.Foo"] },
+    "explore":      { "status": "completed", "exhaustedClasses": ["com.acme.Foo"],
+                      "chunkClassCount": 15, "chunkProcessedClassCount": 4 },
     "finalization": { "status": "completed" },
     "publication":  { "status": "pending",   "isPushed": false,
                       "branch": "ai/<login>/add-lib-support-com.acme-widget-1.4.0" }
@@ -112,6 +113,9 @@ because the marker never enters a successful run's publication staging
 - `explore.exhaustedClasses` is the only EXPLORE state worth keeping: a fresh
   report cannot distinguish an uncovered-but-abandoned class from an
   uncovered-but-untried one.
+- `explore.chunkClassCount` and `explore.chunkProcessedClassCount` record active
+  chunk budget already spent by a failed run, so resume continues the same
+  chunk instead of starting a full new threshold-sized chunk.
 - `publication.isPushed` is stored rather than derived so a stale remote branch
   from an earlier aborted attempt cannot be mistaken for this run's push;
   `publication.branch` is stored so resume targets the original branch namespace
@@ -134,6 +138,12 @@ A resume run reads the marker from the preserved branch and:
 5. Enters the phase named by `continueFrom` and applies that phase's resume
    action from §1, skipping every earlier completed or skipped phase.
 
+If a resumed run fails again while `continueFrom` still points to the same
+phase, Forge treats automatic continuation as exhausted for that issue. It
+removes the `resumable` label, releases the issue claim, and does not post a
+second human-intervention analysis because the first failed-run report remains
+the maintainer-facing diagnostic (§FS-human-intervention-policy).
+
 Publication resume hinges on the push: the branch is read from the marker
 and `isPushed` records whether the branch is already pushed, so a resumed run only
 does the PR making. Opening the pull request is the workflow's
@@ -150,5 +160,7 @@ Continuation does not change the human-intervention contract
 branch and labels the issue `human-intervention`, so a maintainer always retains
 the existing safety signal and diagnostics. The marker rides that same preserved
 branch, giving a later automated run — or the maintainer — a precise place to
-continue. External or transient failures take no issue action and write no
-marker, exactly as today.
+continue. A repeated failure in the same resumed phase only removes
+`resumable`; it leaves the earlier `human-intervention` signal and comment in
+place instead of adding another report. External or transient failures take no
+issue action and write no marker, exactly as today.

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -592,10 +592,16 @@ Chunked mode is automatic after the issue is marked with the
 `chunked-dynamic-access` label. The normal project status remains the run-state
 signal: `Todo` means Forge may claim the next chunk, `In Progress` means a chunk
 is currently being generated or reviewed, and the final PR's `Fixes: #<issue>`
-transition moves the issue to `Done`. Forge must not require an explicit
-resume-state CLI flag; the exhaust report location must be derived from the
-coordinate and loaded automatically by the orchestration scripts, as specified
-by §WF-dynamic-access-exhaust-report.
+transition moves the issue to `Done`. If a non-final chunk PR has failed CI and
+no failed-job rerun remains available, Forge must move the issue back to `Todo`
+and mark that PR for human follow-up so a replacement chunk can be generated.
+Forge must not require an explicit resume-state CLI flag; the exhaust report
+location must be derived from the coordinate and loaded automatically by the
+orchestration scripts, as specified by §WF-dynamic-access-exhaust-report. When
+the issue is being resumed from a preserved failed-run continuation marker,
+Forge may proceed without a coordinate-local exhaust report and use
+`explore.exhaustedClasses` from the marker as the processed-class set for the
+resumed run (§FS-forge-run-continuation.2).
 
 Chunk PRs use `Refs: #<issue>` until the final chunk. Only the final chunk PR
 may use `Fixes: #<issue>` and move the issue to `Done`. Non-final chunk PRs

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -229,7 +229,9 @@ runs never populate them (§WF-dynamic-access-exhaust-report):
 - `chunk_class_count` — maximum number of newly selected dynamic-access classes
   this chunk may process. `forge_metadata.py` computes it from the global class
   threshold and the number of unexhausted classes remaining. A class is never
-  split across chunks.
+  split across chunks. Failed-run continuation also records how many classes in
+  the active chunk already reached a terminal state, so the resumed invocation
+  receives only the remaining budget for that same chunk.
 
 ## 6. Workflow
 
@@ -533,7 +535,10 @@ whether to invoke the normal workflow or the chunked workflow:
 6. The workflow loads the exhaust report from the coordinate-derived persistent
    location, regenerates the current dynamic-access report from the checked-out
    base, and selects the next uncovered classes not present in the exhaust
-   report (§WF-dynamic-access-exhaust-report).
+   report (§WF-dynamic-access-exhaust-report). If this is a failed-run resume
+   with a continuation marker but no coordinate-local exhaust report, the
+   dispatcher uses `explore.exhaustedClasses` from the marker as the processed
+   class set for that resumed invocation (§FS-forge-run-continuation.2).
 7. The workflow processes at most the current chunk class count. Each selected
    class owns all of its dynamic-access call sites; call sites inside one class
    must not be split across chunks.
@@ -542,8 +547,10 @@ whether to invoke the normal workflow or the chunked workflow:
    chunk PR using the linking contract in
    §WF-chunked-dynamic-access-pr-linking.
 9. The issue project status controls continuation: `Todo` means Forge may claim
-   the next chunk, `In Progress` means the current chunk is active. No separate
-   ready/in-progress chunk labels are required.
+   the next chunk, `In Progress` means the current chunk is active. A non-final
+   chunk PR with failed CI is no longer an active chunk after Forge exhausts
+   available reruns; Forge releases the issue back to `Todo` and marks that PR
+   for human follow-up. No separate ready/in-progress chunk labels are required.
 10. Before resuming, Forge verifies that the latest recorded chunk PR commit is
     present in the base branch (§WF-dynamic-access-exhaust-report).
 
@@ -554,7 +561,10 @@ chunk to the issue without completing it unless the chunk is final. Chunk PRs
 carry the `chunked-dynamic-access` label. Non-final chunk PRs use
 `Refs: #<issue>` and commit the exhaust-report state required for the next run
 to skip classes already completed, skipped, exhausted, or failed. Only the final
-chunk PR may use `Fixes: #<issue>` and move the issue to `Done`.
+chunk PR may use `Fixes: #<issue>` and move the issue to `Done`. If a non-final
+chunk PR has failed CI and no eligible failed GitHub Actions job remains to
+rerun, Forge releases the linked issue back to `Todo` so a replacement chunk can
+be generated.
 
 #### WF-dynamic-access-exhaust-report: Dynamic-access exhaust report
 
@@ -571,6 +581,8 @@ dynamic-access report and filters out classes recorded in the exhaust report.
 The exhaust report path is not passed as an explicit resume-state argument. It
 is derived from the coordinate and stored persistently with the library test
 suite so that each merged chunk carries the state needed by the next run.
+Failed-run continuation can resume without this file when the preserved
+continuation marker already records the processed dynamic-access classes.
 Global repository stats remain authoritative: `generateLibraryStats` reports
 dynamic-access coverage against the full current dynamic-access surface, while
 the chunk PR body may additionally report how many classes were processed in

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -136,6 +136,7 @@ from utility_scripts.dynamic_access_exhaust_report import (
 )
 from utility_scripts.continuation_marker import (
     CONTINUATION_MARKER_FILENAME,
+    PHASE_EXPLORE,
     PHASE_PUBLICATION,
     ContinuationMarker,
     continuation_marker_path,
@@ -2478,11 +2479,11 @@ def resolve_non_final_chunked_dynamic_access_issue(pr: dict) -> int | None:
     return int(match.group(1))
 
 
-def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
-    """Move a merged non-final chunk issue back to Todo for the next chunk."""
+def release_non_final_chunked_dynamic_access_issue(pr: dict, reason: str) -> int | None:
+    """Move a non-final chunk issue back to Todo and return the issue number."""
     issue_number = resolve_non_final_chunked_dynamic_access_issue(pr)
     if issue_number is None:
-        return
+        return None
 
     item_id = get_project_item_id(issue_number)
     if item_id is None:
@@ -2495,8 +2496,31 @@ def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
     invalidate_issue_claim_cache_entry(issue_number)
     log_stage(
         "chunked-dynamic-access",
-        f"Released issue #{issue_number} for the next chunk after PR #{pr.get('number')} merged.",
+        f"Released issue #{issue_number} for the next chunk after PR #{pr.get('number')} {reason}.",
     )
+    return issue_number
+
+
+def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
+    """Move a merged non-final chunk issue back to Todo for the next chunk."""
+    release_non_final_chunked_dynamic_access_issue(pr, "merged")
+
+
+def apply_chunked_dynamic_access_failed_ci_follow_up(pr: dict) -> None:
+    """Release a non-final chunk issue when its PR has failed CI and no rerun remains."""
+    issue_number = release_non_final_chunked_dynamic_access_issue(pr, "failed CI")
+    if issue_number is None:
+        return
+    pr_number = pr.get("number")
+    if isinstance(pr_number, int):
+        add_pull_request_label(pr_number, LABEL_HUMAN_INTERVENTION)
+        log_stage(
+            "chunked-dynamic-access",
+            (
+                f"Marked failed non-final chunk PR #{pr_number} as "
+                f"'{LABEL_HUMAN_INTERVENTION}' after releasing issue #{issue_number}."
+            ),
+        )
 
 
 def apply_library_update_alias_split_merge_follow_up(pr: dict) -> None:
@@ -2573,6 +2597,21 @@ def reconcile_reviewed_pull_request(
             f"mergeStateStatus={pr.get('mergeStateStatus')}, "
             f"ci={((pr.get('statusCheckRollup') or {}).get('state'))}]"
         )
+
+        if has_failed_pull_request_ci(pr) and resolve_non_final_chunked_dynamic_access_issue(pr) is not None:
+            head_sha = pr.get("headRefOid")
+            if not isinstance(head_sha, str) or not head_sha:
+                print(f"ERROR: Missing head SHA for chunked PR #{pr_number} with failed CI.", file=sys.stderr)
+                raise RuntimeError(f"Missing head SHA for chunked PR #{pr_number} with failed CI")
+            rerun_count = rerun_failed_pull_request_workflow_jobs(pr_number, head_sha)
+            if rerun_count:
+                print(
+                    f"[Reran failed GitHub Actions job(s) in {rerun_count} workflow run(s) "
+                    f"for chunked PR #{pr_number}; keeping the backing issue in progress for this pass.]"
+                )
+                return True
+            apply_chunked_dynamic_access_failed_ci_follow_up(pr)
+            return True
 
         if review_decision == "CHANGES_REQUESTED":
             add_pull_request_label(pr_number, LABEL_HUMAN_INTERVENTION)
@@ -4604,12 +4643,57 @@ def _processed_dynamic_access_classes(report: DynamicAccessExhaustReport | None)
     return report.processed_classes()
 
 
+def _continuation_processed_dynamic_access_classes(marker: ContinuationMarker | None) -> set[str]:
+    """Return dynamic-access classes recorded in the continuation marker."""
+    if marker is None:
+        return set()
+    explore_phase: dict[str, object] = marker.phases.get(PHASE_EXPLORE, {})
+    exhausted_classes: object = explore_phase.get("exhaustedClasses", [])
+    if not isinstance(exhausted_classes, list):
+        return set()
+    return {
+        class_name
+        for class_name in exhausted_classes
+        if isinstance(class_name, str) and class_name
+    }
+
+
+def _dynamic_access_processed_class_count(
+        report: DynamicAccessExhaustReport | None,
+        marker: ContinuationMarker | None,
+) -> int:
+    """Return the processed class count used for chunking logs."""
+    processed_classes = _processed_dynamic_access_classes(report)
+    processed_classes.update(_continuation_processed_dynamic_access_classes(marker))
+    return len(processed_classes)
+
+
+def _continuation_active_chunk_remaining_budget(marker: ContinuationMarker | None) -> int | None:
+    """Return the remaining class budget for a resumed active chunk."""
+    if marker is None or marker.continue_from != PHASE_EXPLORE:
+        return None
+    explore_phase: dict[str, object] = marker.phases.get(PHASE_EXPLORE, {})
+    raw_chunk_class_count: object = explore_phase.get("chunkClassCount")
+    if raw_chunk_class_count is None:
+        return None
+    try:
+        chunk_class_count = int(raw_chunk_class_count)
+        chunk_processed_class_count = int(explore_phase.get("chunkProcessedClassCount") or 0)
+    except (TypeError, ValueError):
+        return None
+    if chunk_class_count <= 0:
+        return None
+    return max(chunk_class_count - max(chunk_processed_class_count, 0), 0)
+
+
 def _remaining_uncovered_dynamic_access_classes(
         report,
         exhaust_report: DynamicAccessExhaustReport | None,
+        continuation_marker: ContinuationMarker | None,
 ) -> list[str]:
-    """Return current uncovered classes not already recorded in the exhaust report."""
+    """Return current uncovered classes not already recorded as processed."""
     processed_classes = _processed_dynamic_access_classes(exhaust_report)
+    processed_classes.update(_continuation_processed_dynamic_access_classes(continuation_marker))
     return [
         class_coverage.class_name
         for class_coverage in report.classes
@@ -4746,15 +4830,24 @@ def prepare_dynamic_access_chunking(
         )
         return None
 
-    remaining_classes = _remaining_uncovered_dynamic_access_classes(report, exhaust_report)
+    remaining_classes = _remaining_uncovered_dynamic_access_classes(
+        report,
+        exhaust_report,
+        claimed_issue.continuation_marker,
+    )
     current_chunk_class_count = min(threshold, len(remaining_classes))
+    active_chunk_remaining_budget = _continuation_active_chunk_remaining_budget(
+        claimed_issue.continuation_marker
+    )
+    if active_chunk_remaining_budget is not None:
+        current_chunk_class_count = min(current_chunk_class_count, active_chunk_remaining_budget)
     if current_chunk_class_count <= 0:
         log_stage(
             "dynamic-access-chunking",
             (
                 f"No chunk selected for issue #{claimed_issue.issue['number']}: "
                 f"all {len(current_uncovered_classes)} uncovered class(es) are already recorded "
-                "in the exhaust report."
+                "as processed."
             ),
         )
         return None
@@ -4770,15 +4863,21 @@ def prepare_dynamic_access_chunking(
 
     log_stage(
         "dynamic-access-chunking",
-        (
-            f"Chunked dynamic-access selected for issue #{claimed_issue.issue['number']}: "
-            f"already_chunked={already_chunked}, "
-            f"total_uncovered_classes={len(current_uncovered_classes)}, "
-            f"processed_classes={exhaust_report.processed_class_count()}, "
-            f"remaining_classes={len(remaining_classes)}, "
-            f"threshold={threshold}, "
-            f"chunk_class_count={current_chunk_class_count}, "
-            f"exhaust_report={os.path.relpath(exhaust_report_path, claimed_issue.worktree_path)}."
+        "Chunked dynamic-access selected for issue #{issue_number}: "
+        "already_chunked={already_chunked}, total_uncovered_classes={uncovered_count}, "
+        "processed_classes={processed_count}, remaining_classes={remaining_count}, "
+        "threshold={threshold}, chunk_class_count={chunk_count}, exhaust_report={report_path}.".format(
+            issue_number=claimed_issue.issue["number"],
+            already_chunked=already_chunked,
+            uncovered_count=len(current_uncovered_classes),
+            processed_count=_dynamic_access_processed_class_count(
+                exhaust_report,
+                claimed_issue.continuation_marker,
+            ),
+            remaining_count=len(remaining_classes),
+            threshold=threshold,
+            chunk_count=current_chunk_class_count,
+            report_path=os.path.relpath(exhaust_report_path, claimed_issue.worktree_path),
         ),
     )
     return current_chunk_class_count
@@ -5713,12 +5812,22 @@ def resolve_chunked_dynamic_access_exhaust_report(
         issue: dict,
         base_reachability_metadata_path: str,
         coordinate: str,
+        continuation_marker: ContinuationMarker | None = None,
 ) -> DynamicAccessExhaustReport | None:
     """Resolve the persisted exhaust report for an already chunked issue."""
     if not issue_has_label(issue, LABEL_CHUNKED_DYNAMIC_ACCESS):
         return None
     report_path = find_dynamic_access_exhaust_report_path(base_reachability_metadata_path, coordinate)
     if report_path is None:
+        if continuation_marker is not None:
+            log_stage(
+                "chunked-dynamic-access",
+                (
+                    f"Resuming chunked dynamic-access issue #{issue['number']} without an exhaust report; "
+                    "processed classes will be read from the continuation marker."
+                ),
+            )
+            return None
         raise RuntimeError(
             f"Chunked dynamic-access issue #{issue['number']} has no exhaust report for {coordinate}."
         )
@@ -5887,6 +5996,7 @@ def claim_issue_for_processing(
             issue,
             base_reachability_metadata_path,
             issue_coordinates,
+            continuation_marker,
         )
     except Exception as exc:
         print(
@@ -6620,6 +6730,41 @@ def preserve_failed_work_for_follow_up(claimed_issue: ClaimedIssue) -> FailurePr
         return None
 
 
+def _repeated_resume_failure_phase(claimed_issue: ClaimedIssue) -> str | None:
+    """Return the phase when a resumed run failed again without advancing."""
+    resumed_marker = claimed_issue.continuation_marker
+    if resumed_marker is None:
+        return None
+    active_marker = load_continuation_marker(continuation_marker_path(claimed_issue.worktree_path))
+    if active_marker is None:
+        return None
+    resumed_phase = resumed_marker.continue_from
+    if resumed_phase and active_marker.continue_from == resumed_phase:
+        return resumed_phase
+    return None
+
+
+def handle_repeated_resume_failure(claimed_issue: ClaimedIssue, phase_name: str, reason: str) -> None:
+    """Stop automatic continuation after the same resumed phase fails again."""
+    issue_number = claimed_issue.issue["number"]
+    log_stage(
+        "continuation",
+        (
+            f"Issue #{issue_number} resumed at phase {phase_name} and failed there again; "
+            f"removing '{LABEL_RESUMABLE}' without posting another human-intervention report."
+        ),
+    )
+    try:
+        remove_issue_label(issue_number, LABEL_RESUMABLE)
+    except Exception as exc:
+        print(
+            f"ERROR: Failed to remove '{LABEL_RESUMABLE}' label from issue #{issue_number}: {exc!r}",
+            file=sys.stderr,
+        )
+        traceback.print_exc()
+    revert_claimed_issue(claimed_issue, f"{reason}; repeated resume failure at {phase_name}")
+
+
 def handle_failed_claimed_issue(
         claimed_issue: ClaimedIssue,
         reason: str,
@@ -6644,6 +6789,10 @@ def handle_failed_claimed_issue(
             ),
         )
         revert_claimed_issue(claimed_issue, reason)
+        return
+    repeated_resume_failure_phase = _repeated_resume_failure_phase(claimed_issue)
+    if repeated_resume_failure_phase is not None:
+        handle_repeated_resume_failure(claimed_issue, repeated_resume_failure_phase, reason)
         return
     preservation_result = preserve_failed_work_for_follow_up(claimed_issue)
     if is_user_interrupt_requested():

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -50,7 +50,12 @@ def _default_phases() -> dict[str, dict[str, Any]]:
     return {
         PHASE_SETUP: {"status": STATUS_PENDING, "preflightDone": False, "setupDone": False},
         PHASE_FIX: {"status": STATUS_PENDING, "iteration": None},
-        PHASE_EXPLORE: {"status": STATUS_PENDING, "exhaustedClasses": []},
+        PHASE_EXPLORE: {
+            "status": STATUS_PENDING,
+            "exhaustedClasses": [],
+            "chunkClassCount": None,
+            "chunkProcessedClassCount": 0,
+        },
         PHASE_FINALIZATION: {"status": STATUS_PENDING},
         PHASE_PUBLICATION: {"status": STATUS_PENDING, "isPushed": False, "branch": None},
     }
@@ -222,6 +227,19 @@ class ContinuationMarker:
     def record_exhausted_classes(self, exhausted_classes: list[str]) -> None:
         """Record dynamic-access classes that a fresh report cannot reconstruct."""
         self._phase(PHASE_EXPLORE)["exhaustedClasses"] = sorted(set(exhausted_classes))
+        self.recompute_continue_from()
+
+    def record_chunk_progress(
+            self,
+            chunk_class_count: int | None,
+            chunk_processed_class_count: int | None,
+    ) -> None:
+        """Record active chunk progress for failed-run continuation."""
+        phase = self._phase(PHASE_EXPLORE)
+        if chunk_class_count is not None and chunk_class_count > 0:
+            phase["chunkClassCount"] = int(chunk_class_count)
+        if chunk_processed_class_count is not None:
+            phase["chunkProcessedClassCount"] = max(0, int(chunk_processed_class_count))
         self.recompute_continue_from()
 
     def record_preserved_branch(self, branch_name: str) -> None:


### PR DESCRIPTION
## What this fixes

Chunked dynamic-access continuation had three separate failure modes that all left Forge unable to make reliable forward progress. The shared problem was that Forge treated chunk progress as either fully reconstructable from the dynamic-access report or fully represented by the old exhaust report, but failed-run continuation can sit in the middle: the preserved branch may already contain generated coverage, the coordinate-local exhaust report may be absent, and the active chunk may have spent only part of its class budget. This updates the continuation marker and control-plane behavior so chunked runs resume from the preserved state described by `§FS-forge-run-continuation` while keeping the chunk linking rules from `§WF-chunked-dynamic-access-pr-linking`.

## Bugs fixed

| Bug | Before | After |
| --- | --- | --- |
| Missing exhaust report on resumable chunked issues | `claim_issue_for_processing` rejected a `chunked-dynamic-access` issue if `dynamic-access-exhaust-report.json` was missing, even when a preserved continuation marker existed. | Resumable chunked issues may continue without the exhaust report; processed classes are read from `explore.exhaustedClasses` in the marker. |
| Active chunk budget restarted after a failed run | Resume recomputed the global remaining uncovered classes, but forgot how much of the current chunk's threshold was already spent. A chunk with threshold `15` that failed after `9` classes could resume with another `15`. | EXPLORE now records `chunkClassCount` and `chunkProcessedClassCount`; the dispatcher resumes with `min(threshold, remaining_uncovered, chunkClassCount - chunkProcessedClassCount)`. |
| Repeated same-phase resume kept producing follow-up | If a resumed run failed again in the same phase, Forge preserved and reported another human-intervention result even though the earlier one was already the diagnostic signal. | Same-phase resume failure removes `resumable`, reverts the issue claim, and does not post another human-intervention report. |
| Failed non-final chunk PRs left issues parked | A failed non-final chunk PR kept the backing issue `In Progress`, so Forge could not generate a replacement chunk. | When failed CI has no eligible rerun left, Forge releases the linked issue back to `Todo`, clears assignees, invalidates the claim cache, and labels the failed PR `human-intervention`. |

## How the resumed chunk is computed

A failed chunk that started with a class budget of `15` and already processed `9` terminal classes now resumes with `6`, even if the regenerated report still has more than `15` uncovered classes:

```text
remaining active chunk budget = chunkClassCount - chunkProcessedClassCount
                              = 15 - 9
                              = 6
```

The regenerated report still decides which classes are currently uncovered, and the marker only supplies state that the report cannot reconstruct: abandoned classes and the active chunk's already-spent budget. This keeps completed transitive coverage report-driven while preserving the per-chunk boundary required by `§WF-dynamic-access-exhaust-report`.
