### PR TITLE
[GenAI] Improve coverage for org.apache.tomcat.embed:tomcat-embed-core:11.0.18 using gpt-5.5 (chunked dynamic-access)

### DIFF
--- a/metadata/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/reachability-metadata.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/reachability-metadata.json
@@ -178,6 +178,20 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.realm.JAASRealm"
+      },
+      "type" : "com.sun.security.auth.login.ConfigFile",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.net.URI"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "double[]"
@@ -214,7 +228,19 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "jakarta.servlet.MultipartConfigElement"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
+      },
+      "type" : "jakarta.servlet.Servlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "jakarta.servlet.Servlet"
     },
@@ -226,15 +252,39 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "jakarta.servlet.ServletContext"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "type" : "jakarta.servlet.UnavailableException"
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "jakarta.servlet.UnavailableException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "type" : "jakarta.servlet.jsp.JspContext"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.DefaultInstanceManager"
       },
       "type" : "jakarta.xml.ws.WebServiceRef"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.compat.JreCompat"
+      },
+      "type" : "java.io.FileSystem"
     },
     {
       "condition" : {
@@ -286,6 +336,28 @@
         "typeReached" : "org.apache.catalina.startup.Bootstrap"
       },
       "type" : "java.lang.ClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.LogFactory"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.web.WebXmlParser"
+      },
+      "type" : "java.lang.ClassLoader",
+      "fields" : [
+        {
+          "name" : "classLoaderValueMap"
+        }
+      ]
     },
     {
       "condition" : {
@@ -392,6 +464,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.session.StandardSession"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.IntrospectionUtils"
       },
       "type" : "java.lang.Object"
@@ -427,6 +505,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "java.lang.String",
@@ -453,6 +537,12 @@
         "typeReached" : "org.apache.tomcat.util.compat.Jre21Compat"
       },
       "type" : "java.lang.Thread$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.loader.WebappClassLoaderBase"
+      },
+      "type" : "java.lang.Thread[]"
     },
     {
       "condition" : {
@@ -584,6 +674,24 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.core.DefaultInstanceManager"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.session.StandardSession"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "java.math.BigDecimal"
@@ -593,6 +701,42 @@
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "java.math.BigInteger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.util.SessionIdGeneratorBase"
+      },
+      "type" : "java.net.InetAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
+      },
+      "type" : "java.net.InetAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.util.SessionIdGeneratorBase"
+      },
+      "type" : "java.net.InterfaceAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
+      },
+      "type" : "java.net.InterfaceAddress[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.util.SessionIdGeneratorBase"
+      },
+      "type" : "java.net.NetworkInterface[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
+      },
+      "type" : "java.net.NetworkInterface[]"
     },
     {
       "condition" : {
@@ -726,6 +870,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "java.util.concurrent.ScheduledThreadPoolExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.DirectJDKLog"
+      },
+      "type" : "java.util.logging.ConsoleHandler"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "java.util.logging.LogManager",
@@ -768,6 +924,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "javax.management.DynamicMBean"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "javax.management.MBeanOperationInfo",
@@ -780,6 +942,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "javax.management.MBeanRegistration"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "javax.management.MBeanServerBuilder",
@@ -789,6 +957,12 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "javax.management.NotificationBroadcaster"
     },
     {
       "condition" : {
@@ -817,6 +991,12 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "javax.management.modelmbean.ModelMBeanNotificationBroadcaster"
     },
     {
       "condition" : {
@@ -853,6 +1033,18 @@
         "typeReached" : "org.apache.tomcat.util.compat.Jre21Compat"
       },
       "type" : "javax.security.auth.Subject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.LogFactory"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.web.WebXmlParser"
+      },
+      "type" : "jdk.internal.misc.Unsafe"
     },
     {
       "condition" : {
@@ -924,6 +1116,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.net.NioEndpoint"
+      },
+      "type" : "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "long[]"
@@ -936,7 +1134,19 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.AccessLog"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
+      },
+      "type" : "org.apache.catalina.Cluster"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.catalina.Cluster"
     },
@@ -954,13 +1164,37 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.Container"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "type" : "org.apache.catalina.ContainerListener"
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.ContainerListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.ContainerBase"
+      },
+      "type" : "org.apache.catalina.Container[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
+      },
+      "type" : "org.apache.catalina.CredentialHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.catalina.CredentialHandler"
     },
@@ -978,6 +1212,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.LifecycleListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.util.LifecycleBase"
+      },
+      "type" : "org.apache.catalina.LifecycleListener[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "type" : "org.apache.catalina.LifecycleState"
@@ -985,6 +1231,12 @@
     {
       "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
+      },
+      "type" : "org.apache.catalina.LifecycleState"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.catalina.LifecycleState"
     },
@@ -996,7 +1248,19 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.Pipeline"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
+      },
+      "type" : "org.apache.catalina.Realm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.catalina.Realm"
     },
@@ -1008,9 +1272,72 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.Valve"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.StandardPipeline"
+      },
+      "type" : "org.apache.catalina.Valve[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.webresources.StandardRoot"
+      },
+      "type" : "org.apache.catalina.WebResource[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
       },
       "type" : "org.apache.catalina.Wrapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.catalina.Wrapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "type" : "org.apache.catalina.authenticator.BasicAuthenticator",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.authenticator.AuthenticatorBase"
+      },
+      "type" : "org.apache.catalina.authenticator.jaspic.CallbackHandlerImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.authenticator.jaspic.AuthConfigFactoryImpl"
+      },
+      "type" : "org.apache.catalina.authenticator.jaspic.SimpleAuthConfigProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.util.Map",
+            "jakarta.security.auth.message.config.AuthConfigFactory"
+          ]
+        }
+      ]
     },
     {
       "condition" : {
@@ -1021,6 +1348,12 @@
     {
       "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
+      },
+      "type" : "org.apache.catalina.connector.Request"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.catalina.connector.Request"
     },
@@ -1037,6 +1370,18 @@
           ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.DefaultInstanceManager"
+      },
+      "type" : "org.apache.catalina.core.DefaultInstanceManager$AnnotationCacheEntry[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.DefaultInstanceManager"
+      },
+      "type" : "org.apache.catalina.core.StandardContext"
     },
     {
       "condition" : {
@@ -1234,6 +1579,24 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.mapper.Mapper"
+      },
+      "type" : "org.apache.catalina.mapper.Mapper$MappedHost[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ClassNameMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
       },
       "type" : "org.apache.catalina.mbeans.ClassNameMBean",
@@ -1258,9 +1621,57 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ConnectorMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardEngine"
       },
       "type" : "org.apache.catalina.mbeans.ContainerMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ContainerMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextEnvironmentMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextEnvironmentMBean",
       "methods" : [
         {
           "name" : "<init>",
@@ -1282,6 +1693,54 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.WebappServiceLoader"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextResourceMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextResourceMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
       },
       "type" : "org.apache.catalina.mbeans.NamingResourcesMBean",
@@ -1294,7 +1753,31 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "org.apache.catalina.mbeans.NamingResourcesMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardService"
+      },
+      "type" : "org.apache.catalina.mbeans.ServiceMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
       },
       "type" : "org.apache.catalina.mbeans.ServiceMBean",
       "methods" : [
@@ -1358,9 +1841,33 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.Tomcat"
+      },
+      "type" : "org.apache.catalina.startup.ContextConfig",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.startup.LifecycleListenerRule"
       },
       "type" : "org.apache.catalina.startup.EngineConfig",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.Tomcat"
+      },
+      "type" : "org.apache.catalina.startup.FailedContext",
       "methods" : [
         {
           "name" : "<init>",
@@ -1406,6 +1913,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.WebappServiceLoader"
+      },
+      "type" : "org.apache.catalina.util.CharsetMapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.connector.Connector"
       },
       "type" : "org.apache.coyote.AbstractProtocol",
@@ -1421,6 +1940,12 @@
         {
           "name" : "getNameIndex",
           "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setPort",
+          "parameterTypes" : [
+            "int"
+          ]
         }
       ]
     },
@@ -1450,7 +1975,37 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.Adapter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.ContinueResponseTiming"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.Processor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.Request"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.coyote.AbstractProtocol$ConnectionHandler"
+      },
+      "type" : "org.apache.coyote.RequestGroupInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.coyote.RequestGroupInfo"
     },
@@ -1459,6 +2014,18 @@
         "typeReached" : "org.apache.coyote.AbstractProtocol$ConnectionHandler"
       },
       "type" : "org.apache.coyote.RequestInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.Response"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.coyote.UpgradeProtocol"
     },
     {
       "condition" : {
@@ -1518,9 +2085,39 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.coyote.http11.Http11InputBuffer"
+      },
+      "type" : "org.apache.coyote.http11.InputFilter[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.coyote.http11.Http11OutputBuffer"
+      },
+      "type" : "org.apache.coyote.http11.OutputFilter[]"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "type" : "org.apache.juli.logging.Log"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.juli.logging.Log"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
+      },
+      "type" : "org.apache.tomcat.util.descriptor.web.ContextEnvironment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.tomcat.util.http.parser.HttpParser"
     },
     {
       "condition" : {
@@ -1569,6 +2166,12 @@
     {
       "condition" : {
         "typeReached" : "org.apache.coyote.AbstractProtocol$ConnectionHandler"
+      },
+      "type" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.apache.tomcat.util.modeler.BaseModelMBean"
     },
@@ -1754,6 +2357,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.digester.ObjectCreateRule"
+      },
+      "type" : "org.apache.tomcat.util.modeler.ParameterInfo",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "type" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsDigesterSource",
@@ -1826,7 +2441,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "type" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource",
       "methods" : [
@@ -1840,11 +2455,83 @@
       "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
       },
+      "type" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.IntrospectionUtils"
+      },
+      "type" : "org.apache.tomcat.util.net.AbstractEndpoint",
+      "methods" : [
+        {
+          "name" : "setBindOnInit",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.tomcat.util.net.AbstractEndpoint$Handler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.IntrospectionUtils"
+      },
+      "type" : "org.apache.tomcat.util.net.Nio2Endpoint"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.IntrospectionUtils"
+      },
+      "type" : "org.apache.tomcat.util.net.NioEndpoint"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.apache.tomcat.util.net.SSLHostConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
+      },
       "type" : "org.apache.tomcat.util.net.SocketProperties"
     },
     {
       "condition" : {
         "typeReached" : "org.apache.catalina.loader.WebappClassLoaderBase"
+      },
+      "type" : "org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.compat.Jre19Compat"
+      },
+      "type" : "org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.compat.JreCompat"
       },
       "type" : "org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker",
       "fields" : [
@@ -1885,7 +2572,19 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
+      },
+      "type" : "org.ietf.jgss.GSSContext"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
+      },
+      "type" : "org.ietf.jgss.GSSName"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.modules.MbeansDescriptorsIntrospectionSource"
       },
       "type" : "org.ietf.jgss.GSSName"
     },
@@ -2025,9 +2724,39 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.juli.logging.DirectJDKLog"
+      },
+      "type" : "sun.util.logging.resources.logging"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.ConcurrentDateFormat"
+      },
+      "type" : "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.ConcurrentDateFormat"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.http.CookieProcessorBase"
       },
       "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.FastHttpDateFormat"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.ConcurrentDateFormat"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
     },
     {
       "condition" : {
@@ -2037,12 +2766,30 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.FastHttpDateFormat"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.http.CookieProcessorBase"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.FastHttpDateFormat"
       },
       "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
     }
   ],
   "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "META-INF/services/jakarta.servlet.ServletContainerInitializer"
+    },
     {
       "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.Nio2Endpoint"
@@ -2057,9 +2804,27 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.FastHttpDateFormat"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.authenticator.jaspic.AuthConfigFactoryImpl"
+      },
+      "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.startup.Catalina"
       },
       "glob" : "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "META-INF/services/javax.xml.parsers.SAXParserFactory"
     },
     {
       "condition" : {
@@ -2081,6 +2846,186 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "com/sun/jna/FunctionMapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "com/sun/jna/Library.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "conf/Tomcat/localhost/context.xml.default"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "conf/Tomcat/localhost/web.xml.default"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "conf/context.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.file.ConfigurationSource"
+      },
+      "glob" : "conf/server.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.file.ConfigurationSource"
+      },
+      "glob" : "conf/web.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/mail/Authenticator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/ServerAuth.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/callback/PrivateKeyCallback$Request.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/callback/SecretKeyCallback$Request.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/config/AuthConfig.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/config/AuthConfigFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/config/AuthConfigProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/config/ServerAuthConfig.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/security/auth/message/config/ServerAuthContext.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/FilterRegistration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/GenericServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/Registration$Dynamic.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/Registration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/Servlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/ServletConfig.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/ServletContainerInitializer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/ServletContextEvent.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/ServletRegistration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/ServletRequestEvent.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/http/HttpServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/http/HttpServletResponse.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/http/HttpServletResponseWrapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "jakarta/servlet/http/HttpSessionEvent.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "jakarta.servlet.http.HttpServlet"
       },
       "glob" : "jakarta/servlet/http/LocalStrings.properties"
