### PR TITLE
[GenAI] Test fix for org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1 using gpt-5.5

### DIFF
--- a/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/reachability-metadata.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/reachability-metadata.json
@@ -1,0 +1,118 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.FileSystem"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.DaemonParamsKt"
+      },
+      "type": "java.lang.Comparable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "java.util.logging.FileHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "java.util.logging.Handler[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "java.util.logging.SimpleFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.LoopbackNetworkInterface$ClientLoopbackSocketFactory"
+      },
+      "type": "jdk.net.LinuxSocketOptions"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.ClientUtilsKt"
+      },
+      "type": "sun.rmi.registry.RegistryImpl_Stub",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.rmi.server.RemoteRef"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.DaemonParamsKt"
+      },
+      "type": "sun.security.provider.MD5"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.common.ClientUtilsKt"
+      },
+      "type": "sun.security.provider.NativePRNG"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "sun.util.logging.resources.logging"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "type": "sun.util.resources.cldr.CalendarData"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "glob": "META-INF/MANIFEST.MF"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    }
+  ]
+}

--- a/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
@@ -19,6 +19,15 @@
   },
   {
     "metadata-version" : "2.4.20-Beta1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/$version$/kotlin-daemon-embeddable-$version$-sources.jar",
+    "repository-url" : "https://github.com/JetBrains/kotlin",
+    "test-code-url" : "https://github.com/JetBrains/kotlin/tree/v$version$/compiler/daemon/daemon-tests/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/$version$/kotlin-daemon-embeddable-$version$-javadoc.jar",
+    "description" : "This artifact packages the Kotlin compiler daemon implementation for use with the embeddable compiler. It runs compilation work in a separate process so build tools and IDE integrations can invoke Kotlin compilation out of process.",
+    "language" : {
+      "name" : "kotlin",
+      "version" : "2.4"
+    },
     "tested-versions" : [
       "2.4.20-Beta1"
     ],

--- a/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
@@ -16,5 +16,14 @@
     "allowed-packages" : [
       "org.jetbrains.kotlin.daemon"
     ]
+  },
+  {
+    "metadata-version" : "2.4.20-Beta1",
+    "tested-versions" : [
+      "2.4.20-Beta1"
+    ],
+    "allowed-packages" : [
+      "org.jetbrains.kotlin.daemon"
+    ]
   }
 ]

