### PR TITLE
Add Confluent Maven repository fallback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
+        maven {
+            name = "Confluent"
+            url = uri("https://packages.confluent.io/maven/")
+        }
         mavenLocal()
     }
 }

--- a/docs/build-infra.md
+++ b/docs/build-infra.md
@@ -16,6 +16,13 @@ index and stats validation, reporting, CI matrix generation, and packaging
 resolves the selected coordinates and delegates each one to the per-coordinate
 layer.
 
+The harness resolves public library artifacts from Maven Central first. When a
+target artifact or transitive dependency is not present there, Gradle may fall
+through to the Confluent Maven repository at
+`https://packages.confluent.io/maven/`. Confluent publishes some artifacts and
+their transitive dependencies under non-`io.confluent` groups, so the fallback
+is intentionally available for any dependency after Maven Central is tried.
+
 ## 2. Per-coordinate layer
 
 For each selected coordinate the harness delegates to a separate Gradle build

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-settings.settings.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-settings.settings.gradle
@@ -23,6 +23,10 @@ while (!catalogFile.exists()) {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven {
+            name = "Confluent"
+            url = uri("https://packages.confluent.io/maven/")
+        }
     }
     versionCatalogs {
         libs {

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -29,6 +29,10 @@ def skipJacoco = providers.gradleProperty("skipJacoco").map { it.toBoolean() }.g
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        name = "Confluent"
+        url = uri("https://packages.confluent.io/maven/")
+    }
 }
 
 Integer explicitTestJvmVersion(File buildFile) {


### PR DESCRIPTION
Fixes #8612

## What this does

Confluent library requests were blocked by dependency resolution rather than metadata authoring: Maven Central remains the primary source, but some `io.confluent` artifacts and required transitives need the Confluent Maven repository. This adds that repository as a fallback in the root harness and per-coordinate Gradle builds, so new Confluent libraries can keep flowing through metadata-driven coordinate discovery instead of requiring per-library build edits ([§FS-repository-functional-spec.6](docs/functional-spec.md#6-operational-guarantees), [§AR-build-infrastructure.1](docs/build-infra.md#1-harness-layer), [§AR-build-infrastructure.2](docs/build-infra.md#2-per-coordinate-layer)).

## Where resolution changes

| Build layer | Repository order |
| --- | --- |
| Root harness | `mavenCentral()` -> `Confluent` -> `mavenLocal()` |
| TCK settings plugin | `mavenCentral()` -> `Confluent` |
| Per-coordinate TCK plugin | `mavenLocal()` -> `mavenCentral()` -> `Confluent` |