### PR TITLE
[GenAI] Test fix for org.sonatype.sisu:sisu-inject-bean:2.4.1 using gpt-5.5

### DIFF
--- a/metadata/org.sonatype.sisu/sisu-inject-bean/2.4.1/reachability-metadata.json
+++ b/metadata/org.sonatype.sisu/sisu-inject-bean/2.4.1/reachability-metadata.json
@@ -1,0 +1,19 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.eclipse.sisu.space.QualifiedTypeBinder"
+      },
+      "type": "com.google.inject.util.Modules$1"
+    },
+    {
+      "type": "com.google.inject.internal.InjectorShell$RootModule"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.sisu.space.URLClassSpace"
+      },
+      "type": "org.sonatype.guice.bean.reflect.URLClassSpace"
+    }
+  ]
+}

--- a/metadata/org.sonatype.sisu/sisu-inject-bean/2.4.1/reachability-metadata.json
+++ b/metadata/org.sonatype.sisu/sisu-inject-bean/2.4.1/reachability-metadata.json
@@ -1,19 +1,19 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.eclipse.sisu.space.QualifiedTypeBinder"
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.QualifiedTypeBinder"
       },
-      "type": "com.google.inject.util.Modules$1"
+      "type" : "com.google.inject.util.Modules$1"
     },
     {
-      "type": "com.google.inject.internal.InjectorShell$RootModule"
+      "type" : "com.google.inject.internal.InjectorShell$RootModule"
     },
     {
-      "condition": {
-        "typeReached": "org.eclipse.sisu.space.URLClassSpace"
+      "condition" : {
+        "typeReached" : "org.eclipse.sisu.space.URLClassSpace"
       },
-      "type": "org.sonatype.guice.bean.reflect.URLClassSpace"
+      "type" : "org.sonatype.guice.bean.reflect.URLClassSpace"
     }
   ]
 }

--- a/metadata/org.sonatype.sisu/sisu-inject-bean/index.json
+++ b/metadata/org.sonatype.sisu/sisu-inject-bean/index.json
@@ -51,5 +51,17 @@
       "org.aopalliance",
       "org.sonatype"
     ]
+  },
+  {
+    "metadata-version" : "2.4.1",
+    "tested-versions" : [
+      "2.4.1"
+    ],
+    "allowed-packages" : [
+      "javax.enterprise.inject",
+      "javax.inject",
+      "org.aopalliance",
+      "org.sonatype"
+    ]
   }
 ]

--- a/metadata/org.sonatype.sisu/sisu-inject-bean/index.json
+++ b/metadata/org.sonatype.sisu/sisu-inject-bean/index.json
@@ -54,6 +54,11 @@
   },
   {
     "metadata-version" : "2.4.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/$version$/sisu-inject-bean-$version$-sources.jar",
+    "repository-url" : "https://github.com/sonatype/sisu",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/$version$/sisu-inject-bean-$version$-javadoc.jar",
+    "description" : "Sisu Inject Bean is a legacy wrapper around Sonatype Sisu's JSR-330 bean support, packaging Guice-based bean discovery, binding, locating, conversion, and container integration classes for Java applications. It helps applications scan class spaces for annotated components and wire them into Guice injectors while exposing Sonatype-specific injection annotations and utilities.",
     "tested-versions" : [
       "2.4.1"
     ],
@@ -61,6 +66,7 @@
       "javax.enterprise.inject",
       "javax.inject",
       "org.aopalliance",
+      "org.eclipse.sisu",
       "org.sonatype"
     ]
   }