@@ -2096,6 +3041,1374 @@
         "typeReached" : "jakarta.servlet.http.HttpServlet"
       },
       "glob" : "jakarta/servlet/http/LocalStrings_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/XMLSchema.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/datatypes.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/j2ee_1_4.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/j2ee_web_services_1_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/j2ee_web_services_client_1_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jakartaee_10.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jakartaee_11.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jakartaee_9.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jakartaee_web_services_2_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jakartaee_web_services_client_2_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_5.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_6.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_7.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_8.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_1_2.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_1_3.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_1_4.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_client_1_2.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_client_1_3.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/javaee_web_services_client_1_4.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_2_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_2_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_2_2.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_2_3.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_3_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_3_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/jsp_4_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_2_2.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_2_3.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_2_4.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_2_5.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_3_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_3_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_4_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_5_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_6_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-app_6_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_3_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_3_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_4_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_5_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_6_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-common_6_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_3_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_3_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_4_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_5_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_6_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-fragment_6_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_1_1.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_1_2.dtd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_2_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_2_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_3_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_3_1.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/web-jsptaglibrary_4_0.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "jakarta/servlet/resources/xml.xsd"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/beans/PropertyChangeListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/BufferedReader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/CharConversionException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/Closeable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/DataInput.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/FilterInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/FilterOutputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/Flushable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/IOException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/InputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/ObjectInput.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/ObjectInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/ObjectStreamConstants.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/OutputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/PrintStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/PrintWriter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/Reader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/Serializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/io/Writer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Appendable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/AssertionError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/AutoCloseable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/CharSequence.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/ClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Cloneable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Comparable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Enum.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Error.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Exception.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/IllegalStateException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/IndexOutOfBoundsException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Iterable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/LinkageError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Object.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Readable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Runnable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/RuntimeException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/SecurityManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Thread.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/ThreadLocal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/Throwable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/UnsatisfiedLinkError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/annotation/Annotation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/constant/Constable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/instrument/ClassFileTransformer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/ref/Reference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/ref/ReferenceQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/ref/WeakReference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/reflect/AnnotatedElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/lang/reflect/InvocationHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "java/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/net/JarURLConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/net/URLClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/net/URLConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/net/URLStreamHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/net/URLStreamHandlerFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/AsynchronousByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/AsynchronousChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/ByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/Channel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/CompletionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/GatheringByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/ReadableByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/ScatteringByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/channels/WritableByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/charset/Charset.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/nio/charset/CharsetEncoder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/rmi/Remote.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/DEREncodable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/GeneralSecurityException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/PermissionCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/Principal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/PrivilegedAction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/PrivilegedExceptionAction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/SecureClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/cert/Certificate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/cert/X509Certificate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/security/cert/X509Extension.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractSequentialList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/AbstractSet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/ArrayList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Collection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Comparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Deque.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Enumeration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/EventListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/EventObject.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/HashMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/HashSet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Iterator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/LinkedHashMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/LinkedList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/List.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Map$Entry.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Map.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Queue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/RandomAccess.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/SequencedCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/SequencedMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/Set.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/TimerTask.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/AbstractExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/BlockingQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/Callable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ConcurrentMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/Executor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ForkJoinWorkerThread.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/Future.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/LinkedBlockingQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/RejectedExecutionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ScheduledExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ThreadFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/ThreadPoolExecutor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/locks/AbstractOwnableSynchronizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/locks/AbstractQueuedSynchronizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/locks/Lock.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/concurrent/locks/ReadWriteLock.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "java/util/concurrent/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/function/Consumer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/function/Function.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/function/Predicate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/jar/JarInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/logging/Filter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/logging/Formatter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/logging/Handler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/logging/LogManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/logging/Logger.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "java/util/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/zip/InflaterInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/zip/ZipConstants.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "java/util/zip/ZipInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/DynamicMBean.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/MBeanRegistration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/MBeanServer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/MBeanServerConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/NotificationBroadcaster.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/NotificationEmitter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/NotificationFilter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/NotificationListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/management/modelmbean/ModelMBeanNotificationBroadcaster.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/Context.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/NameParser.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/NamingEnumeration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/Reference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/spi/InitialContextFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/naming/spi/ObjectFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/KeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/SSLEngine.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/SSLSession.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/SSLSessionContext.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/X509ExtendedKeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/net/ssl/X509KeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/security/auth/callback/Callback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/security/auth/callback/CallbackHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/security/auth/login/LoginException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "javax/security/auth/spi/LoginModule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Contained.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Container.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Context.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/JmxEnabled.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Lifecycle.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Loader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/Realm.class"
     },
     {
       "condition" : {
@@ -2123,9 +4436,21 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/connector/Request$SpecialAttributeAdapter.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
       },
       "glob" : "org/apache/catalina/connector/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/core/ContainerBase.class"
     },
     {
       "condition" : {
@@ -2153,6 +4478,12 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/core/StandardContext.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
       },
       "glob" : "org/apache/catalina/deploy/LocalStrings.properties"
@@ -2162,6 +4493,36 @@
         "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
       },
       "glob" : "org/apache/catalina/deploy/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/filters/CsrfPreventionFilter$NonceCache.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/filters/CsrfPreventionFilterBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/filters/FilterBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/filters/RequestFilter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/filters/RestCsrfPreventionFilter$RestCsrfPreventionStrategy.class"
     },
     {
       "condition" : {
@@ -2177,9 +4538,27 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/loader/WebappClassLoaderBase.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
       },
       "glob" : "org/apache/catalina/loader/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/manager/ManagerServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/manager/host/HostManagerServlet.class"
     },
     {
       "condition" : {
@@ -2189,9 +4568,21 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/mapper/Mapper$MapElement.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.mbeans.MBeanFactory"
       },
       "glob" : "org/apache/catalina/mbeans/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/mbeans/SparseUserDatabaseMBean.class"
     },
     {
       "condition" : {
@@ -2201,9 +4592,33 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/realm/JAASRealm.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.realm.RealmBase"
       },
       "glob" : "org/apache/catalina/realm/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/realm/MemoryRealm.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/realm/RealmBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/realm/X509UsernameRetriever.class"
     },
     {
       "condition" : {
@@ -2213,9 +4628,27 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/servlets/WebdavServlet$PropertyStore.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.session.ManagerBase"
       },
       "glob" : "org/apache/catalina/session/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/session/PersistentManagerBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/session/StoreBase.class"
     },
     {
       "condition" : {
@@ -2225,7 +4658,25 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/startup/Authenticators.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/startup/Catalina.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.startup.Catalina"
+      },
+      "glob" : "org/apache/catalina/startup/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.CatalinaBaseConfigurationSource"
       },
       "glob" : "org/apache/catalina/startup/LocalStrings.properties"
     },
@@ -2234,6 +4685,12 @@
         "typeReached" : "org.apache.catalina.startup.Tomcat"
       },
       "glob" : "org/apache/catalina/startup/MimeTypeMappings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/startup/UserDatabase.class"
     },
     {
       "condition" : {
@@ -2255,9 +4712,27 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/users/SparseUserDatabase.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
       },
       "glob" : "org/apache/catalina/users/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/util/LifecycleBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/util/LifecycleMBeanBase.class"
     },
     {
       "condition" : {
@@ -2267,9 +4742,33 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/util/RateLimiter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/util/RateLimiterBase.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.util.ServerInfo"
       },
       "glob" : "org/apache/catalina/util/ServerInfo.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/util/TimeBucketCounterBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/valves/AbstractAccessLogValve$ElapsedTimeElement$Style.class"
     },
     {
       "condition" : {
@@ -2279,9 +4778,45 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/valves/RequestFilterValve.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/valves/ValveBase.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.mbeans.MBeanUtils"
       },
       "glob" : "org/apache/catalina/valves/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/valves/rewrite/RewriteMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/valves/rewrite/Substitution$SubstitutionElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/webresources/AbstractResource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/webresources/AbstractResourceSet.class"
     },
     {
       "condition" : {
@@ -2291,15 +4826,69 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/catalina/webresources/StandardRoot.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.core.StandardContext"
       },
       "glob" : "org/apache/catalina/webresources/mbeans-descriptors.xml"
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/AbstractProcessorLight.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/ActionHook.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/Adapter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/AsyncContextCallback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/BadRequestException.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.coyote.AbstractProtocol"
       },
       "glob" : "org/apache/coyote/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/Processor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/ProtocolHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http11/HttpOutputBuffer.class"
     },
     {
       "condition" : {
@@ -2315,9 +4904,117 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/AbstractStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/HpackDecoder$HeaderEmitter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/HpackEncoder$HpackHeaderFunction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/HpackEncoder$TableEntry.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2Exception.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2Parser$Input.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2Parser$Output.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2Parser.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2UpgradeHandler$HeaderFrameBuffers.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2UpgradeHandler$PingManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Http2UpgradeHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/coyote/http2/Stream$StreamInputBuffer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/juli/FileHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/juli/OneLineFormatter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/juli/WebappProperties.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/juli/logging/Log.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/apache/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
       },
       "glob" : "org/apache/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.NamingContext"
+      },
+      "glob" : "org/apache/naming/LocalStrings.properties"
     },
     {
       "condition" : {
@@ -2327,9 +5024,21 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.naming.NamingContext"
+      },
+      "glob" : "org/apache/naming/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.naming.StringManager"
       },
       "glob" : "org/apache/naming/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.NamingContext"
