### PR TITLE
[GenAI] Mark io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter as not for Native Image

### DIFF
--- a/metadata/io.opentelemetry.instrumentation/opentelemetry-spring-boot-starter/index.json
+++ b/metadata/io.opentelemetry.instrumentation/opentelemetry-spring-boot-starter/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published starter JAR contains only META-INF/MANIFEST.MF and no JVM class files; Native Image metadata should target the Spring Boot autoconfigure module it depends on.",
+    "replacement": "io.opentelemetry.instrumentation:opentelemetry-spring-boot-autoconfigure:2.28.1"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8517

This PR records `io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published starter JAR contains only META-INF/MANIFEST.MF and no JVM class files; Native Image metadata should target the Spring Boot autoconfigure module it depends on.

Replacement guidance:
- io.opentelemetry.instrumentation:opentelemetry-spring-boot-autoconfigure:2.28.1

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `c7eb09099eca75d0fe20a3196348b92afc617b50`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