--- a/stats/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/execution-metrics.json
+++ b/stats/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/execution-metrics.json
@@ -1,0 +1,99 @@
+{
+  "fix_javac_fail:2026-06-26": {
+    "timestamp": "2026-06-26T10:14:27.242166Z",
+    "library": "org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1",
+    "starting_commit": "5d9e973c8fc7f56a0c6fc6e40e732c0420e8ce40",
+    "ending_commit": "c1704ab3f6409d2e74be1b676605984efffef9c2",
+    "previous_library": "org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.4.20-Beta1",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 1,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 1,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2520,
+          "missed": 9256,
+          "ratio": 0.213995,
+          "total": 11776
+        },
+        "line": {
+          "covered": 367,
+          "missed": 1691,
+          "ratio": 0.178328,
+          "total": 2058
+        },
+        "method": {
+          "covered": 134,
+          "missed": 537,
+          "ratio": 0.199702,
+          "total": 671
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "2.3.20",
+      "dynamicAccess": {
+        "breakdown": {
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 1
+          }
+        },
+        "coverageRatio": 0.0,
+        "coveredCalls": 0,
+        "totalCalls": 1
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1794,
+          "missed": 9451,
+          "ratio": 0.159538,
+          "total": 11245
+        },
+        "line": {
+          "covered": 235,
+          "missed": 1664,
+          "ratio": 0.123749,
+          "total": 1899
+        },
+        "method": {
+          "covered": 105,
+          "missed": 537,
+          "ratio": 0.163551,
+          "total": 642
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 173289,
+      "cached_input_tokens_used": 1096704,
+      "output_tokens_used": 14803,
+      "iterations": 2,
+      "cost_usd": 0.9925,
+      "tested_library_loc": 367,
+      "metadata_entries": 20,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 17.83,
+      "previous_library_coverage_percent": 12.37
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java",
+      "metadata_file": "metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/stats.json
+++ b/stats/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.4.20-Beta1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 1,
+          "totalCalls" : 1
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 1,
+      "totalCalls" : 1
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2520,
+        "missed" : 9256,
+        "ratio" : 0.213995,
+        "total" : 11776
+      },
+      "line" : {
+        "covered" : 367,
+        "missed" : 1691,
+        "ratio" : 0.178328,
+        "total" : 2058
+      },
+      "method" : {
+        "covered" : 134,
+        "missed" : 537,
+        "ratio" : 0.199702,
+        "total" : 671
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/.gitignore
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/build.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/build.gradle
@@ -1,0 +1,57 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+File generatedTestResourcesDir = layout.buildDirectory.dir("generated/test-resources").get().asFile
+
+sourceSets {
+    test {
+        resources.srcDir generatedTestResourcesDir
+    }
+}
+
+tasks.register("generateMissingNativeImageResources") {
+    outputs.dir(generatedTestResourcesDir)
+    doLast {
+        [
+                "jline-terminal",
+                "jline-terminal-jna",
+                "jline-terminal-jni",
+                "jline-terminal-jansi"
+        ].each { moduleName ->
+            File baseDir = new File(generatedTestResourcesDir, "META-INF/native-image/org.jline/${moduleName}")
+            baseDir.mkdirs()
+            new File(baseDir, "reflection-config.json").text = "[]\n"
+            new File(baseDir, "resource-config.json").text = '{ "resources": { "includes": [] } }\n'
+        }
+    }
+}
+
+tasks.named("processTestResources") {
+    dependsOn("generateMissingNativeImageResources")
+}
+
+dependencies {
+    testImplementation "org.jetbrains.kotlin:kotlin-daemon-embeddable:$libraryVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$libraryVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/gradle.properties
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1
+library.version = 2.4.20-Beta1
+metadata.dir = org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/settings.gradle
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jetbrains.kotlin.kotlin-daemon-embeddable_tests'

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/KotlinCompileDaemonBaseTest.java
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/KotlinCompileDaemonBaseTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_kotlin.kotlin_daemon_embeddable;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Timer;
+import java.util.logging.LogManager;
+
+import kotlin.Pair;
+import kotlin.jvm.functions.Function0;
+import org.jetbrains.kotlin.cli.common.CompilerSystemProperties;
+import org.jetbrains.kotlin.daemon.CompileServiceImplBase;
+import org.jetbrains.kotlin.daemon.CompilerSelector;
+import org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase;
+import org.jetbrains.kotlin.daemon.common.CompilerId;
+import org.jetbrains.kotlin.daemon.common.DaemonJVMOptions;
+import org.jetbrains.kotlin.daemon.common.DaemonOptions;
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KotlinCompileDaemonBaseTest {
+
+    @Test
+    void mainImplLoadsImplementationVersionFromManifestBeforeStartingServer(@TempDir Path tempDir) throws Exception {
+        Map<CompilerSystemProperties, String> previousValues = snapshotProperties(
+                CompilerSystemProperties.COMPILE_DAEMON_LOG_PATH_PROPERTY
+        );
+        try {
+            Path logFile = tempDir.resolve("daemon.log");
+            Files.createFile(logFile);
+            CompilerSystemProperties.COMPILE_DAEMON_LOG_PATH_PROPERTY.setValue(logFile.toString());
+
+            VersionLoadingDaemon daemon = new VersionLoadingDaemon();
+
+            daemon.startWithoutServer();
+
+            assertThat(daemon.synchronizedSectionReached).isTrue();
+        } finally {
+            restoreProperties(previousValues);
+            LogManager.getLogManager().reset();
+        }
+    }
+
+    private static Map<CompilerSystemProperties, String> snapshotProperties(CompilerSystemProperties... properties) {
+        Map<CompilerSystemProperties, String> previousValues = new EnumMap<>(CompilerSystemProperties.class);
+        for (CompilerSystemProperties property : properties) {
+            previousValues.put(property, property.getValue());
+        }
+        return previousValues;
+    }
+
+    private static void restoreProperties(Map<CompilerSystemProperties, String> previousValues) {
+        for (Map.Entry<CompilerSystemProperties, String> entry : previousValues.entrySet()) {
+            if (entry.getValue() == null) {
+                entry.getKey().clear();
+            } else {
+                entry.getKey().setValue(entry.getValue());
+            }
+        }
+    }
+
+    private static final class VersionLoadingDaemon extends KotlinCompileDaemonBase {
+
+        private boolean synchronizedSectionReached;
+
+        private void startWithoutServer() {
+            mainImpl(new String[0]);
+        }
+
+        @Override
+        protected <T> T runSynchronized(Function0<? extends T> block) {
+            synchronizedSectionReached = true;
+            return null;
+        }
+
+        @Override
+        protected Pair<CompileServiceImplBase, Integer> getCompileServiceAndPort(
+                CompilerSelector compilerSelector,
+                CompilerId compilerId,
+                JavaLanguageVersion javaLanguageVersion,
+                DaemonOptions daemonOptions,
+                DaemonJVMOptions daemonJVMOptions,
+                Timer timer
+        ) {
+            throw new AssertionError("Server startup should not be reached");
+        }
+    }
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_kotlin.kotlin_daemon_embeddable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function2;
+import kotlin.sequences.SequencesKt;
+import org.jetbrains.kotlin.cli.common.CompilerSystemProperties;
+import org.jetbrains.kotlin.daemon.RemoteInputStreamClient;
+import org.jetbrains.kotlin.daemon.RemoteOutputStreamClient;
+import org.jetbrains.kotlin.daemon.RunningCompilations;
+import org.jetbrains.kotlin.daemon.common.ClientUtilsKt;
+import org.jetbrains.kotlin.daemon.common.CompilerId;
+import org.jetbrains.kotlin.daemon.common.DaemonJVMOptions;
+import org.jetbrains.kotlin.daemon.common.DaemonOptions;
+import org.jetbrains.kotlin.daemon.common.DaemonParamsKt;
+import org.jetbrains.kotlin.daemon.common.DaemonReportCategory;
+import org.jetbrains.kotlin.daemon.common.DaemonWithMetadata;
+import org.jetbrains.kotlin.daemon.common.DummyProfiler;
+import org.jetbrains.kotlin.daemon.common.LoopbackNetworkInterface;
+import org.jetbrains.kotlin.daemon.common.RemoteInputStream;
+import org.jetbrains.kotlin.daemon.common.RemoteOutputStream;
+import org.jetbrains.kotlin.progress.CompilationCanceledException;
+import org.jetbrains.kotlin.progress.CompilationCanceledStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Kotlin_daemon_embeddableTest {
+
+    @Test
+    void configureDaemonOptionsUsesSystemPropertiesAndDefaults(@TempDir Path tempDir) {
+        Map<CompilerSystemProperties, String> previousValues = snapshotProperties(
+                CompilerSystemProperties.COMPILE_DAEMON_OPTIONS_PROPERTY,
+                CompilerSystemProperties.COMPILE_DAEMON_VERBOSE_REPORT_PROPERTY,
+                CompilerSystemProperties.COMPILE_DAEMON_CUSTOM_RUN_FILES_PATH_FOR_TESTS
+        );
+        try {
+            Path configuredRunFilesPath = tempDir.resolve("configured-run-files");
+            Path defaultRunFilesPath = tempDir.resolve("default-run-files");
+            CompilerSystemProperties.COMPILE_DAEMON_OPTIONS_PROPERTY.setValue(
+                    "runFilesPath=" + configuredRunFilesPath
+                            + ",autoshutdownIdleSeconds=42"
+                            + ",autoshutdownUnusedSeconds=17"
+                            + ",shutdownDelayMilliseconds=2500"
+                            + ",reportPerf"
+            );
+            CompilerSystemProperties.COMPILE_DAEMON_VERBOSE_REPORT_PROPERTY.setValue("true");
+            CompilerSystemProperties.COMPILE_DAEMON_CUSTOM_RUN_FILES_PATH_FOR_TESTS.setValue(defaultRunFilesPath.toString());
+
+            DaemonOptions options = DaemonParamsKt.configureDaemonOptions(new DaemonOptions());
+
+            assertThat(options.getRunFilesPath()).isEqualTo(configuredRunFilesPath.toString());
+            assertThat(options.getAutoshutdownIdleSeconds()).isEqualTo(42);
+            assertThat(options.getAutoshutdownUnusedSeconds()).isEqualTo(17);
+            assertThat(options.getShutdownDelayMilliseconds()).isEqualTo(2500L);
+            assertThat(options.getVerbose()).isTrue();
+            assertThat(options.getReportPerf()).isTrue();
+            assertThat(DaemonParamsKt.getRunFilesPathOrDefault(options)).isEqualTo(configuredRunFilesPath.toString());
+
+            options.setRunFilesPath("");
+            assertThat(DaemonParamsKt.getRunFilesPathOrDefault(options)).isEqualTo(defaultRunFilesPath.toString());
+        } finally {
+            restoreProperties(previousValues);
+        }
+    }
+
+    @Test
+    void configureDaemonJVMOptionsParsesMemoryFlagsAndRetainsRemainingJvmParams() {
+        Map<CompilerSystemProperties, String> previousValues = snapshotProperties(
+                CompilerSystemProperties.COMPILE_DAEMON_JVM_OPTIONS_PROPERTY
+        );
+        try {
+            CompilerSystemProperties.COMPILE_DAEMON_JVM_OPTIONS_PROPERTY.setValue(
+                    "\"-Xmx768m,-XX:MaxMetaspaceSize=256m,-Dsample.flag=a\\,b,-Dfeature.enabled=true\""
+            );
+
+            DaemonJVMOptions options = DaemonParamsKt.configureDaemonJVMOptions(
+                    new DaemonJVMOptions(),
+                    List.of("-Dextra=value"),
+                    false,
+                    false,
+                    false
+            );
+
+            assertThat(options.getMaxMemory()).isEqualTo("768m");
+            assertThat(options.getMaxMetaspaceSize()).isEqualTo("256m");
+            assertThat(options.getReservedCodeCacheSize()).isEqualTo("320m");
+            assertThat(options.getJvmParams()).containsExactly(
+                    "Dsample.flag=a,b",
+                    "Dfeature.enabled=true",
+                    "-Dextra=value",
+                    "ea"
+            );
+        } finally {
+            restoreProperties(previousValues);
+        }
+    }
+
+    @Test
+    void memoryComparisonAndUpperBoundUpdatesRespectHumanReadableSizes() {
+        DaemonJVMOptions smaller = new DaemonJVMOptions();
+        smaller.setMaxMemory("512m");
+        smaller.setMaxMetaspaceSize("128m");
+        smaller.setReservedCodeCacheSize("128m");
+
+        DaemonJVMOptions larger = new DaemonJVMOptions();
+        larger.setMaxMemory("1g");
+        larger.setMaxMetaspaceSize("256m");
+        larger.setReservedCodeCacheSize("192m");
+
+        assertThat(DaemonParamsKt.memorywiseFitsInto(smaller, larger)).isTrue();
+        assertThat(DaemonParamsKt.memorywiseFitsInto(larger, smaller)).isFalse();
+        assertThat(DaemonParamsKt.compareDaemonJVMOptionsMemory(smaller, larger)).isEqualTo(-1);
+        assertThat(DaemonParamsKt.compareDaemonJVMOptionsMemory(larger, smaller)).isEqualTo(1);
+
+        DaemonJVMOptions updated = DaemonParamsKt.updateMemoryUpperBounds(smaller, larger);
+        assertThat(updated).isSameAs(smaller);
+        assertThat(updated.getMaxMemory()).isEqualTo("1g");
+        assertThat(updated.getMaxMetaspaceSize()).isEqualTo("256m");
+        assertThat(updated.getReservedCodeCacheSize()).isEqualTo("192m");
+    }
+
+    @Test
+    void loopbackSocketFactoriesExchangeDataOverLoopback() throws Exception {
+        LoopbackNetworkInterface loopback = LoopbackNetworkInterface.INSTANCE;
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = loopback.getServerLoopbackSocketFactory().createServerSocket(0)) {
+            Future<String> acceptedRemoteAddress = executor.submit(() -> {
+                try (Socket acceptedSocket = serverSocket.accept()) {
+                    int received = acceptedSocket.getInputStream().read();
+                    acceptedSocket.getOutputStream().write(received + 1);
+                    acceptedSocket.getOutputStream().flush();
+                    return acceptedSocket.getInetAddress().getHostAddress();
+                }
+            });
+
+            try (Socket clientSocket = loopback.getClientLoopbackSocketFactory()
+                    .createSocket(loopback.getLoopbackInetAddressName(), serverSocket.getLocalPort())) {
+                clientSocket.getOutputStream().write(41);
+                clientSocket.getOutputStream().flush();
+
+                assertThat(clientSocket.getInputStream().read()).isEqualTo(42);
+                assertThat(clientSocket.getInetAddress().isLoopbackAddress()).isTrue();
+            }
+
+            String remoteAddress = acceptedRemoteAddress.get(5, TimeUnit.SECONDS);
+            assertThat(InetAddress.getByName(remoteAddress).isLoopbackAddress()).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void compilerIdDigestIsStableAcrossClasspathOrderAndDuplicates() {
+        CompilerId orderedWithDuplicates = new CompilerId(List.of("b.jar", "a.jar", "a.jar"), "embedded-test");
+        CompilerId orderedWithoutDuplicates = new CompilerId(List.of("a.jar", "b.jar"), "other-version");
+        CompilerId differentClasspath = new CompilerId(List.of("a.jar", "c.jar"), "embedded-test");
+
+        assertThat(orderedWithDuplicates.digest()).isEqualTo(orderedWithoutDuplicates.digest());
+        assertThat(orderedWithDuplicates.digest()).isNotEqualTo(differentClasspath.digest());
+        assertThat(orderedWithDuplicates.digest()).hasSize(32).matches("[0-9a-f]+$");
+    }
+
+    @Test
+    void walkDaemonsDeletesOrphanedRunFiles(@TempDir Path tempDir) throws Exception {
+        CompilerId compilerId = new CompilerId(List.of(tempDir.resolve("compiler.jar").toString()), "embedded-test");
+        Path runFile = tempDir.resolve(ClientUtilsKt.makeRunFilenameString(
+                "2024-04-20T12:34:56.789Z",
+                compilerId.digest(),
+                "17042",
+                ""
+        ));
+        Files.createFile(runFile);
+        Files.setLastModifiedTime(runFile, FileTime.fromMillis(System.currentTimeMillis() - 1_500_000L));
+
+        Path referenceFile = tempDir.resolve("reference.txt");
+        Files.writeString(referenceFile, "reference");
+
+        List<String> reports = new java.util.ArrayList<>();
+        List<DaemonWithMetadata> daemons = SequencesKt.toList(ClientUtilsKt.walkDaemons(
+                tempDir.toFile(),
+                compilerId,
+                referenceFile.toFile(),
+                (Function2<File, Integer, Boolean>) (file, daemonPort) -> true,
+                (Function2<DaemonReportCategory, String, Unit>) (category, message) -> {
+                    reports.add(category + ":" + message);
+                    return Unit.INSTANCE;
+                }
+        ));
+
+        assertThat(daemons).isEmpty();
+        assertThat(Files.exists(runFile)).isFalse();
+        assertThat(reports).anySatisfy(report -> assertThat(report).contains("seemingly orphaned run file"));
+    }
+
+    @Test
+    void runningCompilationStatusStaysActiveUntilCompilationIsRemoved() {
+        RunningCompilations runningCompilations = new RunningCompilations();
+        int compilationId = 101;
+        runningCompilations.add(compilationId);
+
+        CompilationCanceledStatus status = runningCompilations.getCompilationCanceledStatus(compilationId);
+
+        assertThatCode(status::checkCanceled).doesNotThrowAnyException();
+
+        runningCompilations.remove(compilationId);
+
+        assertThatThrownBy(status::checkCanceled).isInstanceOf(CompilationCanceledException.class);
+    }
+
+    @Test
+    void cancelAllCancelsEveryTrackedCompilationStatus() {
+        RunningCompilations runningCompilations = new RunningCompilations();
+        runningCompilations.add(7);
+        runningCompilations.add(9);
+
+        CompilationCanceledStatus firstStatus = runningCompilations.getCompilationCanceledStatus(7);
+        CompilationCanceledStatus secondStatus = runningCompilations.getCompilationCanceledStatus(9);
+
+        assertThatCode(firstStatus::checkCanceled).doesNotThrowAnyException();
+        assertThatCode(secondStatus::checkCanceled).doesNotThrowAnyException();
+
+        runningCompilations.cancelAll();
+
+        assertThatThrownBy(firstStatus::checkCanceled).isInstanceOf(CompilationCanceledException.class);
+        assertThatThrownBy(secondStatus::checkCanceled).isInstanceOf(CompilationCanceledException.class);
+    }
+
+    @Test
+    void remoteOutputStreamClientForwardsWholePartialAndSingleByteWrites() throws Exception {
+        RecordingRemoteOutputStream remoteOutputStream = new RecordingRemoteOutputStream();
+        RemoteOutputStreamClient client = new RemoteOutputStreamClient(remoteOutputStream, new DummyProfiler());
+
+        client.write(new byte[]{10, 20});
+        client.write(new byte[]{30, 40, 50}, 1, 2);
+        client.write(60);
+
+        assertThat(remoteOutputStream.toByteArray()).containsExactly(10, 20, 40, 50, 60);
+    }
+
+    @Test
+    void remoteInputStreamClientReadsRequestedRangesWithoutTouchingOtherBytes() throws Exception {
+        RemoteInputStreamClient client = new RemoteInputStreamClient(
+                new ChunkedRemoteInputStream(new byte[]{10, 20, 30, 40}),
+                new DummyProfiler()
+        );
+
+        assertThat(client.read()).isEqualTo(10);
+
+        byte[] destination = new byte[]{99, 99, 99, 99, 99};
+        int bytesRead = client.read(destination, 1, 2);
+
+        assertThat(bytesRead).isEqualTo(2);
+        assertThat(destination).containsExactly(99, 20, 30, 99, 99);
+        assertThat(client.read()).isEqualTo(40);
+    }
+
+    private static Map<CompilerSystemProperties, String> snapshotProperties(CompilerSystemProperties... properties) {
+        Map<CompilerSystemProperties, String> previousValues = new EnumMap<>(CompilerSystemProperties.class);
+        for (CompilerSystemProperties property : properties) {
+            previousValues.put(property, property.getValue());
+        }
+        return previousValues;
+    }
+
+    private static void restoreProperties(Map<CompilerSystemProperties, String> previousValues) {
+        for (Map.Entry<CompilerSystemProperties, String> entry : previousValues.entrySet()) {
+            if (entry.getValue() == null) {
+                entry.getKey().clear();
+            } else {
+                entry.getKey().setValue(entry.getValue());
+            }
+        }
+    }
+
+    private static final class RecordingRemoteOutputStream implements RemoteOutputStream {
+
+        private final ByteArrayOutputStream writtenBytes = new ByteArrayOutputStream();
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void write(byte[] data, int offset, int length) {
+            writtenBytes.write(data, offset, length);
+        }
+
+        @Override
+        public void write(int value) {
+            writtenBytes.write(value);
+        }
+
+        byte[] toByteArray() {
+            return writtenBytes.toByteArray();
+        }
+    }
+
+    private static final class ChunkedRemoteInputStream implements RemoteInputStream {
+
+        private final byte[] source;
+        private int nextIndex;
+
+        private ChunkedRemoteInputStream(byte[] source) {
+            this.source = Arrays.copyOf(source, source.length);
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public byte[] read(int length) {
+            int remaining = source.length - nextIndex;
+            int bytesToRead = Math.min(length, remaining);
+            byte[] chunk = Arrays.copyOfRange(source, nextIndex, nextIndex + bytesToRead);
+            nextIndex += bytesToRead;
+            return chunk;
+        }
+
+        @Override
+        public int read() {
+            if (nextIndex >= source.length) {
+                return -1;
+            }
+            return source[nextIndex++] & 0xFF;
+        }
+    }
+
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.daemon.common.DaemonParamsKt;
 import org.jetbrains.kotlin.daemon.common.DaemonReportCategory;
 import org.jetbrains.kotlin.daemon.common.DaemonWithMetadata;
 import org.jetbrains.kotlin.daemon.common.DummyProfiler;
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion;
 import org.jetbrains.kotlin.daemon.common.LoopbackNetworkInterface;
 import org.jetbrains.kotlin.daemon.common.RemoteInputStream;
 import org.jetbrains.kotlin.daemon.common.RemoteOutputStream;
@@ -50,7 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Kotlin_daemon_embeddableTest {
+public class Kotlin_daemon_embeddableTest {
 
     @Test
     void configureDaemonOptionsUsesSystemPropertiesAndDefaults(@TempDir Path tempDir) {
@@ -176,22 +177,25 @@ class Kotlin_daemon_embeddableTest {
     }
 
     @Test
-    void compilerIdDigestIsStableAcrossClasspathOrderAndDuplicates() {
+    void runFileDigestIsStableAcrossClasspathOrderAndDuplicates() {
+        JavaLanguageVersion javaLanguageVersion = currentJavaLanguageVersion();
         CompilerId orderedWithDuplicates = new CompilerId(List.of("b.jar", "a.jar", "a.jar"), "embedded-test");
         CompilerId orderedWithoutDuplicates = new CompilerId(List.of("a.jar", "b.jar"), "other-version");
         CompilerId differentClasspath = new CompilerId(List.of("a.jar", "c.jar"), "embedded-test");
 
-        assertThat(orderedWithDuplicates.digest()).isEqualTo(orderedWithoutDuplicates.digest());
-        assertThat(orderedWithDuplicates.digest()).isNotEqualTo(differentClasspath.digest());
-        assertThat(orderedWithDuplicates.digest()).hasSize(32).matches("[0-9a-f]+$");
+        String digest = runFileDigest(javaLanguageVersion, orderedWithDuplicates);
+        assertThat(digest).isEqualTo(runFileDigest(javaLanguageVersion, orderedWithoutDuplicates));
+        assertThat(digest).isNotEqualTo(runFileDigest(javaLanguageVersion, differentClasspath));
+        assertThat(digest).hasSize(32).matches("[0-9a-f]+$");
     }
 
     @Test
     void walkDaemonsDeletesOrphanedRunFiles(@TempDir Path tempDir) throws Exception {
+        JavaLanguageVersion javaLanguageVersion = currentJavaLanguageVersion();
         CompilerId compilerId = new CompilerId(List.of(tempDir.resolve("compiler.jar").toString()), "embedded-test");
         Path runFile = tempDir.resolve(ClientUtilsKt.makeRunFilenameString(
                 "2024-04-20T12:34:56.789Z",
-                compilerId.digest(),
+                runFileDigest(javaLanguageVersion, compilerId),
                 "17042",
                 ""
         ));
@@ -205,6 +209,7 @@ class Kotlin_daemon_embeddableTest {
         List<DaemonWithMetadata> daemons = SequencesKt.toList(ClientUtilsKt.walkDaemons(
                 tempDir.toFile(),
                 compilerId,
+                javaLanguageVersion,
                 referenceFile.toFile(),
                 (Function2<File, Integer, Boolean>) (file, daemonPort) -> true,
                 (Function2<DaemonReportCategory, String, Unit>) (category, message) -> {
@@ -278,6 +283,19 @@ class Kotlin_daemon_embeddableTest {
         assertThat(bytesRead).isEqualTo(2);
         assertThat(destination).containsExactly(99, 20, 30, 99, 99);
         assertThat(client.read()).isEqualTo(40);
+    }
+
+    private static JavaLanguageVersion currentJavaLanguageVersion() {
+        return JavaLanguageVersion.Companion.of(Runtime.version().feature());
+    }
+
+    private static String runFileDigest(JavaLanguageVersion javaLanguageVersion, CompilerId compilerId) {
+        return DaemonParamsKt.makeRunFileDigest(
+                javaLanguageVersion,
+                compilerId.getCompilerClasspath().stream()
+                        .map(classpathEntry -> Path.of(classpathEntry))
+                        .toList()
+        );
     }
 
     private static Map<CompilerSystemProperties, String> snapshotProperties(CompilerSystemProperties... properties) {

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jetbrains.kotlin.daemon.**"
+    }
+  ]
+}

--- a/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
+++ b/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jetbrains.kotlin.daemon.**"
+      "includeClasses" : "org.jetbrains.kotlin.daemon.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_kotlin.kotlin_daemon_embeddable.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #8601

This PR provides test fixes and new metadata for org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 173289
- Cached input tokens: 1096704
- Output tokens: 14803
- Metadata entries: 20
- Iterations: 2
- Library coverage percentage: 17.83
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 12.37

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20: 0/1 covered calls (0.00%)
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1: 1/1 covered calls (100.00%)

**Resources:**
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20: 0/1 covered calls (0.00%)
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1: 1/1 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20: 1794/11245 (15.95%)
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1: 2520/11776 (21.40%)

**Line:**
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20: 235/1899 (12.37%)
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1: 367/2058 (17.83%)

**Method:**
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.3.20: 105/642 (16.36%)
- org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.20-Beta1: 134/671 (19.97%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/KotlinCompileDaemonBaseTest.java 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/KotlinCompileDaemonBaseTest.java
new file mode 100644
index 0000000000..4d6891fddb
--- /dev/null
+++ 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/KotlinCompileDaemonBaseTest.java
@@ -0,0 +1,98 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jetbrains_kotlin.kotlin_daemon_embeddable;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Timer;
+import java.util.logging.LogManager;
+
+import kotlin.Pair;
+import kotlin.jvm.functions.Function0;
+import org.jetbrains.kotlin.cli.common.CompilerSystemProperties;
+import org.jetbrains.kotlin.daemon.CompileServiceImplBase;
+import org.jetbrains.kotlin.daemon.CompilerSelector;
+import org.jetbrains.kotlin.daemon.KotlinCompileDaemonBase;
+import org.jetbrains.kotlin.daemon.common.CompilerId;
+import org.jetbrains.kotlin.daemon.common.DaemonJVMOptions;
+import org.jetbrains.kotlin.daemon.common.DaemonOptions;
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KotlinCompileDaemonBaseTest {
+
+    @Test
+    void mainImplLoadsImplementationVersionFromManifestBeforeStartingServer(@TempDir Path tempDir) throws Exception {
+        Map<CompilerSystemProperties, String> previousValues = snapshotProperties(
+                CompilerSystemProperties.COMPILE_DAEMON_LOG_PATH_PROPERTY
+        );
+        try {
+            Path logFile = tempDir.resolve("daemon.log");
+            Files.createFile(logFile);
+            CompilerSystemProperties.COMPILE_DAEMON_LOG_PATH_PROPERTY.setValue(logFile.toString());
+
+            VersionLoadingDaemon daemon = new VersionLoadingDaemon();
+
+            daemon.startWithoutServer();
+
+            assertThat(daemon.synchronizedSectionReached).isTrue();
+        } finally {
+            restoreProperties(previousValues);
+            LogManager.getLogManager().reset();
+        }
+    }
+
+    private static Map<CompilerSystemProperties, String> snapshotProperties(CompilerSystemProperties... properties) {
+        Map<CompilerSystemProperties, String> previousValues = new EnumMap<>(CompilerSystemProperties.class);
+        for (CompilerSystemProperties property : properties) {
+            previousValues.put(property, property.getValue());
+        }
+        return previousValues;
+    }
+
+    private static void restoreProperties(Map<CompilerSystemProperties, String> previousValues) {
+        for (Map.Entry<CompilerSystemProperties, String> entry : previousValues.entrySet()) {
+            if (entry.getValue() == null) {
+                entry.getKey().clear();
+            } else {
+                entry.getKey().setValue(entry.getValue());
+            }
+        }
+    }
+
+    private static final class VersionLoadingDaemon extends KotlinCompileDaemonBase {
+
+        private boolean synchronizedSectionReached;
+
+        private void startWithoutServer() {
+            mainImpl(new String[0]);
+        }
+
+        @Override
+        protected <T> T runSynchronized(Function0<? extends T> block) {
+            synchronizedSectionReached = true;
+            return null;
+        }
+
+        @Override
+        protected Pair<CompileServiceImplBase, Integer> getCompileServiceAndPort(
+                CompilerSelector compilerSelector,
+                CompilerId compilerId,
+                JavaLanguageVersion javaLanguageVersion,
+                DaemonOptions daemonOptions,
+                DaemonJVMOptions daemonJVMOptions,
+                Timer timer
+        ) {
+            throw new AssertionError("Server startup should not be reached");
+        }
+    }
+}
diff --git 1/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.3.20/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
index 67acd9de5e..b9186d22a7 100644
--- 1/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.3.20/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
+++ 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/src/test/java/org_jetbrains_kotlin/kotlin_daemon_embeddable/Kotlin_daemon_embeddableTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.daemon.common.DaemonParamsKt;
 import org.jetbrains.kotlin.daemon.common.DaemonReportCategory;
 import org.jetbrains.kotlin.daemon.common.DaemonWithMetadata;
 import org.jetbrains.kotlin.daemon.common.DummyProfiler;
+import org.jetbrains.kotlin.daemon.common.JavaLanguageVersion;
 import org.jetbrains.kotlin.daemon.common.LoopbackNetworkInterface;
 import org.jetbrains.kotlin.daemon.common.RemoteInputStream;
 import org.jetbrains.kotlin.daemon.common.RemoteOutputStream;
@@ -50,7 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Kotlin_daemon_embeddableTest {
+public class Kotlin_daemon_embeddableTest {
 
     @Test
     void configureDaemonOptionsUsesSystemPropertiesAndDefaults(@TempDir Path tempDir) {
@@ -176,22 +177,25 @@ class Kotlin_daemon_embeddableTest {
     }
 
     @Test
-    void compilerIdDigestIsStableAcrossClasspathOrderAndDuplicates() {
+    void runFileDigestIsStableAcrossClasspathOrderAndDuplicates() {
+        JavaLanguageVersion javaLanguageVersion = currentJavaLanguageVersion();
         CompilerId orderedWithDuplicates = new CompilerId(List.of("b.jar", "a.jar", "a.jar"), "embedded-test");
         CompilerId orderedWithoutDuplicates = new CompilerId(List.of("a.jar", "b.jar"), "other-version");
         CompilerId differentClasspath = new CompilerId(List.of("a.jar", "c.jar"), "embedded-test");
 
-        assertThat(orderedWithDuplicates.digest()).isEqualTo(orderedWithoutDuplicates.digest());
-        assertThat(orderedWithDuplicates.digest()).isNotEqualTo(differentClasspath.digest());
-        assertThat(orderedWithDuplicates.digest()).hasSize(32).matches("[0-9a-f]+$");
+        String digest = runFileDigest(javaLanguageVersion, orderedWithDuplicates);
+        assertThat(digest).isEqualTo(runFileDigest(javaLanguageVersion, orderedWithoutDuplicates));
+        assertThat(digest).isNotEqualTo(runFileDigest(javaLanguageVersion, differentClasspath));
+        assertThat(digest).hasSize(32).matches("[0-9a-f]+$");
     }
 
     @Test
     void walkDaemonsDeletesOrphanedRunFiles(@TempDir Path tempDir) throws Exception {
+        JavaLanguageVersion javaLanguageVersion = currentJavaLanguageVersion();
         CompilerId compilerId = new CompilerId(List.of(tempDir.resolve("compiler.jar").toString()), "embedded-test");
         Path runFile = tempDir.resolve(ClientUtilsKt.makeRunFilenameString(
                 "2024-04-20T12:34:56.789Z",
-                compilerId.digest(),
+                runFileDigest(javaLanguageVersion, compilerId),
                 "17042",
                 ""
         ));
@@ -205,6 +209,7 @@ class Kotlin_daemon_embeddableTest {
         List<DaemonWithMetadata> daemons = SequencesKt.toList(ClientUtilsKt.walkDaemons(
                 tempDir.toFile(),
                 compilerId,
+                javaLanguageVersion,
                 referenceFile.toFile(),
                 (Function2<File, Integer, Boolean>) (file, daemonPort) -> true,
                 (Function2<DaemonReportCategory, String, Unit>) (category, message) -> {
@@ -280,6 +285,19 @@ class Kotlin_daemon_embeddableTest {
         assertThat(client.read()).isEqualTo(40);
     }
 
+    private static JavaLanguageVersion currentJavaLanguageVersion() {
+        return JavaLanguageVersion.Companion.of(Runtime.version().feature());
+    }
+
+    private static String runFileDigest(JavaLanguageVersion javaLanguageVersion, CompilerId compilerId) {
+        return DaemonParamsKt.makeRunFileDigest(
+                javaLanguageVersion,
+                compilerId.getCompilerClasspath().stream()
+                        .map(classpathEntry -> Path.of(classpathEntry))
+                        .toList()
+        );
+    }
+
     private static Map<CompilerSystemProperties, String> snapshotProperties(CompilerSystemProperties... properties) {
         Map<CompilerSystemProperties, String> previousValues = new EnumMap<>(CompilerSystemProperties.class);
         for (CompilerSystemProperties property : properties) {
diff --git 1/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.3.20/user-code-filter.json 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
index be4ed092fe..d2ef6942af 100644
--- 1/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.3.20/user-code-filter.json
+++ 2/tests/src/org.jetbrains.kotlin/kotlin-daemon-embeddable/2.4.20-Beta1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jetbrains.kotlin.daemon.**"
+      "includeClasses" : "org.jetbrains.kotlin.daemon.**"
+    },
+    {
+      "includeClasses" : "org_jetbrains_kotlin.kotlin_daemon_embeddable.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