+      },
+      "glob" : "org/apache/naming/LocalStrings_en_US.properties"
     },
     {
       "condition" : {
@@ -2339,15 +5048,75 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/naming/factory/FactoryBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.BeanFactory"
+      },
+      "glob" : "org/apache/naming/factory/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.BeanFactory"
+      },
+      "glob" : "org/apache/naming/factory/LocalStrings_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.BeanFactory"
+      },
+      "glob" : "org/apache/naming/factory/LocalStrings_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/naming/factory/ResourceLinkFactory.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.naming.NamingContext"
       },
       "glob" : "org/apache/naming/jndiprovider.properties"
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/ContextBind.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/InstanceManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/InstrumentableClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/PeriodicEventListener.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.catalina.connector.Connector"
       },
       "glob" : "org/apache/tomcat/jni/AprStatus.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/apache/tomcat/mbeans-descriptors.xml"
     },
     {
       "condition" : {
@@ -2363,9 +5132,45 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/bcel/classfile/ElementValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/buf/ByteChunk$ByteInputChannel.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.buf.AbstractChunk"
       },
       "glob" : "org/apache/tomcat/util/buf/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.buf.EncodedSolidusHandling"
+      },
+      "glob" : "org/apache/tomcat/util/buf/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/apache/tomcat/util/buf/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/collections/SynchronizedStack.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/compat/JreCompat.class"
     },
     {
       "condition" : {
@@ -2381,9 +5186,45 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.DigesterFactory"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/web/Injectable.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.descriptor.web.SecurityConstraint"
       },
       "glob" : "org/apache/tomcat/util/descriptor/web/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.descriptor.web.WebXmlParser"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/web/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/web/NamingResources.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/web/ResourceBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/descriptor/web/XmlEncodingBase.class"
     },
     {
       "condition" : {
@@ -2393,9 +5234,75 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/AbstractObjectCreationFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/CallMethodRule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/CallParamRule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/Digester$EntityResolverWrapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/DocumentProperties$Charset.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.digester.Digester"
       },
       "glob" : "org/apache/tomcat/util/digester/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/ObjectCreateRule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/ObjectCreationFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/Rule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/digester/RuleSet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/file/ConfigurationSource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.http.MimeHeaders"
+      },
+      "glob" : "org/apache/tomcat/util/http/LocalStrings.properties"
     },
     {
       "condition" : {
@@ -2405,9 +5312,75 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/FileItemHeadersSupport.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/FileUploadBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/ThresholdingOutputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/impl/SizeException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/util/Closeable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/fileupload/util/LimitedInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/parser/HttpHeaderParser$HeaderDataSource.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.http.parser.HttpParser"
       },
       "glob" : "org/apache/tomcat/util/http/parser/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/parser/StructuredField$SfItem.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/http/parser/StructuredField$SfListMember.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/json/JSONParserConstants.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/apache/tomcat/util/mbeans-descriptors.xml"
     },
     {
       "condition" : {
@@ -2417,9 +5390,39 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/BaseModelMBean.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/FeatureInfo.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/LocalStrings.properties"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.modeler.Registry"
       },
       "glob" : "org/apache/tomcat/util/modeler/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/Registry.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/RegistryMBean.class"
     },
     {
       "condition" : {
@@ -2441,9 +5444,87 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/modeler/modules/ModelerSource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/AbstractEndpoint$Handler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/ApplicationBufferHandler.class"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
       },
       "glob" : "org/apache/tomcat/util/net/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/Nio2Channel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/NioChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SendfileDataBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SocketBufferHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SocketProcessorBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SocketWrapperBase$CompletionCheck.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SocketWrapperBase$OperationState.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/SocketWrapperBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/net/WriteBuffer$Sink.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/apache/tomcat/util/net/mbeans-descriptors.xml"
     },
     {
       "condition" : {
@@ -2465,9 +5546,3867 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/threads/ResizableExecutor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/apache/tomcat/util/threads/ThreadPoolExecutor$RejectedExecutionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/annotations"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Abstract2DArrayAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractArrayAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractAtomicFieldUpdaterAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractAtomicReferenceAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractCharacterAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractCollectionAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractComparableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractDoubleArrayAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractEnumerableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractFileAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractFileSizeAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractFutureAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractInstantAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractIntArrayAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractIntegerAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractIterableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractIteratorAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractListAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractLocalDateAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractLongAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractObjectAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractOffsetTimeAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractOptionalDoubleAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractPathAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractPredicateAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractPredicateLikeAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractSoftAssertions.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractThrowableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AbstractZonedDateTimeAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AfterAssertionErrorCollected.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Array2DAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/ArraySortedAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Assert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AssertFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/AssertionErrorCollector.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Assertions.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/BDDSoftAssertionsProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/ComparableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/DefaultAssertionErrorCollector.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Descriptable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/EnumerableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/ExtensionPoints.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/FactoryBasedNavigableListAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/FloatingPointNumberAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/IndexedObjectEnumerableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/InstanceOfAssertFactories.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Java6BDDSoftAssertionsProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/Java6StandardSoftAssertionsProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/NumberAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/ObjectEnumerableAssert.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/SoftAssertions.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/SoftAssertionsProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/SoftAssertionsRule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/exception"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/filter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/filter/FilterOperator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/junit"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/junit/jupiter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/recursive"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/api/recursive/comparison"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/api/recursive/comparison/ComparisonDifference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/condition"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/data"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/data/TemporalOffset.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/data/TemporalUnitOffset.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/description"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/description/Description.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/description/TextDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/error"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/error/AbstractShouldHaveTextContent.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/error/BasicErrorMessageFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/error/ErrorMessageFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/error/array2d"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/error/future"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/error/uri"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/extractor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/groups"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/AbstractComparisonStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/ComparisonStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/FieldByFieldComparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/Numbers.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/RealNumbers.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/StandardComparisonStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/TypeHolder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/WholeNumbers.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy$Suffixing$BaseNameResolver$ForGivenType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy$Suffixing$BaseNameResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy$Suffixing.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy$SuffixingRandom$BaseNameResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/NamingStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$CircularityLock.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$ClassFileBufferStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$ClassFileBufferStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$Default$Delegator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$Default$ExecutingTransformer$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$Default$WarmupStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$DescriptionStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$FallbackStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$Identified.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InitializationStrategy$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InitializationStrategy$SelfInjection$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InitializationStrategy$SelfInjection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InitializationStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InjectionStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$InstallationListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$LambdaInstrumentationStrategy$LambdaMetafactoryFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$LambdaInstrumentationStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$Listener$Adapter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$LocationStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$PoolStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RawMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionListenable$ResubmissionImmediateMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionListenable$ResubmissionOnErrorMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionListenable$WithResubmissionSpecification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionListenable$WithoutResubmissionSpecification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionListenable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$Collector.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$DiscoveryStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$Listener$Adapter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$Listener$ErrorEscalating.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$Listener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$ResubmissionEnforcer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$RedefinitionStrategy$ResubmissionScheduler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder$TypeStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/AgentBuilder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/ResettableClassFileTransformer$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/agent/builder/ResettableClassFileTransformer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ArgumentHandler$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ArgumentHandler$ForAdvice$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ArgumentHandler$ForAdvice.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ArgumentHandler$ForInstrumentedMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ArgumentHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$AssignReturned$ExceptionHandler$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$AssignReturned$Handler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Delegator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Bound.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Delegating$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Inlining$Resolved$ForMethodExit.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Inlining$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$RelocationHandler$Bound.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$RelocationHandler$ForValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$RelocationHandler$Relocation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Resolved$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Resolved$ForMethodEnter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Resolved$ForMethodExit.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$SuppressionHandler$Bound.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$SuppressionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher$Unresolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ExceptionHandler$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$ExceptionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$MethodSizeHandler$ForInstrumentedMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$MethodSizeHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$ForArgument.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$ForField.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$ForOrigin$Renderer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$Sort.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$Target$ForDefaultValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$Target$ForVariable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$OffsetMapping.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$PostProcessor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler$Default$Initialization.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler$Default$TranslationMode.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler$Default$WithPreservedArguments.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler$ForInstrumentedMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler$ForPostProcessor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/Advice$StackMapFrameHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/AsmVisitorWrapper$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/AsmVisitorWrapper$ForDeclaredMethods$MethodVisitorWrapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/AsmVisitorWrapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberAttributeExtension.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$Replacement$Binding.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$Replacement$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$Substitution$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$Substitution$ForFieldAccess$FieldResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$Substitution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$TypePoolResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/asm/MemberSubstitution$WithoutSpecification.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/AccessControllerPlugin$Initializer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/EntryPoint.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/HashCodeAndEqualsPlugin$Enhance$InvokeSuper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Dispatcher$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$ErrorHandler$Failing.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$ErrorHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Listener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$PoolStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Source$Origin.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Target$Sink.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$TypeStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Engine$TypeStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Factory$UsingReflection$ArgumentResolver$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Factory$UsingReflection$ArgumentResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Factory$UsingReflection$Instantiator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin$ForElementMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/build/Plugin.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ByteCodeElement$Token.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ByteCodeElement$TypeDependant.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ByteCodeElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/DeclaredByType$WithMandatoryDeclaration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/DeclaredByType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$ForFieldDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$ForMethodDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$ForParameterDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$ForTypeDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$OfAbstraction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$OfByteCodeElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable$OfEnumeration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/ModifierReviewable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/NamedElement$WithDescriptor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/NamedElement$WithGenericName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/NamedElement$WithOptionalName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/NamedElement$WithRuntimeName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/NamedElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/TypeVariableSource$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/TypeVariableSource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationDescription$Loadable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationDescription$RenderingDispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationSource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$ForConstant$PropertyDelegate$ForArrayType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$ForConstant$PropertyDelegate$ForNonArrayType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$ForConstant$PropertyDelegate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$Loaded$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue$Loaded.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/annotation/AnnotationValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/enumeration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/enumeration/EnumerationDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/enumeration/EnumerationDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldDescription$InDefinedShape$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldDescription$InDefinedShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldDescription$InGenericShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/field/FieldList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodDescription$InDefinedShape$AbstractBase$ForLoadedExecutable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodDescription$InDefinedShape$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodDescription$InDefinedShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/MethodList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterDescription$ForLoadedParameter$ParameterAnnotationSource.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterDescription$InDefinedShape$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterDescription$InDefinedShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterList$ForLoadedExecutable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/method/ParameterList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier/ModifierContributor$ForField.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier/ModifierContributor$ForMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier/ModifierContributor$ForParameter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier/ModifierContributor$ForType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/modifier/ModifierContributor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/PackageDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/PackageDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentDescription$InDefinedShape$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentDescription$InDefinedShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentDescription$InGenericShape.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/RecordComponentList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$AbstractBase$OfSimpleType$WithDelegation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$AbstractBase$OfSimpleType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$AnnotationReader$Delegator$Chained.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$AnnotationReader$Delegator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$AnnotationReader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Builder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$LazyProjection$WithEagerNavigation$OfAnnotatedElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$LazyProjection$WithEagerNavigation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$LazyProjection$WithLazyNavigation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$LazyProjection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfGenericArray.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfNonGenericType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfParameterizedType$RenderingDelegate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfParameterizedType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfTypeVariable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$OfWildcardType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor$ForSignatureVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor$Reifying.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor$Substitutor$WithoutTypeSubstitution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor$Substitutor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor$Validator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic$Visitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription$Generic.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeDescription.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeList$Generic$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeList$Generic.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/description/type/TypeList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator$ForInstrumentation$ClassLoadingDelegate$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator$ForInstrumentation$ClassLoadingDelegate$ForDelegatingClassLoader$Dispatcher$Initializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator$ForInstrumentation$ClassLoadingDelegate$ForDelegatingClassLoader$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator$ForInstrumentation$ClassLoadingDelegate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/ClassFileLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$AbstractBase$Adapter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$AbstractBase$Delegator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition$Optional$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition$Optional$Valuable$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition$Optional$Valuable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition$Optional.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition$Valuable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$FieldDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$InnerTypeDefinition$ForType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$InnerTypeDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$AbstractBase$Adapter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ExceptionDefinition$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ExceptionDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ImplementationDefinition$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ImplementationDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Annotatable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Initial$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Simple$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Simple$Annotatable$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Simple$Annotatable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition$Simple.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ParameterDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ReceiverTypeDefinition$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$ReceiverTypeDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$TypeVariableDefinition$Annotatable$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition$TypeVariableDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$MethodDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$RecordComponentDefinition$Optional$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$RecordComponentDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder$TypeVariableDefinition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType$Builder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/DynamicType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/NexusAccessor$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/Transformer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/TypeResolutionStrategy$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ByteArrayClassLoader$PackageLookupStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ByteArrayClassLoader$PersistenceHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ByteArrayClassLoader$SynchronizationStrategy$Initializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ByteArrayClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassFilePostProcessor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingJna$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingReflection$Dispatcher$Direct.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingReflection$Dispatcher$Initializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingReflection$Dispatcher$UsingUnsafeOverride.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingReflection$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingUnsafe$Dispatcher$Initializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassInjector$UsingUnsafe$Factory$AccessResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassLoadingStrategy$Configurable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassLoadingStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassReloadingStrategy$BootstrapInjection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/ClassReloadingStrategy$Strategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/PackageDefinitionStrategy$ManifestReading$SealBaseLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/loading/PackageDefinitionStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/ClassWriterStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/ClassWriterStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/FieldLocator$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/FieldLocator$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/FieldLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/InstrumentedType$Factory$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/InstrumentedType$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/InstrumentedType$WithFlexibleName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/InstrumentedType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodGraph$Compiler$Default$Harmonizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodGraph$Compiler$Default$Key$Store$Entry.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodGraph$Compiler$Default$Key.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodGraph$Compiler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodGraph$Node.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodRegistry$Handler$Compiled.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodRegistry$Handler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/MethodRegistry$Prepared.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/RecordComponentRegistry$Compiled.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeInitializer$Drain.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeInitializer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler$Appending$FrameWriter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler$Appending$WithoutDrain.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default$ForInlining$WithFullProcessing$InitializationHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default$ForInlining.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default$ValidatingClassVisitor$Constraint.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$FieldPool$Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$FieldPool.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$MethodPool$Record$ForDefinedMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$MethodPool$Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$RecordComponentPool$Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter$RecordComponentPool.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/TypeWriter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/inline"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/inline/AbstractInliningDynamicTypeBuilder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/inline/MethodRebaseResolver$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/inline/MethodRebaseResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/subclass"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/subclass/ConstructorStrategy$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/dynamic/scaffold/subclass/ConstructorStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/EqualsMethod$NullValueGuard.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/EqualsMethod$TypePropertyComparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/EqualsMethod$ValueComparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/ExceptionMethod$ConstructionDelegate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$AssignerConfigurable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$FieldLocation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$FieldNameExtractor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$ForSetter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$OwnerTypeLocatable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor$PropertyConfigurable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/FieldAccessor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/HashCodeMethod$OffsetProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/HashCodeMethod$ValueTransformer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Composable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Context$Default$AbstractPropertyAccessorMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Context$ExtractableView$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Context.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$SpecialMethodInvocation$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$SpecialMethodInvocation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Target$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Target$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/Implementation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvocationHandlerAdapter$AssignerConfigurable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvocationHandlerAdapter$WithoutPrivilegeConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$AbstractDelegator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$ArgumentProvider$ConstantPoolWrapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$ArgumentProvider$ForField.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$ArgumentProvider$ForMethodParameter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$ArgumentProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$Target$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$InvocationProvider$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$WithImplicitArguments.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/InvokeDynamic$WithImplicitType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodAccessorFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$ArgumentLoader$ArgumentProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$ArgumentLoader$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$ArgumentLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$MethodInvoker$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$MethodInvoker.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$MethodLocator$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$MethodLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TargetHandler$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TargetHandler$ForField$Location.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TargetHandler$Resolved.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TargetHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TerminationHandler$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodCall$TerminationHandler$Simple.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodDelegation$ImplementationDelegate$ForField.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/MethodDelegation$ImplementationDelegate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/ToStringMethod$PrefixResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/AnnotationAppender$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/AnnotationValueFilter$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/AnnotationValueFilter$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/AnnotationValueFilter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/FieldAttributeAppender$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/MethodAttributeAppender$Explicit$Target.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/MethodAttributeAppender$ForInstrumentedMethod.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/MethodAttributeAppender.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/RecordComponentAttributeAppender$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/RecordComponentAttributeAppender.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/attribute/TypeAttributeAppender.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/auxiliary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/auxiliary/AuxiliaryType$NamingStrategy.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/auxiliary/AuxiliaryType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/auxiliary/TypeProxy$InvocationFactory$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/auxiliary/TypeProxy$InvocationFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$AmbiguityResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$BindingResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$MethodInvoker.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$ParameterBinding.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/MethodDelegationBinder$TerminationHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/Argument.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/DefaultCall$Binder$DefaultMethodLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/DefaultMethod$Binder$MethodLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/FieldProxy$Binder$FieldResolver$Factory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/FieldProxy$Binder$FieldResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/Morph$Binder$DefaultMethodLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/Super$Binder$TypeLocator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/Super$Instantiation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/TargetMethodAnnotationDrivenBinder$ParameterBinder$ForFixedValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bind/annotation/TargetMethodAnnotationDrivenBinder$ParameterBinder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/ByteCodeAppender.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/Duplication.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/Removal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/StackManipulation$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/StackManipulation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/Assigner$EqualTypesOnly.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/Assigner.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/primitive"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/reference"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/reference/GenericTypeAwareAssigner$IsAssignableToVisitor$OfManifestType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/assign/reference/GenericTypeAwareAssigner$IsAssignableToVisitor$OfSimpleType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/collection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/collection/ArrayFactory$ArrayCreator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/collection/CollectionFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/constant"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/constant/MethodConstant$CanCache.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/constant/MethodConstant.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/member"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/member/FieldAccess$AccessDispatcher$AbstractFieldInstruction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/member/MethodInvocation$WithImplicitInvocationTargetType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/implementation/bytecode/member/MethodVariableAccess$MethodLoading$TypeCastingHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/AnnotationVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/ClassVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/ClassWriter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/FieldVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/MethodVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/ModuleVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/RecordComponentVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/Symbol.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/commons"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/commons/ClassRemapper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/signature"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/jar/asm/signature/SignatureVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/CachingMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/ElementMatcher$Junction$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/ElementMatcher$Junction$ForNonNullValues.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/ElementMatcher$Junction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/ElementMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/FilterableList$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/FilterableList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/LatentMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/matcher/StringMatcher$Mode.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$AbstractBase$Hierarchical.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$CacheProvider.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$AnnotationRegistrant$AbstractBase$ForTypeVariable$WithIndex$DoubleIndexed.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$AnnotationRegistrant$AbstractBase$ForTypeVariable$WithIndex.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$AnnotationRegistrant$AbstractBase$ForTypeVariable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$AnnotationRegistrant$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$AnnotationRegistrant.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$GenericTypeExtractor$IncompleteToken$AbstractBase.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$GenericTypeRegistrant$RejectingSignatureVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$GenericTypeRegistrant.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$AnnotationToken$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$GenericTypeToken$OfFormalTypeVariable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$GenericTypeToken$Resolution$ForType.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$GenericTypeToken$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$GenericTypeToken.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default$LazyTypeDescription$LazyAnnotationValue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Default.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool$Resolution.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/pool/TypePool.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/FileSystem.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/Invoker.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/JavaConstant$Simple$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/JavaConstant$Simple.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/JavaConstant$Visitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/JavaConstant.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/dispatcher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/dispatcher/JavaDispatcher$Dispatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/dispatcher/JavaDispatcher$DynamicClassLoader$Resolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/nullability"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/privilege"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/visitor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/visitor/ExceptionTableSensitiveMethodVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/visitor/LocalVariableAwareMethodVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/internal/bytebuddy/utility/visitor/MetadataAwareClassVisitor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/matcher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/presentation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/presentation/Representation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/util"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/util/NullSafeComparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/util/diff"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/util/diff/Delta.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/util/diff/myers"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/assertj/core/util/diff/myers/PathNode.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/util/introspection"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.scan.JarFileUrlJar"
+      },
+      "glob" : "org/assertj/core/util/xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/hamcrest/BaseMatcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/hamcrest/Matcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/hamcrest/SelfDescribing.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/AfterEachCallback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/AfterTestExecutionCallback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/BeforeEachCallback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/Extension.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/ParameterResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/jupiter/api/extension/TestInstancePostProcessor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/rules/TestRule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/junit/runners/model/Statement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.Registry"
+      },
+      "glob" : "org/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
         "typeReached" : "org.apache.tomcat.util.net.AbstractEndpoint"
       },
       "glob" : "org/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/opentest4j/IncompleteExecutionException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/opentest4j/MultipleFailuresError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ContentHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/DTDHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/EntityResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ErrorHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ext/DeclHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ext/DefaultHandler2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ext/EntityResolver2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/ext/LexicalHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "org/xml/sax/helpers/DefaultHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "tomcat/ContextConfigTest$MatchingServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "tomcat/ContextConfigTest$TrackedServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "tomcat/JAASRealmTest$NamedPrincipal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.WebAnnotationSet"
