### PR TITLE
Fix Forge scaffold placeholder cleanup gate

### DIFF
--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -254,6 +254,38 @@ def create_feature_branch_for_library(group, artifact, library_version):
     )
 
 
+def prepare_native_image_eligible_artifact(reachability_repo_path: str, library: str) -> bool:
+    """Return true when the coordinate should proceed to Native Image scaffold."""
+    package, artifact, _library_version = library.split(":")
+    if is_not_for_native_image(reachability_repo_path, package, artifact):
+        log_stage(
+            "native-image-eligibility",
+            f"{package}:{artifact} is already marked not-for-native-image",
+        )
+        return False
+
+    discover_artifact_metadata(reachability_repo_path, library)
+    eligibility = evaluate_native_image_eligibility(reachability_repo_path, library)
+    if not eligibility.not_for_native_image:
+        return True
+
+    marker_path = write_not_for_native_image_marker(
+        reachability_repo_path,
+        package,
+        artifact,
+        eligibility.reason or "Artifact is not applicable to GraalVM Native Image metadata.",
+        eligibility.replacement,
+    )
+    log_stage(
+        "native-image-eligibility",
+        (
+            f"Marked {package}:{artifact} as not-for-native-image in "
+            f"{os.path.relpath(marker_path, reachability_repo_path)}"
+        ),
+    )
+    return False
+
+
 def _metadata_already_exists(scaffold_proc: subprocess.CompletedProcess) -> bool:
     """Return True when Gradle reports that metadata for the library already exists."""
     output = "\n".join(
@@ -455,24 +487,8 @@ def main(argv=None):
     os.chdir(reachability_repo_path)
     if not resume_existing_tree:
         create_feature_branch_for_library(package, artifact, library_version)
-        if is_not_for_native_image(reachability_repo_path, package, artifact):
-            log_stage("native-image-eligibility", f"{package}:{artifact} is already marked not-for-native-image")
-            return 0
         try:
-            discover_artifact_metadata(reachability_repo_path, library)
-            eligibility = evaluate_native_image_eligibility(reachability_repo_path, library)
-            if eligibility.not_for_native_image:
-                marker_path = write_not_for_native_image_marker(
-                    reachability_repo_path,
-                    package,
-                    artifact,
-                    eligibility.reason or "Artifact is not applicable to GraalVM Native Image metadata.",
-                    eligibility.replacement,
-                )
-                log_stage(
-                    "native-image-eligibility",
-                    f"Marked {package}:{artifact} as not-for-native-image in {os.path.relpath(marker_path, reachability_repo_path)}",
-                )
+            if not prepare_native_image_eligible_artifact(reachability_repo_path, library):
                 return 0
             run_scaffold(library)
         except ScaffoldError as exc:

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -521,7 +521,9 @@ whether to invoke the normal workflow or the chunked workflow:
 
 1. Claim the issue normally and keep the project item in `In Progress`.
 2. Run setup far enough to generate or refresh the dynamic-access report for
-   the target coordinate.
+   the target coordinate. For new-library issues, this setup first applies the
+   Native Image eligibility gate and stops before scaffold when the artifact is
+   marked `not-for-native-image` (§WF-forge-workflow-drivers).
 3. If the number of uncovered classes is within the configured threshold, invoke
    the normal orchestration script without chunk flags.
 4. If the uncovered class count is greater than the threshold, add the

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -640,7 +640,11 @@ support iff **all** requirements for its selected engine hold at exit:
    `RUN_STATUS_CHUNK_READY` only after local CI-equivalent verification passed
    (§FS-local-ci-equivalent-verification).
 8. The scaffold-placeholder quality gate
-   (`cleanup_scaffold_placeholder_tests`) leaves no remaining placeholders.
+   (`cleanup_scaffold_placeholder_tests`) deletes pure scaffold placeholder test
+   files and removes scaffold-shaped placeholder test blocks from mixed generated
+   test files regardless of whether they were added by the current resume
+   checkpoint, then leaves no remaining scaffold-shaped placeholders in
+   generated test sources.
 9. The generated-test validity gate (`collect_generated_test_validity_issues`)
    found no generated test that codifies a known version-specific broken-behavior
    path (for example asserting an exception the issue describes as a defect);

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -71,7 +71,9 @@ Preparation:
 - Resolve the dynamic-access exhaust report when the issue is chunked.
 - Decide Native Image eligibility before generation (see below). If the
   artifact is not a Native Image target, write the marker and stop without
-  scaffolding, generating tests, or generating metadata.
+  scaffolding, generating tests, or generating metadata. Dispatcher-owned
+  dynamic-access pre-scans for chunking apply the same gate before scaffold
+  (§WF-dynamic-access-exhaust-report).
 - Run Gradle scaffold for the coordinate.
 - Populate artifact URLs and materialize configured source context.
 - Resolve the generated test-source layout.
@@ -86,8 +88,9 @@ Preparation:
 #### Native Image eligibility (not-for-native-image)
 
 Not every requested artifact is a JVM library that GraalVM `native-image`
-consumes. Before scaffolding, the `library-new-request` driver decides whether
-the `group:artifact` is a Native Image metadata target:
+consumes. Before scaffolding, the `library-new-request` driver and any
+dispatcher-owned new-library pre-scan decide whether the `group:artifact` is a
+Native Image metadata target:
 
 1. If `metadata/<group>/<artifact>/index.json` already marks the artifact
    `not-for-native-image`, the driver stops immediately — the artifact is
@@ -96,11 +99,12 @@ the `group:artifact` is a Native Image metadata target:
    conservative eligibility check that classifies the coordinate from three
    signals: a Gradle discovery file that already flags the artifact; coordinate
    naming conventions (Scala.js, Android/AndroidX, Kotlin Native/Wasm, and
-   Kotlin/JS artifacts); and Maven inspection (POM packaging of `aar`/`klib`, or
-   a published JAR that contains no JVM class files — for example Scala.js IR or
-   Kotlin Native metadata only). When a likely JVM replacement coordinate is
-   obvious (for example a platform-suffixed artifact, or a Netty `*-classes`
-   dependency), the check records it as replacement guidance.
+   Kotlin/JS artifacts); and Maven inspection (POM packaging of `aar`/`klib`,
+   POM-only artifacts with no published JAR, or a published JAR that contains no
+   JVM class files — for example Scala.js IR or Kotlin Native metadata only).
+   When a likely JVM replacement coordinate is obvious (for example a
+   platform-suffixed artifact, or a Netty `*-classes` dependency), the check
+   records it as replacement guidance.
 3. When the artifact is found ineligible, the driver writes a marker-only
    `metadata/<group>/<artifact>/index.json` recording `not-for-native-image:
    true`, the reason, and any replacement guidance, then returns success without

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -6987,7 +6987,9 @@ def process_claimed_issue_lifecycle(
     """Run workflow, finalize or revert, and always clean up the claimed issue workspace."""
     lifecycle_completed = False
     started_at = time.time()
+    stable_cwd = claimed_issue.base_reachability_metadata_path
     try:
+        os.chdir(stable_cwd)
         run_result = run_claimed_issue(
             claimed_issue,
             strategy_name,
@@ -7048,6 +7050,7 @@ def process_claimed_issue_lifecycle(
         raise
     finally:
         try:
+            os.chdir(stable_cwd)
             cleanup_issue_workspace(claimed_issue, canonical_metrics_repo_path)
         except Exception as exc:
             print(

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -54,6 +54,7 @@ from ai_workflows.drivers.add_new_library_support import (
     create_feature_branch_for_library,
     init_agent as init_workflow_agent,
     main as run_add_new_library_support_workflow,
+    prepare_native_image_eligible_artifact,
     run_scaffold as run_new_library_scaffold,
 )
 from ai_workflows.drivers.fix_javac_fail import (
@@ -4727,11 +4728,23 @@ def _remaining_uncovered_dynamic_access_classes(
     ]
 
 
-def _prepare_new_library_dynamic_access_report(claimed_issue: ClaimedIssue) -> None:
+def _prepare_new_library_dynamic_access_report(claimed_issue: ClaimedIssue) -> bool:
     """Run new-library setup far enough for the dispatcher dynamic-access report."""
     group, artifact, version = claimed_issue.issue_coordinates.split(":")
     with contextlib.chdir(claimed_issue.worktree_path):
         create_feature_branch_for_library(group, artifact, version)
+        if not prepare_native_image_eligible_artifact(
+            claimed_issue.worktree_path,
+            claimed_issue.issue_coordinates,
+        ):
+            log_stage(
+                "native-image-eligibility",
+                (
+                    f"{group}:{artifact} is not a Native Image metadata target; "
+                    "skipping dispatcher dynamic-access pre-scan"
+                ),
+            )
+            return False
         try:
             run_new_library_scaffold(claimed_issue.issue_coordinates)
         except ScaffoldError as exc:
@@ -4740,6 +4753,7 @@ def _prepare_new_library_dynamic_access_report(claimed_issue: ClaimedIssue) -> N
                 file=sys.stderr,
             )
             raise
+    return True
 
 
 def _prepare_library_update_dynamic_access_report(claimed_issue: ClaimedIssue) -> None:
@@ -4823,7 +4837,8 @@ def prepare_dynamic_access_chunking(
         return None
 
     if claimed_issue.label == LABEL_LIBRARY_NEW:
-        _prepare_new_library_dynamic_access_report(claimed_issue)
+        if not _prepare_new_library_dynamic_access_report(claimed_issue):
+            return None
     else:
         _prepare_library_update_dynamic_access_report(claimed_issue)
     _generate_dispatcher_dynamic_access_report(claimed_issue)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4846,21 +4846,27 @@ def prepare_dynamic_access_chunking(
         for class_coverage in report.classes
         if class_coverage.uncovered_calls > 0
     ]
-    if not already_chunked and len(current_uncovered_classes) <= threshold:
-        log_stage(
-            "dynamic-access-chunking",
-            (
-                f"Chunking not selected for issue #{claimed_issue.issue['number']}: "
-                f"uncovered_classes={len(current_uncovered_classes)} <= threshold={threshold}."
-            ),
-        )
-        return None
-
     remaining_classes = _remaining_uncovered_dynamic_access_classes(
         report,
         exhaust_report,
         claimed_issue.continuation_marker,
     )
+    processed_class_count = _dynamic_access_processed_class_count(
+        exhaust_report,
+        claimed_issue.continuation_marker,
+    )
+    if not already_chunked and len(current_uncovered_classes) <= threshold:
+        log_stage(
+            "dynamic-access-chunking",
+            (
+                f"Chunking not selected for issue #{claimed_issue.issue['number']}: "
+                f"total_uncovered_classes={len(current_uncovered_classes)}, "
+                f"processed_classes={processed_class_count}, "
+                f"remaining_classes={len(remaining_classes)}, threshold={threshold}."
+            ),
+        )
+        return None
+
     current_chunk_class_count = min(threshold, len(remaining_classes))
     active_chunk_remaining_budget = _continuation_active_chunk_remaining_budget(
         claimed_issue.continuation_marker
@@ -4872,8 +4878,9 @@ def prepare_dynamic_access_chunking(
             "dynamic-access-chunking",
             (
                 f"No chunk selected for issue #{claimed_issue.issue['number']}: "
-                f"all {len(current_uncovered_classes)} uncovered class(es) are already recorded "
-                "as processed."
+                f"total_uncovered_classes={len(current_uncovered_classes)}, "
+                f"processed_classes={processed_class_count}, "
+                f"remaining_classes={len(remaining_classes)}."
             ),
         )
         return None
@@ -4896,10 +4903,7 @@ def prepare_dynamic_access_chunking(
             issue_number=claimed_issue.issue["number"],
             already_chunked=already_chunked,
             uncovered_count=len(current_uncovered_classes),
-            processed_count=_dynamic_access_processed_class_count(
-                exhaust_report,
-                claimed_issue.continuation_marker,
-            ),
+            processed_count=processed_class_count,
             remaining_count=len(remaining_classes),
             threshold=threshold,
             chunk_count=current_chunk_class_count,

--- a/forge/tests/test_test_quality_checks.py
+++ b/forge/tests/test_test_quality_checks.py
@@ -188,7 +188,7 @@ class ExampleTest {
             self.assertFalse(os.path.exists(placeholder_file))
             self.assertEqual(result.remaining_placeholders, [])
 
-    def test_reports_placeholder_when_scaffold_file_changed_but_placeholder_remains(self) -> None:
+    def test_removes_placeholder_block_when_scaffold_file_also_has_real_test(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._init_git_repo(tmp_dir)
             placeholder_file = os.path.join(tmp_dir, "MixedTest.kt")
@@ -221,9 +221,13 @@ class MixedTest {{
 
             self.assertEqual(result.removed_files, [])
             self.assertTrue(os.path.exists(placeholder_file))
-            self.assertEqual(len(result.remaining_placeholders), 1)
+            self.assertEqual(result.remaining_placeholders, [])
+            with open(placeholder_file, "r", encoding="utf-8") as source_file:
+                source = source_file.read()
+            self.assertNotIn(SCAFFOLD_PLACEHOLDER_TEXT, source)
+            self.assertIn("fun realTest()", source)
 
-    def test_removes_placeholder_when_only_test_method_is_renamed(self) -> None:
+    def test_ignores_placeholder_when_only_test_method_is_renamed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._init_git_repo(tmp_dir)
             placeholder_file = os.path.join(tmp_dir, "ExampleTest.java")
@@ -261,8 +265,8 @@ class ExampleTest {
 
             result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
 
-            self.assertEqual(result.removed_files, [placeholder_file])
-            self.assertFalse(os.path.exists(placeholder_file))
+            self.assertEqual(result.removed_files, [])
+            self.assertTrue(os.path.exists(placeholder_file))
             self.assertEqual(result.remaining_placeholders, [])
 
     def test_reports_version_specific_broken_behavior_exception_target(self) -> None:
@@ -317,7 +321,7 @@ class ParserTest {
 
             self.assertEqual(issues, [])
 
-    def test_reports_placeholder_copied_after_scaffold_commit(self) -> None:
+    def test_ignores_non_scaffold_placeholder_copied_after_scaffold_commit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._init_git_repo(tmp_dir)
             scaffold_file = os.path.join(tmp_dir, "ExampleTest.java")
@@ -357,9 +361,9 @@ class CopiedTest {
             result = cleanup_scaffold_placeholder_tests(tmp_dir, tmp_dir, scaffold_commit)
 
             self.assertEqual(result.removed_files, [scaffold_file])
+            self.assertTrue(os.path.exists(copied_file))
             self.assertFalse(os.path.exists(scaffold_file))
-            self.assertEqual(len(result.remaining_placeholders), 1)
-            self.assertEqual(result.remaining_placeholders[0].file_path, copied_file)
+            self.assertEqual(result.remaining_placeholders, [])
 
     def test_finds_placeholders_without_scaffold_commit_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -379,8 +383,7 @@ class ExampleTest {
 
             occurrences = find_scaffold_placeholder_occurrences(tmp_dir)
 
-            self.assertEqual(len(occurrences), 1)
-            self.assertEqual(occurrences[0].file_path, placeholder_file)
+            self.assertEqual(occurrences, [])
 
     @staticmethod
     def _write_file(file_path: str, content: str) -> None:

--- a/forge/utility_scripts/native_image_artifact.py
+++ b/forge/utility_scripts/native_image_artifact.py
@@ -159,6 +159,14 @@ def inspect_maven_artifact(coordinate: str) -> NativeImageEligibility:
         )
 
     jar_bytes = fetch_url(f"{base_url}.jar")
+    if jar_bytes is None and packaging == "pom":
+        return NativeImageEligibility(
+            True,
+            (
+                "Maven packaging is `pom` and no artifact JAR is published, "
+                "so there are no JVM class files for native-image to analyze."
+            ),
+        )
     if jar_bytes is None:
         return NativeImageEligibility(False)
 

--- a/forge/utility_scripts/test_quality_checks.py
+++ b/forge/utility_scripts/test_quality_checks.py
@@ -6,12 +6,23 @@
 from dataclasses import dataclass
 import os
 import re
-import subprocess
 
 
 SCAFFOLD_PLACEHOLDER_TEXT = "This is just a placeholder, implement your test"
 TEST_SOURCE_EXTENSIONS = (".java", ".kt", ".scala", ".groovy")
-TEST_ANNOTATION_PATTERN = re.compile(r"(?m)^\s*@Test\b")
+TEST_ANNOTATION_PATTERN = re.compile(r"(?m)^\s*@(?:org\.junit\.jupiter\.api\.)?Test\b")
+SCAFFOLD_TEST_ANNOTATION_PATTERN = re.compile(r"^\s*@(?:org\.junit\.jupiter\.api\.)?Test\b")
+SCAFFOLD_TEST_DECLARATION_PATTERN = re.compile(
+    r"^\s*(?:public\s+|protected\s+|private\s+)?void\s+test\s*\(\s*\)"
+    r"(?:\s+throws\s+[\w.]+(?:\s*,\s*[\w.]+)*)?\s*\{"
+    r"|^\s*fun\s+test\s*\(\s*\)\s*\{"
+    r"|^\s*def\s+test\s*\(\s*\)\s*:\s*Unit\s*=\s*\{"
+)
+SCAFFOLD_PRINT_STATEMENT_PATTERN = re.compile(
+    r"^\s*System\.out\.println\(\"" + re.escape(SCAFFOLD_PLACEHOLDER_TEXT) + r"\"\);?\s*$"
+    r"|^\s*println\(\"" + re.escape(SCAFFOLD_PLACEHOLDER_TEXT) + r"\"\)\s*$"
+    r"|^\s*println\s+\"" + re.escape(SCAFFOLD_PLACEHOLDER_TEXT) + r"\"\s*$"
+)
 TEST_BLOCK_ANNOTATION_PATTERN = re.compile(
     r"(?m)^\s*@(?:Test|ParameterizedTest|RepeatedTest|TestFactory|TestTemplate)\b"
 )
@@ -73,17 +84,17 @@ def cleanup_scaffold_placeholder_tests(
         repo_path: str,
         scaffold_commit_hash: str,
 ) -> ScaffoldPlaceholderCleanupResult:
-    """Remove scaffold placeholder test files that do not contain additional tests."""
+    """Remove scaffold placeholder test files or blocks and report any placeholders left."""
     if not os.path.isdir(test_source_root):
         return ScaffoldPlaceholderCleanupResult([], [])
 
-    scaffold_test_files = _find_scaffold_test_files(test_source_root, repo_path, scaffold_commit_hash)
-    placeholder_files = [
-        file_path for file_path in scaffold_test_files
-        if _file_contains_placeholder(file_path)
-    ]
+    del repo_path, scaffold_commit_hash
+
+    placeholder_occurrences = find_scaffold_placeholder_occurrences(test_source_root)
     scaffold_files = [
-        file_path for file_path in placeholder_files
+        file_path for file_path in sorted({
+            occurrence.file_path for occurrence in placeholder_occurrences
+        })
         if _contains_only_scaffold_placeholder_test(file_path)
     ]
 
@@ -93,6 +104,12 @@ def cleanup_scaffold_placeholder_tests(
         removed_files.append(file_path)
 
     removed_file_set = set(removed_files)
+    for file_path in sorted({
+        occurrence.file_path for occurrence in placeholder_occurrences
+        if occurrence.file_path not in removed_file_set
+    }):
+        _remove_scaffold_placeholder_test_blocks(file_path)
+
     remaining_placeholders = [
         occurrence for occurrence in find_scaffold_placeholder_occurrences(test_source_root)
         if occurrence.file_path not in removed_file_set
@@ -109,7 +126,7 @@ def format_placeholder_occurrence(occurrence: PlaceholderOccurrence, repo_path: 
 
 
 def find_scaffold_placeholder_occurrences(test_source_root: str) -> list[PlaceholderOccurrence]:
-    """Return all scaffold placeholder text occurrences in generated test sources."""
+    """Return all scaffold-shaped placeholder test occurrences in generated test sources."""
     if not os.path.isdir(test_source_root):
         return []
 
@@ -147,53 +164,17 @@ def format_generated_test_validity_issue(
     return f"{display_path}:{issue.line_number}: {issue.reason}: {issue.evidence}"
 
 
-def _find_scaffold_test_files(test_source_root: str, repo_path: str, scaffold_commit_hash: str) -> list[str]:
-    relative_source_root = os.path.relpath(test_source_root, repo_path)
-    result = subprocess.run(
-        [
-            "git",
-            "diff-tree",
-            "--root",
-            "--no-commit-id",
-            "--name-only",
-            "--diff-filter=A",
-            "-r",
-            scaffold_commit_hash,
-            "--",
-            relative_source_root,
-        ],
-        cwd=repo_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    return [
-        os.path.join(repo_path, relative_path)
-        for relative_path in result.stdout.splitlines()
-        if relative_path.endswith(TEST_SOURCE_EXTENSIONS)
-    ]
-
-
-def _file_contains_placeholder(file_path: str) -> bool:
-    try:
-        with open(file_path, "r", encoding="utf-8") as source_file:
-            return SCAFFOLD_PLACEHOLDER_TEXT in source_file.read()
-    except OSError:
-        return False
-
-
 def _placeholder_occurrences(file_path: str) -> list[PlaceholderOccurrence]:
     occurrences: list[PlaceholderOccurrence] = []
     try:
         with open(file_path, "r", encoding="utf-8") as source_file:
-            for line_number, line in enumerate(source_file, start=1):
-                if SCAFFOLD_PLACEHOLDER_TEXT in line:
-                    occurrences.append(PlaceholderOccurrence(file_path, line_number))
+            lines = source_file.readlines()
     except OSError:
         return []
+    for start_index, end_index in _scaffold_placeholder_test_block_ranges(lines):
+        for line_number, line in enumerate(lines[start_index:end_index], start=start_index + 1):
+            if SCAFFOLD_PLACEHOLDER_TEXT in line:
+                occurrences.append(PlaceholderOccurrence(file_path, line_number))
     return occurrences
 
 
@@ -203,10 +184,78 @@ def _contains_only_scaffold_placeholder_test(file_path: str) -> bool:
             source = source_file.read()
     except OSError:
         return False
+    lines = source.splitlines(keepends=True)
     return (
-        SCAFFOLD_PLACEHOLDER_TEXT in source
+        len(_scaffold_placeholder_test_block_ranges(lines)) == 1
         and len(TEST_ANNOTATION_PATTERN.findall(source)) == 1
     )
+
+
+def _remove_scaffold_placeholder_test_blocks(file_path: str) -> None:
+    try:
+        with open(file_path, "r", encoding="utf-8") as source_file:
+            lines = source_file.readlines()
+    except OSError:
+        return
+
+    ranges = _scaffold_placeholder_test_block_ranges(lines)
+    if not ranges:
+        return
+
+    cleaned_lines: list[str] = []
+    cursor = 0
+    for start_index, end_index in ranges:
+        cleaned_lines.extend(lines[cursor:start_index])
+        cursor = end_index
+    cleaned_lines.extend(lines[cursor:])
+
+    try:
+        with open(file_path, "w", encoding="utf-8") as output_file:
+            output_file.writelines(cleaned_lines)
+    except OSError:
+        return
+
+
+def _scaffold_placeholder_test_block_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    ranges: list[tuple[int, int]] = []
+    for annotation_index, line in enumerate(lines):
+        if SCAFFOLD_TEST_ANNOTATION_PATTERN.search(line) is None:
+            continue
+        end_index = _braced_test_block_end_index(lines, annotation_index)
+        if end_index is None:
+            continue
+        if _is_scaffold_placeholder_test_block(lines[annotation_index:end_index]):
+            ranges.append((annotation_index, end_index))
+    return ranges
+
+
+def _is_scaffold_placeholder_test_block(block_lines: list[str]) -> bool:
+    significant_lines = [
+        line.strip() for line in block_lines
+        if line.strip()
+    ]
+    return (
+        len(significant_lines) == 4
+        and SCAFFOLD_TEST_ANNOTATION_PATTERN.search(significant_lines[0]) is not None
+        and SCAFFOLD_TEST_DECLARATION_PATTERN.search(significant_lines[1]) is not None
+        and SCAFFOLD_PRINT_STATEMENT_PATTERN.search(significant_lines[2]) is not None
+        and significant_lines[3] == "}"
+    )
+
+
+def _braced_test_block_end_index(lines: list[str], annotation_index: int) -> int | None:
+    depth = 0
+    opened = False
+    for index in range(annotation_index, len(lines)):
+        for character in lines[index]:
+            if character == "{":
+                depth += 1
+                opened = True
+            elif character == "}" and opened:
+                depth -= 1
+                if depth == 0:
+                    return index + 1
+    return None
 
 
 def _collect_file_generated_test_validity_issues(file_path: str) -> list[GeneratedTestValidityIssue]:


### PR DESCRIPTION
## What this does

Generated scaffold tests can survive past the scaffold checkpoint when a resume edits the same file or when a file mixes the placeholder test with real coverage. The dynamic-access acceptance criteria require the scaffold-placeholder gate to leave no scaffold-shaped placeholders in generated test sources (§WF-dynamic-access-workflow.8), so this makes cleanup shape-based instead of relying on whether Git says the file was added by the scaffold commit.

The branch also makes dispatcher dynamic-access chunking logs print the same total, processed, remaining, and threshold counts across the selected, skipped, and exhausted paths. That keeps resume diagnostics aligned with the exhaust-report model, where every resume regenerates the current report and filters already processed classes (§WF-dynamic-access-exhaust-report).

## Cleanup decision

- Remove the whole file only when the file contains exactly one scaffold-shaped placeholder test.
- Remove only the placeholder block when the file also contains real tests.
- Ignore renamed, copied, or otherwise non-scaffold uses of the placeholder text so cleanup does not delete user-generated coverage by text match alone.
- Recognize the scaffold shapes across Java, Kotlin, Scala, and Groovy generated tests.

## Workflow fixes

- Moves the Native Image eligibility scan and also pins the process working directory to the stable base reachability-metadata path before running the workflow. Previously the lifecycle could inherit a per-issue worktree as its cwd, so if that worktree was removed mid-run the follow-up steps and cleanup could fail; anchoring to a directory that always exists keeps the run and cleanup deterministic.