--- a/stats/org.sonatype.sisu/sisu-inject-bean/2.4.1/execution-metrics.json
+++ b/stats/org.sonatype.sisu/sisu-inject-bean/2.4.1/execution-metrics.json
@@ -1,0 +1,106 @@
+{
+  "fix_javac_fail:2026-06-26": {
+    "timestamp": "2026-06-26T12:39:51.513539Z",
+    "library": "org.sonatype.sisu:sisu-inject-bean:2.4.1",
+    "starting_commit": "7d7a647370123763419ef88eb054e9ee3e632280",
+    "ending_commit": "caee3167b1edde072718c3b7e05d655bfee90c7a",
+    "previous_library": "org.sonatype.sisu:sisu-inject-bean:1.4.2",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.4.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 2,
+        "totalCalls": 2
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 51,
+          "missed": 802,
+          "ratio": 0.059789,
+          "total": 853
+        },
+        "line": {
+          "covered": 10,
+          "missed": 215,
+          "ratio": 0.044444,
+          "total": 225
+        },
+        "method": {
+          "covered": 5,
+          "missed": 128,
+          "ratio": 0.037594,
+          "total": 133
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.4.2",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 8,
+            "totalCalls": 8
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 2,
+            "totalCalls": 2
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 10,
+        "totalCalls": 10
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 477,
+          "missed": 13196,
+          "ratio": 0.034886,
+          "total": 13673
+        },
+        "line": {
+          "covered": 111,
+          "missed": 1129,
+          "ratio": 0.089516,
+          "total": 1240
+        },
+        "method": {
+          "covered": 38,
+          "missed": 459,
+          "ratio": 0.076459,
+          "total": 497
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 150712,
+      "cached_input_tokens_used": 900608,
+      "output_tokens_used": 9594,
+      "iterations": 3,
+      "cost_usd": 0.7381,
+      "tested_library_loc": 10,
+      "metadata_entries": 3,
+      "test_only_metadata_entries": 1,
+      "previous_library_metadata_entries": 2,
+      "previous_library_test_only_metadata_entries": 1,
+      "code_coverage_percent": 4.44,
+      "previous_library_coverage_percent": 8.95
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java",
+      "metadata_file": "metadata/org.sonatype.sisu/sisu-inject-bean/2.4.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.sonatype.sisu/sisu-inject-bean/2.4.1/stats.json
+++ b/stats/org.sonatype.sisu/sisu-inject-bean/2.4.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.4.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 2,
+          "totalCalls" : 2
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 2,
+      "totalCalls" : 2
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 51,
+        "missed" : 802,
+        "ratio" : 0.059789,
+        "total" : 853
+      },
+      "line" : {
+        "covered" : 10,
+        "missed" : 215,
+        "ratio" : 0.044444,
+        "total" : 225
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 128,
+        "ratio" : 0.037594,
+        "total" : 133
+      }
+    }
+  } ]
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/.gitignore
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/build.gradle
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.sonatype.sisu:sisu-inject-bean:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/gradle.properties
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.sonatype.sisu:sisu-inject-bean:2.4.1
+library.version = 2.4.1
+metadata.dir = org.sonatype.sisu/sisu-inject-bean/2.4.1/

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/settings.gradle
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.sonatype.sisu.sisu-inject-bean_tests'

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.reflect.BeanProperties;
+import org.sonatype.guice.bean.reflect.BeanProperty;
+import org.sonatype.guice.bean.reflect.IgnoreSetters;
+
+public class BeanPropertyFieldTest {
+    @Test
+    void setUpdatesPrivateFieldDiscoveredAsBeanProperty() {
+        FieldBackedBean bean = new FieldBackedBean();
+        BeanProperty<Object> property = firstPropertyOf(FieldBackedBean.class);
+
+        property.set(bean, "configured");
+
+        assertThat(property.getName()).isEqualTo("value");
+        assertThat(bean.value()).isEqualTo("configured");
+    }
+
+    private static BeanProperty<Object> firstPropertyOf(Class<?> beanType) {
+        return new BeanProperties(beanType).iterator().next();
+    }
+
+    @IgnoreSetters
+    private static final class FieldBackedBean {
+        private String value;
+
+        private String value() {
+            return value;
+        }
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
@@ -8,10 +8,9 @@ package org_sonatype_sisu.sisu_inject_bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.BeanProperties;
-import org.sonatype.guice.bean.reflect.BeanProperty;
-import org.sonatype.guice.bean.reflect.IgnoreSetters;
 
 public class BeanPropertyFieldTest {
     @Test
@@ -29,7 +28,6 @@ public class BeanPropertyFieldTest {
         return new BeanProperties(beanType).iterator().next();
     }
 
-    @IgnoreSetters
     private static final class FieldBackedBean {
         private String value;
 

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.reflect.BeanProperties;
+import org.sonatype.guice.bean.reflect.BeanProperty;
+
+public class BeanPropertySetterTest {
+    @Test
+    void setInvokesDiscoveredPrivateSetter() {
+        SetterBackedBean bean = new SetterBackedBean();
+        BeanProperty<Object> property = propertyNamed(SetterBackedBean.class, "configured");
+
+        property.set(bean, "configured-value");
+
+        assertThat(property.getName()).isEqualTo("configured");
+        assertThat(bean.configuredValue()).isEqualTo("configured-value");
+        assertThat(bean.setterInvocationCount()).isEqualTo(1);
+    }
+
+    private static BeanProperty<Object> propertyNamed(Class<?> beanType, String name) {
+        for (BeanProperty<Object> property : new BeanProperties(beanType)) {
+            if (name.equals(property.getName())) {
+                return property;
+            }
+        }
+        throw new AssertionError("No bean property named " + name);
+    }
+
+    private static final class SetterBackedBean {
+        private String configuredValue;
+
+        private int setterInvocationCount;
+
+        private void setConfigured(String configuredValue) {
+            this.configuredValue = configuredValue;
+            setterInvocationCount++;
+        }
+
+        private String configuredValue() {
+            return configuredValue;
+        }
+
+        private int setterInvocationCount() {
+            return setterInvocationCount;
+        }
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
@@ -8,9 +8,9 @@ package org_sonatype_sisu.sisu_inject_bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.BeanProperties;
-import org.sonatype.guice.bean.reflect.BeanProperty;
 
 public class BeanPropertySetterTest {
     @Test

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
@@ -13,9 +13,9 @@ import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.sisu.bean.DeclaredMembers;
+import org.eclipse.sisu.bean.DeclaredMembers.View;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.DeclaredMembers;
-import org.sonatype.guice.bean.reflect.DeclaredMembers.View;
 
 public class DeclaredMembersInnerViewAnonymous1Test {
     @Test

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.reflect.DeclaredMembers;
+import org.sonatype.guice.bean.reflect.DeclaredMembers.View;
+
+public class DeclaredMembersInnerViewAnonymous1Test {
+    @Test
+    void constructorsViewIteratesDeclaredConstructors() {
+        List<Constructor<?>> constructors = new ArrayList<>();
+
+        for (Member member : new DeclaredMembers(ConstructorFixture.class, View.CONSTRUCTORS)) {
+            assertThat(member).isInstanceOf(Constructor.class);
+            constructors.add((Constructor<?>) member);
+        }
+
+        assertThat(constructors)
+            .hasSize(3)
+            .extracting(Constructor::getParameterCount)
+            .containsExactlyInAnyOrder(0, 1, 2);
+    }
+
+    static final class ConstructorFixture {
+        ConstructorFixture() {
+        }
+
+        private ConstructorFixture(String value) {
+            assertThat(value).isNotNull();
+        }
+
+        ConstructorFixture(String value, int number) {
+            assertThat(value).isNotNull();
+            assertThat(number).isNotNegative();
+        }
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.binders.QualifiedTypeBinder;
+
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+
+public class QualifiedTypeBinderTest {
+    private static final Object SOURCE = "qualified-module-source";
+
+    @Test
+    void hearInstallsConcreteModuleByInvokingItsNoArgConstructor() {
+        InstalledPrivateConstructorModule.created().set(0);
+
+        List<Element> elements = Elements.getElements(new ScanningModule());
+
+        boolean installedBinding = elements.stream()
+            .filter(Binding.class::isInstance)
+            .map(Binding.class::cast)
+            .anyMatch(binding -> Key.get(ModuleBoundService.class).equals(binding.getKey()));
+        assertThat(InstalledPrivateConstructorModule.created().get()).isEqualTo(1);
+        assertThat(installedBinding).isTrue();
+    }
+
+    private static final class ScanningModule implements Module {
+        @Override
+        public void configure(Binder binder) {
+            new QualifiedTypeBinder(binder).hear(null, InstalledPrivateConstructorModule.class, SOURCE);
+        }
+    }
+
+    private static final class InstalledPrivateConstructorModule implements Module {
+        private static final AtomicInteger CREATED = new AtomicInteger();
+
+        private InstalledPrivateConstructorModule() {
+            CREATED.incrementAndGet();
+        }
+
+        @Override
+        public void configure(Binder binder) {
+            binder.bind(ModuleBoundService.class).toInstance(new ModuleBoundService());
+        }
+
+        private static AtomicInteger created() {
+            return CREATED;
+        }
+    }
+
+    private static final class ModuleBoundService {
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.sisu.space.QualifiedTypeBinder;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.binders.QualifiedTypeBinder;
 
 import com.google.inject.Binder;
 import com.google.inject.Binding;
@@ -41,7 +41,7 @@ public class QualifiedTypeBinderTest {
     private static final class ScanningModule implements Module {
         @Override
         public void configure(Binder binder) {
-            new QualifiedTypeBinder(binder).hear(null, InstalledPrivateConstructorModule.class, SOURCE);
+            new QualifiedTypeBinder(binder).hear(InstalledPrivateConstructorModule.class, SOURCE);
         }
     }
 

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceAnonymous2Test.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceAnonymous2Test.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.containers.SisuGuice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+public class SisuGuiceAnonymous2Test {
+    @Test
+    void enhancedInjectorDelegatesRegularInjectorMethods() {
+        Injector injector = Guice.createInjector(new ServiceModule());
+        Injector enhancedInjector = SisuGuice.enhance(injector);
+
+        Map<Key<?>, Binding<?>> bindings = enhancedInjector.getBindings();
+
+        assertThat(bindings).containsKey(Key.get(Service.class));
+    }
+
+    private static final class ServiceModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Service.class).toInstance(new Service());
+        }
+    }
+
+    private static final class Service {
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.containers.SisuGuice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class SisuGuiceTest {
+    @Test
+    void enhanceWrapsInjectorInDynamicProxy() {
+        Injector injector = Guice.createInjector(new TestModule());
+
+        Injector enhancedInjector = SisuGuice.enhance(injector);
+
+        Class<?> enhancedType = enhancedInjector.getClass();
+        assertThat(Proxy.isProxyClass(enhancedType)).isTrue();
+        assertThat(Injector.class.isAssignableFrom(enhancedType)).isTrue();
+    }
+
+    private static final class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Service.class).toInstance(new Service());
+        }
+    }
+
+    private static final class Service {
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/URLClassSpaceTest.java
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/URLClassSpaceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.reflect.URLClassSpace;
+
+public class URLClassSpaceTest {
+    private static final String RESOURCE_NAME = "org_sonatype_sisu/sisu_inject_bean/url-class-space-resource.txt";
+
+    @Test
+    void loadClassDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Class<?> loadedClass = classSpace.loadClass(URLClassSpace.class.getName());
+
+        assertThat(loadedClass).isSameAs(URLClassSpace.class);
+    }
+
+    @Test
+    void getResourceDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        URL resource = classSpace.getResource(RESOURCE_NAME);
+
+        assertThat(resource).isNotNull();
+        assertThat(resource.toString()).endsWith(RESOURCE_NAME);
+    }
+
+    @Test
+    void getResourcesDelegatesToBackingClassLoader() {
+        URLClassSpace classSpace = new URLClassSpace(URLClassSpaceTest.class.getClassLoader());
+
+        Enumeration<URL> resourceEnumeration = classSpace.getResources(RESOURCE_NAME);
+        List<URL> resources = Collections.list(resourceEnumeration);
+
+        assertThat(resources).isNotEmpty();
+        assertThat(resources).allSatisfy(resource -> assertThat(resource.toString()).endsWith(RESOURCE_NAME));
+    }
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.sonatype.guice.bean.reflect.URLClassSpace"
+      },
+      "glob" : "org_sonatype_sisu/sisu_inject_bean/url-class-space-resource.txt"
+    }
+  ]
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/resources/org_sonatype_sisu/sisu_inject_bean/url-class-space-resource.txt
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/resources/org_sonatype_sisu/sisu_inject_bean/url-class-space-resource.txt
@@ -1,0 +1,1 @@
+resource visible to URLClassSpaceTest

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
@@ -1,0 +1,22 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "javax.enterprise.inject.**"
+    },
+    {
+      "includeClasses" : "javax.inject.**"
+    },
+    {
+      "includeClasses" : "org.aopalliance.**"
+    },
+    {
+      "includeClasses" : "org.sonatype.**"
+    },
+    {
+      "includeClasses" : "org_sonatype_sisu.sisu_inject_bean.**"
+    }
+  ]
+}

--- a/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
+++ b/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
@@ -4,16 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.enterprise.inject.**"
+      "includeClasses" : "org.sonatype.guice.bean.**"
     },
     {
-      "includeClasses" : "javax.inject.**"
-    },
-    {
-      "includeClasses" : "org.aopalliance.**"
-    },
-    {
-      "includeClasses" : "org.sonatype.**"
+      "includeClasses" : "org.sonatype.inject.**"
     },
     {
       "includeClasses" : "org_sonatype_sisu.sisu_inject_bean.**"


### PR DESCRIPTION
## What does this PR do?

Fixes: #8602

This PR provides test fixes and new metadata for org.sonatype.sisu:sisu-inject-bean:2.4.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 150712
- Cached input tokens: 900608
- Output tokens: 9594
- Metadata entries: 3
- Test-only metadata entries: 1
- Iterations: 3
- Library coverage percentage: 4.44
- Previous library version metadata entries: 2
- Previous library version test-only metadata entries: 1
- Previous library version coverage percentage: 8.95

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.sonatype.sisu:sisu-inject-bean:1.4.2: 10/10 covered calls (100.00%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: 2/2 covered calls (100.00%)

**Reflection:**
- org.sonatype.sisu:sisu-inject-bean:1.4.2: 8/8 covered calls (100.00%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: 2/2 covered calls (100.00%)

**Resources:**
- org.sonatype.sisu:sisu-inject-bean:1.4.2: 2/2 covered calls (100.00%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: N/A

#### Library coverage

**Instruction:**
- org.sonatype.sisu:sisu-inject-bean:1.4.2: 477/13673 (3.49%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: 51/853 (5.98%)

**Line:**
- org.sonatype.sisu:sisu-inject-bean:1.4.2: 111/1240 (8.95%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: 10/225 (4.44%)

**Method:**
- org.sonatype.sisu:sisu-inject-bean:1.4.2: 38/497 (7.65%)
- org.sonatype.sisu:sisu-inject-bean:2.4.1: 5/133 (3.76%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
index 7fd987b2a2..0492ca9288 100644
--- 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertyFieldTest.java
@@ -8,10 +8,9 @@ package org_sonatype_sisu.sisu_inject_bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.BeanProperties;
-import org.sonatype.guice.bean.reflect.BeanProperty;
-import org.sonatype.guice.bean.reflect.IgnoreSetters;
 
 public class BeanPropertyFieldTest {
     @Test
@@ -29,7 +28,6 @@ public class BeanPropertyFieldTest {
         return new BeanProperties(beanType).iterator().next();
     }
 
-    @IgnoreSetters
     private static final class FieldBackedBean {
         private String value;
 
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
index e720d3dbfe..54bcfc3de0 100644
--- 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/BeanPropertySetterTest.java
@@ -8,9 +8,9 @@ package org_sonatype_sisu.sisu_inject_bean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.eclipse.sisu.bean.BeanProperties;
+import org.eclipse.sisu.bean.BeanProperty;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.BeanProperties;
-import org.sonatype.guice.bean.reflect.BeanProperty;
 
 public class BeanPropertySetterTest {
     @Test
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
index cd202482dc..6c8dd509ef 100644
--- 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/DeclaredMembersInnerViewAnonymous1Test.java
@@ -13,9 +13,9 @@ import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.sisu.bean.DeclaredMembers;
+import org.eclipse.sisu.bean.DeclaredMembers.View;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.reflect.DeclaredMembers;
-import org.sonatype.guice.bean.reflect.DeclaredMembers.View;
 
 public class DeclaredMembersInnerViewAnonymous1Test {
     @Test
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
index 8f355d9556..ae0d61e707 100644
--- 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/QualifiedTypeBinderTest.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.sisu.space.QualifiedTypeBinder;
 import org.junit.jupiter.api.Test;
-import org.sonatype.guice.bean.binders.QualifiedTypeBinder;
 
 import com.google.inject.Binder;
 import com.google.inject.Binding;
@@ -41,7 +41,7 @@ public class QualifiedTypeBinderTest {
     private static final class ScanningModule implements Module {
         @Override
         public void configure(Binder binder) {
-            new QualifiedTypeBinder(binder).hear(null, InstalledPrivateConstructorModule.class, SOURCE);
+            new QualifiedTypeBinder(binder).hear(InstalledPrivateConstructorModule.class, SOURCE);
         }
     }
 
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceAnonymous2Test.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceAnonymous2Test.java
new file mode 100644
index 0000000000..2bb8493621
--- /dev/null
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceAnonymous2Test.java
@@ -0,0 +1,42 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.containers.SisuGuice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+public class SisuGuiceAnonymous2Test {
+    @Test
+    void enhancedInjectorDelegatesRegularInjectorMethods() {
+        Injector injector = Guice.createInjector(new ServiceModule());
+        Injector enhancedInjector = SisuGuice.enhance(injector);
+
+        Map<Key<?>, Binding<?>> bindings = enhancedInjector.getBindings();
+
+        assertThat(bindings).containsKey(Key.get(Service.class));
+    }
+
+    private static final class ServiceModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Service.class).toInstance(new Service());
+        }
+    }
+
+    private static final class Service {
+    }
+}
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceTest.java 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceTest.java
new file mode 100644
index 0000000000..1f40a1320d
--- /dev/null
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/src/test/java/org_sonatype_sisu/sisu_inject_bean/SisuGuiceTest.java
@@ -0,0 +1,41 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_sonatype_sisu.sisu_inject_bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.guice.bean.containers.SisuGuice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class SisuGuiceTest {
+    @Test
+    void enhanceWrapsInjectorInDynamicProxy() {
+        Injector injector = Guice.createInjector(new TestModule());
+
+        Injector enhancedInjector = SisuGuice.enhance(injector);
+
+        Class<?> enhancedType = enhancedInjector.getClass();
+        assertThat(Proxy.isProxyClass(enhancedType)).isTrue();
+        assertThat(Injector.class.isAssignableFrom(enhancedType)).isTrue();
+    }
+
+    private static final class TestModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Service.class).toInstance(new Service());
+        }
+    }
+
+    private static final class Service {
+    }
+}
diff --git 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/user-code-filter.json 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
index 239ce5663f..4195427d9b 100644
--- 1/tests/src/org.sonatype.sisu/sisu-inject-bean/1.4.2/user-code-filter.json
+++ 2/tests/src/org.sonatype.sisu/sisu-inject-bean/2.4.1/user-code-filter.json
@@ -4,16 +4,10 @@
       "excludeClasses" : "**"
     },
     {
-      "includeClasses" : "javax.enterprise.inject.**"
+      "includeClasses" : "org.sonatype.guice.bean.**"
     },
     {
-      "includeClasses" : "javax.inject.**"
-    },
-    {
-      "includeClasses" : "org.aopalliance.**"
-    },
-    {
-      "includeClasses" : "org.sonatype.**"
+      "includeClasses" : "org.sonatype.inject.**"
     },
     {
       "includeClasses" : "org_sonatype_sisu.sisu_inject_bean.**"

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