+      },
+      "glob" : "tomcat/TomcatTests$MyServlet.class"
     },
     {
       "condition" : {
@@ -2483,7 +9422,1027 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.apache.juli.logging.DirectJDKLog"
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "worker/org/gradle/internal/classloader/ClassLoaderUtils$AbstractClassLoaderLookuper.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "glob" : "worker/org/gradle/internal/classloader/ClassLoaderUtils$ClassLoaderPackagesFetcher.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/BufferedReader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/CharConversionException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/Closeable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/DataInput.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/FilterInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/FilterOutputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/Flushable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/IOException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/InputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/ObjectInput.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/ObjectInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/ObjectStreamConstants.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/OutputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/PrintStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/PrintWriter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/Reader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/Serializable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/io/Writer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Appendable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/AssertionError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/AutoCloseable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/CharSequence.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/ClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Cloneable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Comparable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Enum.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Error.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Exception.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/IllegalStateException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/IndexOutOfBoundsException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Iterable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/LinkageError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Object.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Readable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Record.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Runnable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/RuntimeException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/SecurityManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Thread.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/ThreadLocal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/Throwable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/UnsatisfiedLinkError.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/annotation/Annotation.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/constant/Constable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/ref/Reference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/ref/ReferenceQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/ref/WeakReference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/reflect/AnnotatedElement.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/lang/reflect/InvocationHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/net/JarURLConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/net/URLClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/net/URLConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/net/URLStreamHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/net/URLStreamHandlerFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/AsynchronousByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/AsynchronousChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/ByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/Channel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/CompletionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/GatheringByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/ReadableByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/ScatteringByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/channels/WritableByteChannel.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/charset/Charset.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/nio/charset/CharsetEncoder.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/DEREncodable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/GeneralSecurityException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/PermissionCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/Principal.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/PrivilegedAction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/PrivilegedExceptionAction.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/SecureClassLoader.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/cert/Certificate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/cert/X509Certificate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/security/cert/X509Extension.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractSequentialList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/AbstractSet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/ArrayList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Collection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Comparator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Deque.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Enumeration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/EventListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/EventObject.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/HashMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/HashSet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Iterator.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/LinkedHashMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/LinkedList.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/List.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Map$Entry.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Map.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Queue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/RandomAccess.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/SequencedCollection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/SequencedMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/Set.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/TimerTask.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/AbstractExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/BlockingQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/Callable.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ConcurrentMap.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/Executor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ForkJoinWorkerThread.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/Future.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/LinkedBlockingQueue.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/RejectedExecutionHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ScheduledExecutorService.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ThreadFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/ThreadPoolExecutor.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/locks/AbstractOwnableSynchronizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/locks/AbstractQueuedSynchronizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/locks/Lock.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/concurrent/locks/ReadWriteLock.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/function/Consumer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/function/Function.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/function/Predicate.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/jar/JarInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/zip/InflaterInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/zip/ZipConstants.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "java/util/zip/ZipInputStream.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/KeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/SSLEngine.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/SSLSession.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/SSLSessionContext.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/X509ExtendedKeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/net/ssl/X509KeyManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/security/auth/callback/Callback.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/security/auth/callback/CallbackHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/security/auth/login/LoginException.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.base",
+      "glob" : "javax/security/auth/spi/LoginModule.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.desktop",
+      "glob" : "java/beans/PropertyChangeListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.instrument",
+      "glob" : "java/lang/instrument/ClassFileTransformer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.logging",
+      "glob" : "java/util/logging/Filter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.logging",
+      "glob" : "java/util/logging/Formatter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.logging",
+      "glob" : "java/util/logging/Handler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.logging",
+      "glob" : "java/util/logging/LogManager.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.logging",
+      "glob" : "java/util/logging/Logger.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.Bootstrap"
       },
       "module" : "java.logging",
       "glob" : "sun/util/logging/resources/logging_en.properties"
@@ -2493,7 +10452,196 @@
         "typeReached" : "org.apache.juli.logging.DirectJDKLog"
       },
       "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.Bootstrap"
+      },
+      "module" : "java.logging",
       "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.logging.DirectJDKLog"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/DynamicMBean.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/MBeanRegistration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/MBeanServer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/MBeanServerConnection.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/NotificationBroadcaster.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/NotificationEmitter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/NotificationFilter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/NotificationListener.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.management",
+      "glob" : "javax/management/modelmbean/ModelMBeanNotificationBroadcaster.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/Context.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/NameParser.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/NamingEnumeration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/Reference.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/spi/InitialContextFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.naming",
+      "glob" : "javax/naming/spi/ObjectFactory.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.rmi",
+      "glob" : "java/rmi/Remote.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ContentHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/DTDHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/EntityResolver.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ErrorHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ext/DeclHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ext/DefaultHandler2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ext/EntityResolver2.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/ext/LexicalHandler.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "module" : "java.xml",
+      "glob" : "org/xml/sax/helpers/DefaultHandler.class"
     },
     {
       "condition" : {
@@ -2560,6 +10708,9 @@
       "bundle" : "org.apache.naming.LocalStrings"
     },
     {
+      "bundle" : "org.apache.naming.factory.LocalStrings"
+    },
+    {
       "bundle" : "org.apache.tomcat.util.LocalStrings"
     },
     {
@@ -2570,6 +10721,9 @@
     },
     {
       "bundle" : "org.apache.tomcat.util.concurrent.LocalStrings"
+    },
+    {
+      "bundle" : "org.apache.tomcat.util.descriptor.LocalStrings"
     },
     {
       "bundle" : "org.apache.tomcat.util.descriptor.web.LocalStrings"
@@ -2597,6 +10751,9 @@
     },
     {
       "bundle" : "org.apache.tomcat.util.threads.LocalStrings"
+    },
+    {
+      "bundle" : "sun.security.util.resources.security"
     },
     {
       "bundle" : "sun.util.logging.resources.logging"

--- a/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/execution-metrics.json
+++ b/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/execution-metrics.json
@@ -64,5 +64,102 @@
       "test_file": "tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/TomcatTests.java",
       "metadata_file": "metadata/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/reachability-metadata.json"
     }
+  },
+  "improve_library_coverage:2026-06-22": {
+    "timestamp": "2026-06-22T22:18:01.900250Z",
+    "library": "org.apache.tomcat.embed:tomcat-embed-core:11.0.18",
+    "starting_commit": "ff02b80648c605f2de2a04206fe73e4365729f77",
+    "ending_commit": "b03ad2d18fbce4a24b70ac1b76547cdebcb051d6",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "chunk_ready",
+    "stats": {
+      "version": "11.0.18",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.57289,
+            "coveredCalls": 224,
+            "totalCalls": 391
+          },
+          "resources": {
+            "coverageRatio": 0.634146,
+            "coveredCalls": 26,
+            "totalCalls": 41
+          }
+        },
+        "coverageRatio": 0.578704,
+        "coveredCalls": 250,
+        "totalCalls": 432
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 63988,
+          "missed": 281534,
+          "ratio": 0.185192,
+          "total": 345522
+        },
+        "line": {
+          "covered": 15641,
+          "missed": 65657,
+          "ratio": 0.192391,
+          "total": 81298
+        },
+        "method": {
+          "covered": 2937,
+          "missed": 9836,
+          "ratio": 0.229938,
+          "total": 12773
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "action": "no_action",
+      "agent_guidance": "",
+      "applied_setup": [],
+      "deterministic_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8328 Update existing library: org.apache.tomcat.embed:tomcat-embed-core:11.0.18; label=library-update-request; body_chars=2556"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "12 existing test file path(s) included"
+        }
+      ],
+      "input_tokens_used": 54059,
+      "issue_label": "library-update-request",
+      "issue_number": 8328,
+      "library": "org.apache.tomcat.embed:tomcat-embed-core:11.0.18",
+      "model": "oca/gpt-5.5",
+      "output_tokens_used": 3640,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "risks": [
+        "Optional Tomcat areas such as JSP/Jasper, WebSocket, APR/native SSL, clustering, or external persistence would need additional artifacts or native libraries, but they are not needed for the reported Connector.getProperty/setProperty coverage path.",
+        "Tests should avoid fixed ports and external services; use local embedded Tomcat/Connector APIs and clean lifecycle shutdown, with Gradle/native-image verification remaining authoritative."
+      ],
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/library-preparation-preflight/pi-generation-2026-06-22T12-10-29-258589Z.log",
+      "status": "completed",
+      "summary": "No extra setup is required: tomcat-embed-core 11.0.18 resolves with only tomcat-annotations-api as a compile dependency, bundles the servlet/security APIs needed for direct embedded-core usage, and the reported Connector/AbstractProtocol introspection path is reachable with the library itself."
+    },
+    "metrics": {
+      "input_tokens_used": 1140600,
+      "cached_input_tokens_used": 12026368,
+      "output_tokens_used": 125404,
+      "iterations": 21,
+      "cost_usd": 9.7753,
+      "generated_loc": 2258,
+      "tested_library_loc": 15641,
+      "metadata_entries": 1966,
+      "test_only_metadata_entries": 251,
+      "code_coverage_percent": 19.24
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/NamingContextListenerTest.java",
+      "metadata_file": "metadata/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/stats.json
+++ b/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/stats.json
@@ -4,37 +4,37 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.368286,
-          "coveredCalls" : 144,
+          "coverageRatio" : 0.57289,
+          "coveredCalls" : 224,
           "totalCalls" : 391
         },
         "resources" : {
-          "coverageRatio" : 0.341463,
-          "coveredCalls" : 14,
+          "coverageRatio" : 0.634146,
+          "coveredCalls" : 26,
           "totalCalls" : 41
         }
       },
-      "coverageRatio" : 0.365741,
-      "coveredCalls" : 158,
+      "coverageRatio" : 0.578704,
+      "coveredCalls" : 250,
       "totalCalls" : 432
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 49769,
-        "missed" : 295753,
-        "ratio" : 0.14404,
+        "covered" : 63988,
+        "missed" : 281534,
+        "ratio" : 0.185192,
         "total" : 345522
       },
       "line" : {
-        "covered" : 12109,
-        "missed" : 69189,
-        "ratio" : 0.148946,
+        "covered" : 15641,
+        "missed" : 65657,
+        "ratio" : 0.192391,
         "total" : 81298
       },
       "method" : {
-        "covered" : 2348,
-        "missed" : 10425,
-        "ratio" : 0.183825,
+        "covered" : 2937,
+        "missed" : 9836,
+        "ratio" : 0.229938,
         "total" : 12773
       }
     }

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/build.gradle
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String javaHome = System.getenv('JAVA_HOME') ?: System.getenv('GRAALVM_HOME')
 
 dependencies {
 	testImplementation "org.apache.tomcat.embed:tomcat-embed-core:$libraryVersion"
@@ -19,15 +20,22 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens=java.base/java.io=ALL-UNNAMED'
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    jvmArgs '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
     jvmArgs '--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED'
+}
+
+tasks.named("nativeTest") {
+    runtimeArgs.add("-Djava.home=${javaHome}")
 }
 
 graalvmNative {
     binaries {
         test {
             buildArgs.add('--allow-incomplete-classpath')
+            runtimeArgs("-Djava.home=${javaHome}")
         }
     }
     agent {

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/dynamic-access-exhaust-report.json
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/dynamic-access-exhaust-report.json
@@ -1,0 +1,29 @@
+{
+  "classThreshold": 15,
+  "completedClasses": [
+    "org.apache.catalina.startup.Tomcat",
+    "org.apache.catalina.startup.WebappServiceLoader",
+    "org.apache.juli.FileHandler",
+    "org.apache.naming.factory.BeanFactory",
+    "org.apache.naming.factory.ResourceFactory",
+    "org.apache.tomcat.util.compat.Jre19Compat",
+    "org.apache.catalina.core.NamingContextListener",
+    "org.apache.catalina.startup.CatalinaBaseConfigurationSource",
+    "org.apache.naming.factory.LookupFactory",
+    "org.apache.catalina.authenticator.AuthenticatorBase",
+    "org.apache.catalina.authenticator.jaspic.AuthConfigFactoryImpl",
+    "org.apache.catalina.deploy.NamingResourcesImpl",
+    "org.apache.catalina.realm.JAASRealm",
+    "org.apache.catalina.startup.ContextConfig"
+  ],
+  "coordinate": "org.apache.tomcat.embed:tomcat-embed-core:11.0.18",
+  "currentChunkClassCount": 15,
+  "exhaustedClasses": [
+    "org.apache.tomcat.util.compat.JreCompat"
+  ],
+  "failedClasses": [],
+  "issueNumber": 8328,
+  "latestChunkCommit": "3ad48364a149f8ae654614a15abb5f3a35af05fd",
+  "latestChunkPullRequest": 8579,
+  "skippedClasses": []
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/dynamic-access-exhaust-report.json
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/dynamic-access-exhaust-report.json
@@ -23,7 +23,7 @@
   ],
   "failedClasses": [],
   "issueNumber": 8328,
-  "latestChunkCommit": "3ad48364a149f8ae654614a15abb5f3a35af05fd",
+  "latestChunkCommit": "00adf70df20b37d8e27b0f989d8f32379c0927b5",
   "latestChunkPullRequest": 8579,
   "skippedClasses": []
 }

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/AuthConfigFactoryImplTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/AuthConfigFactoryImplTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.config.AuthConfigFactory;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import org.apache.catalina.Globals;
+import org.apache.catalina.authenticator.jaspic.AuthConfigFactoryImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthConfigFactoryImplTest {
+
+    private static final String SIMPLE_PROVIDER_CLASS_NAME =
+            "org.apache.catalina.authenticator.jaspic.SimpleAuthConfigProvider";
+
+    @TempDir
+    Path catalinaBase;
+
+    private String previousCatalinaBase;
+    private ClassLoader previousContextClassLoader;
+
+    @BeforeEach
+    void configureIsolatedCatalinaBase() throws IOException {
+        previousCatalinaBase = System.getProperty(Globals.CATALINA_BASE_PROP);
+        previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+        System.setProperty(Globals.CATALINA_BASE_PROP, catalinaBase.toString());
+        Files.createDirectories(catalinaBase.resolve("conf"));
+    }
+
+    @AfterEach
+    void restoreThreadAndSystemState() {
+        Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+        if (previousCatalinaBase == null) {
+            System.clearProperty(Globals.CATALINA_BASE_PROP);
+        } else {
+            System.setProperty(Globals.CATALINA_BASE_PROP, previousCatalinaBase);
+        }
+    }
+
+    @Test
+    void registersNamedAuthConfigProviderThroughContextClassLoader() throws Exception {
+        Thread.currentThread().setContextClassLoader(AuthConfigFactoryImplTest.class.getClassLoader());
+        assertRegistersNamedAuthConfigProvider();
+    }
+
+    @Test
+    void registersNamedAuthConfigProviderThroughFactoryClassLoadingFallback() throws Exception {
+        Thread.currentThread().setContextClassLoader(new RejectingClassLoader(SIMPLE_PROVIDER_CLASS_NAME));
+        assertRegistersNamedAuthConfigProvider();
+    }
+
+    private static void assertRegistersNamedAuthConfigProvider() throws Exception {
+        AuthConfigFactoryImpl factory = new AuthConfigFactoryImpl();
+
+        String registrationId = factory.registerConfigProvider(SIMPLE_PROVIDER_CLASS_NAME,
+                Map.of("testProperty", "testValue"), "HttpServlet", "localhost /test", "test provider");
+
+        try {
+            AuthConfigProvider provider = factory.getConfigProvider("HttpServlet", "localhost /test", null);
+            AuthConfigFactory.RegistrationContext registrationContext = factory.getRegistrationContext(registrationId);
+
+            assertThat(provider.getClass().getName()).isEqualTo(SIMPLE_PROVIDER_CLASS_NAME);
+            assertThat(registrationContext.getMessageLayer()).isEqualTo("HttpServlet");
+            assertThat(registrationContext.getAppContext()).isEqualTo("localhost /test");
+            assertThat(registrationContext.getDescription()).isEqualTo("test provider");
+            assertThat(registrationContext.isPersistent()).isTrue();
+
+            CallbackHandler callbackHandler = callbacks -> {
+                // The simple configuration stores the handler without invoking it during creation.
+            };
+            ServerAuthConfig serverAuthConfig = provider.getServerAuthConfig("HttpServlet", "localhost /test",
+                    callbackHandler);
+
+            assertThat(serverAuthConfig.getMessageLayer()).isEqualTo("HttpServlet");
+            assertThat(serverAuthConfig.getAppContext()).isEqualTo("localhost /test");
+            assertThat(serverAuthConfig.isProtected()).isFalse();
+        } finally {
+            factory.removeRegistration(registrationId);
+        }
+    }
+
+    private static final class RejectingClassLoader extends ClassLoader {
+
+        private final String rejectedClassName;
+
+        private RejectingClassLoader(String rejectedClassName) {
+            super(null);
+            this.rejectedClassName = rejectedClassName;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (rejectedClassName.equals(name)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/AuthenticatorBaseTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/AuthenticatorBaseTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.AuthConfigFactory;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ClientAuthConfig;
+import jakarta.security.auth.message.config.RegistrationListener;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+import org.apache.catalina.authenticator.BasicAuthenticator;
+import org.apache.catalina.authenticator.Constants;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthenticatorBaseTest {
+
+    private static final String CALLBACK_HANDLER_CLASS =
+            "org.apache.catalina.authenticator.jaspic.CallbackHandlerImpl";
+
+    @Test
+    void logoutCreatesJaspicCallbackHandlerThroughContextClassLoader() {
+        assertLogoutCreatesCallbackHandler(AuthenticatorBaseTest.class.getClassLoader());
+    }
+
+    @Test
+    void logoutCreatesJaspicCallbackHandlerThroughConfiguredClassName() {
+        assertLogoutCreatesCallbackHandler(null);
+    }
+
+    private static void assertLogoutCreatesCallbackHandler(ClassLoader contextClassLoader) {
+        synchronized (AuthConfigFactory.class) {
+            AuthConfigFactory previousFactory = AuthConfigFactory.getFactory();
+            AtomicBoolean cleanSubjectCalled = new AtomicBoolean();
+            AuthConfigFactory.setFactory(new TestAuthConfigFactory(cleanSubjectCalled));
+
+            ClassLoader previousContextClassLoader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+            try {
+                BasicAuthenticator authenticator = new BasicAuthenticator();
+                authenticator.setJaspicCallbackHandlerClass(CALLBACK_HANDLER_CLASS);
+                Request request = createRequest();
+                request.setNote(Constants.REQ_JASPIC_SUBJECT_NOTE, new Subject());
+
+                authenticator.logout(request);
+
+                assertThat(cleanSubjectCalled).isTrue();
+                assertThat(request.getUserPrincipal()).isNull();
+                assertThat(request.getAuthType()).isNull();
+            } finally {
+                Thread.currentThread().setContextClassLoader(previousContextClassLoader);
+                AuthConfigFactory.setFactory(previousFactory);
+            }
+        }
+    }
+
+    private static Request createRequest() {
+        Connector connector = new Connector();
+        org.apache.coyote.Request coyoteRequest = new org.apache.coyote.Request();
+        org.apache.coyote.Response coyoteResponse = new org.apache.coyote.Response();
+        Request request = new Request(connector, coyoteRequest);
+        Response response = new Response(coyoteResponse);
+        request.setResponse(response);
+        response.setRequest(request);
+        return request;
+    }
+
+    private static final class TestAuthConfigFactory extends AuthConfigFactory {
+
+        private final ServerAuthConfig serverAuthConfig;
+
+        private TestAuthConfigFactory(AtomicBoolean cleanSubjectCalled) {
+            this.serverAuthConfig = new TestServerAuthConfig(cleanSubjectCalled);
+        }
+
+        @Override
+        public AuthConfigProvider getConfigProvider(String layer, String appContext, RegistrationListener listener) {
+            return new TestAuthConfigProvider(serverAuthConfig);
+        }
+
+        @Override
+        public String registerConfigProvider(String className, Map<String, String> properties, String layer,
+                String appContext, String description) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String registerConfigProvider(AuthConfigProvider provider, String layer, String appContext,
+                String description) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeRegistration(String registrationID) {
+            return false;
+        }
+
+        @Override
+        public String[] detachListener(RegistrationListener listener, String layer, String appContext) {
+            return new String[0];
+        }
+
+        @Override
+        public String[] getRegistrationIDs(AuthConfigProvider provider) {
+            return new String[0];
+        }
+
+        @Override
+        public RegistrationContext getRegistrationContext(String registrationID) {
+            return null;
+        }
+
+        @Override
+        public void refresh() {
+            // No cached registration state.
+        }
+
+        @Override
+        public String registerServerAuthModule(ServerAuthModule serverAuthModule, Object context) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeServerAuthModule(Object context) {
+            // No registered modules.
+        }
+    }
+
+    private static final class TestAuthConfigProvider implements AuthConfigProvider {
+
+        private final ServerAuthConfig serverAuthConfig;
+
+        private TestAuthConfigProvider(ServerAuthConfig serverAuthConfig) {
+            this.serverAuthConfig = serverAuthConfig;
+        }
+
+        @Override
+        public ClientAuthConfig getClientAuthConfig(String layer, String appContext, CallbackHandler handler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ServerAuthConfig getServerAuthConfig(String layer, String appContext, CallbackHandler handler) {
+            assertThat(handler).isNotNull();
+            assertThat(handler.getClass().getName()).isEqualTo(CALLBACK_HANDLER_CLASS);
+            return serverAuthConfig;
+        }
+
+        @Override
+        public void refresh() {
+            // No cached configuration state.
+        }
+    }
+
+    private static final class TestServerAuthConfig implements ServerAuthConfig {
+
+        private final ServerAuthContext serverAuthContext;
+
+        private TestServerAuthConfig(AtomicBoolean cleanSubjectCalled) {
+            this.serverAuthContext = new TestServerAuthContext(cleanSubjectCalled);
+        }
+
+        @Override
+        public ServerAuthContext getAuthContext(String authContextID, Subject serviceSubject,
+                Map<String, Object> properties) {
+            return serverAuthContext;
+        }
+
+        @Override
+        public String getMessageLayer() {
+            return "HttpServlet";
+        }
+
+        @Override
+        public String getAppContext() {
+            return null;
+        }
+
+        @Override
+        public String getAuthContextID(MessageInfo messageInfo) {
+            return "test";
+        }
+
+        @Override
+        public void refresh() {
+            // No cached context state.
+        }
+
+        @Override
+        public boolean isProtected() {
+            return true;
+        }
+    }
+
+    private static final class TestServerAuthContext implements ServerAuthContext {
+
+        private final AtomicBoolean cleanSubjectCalled;
+
+        private TestServerAuthContext(AtomicBoolean cleanSubjectCalled) {
+            this.cleanSubjectCalled = cleanSubjectCalled;
+        }
+
+        @Override
+        public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
+                throws AuthException {
+            return AuthStatus.SUCCESS;
+        }
+
+        @Override
+        public void cleanSubject(MessageInfo messageInfo, Subject subject) {
+            assertThat(messageInfo).isNotNull();
+            assertThat(subject).isNotNull();
+            cleanSubjectCalled.set(true);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/BaseModelMBeanTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/BaseModelMBeanTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import javax.management.Attribute;
+import javax.management.DynamicMBean;
+
+import org.apache.tomcat.util.modeler.AttributeInfo;
+import org.apache.tomcat.util.modeler.BaseModelMBean;
+import org.apache.tomcat.util.modeler.ManagedBean;
+import org.apache.tomcat.util.modeler.OperationInfo;
+import org.apache.tomcat.util.modeler.ParameterInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BaseModelMBeanTest extends BaseModelMBean {
+
+    private String localText = "local";
+
+    @Test
+    void invokesManagedBeanAndResourceMethodsThroughDynamicMBeanApi() throws Exception {
+        DynamicMBean localMBean = createMBean(null, localAttribute(), localOperation());
+
+        assertThat(localMBean.getAttribute("localText")).isEqualTo("local");
+        localMBean.setAttribute(new Attribute("localText", "changed"));
+        assertThat(localMBean.invoke("describeLocal", new Object[] {"prefix"},
+                new String[] {String.class.getName()})).isEqualTo("prefix:changed");
+
+        ManagedResource resource = new ManagedResource();
+        DynamicMBean resourceMBean = createMBean(resource, resourceAttribute(), resourceOperation());
+
+        assertThat(resourceMBean.getAttribute("resourceText")).isEqualTo("resource");
+        resourceMBean.setAttribute(new Attribute("resourceText", "updated"));
+        assertThat(resourceMBean.invoke("describeResource", new Object[] {"value"},
+                new String[] {String.class.getName()})).isEqualTo("value:updated");
+    }
+
+    @Test
+    void resolvesAttributeTypesWithoutThreadContextClassLoader() throws Exception {
+        ManagedResource resource = new ManagedResource();
+        DynamicMBean resourceMBean = createMBean(resource, resourceAttribute(), resourceOperation());
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+
+        try {
+            currentThread.setContextClassLoader(null);
+            resourceMBean.setAttribute(new Attribute("resourceText", "resolvedByClassForName"));
+        } finally {
+            currentThread.setContextClassLoader(originalClassLoader);
+        }
+
+        assertThat(resourceMBean.getAttribute("resourceText")).isEqualTo("resolvedByClassForName");
+    }
+
+    public String getLocalText() {
+        return localText;
+    }
+
+    public void setLocalText(String localText) {
+        this.localText = localText;
+    }
+
+    public String describeLocal(String prefix) {
+        return prefix + ':' + localText;
+    }
+
+    private static DynamicMBean createMBean(Object resource, AttributeInfo attribute, OperationInfo operation)
+            throws Exception {
+        ManagedBean managedBean = new ManagedBean();
+        managedBean.setClassName(BaseModelMBeanTest.class.getName());
+        managedBean.setName("testBean");
+        managedBean.setDescription("Test managed bean");
+        managedBean.addAttribute(attribute);
+        managedBean.addOperation(operation);
+        return managedBean.createMBean(resource);
+    }
+
+    private static AttributeInfo localAttribute() {
+        AttributeInfo attribute = new AttributeInfo();
+        attribute.setName("localText");
+        attribute.setDescription("A property declared by the model mbean class");
+        attribute.setType(String.class.getName());
+        return attribute;
+    }
+
+    private static OperationInfo localOperation() {
+        return operation("describeLocal");
+    }
+
+    private static AttributeInfo resourceAttribute() {
+        AttributeInfo attribute = new AttributeInfo();
+        attribute.setName("resourceText");
+        attribute.setDescription("A property declared by the managed resource");
+        attribute.setType(String.class.getName());
+        return attribute;
+    }
+
+    private static OperationInfo resourceOperation() {
+        return operation("describeResource");
+    }
+
+    private static OperationInfo operation(String name) {
+        OperationInfo operation = new OperationInfo();
+        operation.setName(name);
+        operation.setDescription("Describe the current property value");
+        operation.setReturnType(String.class.getName());
+        operation.addParameter(parameter("prefix", String.class.getName()));
+        return operation;
+    }
+
+    private static ParameterInfo parameter(String name, String type) {
+        ParameterInfo parameter = new ParameterInfo();
+        parameter.setName(name);
+        parameter.setDescription("Operation parameter");
+        parameter.setType(type);
+        return parameter;
+    }
+
+    public static class ManagedResource {
+        private String resourceText = "resource";
+
+        public String getResourceText() {
+            return resourceText;
+        }
+
+        public void setResourceText(String resourceText) {
+            this.resourceText = resourceText;
+        }
+
+        public String describeResource(String prefix) {
+            return prefix + ':' + resourceText;
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/BeanFactoryTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/BeanFactoryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import javax.naming.StringRefAddr;
+
+import org.apache.naming.ResourceRef;
+import org.apache.naming.factory.BeanFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanFactoryTest {
+
+    @Test
+    void createsAndConfiguresBeanWithContextClassLoader() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(BeanFactoryTest.class.getClassLoader());
+        try {
+            ConfigurableResource resource = createConfiguredResource();
+
+            assertThat(resource.getName()).isEqualTo("configured-resource");
+            assertThat(resource.getPort()).isEqualTo(8080);
+            assertThat(resource.isEnabled()).isTrue();
+            assertThat(resource.getEndpoint()).extracting(Endpoint::value).isEqualTo("primary");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void createsBeanWhenContextClassLoaderIsUnavailable() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(null);
+        try {
+            ConfigurableResource resource = createConfiguredResource();
+
+            assertThat(resource.getName()).isEqualTo("configured-resource");
+            assertThat(resource.getEndpoint()).extracting(Endpoint::value).isEqualTo("primary");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static ConfigurableResource createConfiguredResource() throws Exception {
+        ResourceRef reference = new ResourceRef(ConfigurableResource.class.getName(), null, null, null, true);
+        reference.add(new StringRefAddr("name", "configured-resource"));
+        reference.add(new StringRefAddr("port", "8080"));
+        reference.add(new StringRefAddr("enabled", "true"));
+        reference.add(new StringRefAddr("endpoint", "primary"));
+
+        Object instance = new BeanFactory().getObjectInstance(reference, null, null, null);
+
+        assertThat(instance).isInstanceOf(ConfigurableResource.class);
+        return (ConfigurableResource) instance;
+    }
+
+    public static class ConfigurableResource {
+
+        private String name;
+        private int port;
+        private boolean enabled;
+        private Endpoint endpoint;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Endpoint getEndpoint() {
+            return endpoint;
+        }
+
+        public void setEndpoint(Endpoint endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+            this.endpoint = new Endpoint(endpoint);
+        }
+    }
+
+    public record Endpoint(String value) {
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/CatalinaBaseConfigurationSourceTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/CatalinaBaseConfigurationSourceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.apache.catalina.startup.Catalina;
+import org.apache.catalina.startup.CatalinaBaseConfigurationSource;
+import org.apache.tomcat.util.file.ConfigurationSource.Resource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CatalinaBaseConfigurationSourceTest {
+
+    private static final String STARTUP_LOCAL_STRINGS = "org/apache/catalina/startup/LocalStrings.properties";
+
+    @TempDir
+    Path catalinaBase;
+
+    @Test
+    void getResourceFallsBackToClasspathResourceWhenFileIsAbsent() throws Exception {
+        Catalina catalina = configureCatalina();
+        CatalinaBaseConfigurationSource source = newSource();
+
+        try (Resource resource = source.getResource(STARTUP_LOCAL_STRINGS)) {
+            String content = readUtf8(resource);
+
+            assertThat(catalina.getConfigFile()).isEqualTo(Catalina.SERVER_XML);
+            assertThat(resource.getURI().toString()).contains("LocalStrings.properties");
+            assertThat(content).contains("catalinaConfigurationSource.cannotObtainURL");
+        }
+    }
+
+    @Test
+    void getURIFallsBackToClasspathResourceWhenFileIsAbsent() {
+        Catalina catalina = configureCatalina();
+        CatalinaBaseConfigurationSource source = newSource();
+
+        assertThat(catalina.getConfigFile()).isEqualTo(Catalina.SERVER_XML);
+        assertThat(source.getURI(STARTUP_LOCAL_STRINGS).toString()).contains("LocalStrings.properties");
+    }
+
+    @Test
+    void getServerXmlFallsBackToLegacyClasspathResourceWhenServerXmlIsAbsent() throws Exception {
+        CatalinaBaseConfigurationSource source = newSource();
+
+        try (Resource resource = source.getServerXml()) {
+            String content = readUtf8(resource);
+
+            assertThat(resource.getURI().toString()).contains(CatalinaBaseConfigurationSource.LEGACY_SERVER_EMBED_XML);
+            assertThat(content).contains("<Server");
+            assertThat(content).contains("shutdown=\"SHUTDOWN\"");
+        }
+    }
+
+    private CatalinaBaseConfigurationSource newSource() {
+        File catalinaBaseFile = catalinaBase.toFile();
+        return new CatalinaBaseConfigurationSource(catalinaBaseFile, Catalina.SERVER_XML);
+    }
+
+    private static Catalina configureCatalina() {
+        Catalina catalina = new Catalina();
+        catalina.setConfigFile(Catalina.SERVER_XML);
+        return catalina;
+    }
+
+    private static String readUtf8(Resource resource) throws Exception {
+        byte[] bytes = resource.getInputStream().readAllBytes();
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ConnectorProtocolIntrospectionTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ConnectorProtocolIntrospectionTest.java
@@ -24,6 +24,13 @@ public class ConnectorProtocolIntrospectionTest {
         connector.setPort(0);
 
         try {
+            connector.getProperty("bindOnInit");
+            boolean bindOnInitUpdated = connector.setProperty("bindOnInit", "false");
+            Object bindOnInitAfterUpdate = connector.getProperty("bindOnInit");
+
+            assertThat(bindOnInitUpdated).isTrue();
+            assertThat(bindOnInitAfterUpdate).isEqualTo("false");
+
             connector.init();
             connector.start();
 

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ContextConfigTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ContextConfigTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HandlesTypes;
+import jakarta.servlet.http.HttpServlet;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.Valve;
+import org.apache.catalina.authenticator.BasicAuthenticator;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.realm.NullRealm;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.tomcat.util.descriptor.web.LoginConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContextConfigTest {
+
+    private static final AtomicReference<Set<Class<?>>> STARTUP_CLASSES = new AtomicReference<>();
+
+    @Test
+    void startsWebappWithAuthenticatorAndHandlesTypesScanning(@TempDir Path temporaryDirectory) throws Exception {
+        Path webappDirectory = temporaryDirectory.resolve("webapp");
+        prepareWebappClasses(webappDirectory);
+
+        Tomcat tomcat = new Tomcat();
+        tomcat.setBaseDir(temporaryDirectory.resolve("base").toString());
+        tomcat.setAddDefaultWebXmlToWebapp(false);
+        Connector connector = new Connector();
+        connector.setPort(0);
+        tomcat.setConnector(connector);
+
+        try {
+            Context context = tomcat.addWebapp("", webappDirectory.toAbsolutePath().toString());
+            ((StandardContext) context).setDelegate(true);
+            context.setRealm(new NullRealm());
+            context.setLoginConfig(new LoginConfig("BASIC", null, null, null));
+
+            STARTUP_CLASSES.set(null);
+            tomcat.start();
+
+            assertThat(context.getPipeline().getValves()).anyMatch(ContextConfigTest::isBasicAuthenticator);
+            assertThat(STARTUP_CLASSES.get()).contains(MatchingServlet.class);
+        } finally {
+            stopAndDestroy(tomcat);
+        }
+    }
+
+    private static void prepareWebappClasses(Path webappDirectory) throws IOException {
+        Path classesDirectory = webappDirectory.resolve("WEB-INF/classes");
+        Files.createDirectories(classesDirectory.resolve("META-INF/services"));
+        Files.writeString(classesDirectory.resolve("META-INF/services/" + ServletContainerInitializer.class.getName()),
+                HandlesTypesInitializer.class.getName() + System.lineSeparator(), StandardCharsets.UTF_8);
+        copyClassResource(MatchingServlet.class, classesDirectory);
+    }
+
+    private static void copyClassResource(Class<?> type, Path classesDirectory) throws IOException {
+        String resourceName = type.getName().replace('.', '/') + ".class";
+        Path target = classesDirectory.resolve(resourceName);
+        Files.createDirectories(target.getParent());
+        try (InputStream inputStream = type.getClassLoader().getResourceAsStream(resourceName)) {
+            assertThat(inputStream).isNotNull();
+            Files.copy(inputStream, target);
+        }
+    }
+
+    private static boolean isBasicAuthenticator(Valve valve) {
+        return valve instanceof BasicAuthenticator;
+    }
+
+    private static void stopAndDestroy(Tomcat tomcat) throws LifecycleException {
+        try {
+            if (tomcat.getServer() != null && tomcat.getServer().getState().isAvailable()) {
+                tomcat.stop();
+            }
+        } finally {
+            if (tomcat.getServer() != null && tomcat.getServer().getState() != LifecycleState.DESTROYED) {
+                tomcat.destroy();
+            }
+        }
+    }
+
+    public interface TrackedServlet {
+    }
+
+    public static class MatchingServlet extends HttpServlet implements TrackedServlet {
+    }
+
+    @HandlesTypes(TrackedServlet.class)
+    public static class HandlesTypesInitializer implements ServletContainerInitializer {
+
+        @Override
+        public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
+            STARTUP_CLASSES.set(classes);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/FileHandlerTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/FileHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Filter;
+import java.util.logging.Formatter;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+import org.apache.juli.FileHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileHandlerTest {
+
+    @Test
+    void configuresFilterAndFormatterFromLogManagerProperties(@TempDir Path logDirectory) throws Exception {
+        String configuration = """
+                org.apache.juli.FileHandler.directory=%s
+                org.apache.juli.FileHandler.prefix=reachability-
+                org.apache.juli.FileHandler.suffix=.log
+                org.apache.juli.FileHandler.rotatable=false
+                org.apache.juli.FileHandler.bufferSize=-1
+                org.apache.juli.FileHandler.level=ALL
+                org.apache.juli.FileHandler.filter=tomcat.FileHandlerTest$AcceptingFilter
+                org.apache.juli.FileHandler.formatter=tomcat.FileHandlerTest$ReachabilityFormatter
+                """.formatted(logDirectory.toAbsolutePath());
+        LogManager.getLogManager().readConfiguration(
+                new ByteArrayInputStream(configuration.getBytes(StandardCharsets.UTF_8)));
+
+        FileHandler handler = new FileHandler();
+        try {
+            LogRecord ignoredRecord = new LogRecord(java.util.logging.Level.INFO, "ignored");
+            LogRecord acceptedRecord = new LogRecord(java.util.logging.Level.INFO, "accepted message");
+
+            handler.publish(ignoredRecord);
+            handler.publish(acceptedRecord);
+            handler.flush();
+
+            Path logFile = logDirectory.resolve("reachability-.log");
+            assertThat(handler.getFilter()).isInstanceOf(AcceptingFilter.class);
+            assertThat(handler.getFormatter()).isInstanceOf(ReachabilityFormatter.class);
+            assertThat(Files.readString(logFile)).isEqualTo("formatted:accepted message" + System.lineSeparator());
+        } finally {
+            handler.close();
+            LogManager.getLogManager().readConfiguration();
+        }
+    }
+
+    public static class AcceptingFilter implements Filter {
+
+        public AcceptingFilter() {
+        }
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            return record.getMessage().contains("accepted");
+        }
+    }
+
+    public static class ReachabilityFormatter extends Formatter {
+
+        public ReachabilityFormatter() {
+        }
+
+        @Override
+        public String format(LogRecord record) {
+            return "formatted:" + record.getMessage() + System.lineSeparator();
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/JAASRealmTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/JAASRealmTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Principal;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.TomcatPrincipal;
+import org.apache.catalina.realm.GenericPrincipal;
+import org.apache.catalina.realm.JAASRealm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JAASRealmTest {
+
+    private static final String APP_NAME = "ReachabilityTest";
+    private static final String RESOURCE_CONFIG = "tomcat/jaas-realm-resource.config";
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void authenticatesWithJaasConfigurationLoadedFromClasspathResource() throws Exception {
+        TestableJAASRealm realm = newRealm(RESOURCE_CONFIG, "resource");
+
+        try {
+            realm.start();
+
+            Principal principal = realm.authenticate("alice", "secret");
+
+            assertAuthenticatedPrincipal(principal, "alice", "admin");
+        } finally {
+            destroy(realm);
+        }
+    }
+
+    @Test
+    void authenticatesWithJaasConfigurationLoadedFromFileSource() throws Exception {
+        Path configFile = temporaryDirectory.resolve("jaas-realm-file.config");
+        Files.writeString(configFile, jaasConfig(), StandardCharsets.UTF_8);
+        TestableJAASRealm realm = newRealm(configFile.toString(), "file");
+
+        try {
+            realm.start();
+
+            Principal principal = realm.authenticate("bob", "secret");
+
+            assertAuthenticatedPrincipal(principal, "bob", "admin");
+        } finally {
+            destroy(realm);
+        }
+    }
+
+    private static TestableJAASRealm newRealm(String configFile, String realmPathSuffix) {
+        TestableJAASRealm realm = new TestableJAASRealm();
+        realm.setAppName(APP_NAME);
+        realm.setConfigFile(configFile);
+        realm.setRealmPath("/" + realmPathSuffix);
+        realm.setUserClassNames(UserPrincipal.class.getName());
+        realm.setRoleClassNames(RolePrincipal.class.getName());
+        return realm;
+    }
+
+    private static String jaasConfig() {
+        return """
+                ReachabilityTest {
+                    tomcat.JAASRealmTest$AcceptingLoginModule required;
+                };
+                """;
+    }
+
+    private static void assertAuthenticatedPrincipal(Principal principal, String username, String role)
+            throws Exception {
+        assertThat(principal).isInstanceOf(GenericPrincipal.class);
+        GenericPrincipal genericPrincipal = (GenericPrincipal) principal;
+        try {
+            assertThat(genericPrincipal.getName()).isEqualTo(username);
+            assertThat(genericPrincipal.getUserPrincipal()).isInstanceOf(UserPrincipal.class);
+            assertThat(genericPrincipal.hasRole(role)).isTrue();
+        } finally {
+            ((TomcatPrincipal) genericPrincipal).logout();
+        }
+    }
+
+    private static void destroy(JAASRealm realm) throws Exception {
+        try {
+            if (realm.getState().isAvailable()) {
+                realm.stop();
+            }
+        } finally {
+            if (realm.getState() != LifecycleState.DESTROYED) {
+                realm.destroy();
+            }
+        }
+    }
+
+    public static class TestableJAASRealm extends JAASRealm {
+
+        @Override
+        public String getObjectNameKeyProperties() {
+            return "type=Realm,realmPath=" + getRealmPath();
+        }
+
+        @Override
+        public String getDomainInternal() {
+            return "JAASRealmTest";
+        }
+    }
+
+    public static class AcceptingLoginModule implements LoginModule {
+
+        private Subject subject;
+        private UserPrincipal userPrincipal;
+        private RolePrincipal rolePrincipal;
+
+        @Override
+        public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState,
+                Map<String, ?> options) {
+            this.subject = subject;
+        }
+
+        @Override
+        public boolean login() {
+            userPrincipal = new UserPrincipal("authenticated-user");
+            rolePrincipal = new RolePrincipal("admin");
+            return true;
+        }
+
+        @Override
+        public boolean commit() {
+            subject.getPrincipals().add(userPrincipal);
+            subject.getPrincipals().add(rolePrincipal);
+            return true;
+        }
+
+        @Override
+        public boolean abort() throws LoginException {
+            return logout();
+        }
+
+        @Override
+        public boolean logout() {
+            subject.getPrincipals().remove(userPrincipal);
+            subject.getPrincipals().remove(rolePrincipal);
+            userPrincipal = null;
+            rolePrincipal = null;
+            return true;
+        }
+    }
+
+    public static class UserPrincipal extends NamedPrincipal {
+
+        public UserPrincipal(String name) {
+            super(name);
+        }
+    }
+
+    public static class RolePrincipal extends NamedPrincipal {
+
+        public RolePrincipal(String name) {
+            super(name);
+        }
+    }
+
+    public abstract static class NamedPrincipal implements Principal {
+
+        private final String name;
+
+        protected NamedPrincipal(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+            NamedPrincipal principal = (NamedPrincipal) other;
+            return Objects.equals(name, principal.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getClass(), name);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/Jre19CompatTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/Jre19CompatTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.tomcat.util.compat.Jre19Compat;
+import org.apache.tomcat.util.threads.ThreadPoolExecutor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jre19CompatTest {
+
+    @Test
+    void getExecutorFindsTomcatExecutorStoredInThreadHolderTask() throws Exception {
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        HolderThreadFactory threadFactory = new HolderThreadFactory();
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+                threadFactory);
+        Future<?> submittedTask = executor.submit(new AwaitingTask(running, release));
+
+        try {
+            assertThat(running.await(10, TimeUnit.SECONDS)).isTrue();
+            HolderThread workerThread = threadFactory.thread();
+
+            assertThat(workerThread).isNotNull();
+            assertThat(new Jre19Compat().getExecutor(workerThread)).isSameAs(executor);
+
+            release.countDown();
+            submittedTask.get(10, TimeUnit.SECONDS);
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static final class AwaitingTask implements Runnable {
+        private final CountDownLatch running;
+        private final CountDownLatch release;
+
+        private AwaitingTask(CountDownLatch running, CountDownLatch release) {
+            this.running = running;
+            this.release = release;
+        }
+
+        @Override
+        public void run() {
+            running.countDown();
+            try {
+                if (!release.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release executor task");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to release executor task", e);
+            }
+        }
+    }
+
+    private static final class HolderThreadFactory implements ThreadFactory {
+        private volatile HolderThread thread;
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            HolderThread result = new HolderThread(runnable);
+            thread = result;
+            return result;
+        }
+
+        private HolderThread thread() {
+            return thread;
+        }
+    }
+
+    public static final class HolderThread extends Thread {
+        public final Holder holder;
+
+        private HolderThread(Runnable task) {
+            super("jre19-compat-holder-thread");
+            this.holder = new Holder(task);
+            setDaemon(true);
+        }
+
+        @Override
+        public void run() {
+            ((Runnable) holder.task).run();
+        }
+    }
+
+    public static final class Holder {
+        public final Object task;
+
+        private Holder(Object task) {
+            this.task = task;
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/JreCompatTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/JreCompatTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.tomcat.util.compat.JreCompat;
+import org.apache.tomcat.util.threads.ThreadPoolExecutor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JreCompatTest {
+
+    @Test
+    void getExecutorFindsTomcatExecutorStoredInThreadTarget() throws Exception {
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        CapturingThreadFactory threadFactory = new CapturingThreadFactory();
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
+                threadFactory);
+        Future<?> submittedTask = executor.submit(new AwaitingTask(running, release));
+
+        try {
+            assertThat(running.await(10, TimeUnit.SECONDS)).isTrue();
+            Thread workerThread = threadFactory.thread();
+
+            assertThat(workerThread).isNotNull();
+            assertThat(new JreCompat().getExecutor(workerThread)).isSameAs(executor);
+
+            release.countDown();
+            submittedTask.get(10, TimeUnit.SECONDS);
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    void disableCanonCachesReportsTheResultFromTheCompatibilityApi() {
+        JreCompat compat = new JreCompat();
+
+        boolean initiallyDisabled = compat.isCanonCachesDisabled();
+        boolean disabledByApi = compat.disableCanonCaches();
+
+        assertThat(compat.isCanonCachesDisabled()).isEqualTo(initiallyDisabled || disabledByApi);
+    }
+
+    private static final class AwaitingTask implements Runnable {
+        private final CountDownLatch running;
+        private final CountDownLatch release;
+
+        private AwaitingTask(CountDownLatch running, CountDownLatch release) {
+            this.running = running;
+            this.release = release;
+        }
+
+        @Override
+        public void run() {
+            running.countDown();
+            try {
+                if (!release.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release executor task");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to release executor task", e);
+            }
+        }
+    }
+
+    private static final class CapturingThreadFactory implements ThreadFactory {
+        private volatile Thread thread;
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread result = new TargetThread(runnable);
+            thread = result;
+            return result;
+        }
+
+        private Thread thread() {
+            return thread;
+        }
+    }
+
+    public static final class TargetThread extends Thread {
+        public final Runnable target;
+
+        private TargetThread(Runnable target) {
+            super("jre-compat-target-thread");
+            this.target = target;
+            setDaemon(true);
+        }
+
+        @Override
+        public void run() {
+            target.run();
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/LookupFactoryTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/LookupFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.RefAddr;
+import javax.naming.StringRefAddr;
+import javax.naming.spi.ObjectFactory;
+
+import org.apache.naming.LookupRef;
+import org.apache.naming.factory.Constants;
+import org.apache.naming.factory.LookupFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LookupFactoryTest {
+
+    @Test
+    void createsObjectWithFactoryLoadedFromContextClassLoader() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(LookupFactoryTest.class.getClassLoader());
+        try {
+            LookupTarget target = createTarget();
+
+            assertThat(target.value()).isEqualTo("created-by-lookup-factory");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
+    void createsObjectWithFactoryLoadedByClassForNameWhenContextClassLoaderIsUnavailable() throws Exception {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(null);
+        try {
+            LookupTarget target = createTarget();
+
+            assertThat(target.value()).isEqualTo("created-by-lookup-factory");
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static LookupTarget createTarget() throws Exception {
+        LookupRef reference = new LookupRef(LookupTarget.class.getName(), null);
+        reference.add(new StringRefAddr(Constants.FACTORY, LookupObjectFactory.class.getName()));
+
+        Object instance = new LookupFactory().getObjectInstance(reference, null, null, null);
+
+        assertThat(instance).isInstanceOf(LookupTarget.class);
+        return (LookupTarget) instance;
+    }
+
+    public record LookupTarget(String value) {
+    }
+
+    public static class LookupObjectFactory implements ObjectFactory {
+
+        @Override
+        public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
+            RefAddr lookupName = ((LookupRef) obj).get(LookupRef.LOOKUP_NAME);
+            assertThat(lookupName).isNull();
+            return new LookupTarget("created-by-lookup-factory");
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/NamingContextListenerTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/NamingContextListenerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import javax.naming.Context;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.core.StandardServer;
+import org.apache.tomcat.util.descriptor.web.ContextEnvironment;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NamingContextListenerTest {
+
+    @Test
+    void serverStartupBindsCustomEnvironmentEntriesConstructedByTypeName() throws Exception {
+        String previousUseNaming = System.getProperty("catalina.useNaming");
+        System.setProperty("catalina.useNaming", "true");
+        StandardServer server = new StandardServer();
+        server.setPeriodicEventDelay(0);
+        server.getGlobalNamingResources().addEnvironment(environment("stringEntry",
+                StringConstructedEnvironmentEntry.class.getName(), "configured"));
+        server.getGlobalNamingResources().addEnvironment(environment("charEntry",
+                CharConstructedEnvironmentEntry.class.getName(), "Q"));
+
+        try {
+            server.start();
+
+            Context globalNamingContext = server.getGlobalNamingContext();
+            assertThat(globalNamingContext.lookup("stringEntry"))
+                    .isInstanceOfSatisfying(StringConstructedEnvironmentEntry.class,
+                            entry -> assertThat(entry.value()).isEqualTo("configured"));
+            assertThat(globalNamingContext.lookup("charEntry"))
+                    .isInstanceOfSatisfying(CharConstructedEnvironmentEntry.class,
+                            entry -> assertThat(entry.value()).isEqualTo('Q'));
+        } finally {
+            stopAndDestroy(server);
+            restoreUseNaming(previousUseNaming);
+        }
+    }
+
+    private static ContextEnvironment environment(String name, String type, String value) {
+        ContextEnvironment environment = new ContextEnvironment();
+        environment.setName(name);
+        environment.setType(type);
+        environment.setValue(value);
+        return environment;
+    }
+
+    private static void stopAndDestroy(StandardServer server) throws LifecycleException {
+        try {
+            if (server.getState().isAvailable()) {
+                server.stop();
+            }
+        } finally {
+            if (server.getState() != LifecycleState.DESTROYED) {
+                server.destroy();
+            }
+        }
+    }
+
+    private static void restoreUseNaming(String previousUseNaming) {
+        if (previousUseNaming == null) {
+            System.clearProperty("catalina.useNaming");
+        } else {
+            System.setProperty("catalina.useNaming", previousUseNaming);
+        }
+    }
+
+    public static final class StringConstructedEnvironmentEntry {
+
+        private final String value;
+
+        public StringConstructedEnvironmentEntry(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+    }
+
+    public static final class CharConstructedEnvironmentEntry {
+
+        private final char value;
+
+        public CharConstructedEnvironmentEntry(char value) {
+            this.value = value;
+        }
+
+        char value() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/NamingResourcesImplTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/NamingResourcesImplTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.beans.PropertyChangeListener;
+
+import javax.naming.NamingException;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.Loader;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.core.StandardServer;
+import org.apache.catalina.deploy.NamingResourcesImpl;
+import org.apache.naming.NamingContext;
+import org.apache.tomcat.util.descriptor.web.ContextEnvironment;
+import org.apache.tomcat.util.descriptor.web.ContextResource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NamingResourcesImplTest {
+
+    @Test
+    void addEnvironmentInfersTypeFromInjectionSetter() {
+        NamingResourcesImpl namingResources = namingResourcesForCurrentClassLoader();
+        ContextEnvironment environment = environmentWithInjectionTarget("setterResource", SetterInjectionTarget.class,
+                "value");
+
+        namingResources.addEnvironment(environment);
+
+        assertThat(namingResources.findEnvironment("setterResource")).isSameAs(environment);
+        assertThat(environment.getType()).isEqualTo(String.class.getCanonicalName());
+    }
+
+    @Test
+    void addEnvironmentInfersTypeFromInjectionFieldWhenSetterIsAbsent() {
+        NamingResourcesImpl namingResources = namingResourcesForCurrentClassLoader();
+        ContextEnvironment environment = environmentWithInjectionTarget("fieldResource", FieldInjectionTarget.class,
+                "value");
+
+        namingResources.addEnvironment(environment);
+
+        assertThat(namingResources.findEnvironment("fieldResource")).isSameAs(environment);
+        assertThat(environment.getType()).isEqualTo(Integer.class.getCanonicalName());
+    }
+
+    @Test
+    void stopClosesSingletonResourceByConfiguredCloseMethod() throws Exception {
+        CloseableResource closeableResource = new CloseableResource();
+        NamingResourcesImpl namingResources = namingResourcesForServerWithGlobalResource("closeableResource",
+                closeableResource);
+        ContextResource resource = new ContextResource();
+        resource.setName("closeableResource");
+        resource.setCloseMethod("closeForNamingResources");
+
+        namingResources.start();
+        try {
+            namingResources.addResource(resource);
+
+            namingResources.stop();
+
+            assertThat(closeableResource.isClosed()).isTrue();
+        } finally {
+            destroyQuietly(namingResources);
+        }
+    }
+
+    private static NamingResourcesImpl namingResourcesForCurrentClassLoader() {
+        StandardContext context = new StandardContext();
+        context.setLoader(new CurrentClassLoader());
+
+        NamingResourcesImpl namingResources = new NamingResourcesImpl();
+        namingResources.setContainer(context);
+        return namingResources;
+    }
+
+    private static ContextEnvironment environmentWithInjectionTarget(String resourceName, Class<?> targetClass,
+            String targetName) {
+        ContextEnvironment environment = new ContextEnvironment();
+        environment.setName(resourceName);
+        environment.setValue("configured");
+        environment.addInjectionTarget(targetClass.getName(), targetName);
+        return environment;
+    }
+
+    private static NamingResourcesImpl namingResourcesForServerWithGlobalResource(String name, Object value)
+            throws NamingException {
+        NamingContext globalNamingContext = new NamingContext(null, "global");
+        globalNamingContext.bind(name, value);
+
+        NamingResourcesImpl namingResources = new NamingResourcesImpl();
+        StandardServer server = new StandardServer();
+        server.setGlobalNamingContext(globalNamingContext);
+        server.setGlobalNamingResources(namingResources);
+        return namingResources;
+    }
+
+    private static void destroyQuietly(NamingResourcesImpl namingResources) throws LifecycleException {
+        if (namingResources.getState().isAvailable()) {
+            namingResources.stop();
+        }
+        namingResources.destroy();
+    }
+
+    public static class SetterInjectionTarget {
+
+        public void setValue(String value) {
+            // Test fixture for Tomcat's injection target introspection.
+        }
+    }
+
+    public static class FieldInjectionTarget {
+
+        public Integer value;
+    }
+
+    public static class CloseableResource {
+
+        private boolean closed;
+
+        public void closeForNamingResources() {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+
+    private static class CurrentClassLoader implements Loader {
+
+        private Context context;
+
+        @Override
+        public void backgroundProcess() {
+            // No background processing is required for class loading in these tests.
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return NamingResourcesImplTest.class.getClassLoader();
+        }
+
+        @Override
+        public Context getContext() {
+            return context;
+        }
+
+        @Override
+        public void setContext(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public boolean getDelegate() {
+            return false;
+        }
+
+        @Override
+        public void setDelegate(boolean delegate) {
+            // Delegation is not configurable for this fixed test class loader.
+        }
+
+        @Override
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+            // This lightweight loader has no mutable properties to publish.
+        }
+
+        @Override
+        public boolean modified() {
+            return false;
+        }
+
+        @Override
+        public void removePropertyChangeListener(PropertyChangeListener listener) {
+            // This lightweight loader has no mutable properties to publish.
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ResourceFactoryTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/ResourceFactoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+
+import org.apache.naming.ResourceRef;
+import org.apache.naming.factory.ResourceFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceFactoryTest implements ObjectFactory {
+
+    @ParameterizedTest
+    @CsvSource({
+            "javax.sql.DataSource, javax.sql.DataSource.Factory",
+            "jakarta.mail.Session, jakarta.mail.Session.Factory"
+    })
+    void createsDefaultResourceFactory(String resourceClassName, String factoryPropertyName) throws Exception {
+        String previousFactoryClassName = System.getProperty(factoryPropertyName);
+        System.setProperty(factoryPropertyName, ResourceFactoryTest.class.getName());
+        try {
+            ResourceRef reference = new ResourceRef(resourceClassName, null, null, null, true);
+
+            Object resource = new ResourceFactory().getObjectInstance(reference, null, null, null);
+
+            assertThat(resource).isEqualTo("created " + resourceClassName);
+        } finally {
+            restoreProperty(factoryPropertyName, previousFactoryClassName);
+        }
+    }
+
+    @Override
+    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
+        assertThat(obj).isInstanceOf(Reference.class);
+        return "created " + ((Reference) obj).getClassName();
+    }
+
+    private static void restoreProperty(String propertyName, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, previousValue);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/TomcatTests.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/TomcatTests.java
@@ -14,14 +14,22 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardHost;
+import org.apache.catalina.startup.ContextConfig;
+import org.apache.catalina.startup.FailedContext;
 import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -30,6 +38,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TomcatTests {
 
     private static final int AUTO_BIND_PORT = 0;
+
+    @Test
+    void addWebappCreatesContextWithReflectiveHostConfiguration(@TempDir Path webappDirectory) throws Exception {
+        Tomcat tomcat = new Tomcat();
+        tomcat.setBaseDir(webappDirectory.resolve("base").toString());
+        tomcat.setAddDefaultWebXmlToWebapp(false);
+
+        try {
+            Context context = tomcat.addWebapp(null, "/webapp", webappDirectory.toAbsolutePath().toString());
+            LifecycleListener[] listeners = context.findLifecycleListeners();
+
+            assertThat(context.getPath()).isEqualTo("/webapp");
+            assertThat(context.getDocBase()).isEqualTo(webappDirectory.toAbsolutePath().toString());
+            assertThat(Arrays.stream(listeners)).anyMatch(ContextConfig.class::isInstance);
+        } finally {
+            tomcat.destroy();
+        }
+    }
+
+    @Test
+    void addContextCreatesConfiguredContextClass(@TempDir Path docBase) throws Exception {
+        Tomcat tomcat = new Tomcat();
+        tomcat.setBaseDir(docBase.resolve("base").toString());
+        StandardHost host = (StandardHost) tomcat.getHost();
+        host.setContextClass(FailedContext.class.getName());
+
+        try {
+            Context context = tomcat.addContext(null, "/custom", docBase.toAbsolutePath().toString());
+
+            assertThat(context).isInstanceOf(FailedContext.class);
+            assertThat(context.getPath()).isEqualTo("/custom");
+            assertThat(context.getDocBase()).isEqualTo(docBase.toAbsolutePath().toString());
+        } finally {
+            tomcat.destroy();
+        }
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {"HTTP/1.1", "org.apache.coyote.http11.Http11NioProtocol",

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/WebappServiceLoaderTest.java
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/java/tomcat/WebappServiceLoaderTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package tomcat;
+
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.Host;
+import org.apache.catalina.Loader;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.mbeans.ContextMBean;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.WebappServiceLoader;
+import org.apache.catalina.util.CharsetMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WebappServiceLoaderTest {
+
+    private static final String SERVICE_RESOURCE = "META-INF/services/" + Object.class.getName();
+
+    @Test
+    void loadUsesSystemResourceBranchAndWebappClassLoaderResources(@TempDir Path baseDirectory) throws Exception {
+        ServiceResourceClassLoader applicationClassLoader = new ServiceResourceClassLoader(
+                getClass().getClassLoader(), SERVICE_RESOURCE,
+                writeServiceConfig(baseDirectory.resolve("application-services"), CharsetMapper.class.getName()));
+        NullParentClassLoaderContext context = new NullParentClassLoaderContext(applicationClassLoader);
+        Tomcat tomcat = createTomcatWithContext(baseDirectory, context);
+        try {
+            WebappServiceLoader<Object> loader = new WebappServiceLoader<>(context);
+
+            List<Object> services = loader.load(Object.class);
+
+            assertThat(services).hasSize(1);
+            assertThat(services.get(0)).isInstanceOf(CharsetMapper.class);
+        } finally {
+            tomcat.destroy();
+        }
+    }
+
+    @Test
+    void loadUsesContainerClassLoaderResourcesBeforeApplicationResources(@TempDir Path baseDirectory) throws Exception {
+        ServiceResourceClassLoader containerClassLoader = new ServiceResourceClassLoader(
+                getClass().getClassLoader(), SERVICE_RESOURCE,
+                writeServiceConfig(baseDirectory.resolve("container-services"), ContextMBean.class.getName()));
+        ServiceResourceClassLoader applicationClassLoader = new ServiceResourceClassLoader(
+                getClass().getClassLoader(), SERVICE_RESOURCE,
+                writeServiceConfig(baseDirectory.resolve("application-services"), CharsetMapper.class.getName()));
+        StandardContext context = new StandardContext();
+        context.setParentClassLoader(containerClassLoader);
+        context.setLoader(new FixedLoader(applicationClassLoader));
+        Tomcat tomcat = createTomcatWithContext(baseDirectory, context);
+        try {
+            WebappServiceLoader<Object> loader = new WebappServiceLoader<>(context);
+
+            List<Object> services = loader.load(Object.class);
+
+            assertThat(services).hasSize(2);
+            assertThat(services.get(0)).isInstanceOf(ContextMBean.class);
+            assertThat(services.get(1)).isInstanceOf(CharsetMapper.class);
+        } finally {
+            tomcat.destroy();
+        }
+    }
+
+    private static URL writeServiceConfig(Path directory, String providerClassName) throws IOException {
+        Path serviceFile = directory.resolve(SERVICE_RESOURCE);
+        Files.createDirectories(serviceFile.getParent());
+        Files.writeString(serviceFile, providerClassName + System.lineSeparator(), StandardCharsets.UTF_8);
+        return serviceFile.toUri().toURL();
+    }
+
+    private static Tomcat createTomcatWithContext(Path baseDirectory, StandardContext context) throws IOException {
+        Tomcat tomcat = new Tomcat();
+        tomcat.setBaseDir(baseDirectory.resolve("base").toString());
+        Path docBase = Files.createDirectories(baseDirectory.resolve("webapp"));
+        context.setName("/service-loader");
+        context.setPath("/service-loader");
+        context.setDocBase(docBase.toAbsolutePath().toString());
+        Host host = tomcat.getHost();
+        host.addChild(context);
+        return tomcat;
+    }
+
+    private static final class NullParentClassLoaderContext extends StandardContext {
+        NullParentClassLoaderContext(ClassLoader applicationClassLoader) {
+            setLoader(new FixedLoader(applicationClassLoader));
+        }
+
+        @Override
+        public ClassLoader getParentClassLoader() {
+            return null;
+        }
+    }
+
+    private static final class FixedLoader implements Loader {
+        private final ClassLoader classLoader;
+        private Context context;
+
+        FixedLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public void backgroundProcess() {
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return classLoader;
+        }
+
+        @Override
+        public Context getContext() {
+            return context;
+        }
+
+        @Override
+        public void setContext(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public boolean getDelegate() {
+            return true;
+        }
+
+        @Override
+        public void setDelegate(boolean delegate) {
+        }
+
+        @Override
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+        }
+
+        @Override
+        public boolean modified() {
+            return false;
+        }
+
+        @Override
+        public void removePropertyChangeListener(PropertyChangeListener listener) {
+        }
+    }
+
+    private static final class ServiceResourceClassLoader extends ClassLoader {
+        private final String resourceName;
+        private final URL serviceConfigUrl;
+
+        ServiceResourceClassLoader(ClassLoader parent, String resourceName, URL serviceConfigUrl) {
+            super(parent);
+            this.resourceName = resourceName;
+            this.serviceConfigUrl = serviceConfigUrl;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (resourceName.equals(name)) {
+                return Collections.enumeration(List.of(serviceConfigUrl));
+            }
+            return super.getResources(name);
+        }
+    }
+}

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -755,6 +755,24 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "tomcat.BaseModelMBeanTest"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.ManagedBean"
+      },
+      "type" : "tomcat.BaseModelMBeanTest$ManagedResource"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.BeanFactory"
+      },
+      "type" : "tomcat.BeanFactoryTest$ConfigurableResource"
+    },
+    {
+      "condition" : {
         "typeReached" : "tomcat.BootstrapTest"
       },
       "type" : "tomcat.BootstrapTest$AwaitCapableCatalina",
@@ -764,6 +782,24 @@
           "parameterTypes" : [ ]
         }
       ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.Bootstrap"
+      },
+      "type" : "tomcat.BootstrapTest$AwaitCapableCatalina"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.WebappServiceLoader"
+      },
+      "type" : "tomcat.ContextConfigTest$HandlesTypesInitializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.ResourceFactoryTest"
+      },
+      "type" : "javax.naming.spi.ObjectFactory"
     },
     {
       "condition" : {
@@ -810,6 +846,18 @@
     },
     {
       "condition" : {
+        "typeReached" : "org.apache.catalina.core.DefaultInstanceManager"
+      },
+      "type" : "tomcat.DefaultInstanceManagerTest$WebappLoadedComponent",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
         "typeReached" : "tomcat.DefaultInstanceManagerTest"
       },
       "type" : "tomcat.DefaultInstanceManagerTest$WebappLoadedComponent",
@@ -825,6 +873,18 @@
         "typeReached" : "tomcat.DefaultInstanceManagerTest$RejectingClassLoader"
       },
       "type" : "tomcat.DefaultInstanceManagerTest$WebappLoadedComponent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "tomcat.FileHandlerTest$AcceptingFilter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "tomcat.FileHandlerTest$ReachabilityFormatter"
     },
     {
       "condition" : {
@@ -898,6 +958,433 @@
           "tomcat.WebappClassLoaderBaseTest$TestRemote"
         ]
       }
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "java.beans.PropertyVetoException"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.WebappServiceLoaderTest"
+      },
+      "type" : "org.apache.catalina.mbeans.ContextMBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BootstrapTest$$Lambda/0x000000004f46d000"
+      },
+      "type" : "org.apache.catalina.startup.Catalina"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.ContextConfigTest"
+      },
+      "type" : "org.apache.catalina.startup.Tomcat$SimpleRealm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.WebappServiceLoaderTest"
+      },
+      "type" : "org.apache.catalina.util.CharsetMapper",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.ConnectorProtocolIntrospectionTest"
+      },
+      "type" : "org.apache.coyote.AbstractProtocol",
+      "methods" : [
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getProperty",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setProperty",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.ConnectorProtocolIntrospectionTest"
+      },
+      "type" : "org.apache.coyote.http11.Http11Nio2Protocol",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.TomcatTests"
+      },
+      "type" : "org.apache.coyote.http11.Http11Nio2Protocol",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.TomcatTests"
+      },
+      "type" : "org.apache.coyote.http11.Http11NioProtocol"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JreCompatTest"
+      },
+      "type" : "org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker",
+      "fields" : [
+        {
+          "name" : "this$0"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "tomcat.BaseModelMBeanTest",
+      "methods" : [
+        {
+          "name" : "describeLocal",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BaseModelMBeanTest"
+      },
+      "type" : "tomcat.BaseModelMBeanTest",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getLocalText",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setLocalText",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.modeler.BaseModelMBean"
+      },
+      "type" : "tomcat.BaseModelMBeanTest$ManagedResource",
+      "methods" : [
+        {
+          "name" : "describeResource",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "getResourceText",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setResourceText",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.BeanFactory"
+      },
+      "type" : "tomcat.BeanFactoryTest$ConfigurableResource",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setEndpoint",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setPort",
+          "parameterTypes" : [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "tomcat.BeanFactoryTest$ConfigurableResourceBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.BeanFactoryTest"
+      },
+      "type" : "tomcat.BeanFactoryTest$ConfigurableResourceCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "type" : "tomcat.ContextConfigTest$HandlesTypesInitializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.startup.ContextConfig"
+      },
+      "type" : "tomcat.ContextConfigTest$MatchingServlet"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "tomcat.FileHandlerTest$AcceptingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.juli.FileHandler"
+      },
+      "type" : "tomcat.FileHandlerTest$ReachabilityFormatter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.realm.JAASRealm"
+      },
+      "type" : "tomcat.JAASRealmTest$AcceptingLoginModule",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.realm.JAASRealm"
+      },
+      "type" : "tomcat.JAASRealmTest$RolePrincipal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest"
+      },
+      "type" : "tomcat.JAASRealmTest$TestableJAASRealm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.realm.JAASRealm"
+      },
+      "type" : "tomcat.JAASRealmTest$UserPrincipal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.compat.Jre19Compat"
+      },
+      "type" : "tomcat.Jre19CompatTest$Holder",
+      "fields" : [
+        {
+          "name" : "task"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.tomcat.util.compat.Jre19Compat"
+      },
+      "type" : "tomcat.Jre19CompatTest$HolderThread",
+      "fields" : [
+        {
+          "name" : "holder"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JreCompatTest"
+      },
+      "type" : "tomcat.JreCompatTest$TargetThread",
+      "fields" : [
+        {
+          "name" : "target"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.LookupFactory"
+      },
+      "type" : "tomcat.LookupFactoryTest$LookupObjectFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.LookupFactory"
+      },
+      "type" : "tomcat.LookupFactoryTest$LookupTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.NamingContextListener"
+      },
+      "type" : "tomcat.NamingContextListenerTest$CharConstructedEnvironmentEntry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "char"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.core.NamingContextListener"
+      },
+      "type" : "tomcat.NamingContextListenerTest$StringConstructedEnvironmentEntry",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
+      },
+      "type" : "tomcat.NamingResourcesImplTest$CloseableResource",
+      "methods" : [
+        {
+          "name" : "closeForNamingResources",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.catalina.deploy.NamingResourcesImpl"
+      },
+      "type" : "tomcat.NamingResourcesImplTest$FieldInjectionTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.NamingResourcesImplTest"
+      },
+      "type" : "tomcat.NamingResourcesImplTest$FieldInjectionTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.NamingResourcesImplTest"
+      },
+      "type" : "tomcat.NamingResourcesImplTest$SetterInjectionTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.naming.factory.ResourceFactory"
+      },
+      "type" : "tomcat.ResourceFactoryTest",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
     }
   ],
   "resources" : [
@@ -966,6 +1453,80 @@
         "typeReached" : "tomcat.WebappClassLoaderBaseTest"
       },
       "glob" : "tomcat/TomcatTests.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest"
+      },
+      "glob" : "/tmp/junit1519270464446824860/jaas-realm-file.config"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.WebappServiceLoaderTest"
+      },
+      "glob" : "META-INF/services/java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest"
+      },
+      "glob" : "META-INF/services/javax.security.auth.spi.LoginModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.AuthConfigFactoryImplTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.AuthConfigFactoryImplTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.CatalinaBaseConfigurationSourceTest"
+      },
+      "glob" : "org/apache/catalina/startup/LocalStrings.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.CatalinaBaseConfigurationSourceTest"
+      },
+      "glob" : "server-embed.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.ContextConfigTest"
+      },
+      "glob" : "tomcat/ContextConfigTest$MatchingServlet.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest"
+      },
+      "glob" : "tomcat/jaas-realm-resource.config"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest"
+      },
+      "glob" : "tomcat/mbeans-descriptors.xml"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest$AcceptingLoginModule"
+      },
+      "module" : "java.base",
+      "glob" : "sun/security/util/resources/security_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "tomcat.JAASRealmTest$AcceptingLoginModule"
+      },
+      "module" : "java.base",
+      "glob" : "sun/security/util/resources/security_en_US.properties"
     }
   ]
 }

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/server-embed.xml
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/server-embed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright and related rights waived via CC0
+
+  You should have received a copy of the CC0 legalcode along with this
+  work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+-->
+<Server port="-2" shutdown="SHUTDOWN">
+  <Service name="Catalina">
+    <Engine name="Catalina" defaultHost="localhost">
+      <Host name="localhost" appBase="webapps" autoDeploy="false" deployOnStartup="false" />
+    </Engine>
+  </Service>
+</Server>

--- a/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/tomcat/jaas-realm-resource.config
+++ b/tests/src/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/src/test/resources/tomcat/jaas-realm-resource.config
@@ -1,0 +1,3 @@
+ReachabilityTest {
+    tomcat.JAASRealmTest$AcceptingLoginModule required;
+};


### PR DESCRIPTION

## What does this PR do?

Refs: #8328

This PR improves dynamic-access coverage for org.apache.tomcat.embed:tomcat-embed-core:11.0.18 by generating additional tests.

Summary:
- Chunked dynamic-access: yes
- Chunk class threshold: 15
- Current chunk class count: 15
- Processed dynamic-access classes: completed=14, skipped=0, exhausted=1, failed=0
- Validation commands: `./gradlew test -Pcoordinates=org.apache.tomcat.embed:tomcat-embed-core:11.0.18`
- Validation result: `success`
- Requested coordinate: `org.apache.tomcat.embed:tomcat-embed-core:11.0.18`
- Match type: `tested-version`
- Matched metadata version: `11.0.18`
- Matched test version: `11.0.18`
- Resolved metadata version: `11.0.18`
- Resolved test version: `11.0.18`
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 1140600
- Cached input tokens: 12026368
- Output tokens: 125404
- Metadata entries (before): 463
- Metadata entries (after): 1966
- Test-only metadata entries (before): 156
- Test-only metadata entries (after): 251
- Iterations: 21
- Library coverage percentage: 19.24
- Generated lines of code: 2258
- Tested library lines of code: 15641

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `edef8c309011b7b1e59da394beb095e27e617c2c`



### Stats comparison for `org.apache.tomcat.embed:tomcat-embed-core:11.0.18`

#### Dynamic access coverage

- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 158/432 covered calls (36.57%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 250/432 covered calls (57.87%)

**Reflection:**
- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 144/391 covered calls (36.83%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 224/391 covered calls (57.29%)

**Resources:**
- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 14/41 covered calls (34.15%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 26/41 covered calls (63.41%)

#### Library coverage

**Instruction:**
- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 49769/345522 (14.40%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 63988/345522 (18.52%)

**Line:**
- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 12109/81298 (14.89%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 15641/81298 (19.24%)

**Method:**
- Before (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 2348/12773 (18.38%)
- After (org.apache.tomcat.embed:tomcat-embed-core:11.0.18): 2937/12773 (22.99%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `forge/.library_update_target.json`
  - `forge/ai_workflows/core/fix_metadata_codex.py`
  - `forge/ai_workflows/drivers/improve_library_coverage.py`
  - `forge/docs/workflows/improve-library-coverage.md`
  - `forge/docs/workflows/native-metadata-tracing.md`
  - `forge/prompt_templates/dynamic_access/dynamic-access-iteration.md`
  - `forge/prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md`
  - `forge/prompt_templates/issue_requested_metadata/issue-requested-metadata.md`
  - `forge/tests/test_native_test_verification.py`
  - `forge/utility_scripts/issue_requested_metadata.py`
  - `forge/utility_scripts/native_test_verification.py`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/failure-analysis/codex_failure_analysis_issue_8328.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T14-41-45-793907Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T14-46-53-571547Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T14-52-11-382876Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T14-58-32-764232Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T15-02-51-008425Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T23-52-55-022896Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-18T23-57-39-520520Z.log`
  - `human-intervention-logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/gradle-test/gradle-test-2026-06-19T00-03-05-652169Z.log`
