### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-micrometer-metrics:4.0.6 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/reachability-metadata.json
@@ -1,0 +1,112 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.ClearCachesApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.context.ConfigurationWarningsApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.context.ContextIdApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.context.FileEncodingApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.builder.ParentContextCloserApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.io.ProtocolResolverApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.support.AnsiOutputApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.core.io.support.SpringFactoriesLoader"
+      },
+      "type": "org.springframework.boot.support.EnvironmentPostProcessorApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
+++ b/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.6",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-micrometer-metrics/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-javadoc.jar",
+    "description" : "Spring Boot Micrometer Metrics provides Spring Boot auto-configuration and actuator support for Micrometer metrics. It configures meter registries, common binders, metric export integrations, and related endpoint infrastructure for Spring Boot applications.",
+    "tested-versions" : [
+      "4.0.6"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.micrometer.metrics"
+    ]
+  }
+]

--- a/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
+++ b/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.6",
-    "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-boot",
-    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-micrometer-metrics/src/test",
-    "documentation-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-javadoc.jar",
-    "description" : "Spring Boot Micrometer Metrics provides Spring Boot auto-configuration and actuator support for Micrometer metrics. It configures meter registries, common binders, metric export integrations, and related endpoint infrastructure for Spring Boot applications.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.0.6",
+    "source-code-url": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-boot",
+    "test-code-url": "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-micrometer-metrics/src/test",
+    "documentation-url": "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-javadoc.jar",
+    "description": "Spring Boot Micrometer Metrics provides Spring Boot auto-configuration and actuator support for Micrometer metrics. It configures meter registries, common binders, metric export integrations, and related endpoint infrastructure for Spring Boot applications.",
+    "tested-versions": [
       "4.0.6"
     ],
-    "allowed-packages" : [
-      "org.springframework.boot.micrometer.metrics"
+    "allowed-packages": [
+      "org.springframework.boot.micrometer.metrics",
+      "org.springframework.core.io.support"
     ]
   }
 ]

--- a/stats/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/execution-metrics.json
@@ -1,0 +1,56 @@
+{
+  "add_new_library_support:2026-06-26": {
+    "timestamp": "2026-06-26T13:17:20.814261Z",
+    "library": "org.springframework.boot:spring-boot-micrometer-metrics:4.0.6",
+    "starting_commit": "bada11251b41a27f539c4a33ccf6e9a6670e693e",
+    "ending_commit": "ddc059a143e4bb198cf5033af39be557dbba6a35",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1184,
+          "missed": 5369,
+          "ratio": 0.180681,
+          "total": 6553
+        },
+        "line": {
+          "covered": 281,
+          "missed": 1323,
+          "ratio": 0.175187,
+          "total": 1604
+        },
+        "method": {
+          "covered": 105,
+          "missed": 852,
+          "ratio": 0.109718,
+          "total": 957
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 213017,
+      "cached_input_tokens_used": 1836544,
+      "output_tokens_used": 19684,
+      "iterations": 3,
+      "cost_usd": 1.5088,
+      "generated_loc": 258,
+      "tested_library_loc": 281,
+      "metadata_entries": 18,
+      "code_coverage_percent": 17.52
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/stats.json
+++ b/stats/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1184,
+        "missed" : 5369,
+        "ratio" : 0.180681,
+        "total" : 6553
+      },
+      "line" : {
+        "covered" : 281,
+        "missed" : 1323,
+        "ratio" : 0.175187,
+        "total" : 1604
+      },
+      "method" : {
+        "covered" : 105,
+        "missed" : 852,
+        "ratio" : 0.109718,
+        "total" : 957
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-micrometer-metrics:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-micrometer-metrics:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-actuator:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-micrometer-metrics:4.0.6
+library.version = 4.0.6
+metadata.dir = org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-micrometer-metrics_tests'

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_micrometer_metrics;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_micrometer_metricsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
@@ -17,12 +17,14 @@ import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.simple.CountingMode;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -40,6 +42,8 @@ import org.springframework.boot.micrometer.metrics.autoconfigure.MeterValue;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
 import org.springframework.boot.micrometer.metrics.autoconfigure.PropertiesMeterFilter;
 import org.springframework.boot.micrometer.metrics.autoconfigure.ServiceLevelObjectiveBoundary;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleProperties;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimplePropertiesConfigAdapter;
 import org.springframework.boot.micrometer.metrics.startup.StartupTimeMetricsListener;
 import org.springframework.boot.micrometer.metrics.system.DiskSpaceMetricsBinder;
 
@@ -132,6 +136,35 @@ public class Spring_boot_micrometer_metricsTest {
         assertThat(numericBoundary.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isEqualTo(3.5);
         assertThat(durationBoundary.getValue(Meter.Type.TIMER)).isEqualTo(2_000_000_000.0);
         assertThat(durationBoundary.getValue(Meter.Type.COUNTER)).isNull();
+    }
+
+    @Test
+    void simpleMetricsExportConfigAdapterControlsSimpleRegistryStepCounting() {
+        SimpleProperties properties = new SimpleProperties();
+        properties.setStep(Duration.ofSeconds(1));
+        properties.setMode(CountingMode.STEP);
+        SimplePropertiesConfigAdapter config = new SimplePropertiesConfigAdapter(properties);
+        MockClock clock = new MockClock();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry(config, clock);
+        try {
+            Counter counter = registry.counter("configured.step.requests");
+
+            counter.increment(5.0);
+            assertThat(config.prefix()).isEqualTo("management.simple.metrics.export");
+            assertThat(config.step()).isEqualTo(Duration.ofSeconds(1));
+            assertThat(config.mode()).isEqualTo(CountingMode.STEP);
+            assertThat(counter.count()).isZero();
+
+            clock.add(Duration.ofSeconds(1));
+            assertThat(counter.count()).isEqualTo(5.0);
+            counter.increment(2.0);
+            assertThat(counter.count()).isEqualTo(5.0);
+            clock.add(Duration.ofSeconds(1));
+            assertThat(counter.count()).isEqualTo(2.0);
+        }
+        finally {
+            registry.close();
+        }
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Counter;
@@ -19,13 +20,17 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.boot.micrometer.metrics.MaximumAllowableTagsMeterFilter;
 import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint;
 import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint.AvailableTag;
@@ -35,6 +40,7 @@ import org.springframework.boot.micrometer.metrics.autoconfigure.MeterValue;
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
 import org.springframework.boot.micrometer.metrics.autoconfigure.PropertiesMeterFilter;
 import org.springframework.boot.micrometer.metrics.autoconfigure.ServiceLevelObjectiveBoundary;
+import org.springframework.boot.micrometer.metrics.startup.StartupTimeMetricsListener;
 import org.springframework.boot.micrometer.metrics.system.DiskSpaceMetricsBinder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -147,6 +153,44 @@ public class Spring_boot_micrometer_metricsTest {
             assertThat(registry.find("disk.total").tag("scope", "filesystem").gauges()).hasSize(2);
             assertThat(tags).contains(Tag.of("path", firstPath.getAbsolutePath()),
                     Tag.of("path", secondPath.getAbsolutePath()));
+        }
+        finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void startupTimeMetricsListenerRegistersStartedAndReadyGaugesWithApplicationTags() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            StartupTimeMetricsListener listener = new StartupTimeMetricsListener(registry, "test.application.started",
+                    "test.application.ready", Tags.of("deployment", "test"));
+            SpringApplication application = new SpringApplication(Spring_boot_micrometer_metricsTest.class);
+            application.setMainApplicationClass(Spring_boot_micrometer_metricsTest.class);
+
+            assertThat(listener.supportsEventType(ApplicationStartedEvent.class)).isTrue();
+            assertThat(listener.supportsEventType(ApplicationReadyEvent.class)).isTrue();
+
+            listener.onApplicationEvent(new ApplicationStartedEvent(application, new String[0], null,
+                    Duration.ofMillis(1500)));
+            listener.onApplicationEvent(new ApplicationReadyEvent(application, new String[0], null,
+                    Duration.ofMillis(2750)));
+
+            String mainApplicationClass = Spring_boot_micrometer_metricsTest.class.getName();
+            TimeGauge started = registry.get("test.application.started")
+                .tag("deployment", "test")
+                .tag("main.application.class", mainApplicationClass)
+                .timeGauge();
+            TimeGauge ready = registry.get("test.application.ready")
+                .tag("deployment", "test")
+                .tag("main.application.class", mainApplicationClass)
+                .timeGauge();
+
+            assertThat(started.getId().getDescription()).isEqualTo("Time taken to start the application");
+            assertThat(started.value(TimeUnit.MILLISECONDS)).isEqualTo(1500.0);
+            assertThat(ready.getId().getDescription())
+                .isEqualTo("Time taken for the application to be ready to service requests");
+            assertThat(ready.value(TimeUnit.MILLISECONDS)).isEqualTo(2750.0);
         }
         finally {
             registry.close();

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
@@ -6,11 +6,215 @@
  */
 package org_springframework_boot.spring_boot_micrometer_metrics;
 
-import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-class Spring_boot_micrometer_metricsTest {
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
+import org.springframework.boot.micrometer.metrics.MaximumAllowableTagsMeterFilter;
+import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint.AvailableTag;
+import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint.MetricDescriptor;
+import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint.Sample;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterValue;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsProperties;
+import org.springframework.boot.micrometer.metrics.autoconfigure.PropertiesMeterFilter;
+import org.springframework.boot.micrometer.metrics.autoconfigure.ServiceLevelObjectiveBoundary;
+import org.springframework.boot.micrometer.metrics.system.DiskSpaceMetricsBinder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class Spring_boot_micrometer_metricsTest {
+
+    @TempDir
+    private Path tempDir;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void maximumAllowableTagsFilterDeniesNewTagValuesAfterLimit() {
+        MaximumAllowableTagsMeterFilter filter = new MaximumAllowableTagsMeterFilter("http.server.requests", "uri",
+                2, "Use templated URIs.");
+
+        assertThat(filter.accept(id("http.server.requests", Meter.Type.COUNTER, Tags.of("uri", "/one"))))
+                .isEqualTo(MeterFilterReply.NEUTRAL);
+        assertThat(filter.accept(id("http.server.requests", Meter.Type.COUNTER, Tags.of("uri", "/two"))))
+                .isEqualTo(MeterFilterReply.NEUTRAL);
+        assertThat(filter.accept(id("http.server.requests", Meter.Type.COUNTER, Tags.of("uri", "/one"))))
+                .isEqualTo(MeterFilterReply.NEUTRAL);
+        assertThat(filter.accept(id("http.server.requests", Meter.Type.COUNTER, Tags.of("uri", "/three"))))
+                .isEqualTo(MeterFilterReply.DENY);
+        assertThat(filter.accept(id("http.client.requests", Meter.Type.COUNTER, Tags.of("uri", "/outside"))))
+                .isEqualTo(MeterFilterReply.NEUTRAL);
     }
+
+    @Test
+    void propertiesMeterFilterAppliesCommonTagsAndEnablementByMostSpecificName() {
+        MetricsProperties properties = new MetricsProperties();
+        properties.getTags().put("application", "native-metadata-test");
+        properties.getTags().put("cluster", "test");
+        properties.getEnable().put("all", false);
+        properties.getEnable().put("http.server", true);
+        properties.getEnable().put("http.server.requests", false);
+        PropertiesMeterFilter filter = new PropertiesMeterFilter(properties);
+
+        Meter.Id serverRequests = id("http.server.requests", Meter.Type.TIMER, Tags.of("method", "GET"));
+        Meter.Id serverActive = id("http.server.active", Meter.Type.GAUGE, Tags.empty());
+        Meter.Id unrelated = id("cache.gets", Meter.Type.COUNTER, Tags.empty());
+
+        assertThat(filter.accept(serverRequests)).isEqualTo(MeterFilterReply.DENY);
+        assertThat(filter.accept(serverActive)).isEqualTo(MeterFilterReply.NEUTRAL);
+        assertThat(filter.accept(unrelated)).isEqualTo(MeterFilterReply.DENY);
+        assertThat(filter.map(serverActive).getTags()).contains(Tag.of("application", "native-metadata-test"),
+                Tag.of("cluster", "test"));
+    }
+
+    @Test
+    void propertiesMeterFilterConfiguresDistributionStatisticsForMatchingMeters() {
+        MetricsProperties properties = new MetricsProperties();
+        MetricsProperties.Distribution distribution = properties.getDistribution();
+        distribution.getPercentilesHistogram().put("all", false);
+        distribution.getPercentilesHistogram().put("http.server", true);
+        distribution.getPercentiles().put("http.server.requests", new double[] { 0.5, 0.95 });
+        distribution.getSlo()
+                .put("http.server.requests",
+                        new ServiceLevelObjectiveBoundary[] { ServiceLevelObjectiveBoundary.valueOf("100ms"),
+                                ServiceLevelObjectiveBoundary.valueOf("250ms") });
+        distribution.getMinimumExpectedValue().put("http.server.requests", "10ms");
+        distribution.getMaximumExpectedValue().put("http.server.requests", "2s");
+        distribution.getExpiry().put("http.server", Duration.ofSeconds(30));
+        distribution.getBufferLength().put("http.server", 4);
+        PropertiesMeterFilter filter = new PropertiesMeterFilter(properties);
+
+        Meter.Id requests = id("http.server.requests", Meter.Type.TIMER, Tags.empty());
+        DistributionStatisticConfig config = filter.configure(requests, DistributionStatisticConfig.DEFAULT);
+
+        assertThat(config.isPercentileHistogram()).isTrue();
+        assertThat(config.getPercentiles()).containsExactly(0.5, 0.95);
+        assertThat(config.getServiceLevelObjectiveBoundaries()).containsExactly(100_000_000.0, 250_000_000.0);
+        assertThat(config.getMinimumExpectedValue()).isEqualTo(10_000_000.0);
+        assertThat(config.getMaximumExpectedValue()).isEqualTo(2_000_000_000.0);
+        assertThat(config.getExpiry()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(config.getBufferLength()).isEqualTo(4);
+    }
+
+    @Test
+    void meterValuesAndServiceLevelObjectivesConvertByMeterType() {
+        MeterValue numeric = MeterValue.valueOf("42");
+        MeterValue duration = MeterValue.valueOf("125ms");
+        ServiceLevelObjectiveBoundary numericBoundary = ServiceLevelObjectiveBoundary.valueOf(3.5);
+        ServiceLevelObjectiveBoundary durationBoundary = ServiceLevelObjectiveBoundary.valueOf("2s");
+
+        assertThat(numeric.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isEqualTo(42.0);
+        assertThat(numeric.getValue(Meter.Type.TIMER)).isEqualTo(42_000_000.0);
+        assertThat(duration.getValue(Meter.Type.TIMER)).isEqualTo(125_000_000.0);
+        assertThat(duration.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isNull();
+        assertThat(numericBoundary.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isEqualTo(3.5);
+        assertThat(durationBoundary.getValue(Meter.Type.TIMER)).isEqualTo(2_000_000_000.0);
+        assertThat(durationBoundary.getValue(Meter.Type.COUNTER)).isNull();
+    }
+
+    @Test
+    void diskSpaceBinderRegistersMetersForEveryConfiguredPath() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            File firstPath = this.tempDir.toFile();
+            File secondPath = this.tempDir.getParent().toFile();
+            DiskSpaceMetricsBinder binder = new DiskSpaceMetricsBinder(List.of(firstPath, secondPath),
+                    Tags.of("scope", "filesystem"));
+
+            binder.bindTo(registry);
+
+            List<Tag> tags = registry.getMeters()
+                .stream()
+                .flatMap((meter) -> meter.getId().getTags().stream())
+                .toList();
+            assertThat(registry.find("disk.free").tag("scope", "filesystem").gauges()).hasSize(2);
+            assertThat(registry.find("disk.total").tag("scope", "filesystem").gauges()).hasSize(2);
+            assertThat(tags).contains(Tag.of("path", firstPath.getAbsolutePath()),
+                    Tag.of("path", secondPath.getAbsolutePath()));
+        }
+        finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    void metricsEndpointListsFiltersAndDescribesMeters() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            Counter.builder("library.requests")
+                .description("Requests handled by the library")
+                .baseUnit("requests")
+                .tag("region", "us-east")
+                .tag("status", "ok")
+                .register(registry)
+                .increment(2.0);
+            Counter.builder("library.requests")
+                .description("Requests handled by the library")
+                .baseUnit("requests")
+                .tag("region", "us-east")
+                .tag("status", "failed")
+                .register(registry)
+                .increment(3.0);
+            Counter.builder("library.background").register(registry).increment();
+            MetricsEndpoint endpoint = new MetricsEndpoint(registry);
+
+            assertThat(endpoint.listNames().getNames()).containsExactly("library.background", "library.requests");
+
+            MetricDescriptor allRequests = endpoint.metric("library.requests", null);
+            assertThat(allRequests).isNotNull();
+            assertThat(allRequests.getName()).isEqualTo("library.requests");
+            assertThat(allRequests.getDescription()).isEqualTo("Requests handled by the library");
+            assertThat(allRequests.getBaseUnit()).isEqualTo("requests");
+            assertThat(samplesByStatistic(allRequests)).containsEntry(Statistic.COUNT, 5.0);
+            assertThat(availableTagsByName(allRequests)).containsEntry("region", Set.of("us-east"))
+                .containsEntry("status", Set.of("ok", "failed"));
+
+            MetricDescriptor successfulRequests = endpoint.metric("library.requests", List.of("status:ok"));
+            assertThat(successfulRequests).isNotNull();
+            assertThat(samplesByStatistic(successfulRequests)).containsEntry(Statistic.COUNT, 2.0);
+            assertThat(availableTagsByName(successfulRequests)).containsEntry("region", Set.of("us-east"))
+                .doesNotContainKey("status");
+            assertThat(endpoint.metric("library.requests", List.of("status:missing"))).isNull();
+            assertThat(endpoint.metric("missing", null)).isNull();
+            assertThatThrownBy(() -> endpoint.metric("library.requests", List.of("status")))
+                    .isInstanceOf(InvalidEndpointRequestException.class)
+                    .hasMessageContaining("Each tag parameter must be in the form 'key:value'");
+        }
+        finally {
+            registry.close();
+        }
+    }
+
+    private static Meter.Id id(String name, Meter.Type type, Tags tags) {
+        return new Meter.Id(name, tags, null, null, type);
+    }
+
+    private static Map<Statistic, Double> samplesByStatistic(MetricDescriptor descriptor) {
+        return descriptor.getMeasurements()
+            .stream()
+            .collect(Collectors.toMap(Sample::getStatistic, Sample::getValue));
+    }
+
+    private static Map<String, Set<String>> availableTagsByName(MetricDescriptor descriptor) {
+        return descriptor.getAvailableTags()
+            .stream()
+            .collect(Collectors.toMap(AvailableTag::getTag, AvailableTag::getValues, (first, second) -> first));
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/src/test/java/org_springframework_boot/spring_boot_micrometer_metrics/Spring_boot_micrometer_metricsTest.java
@@ -99,10 +99,10 @@ public class Spring_boot_micrometer_metricsTest {
         MetricsProperties.Distribution distribution = properties.getDistribution();
         distribution.getPercentilesHistogram().put("all", false);
         distribution.getPercentilesHistogram().put("http.server", true);
-        distribution.getPercentiles().put("http.server.requests", new double[] { 0.5, 0.95 });
+        distribution.getPercentiles().put("http.server.requests", new double[] {0.5, 0.95 });
         distribution.getSlo()
                 .put("http.server.requests",
-                        new ServiceLevelObjectiveBoundary[] { ServiceLevelObjectiveBoundary.valueOf("100ms"),
+                        new ServiceLevelObjectiveBoundary[] {ServiceLevelObjectiveBoundary.valueOf("100ms"),
                                 ServiceLevelObjectiveBoundary.valueOf("250ms") });
         distribution.getMinimumExpectedValue().put("http.server.requests", "10ms");
         distribution.getMaximumExpectedValue().put("http.server.requests", "2s");
@@ -161,8 +161,7 @@ public class Spring_boot_micrometer_metricsTest {
             assertThat(counter.count()).isEqualTo(5.0);
             clock.add(Duration.ofSeconds(1));
             assertThat(counter.count()).isEqualTo(2.0);
-        }
-        finally {
+        } finally {
             registry.close();
         }
     }
@@ -186,8 +185,7 @@ public class Spring_boot_micrometer_metricsTest {
             assertThat(registry.find("disk.total").tag("scope", "filesystem").gauges()).hasSize(2);
             assertThat(tags).contains(Tag.of("path", firstPath.getAbsolutePath()),
                     Tag.of("path", secondPath.getAbsolutePath()));
-        }
-        finally {
+        } finally {
             registry.close();
         }
     }
@@ -224,8 +222,7 @@ public class Spring_boot_micrometer_metricsTest {
             assertThat(ready.getId().getDescription())
                 .isEqualTo("Time taken for the application to be ready to service requests");
             assertThat(ready.value(TimeUnit.MILLISECONDS)).isEqualTo(2750.0);
-        }
-        finally {
+        } finally {
             registry.close();
         }
     }
@@ -272,8 +269,7 @@ public class Spring_boot_micrometer_metricsTest {
             assertThatThrownBy(() -> endpoint.metric("library.requests", List.of("status")))
                     .isInstanceOf(InvalidEndpointRequestException.class)
                     .hasMessageContaining("Each tag parameter must be in the form 'key:value'");
-        }
-        finally {
+        } finally {
             registry.close();
         }
     }

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.micrometer.metrics.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-micrometer-metrics/4.0.6/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.micrometer.metrics.**"
+      "includeClasses" : "org.springframework.boot.micrometer.metrics.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_micrometer_metrics.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #7694

This PR introduces tests and metadata for org.springframework.boot:spring-boot-micrometer-metrics:4.0.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 213017
- Cached input tokens: 1836544
- Output tokens: 19684
- Metadata entries: 18
- Iterations: 3
- Library coverage percentage: 17.52
- Generated lines of code: 258
- Tested library lines of code: 281

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1184/6553 (18.07%)
- Line: 281/1604 (17.52%)
- Method: 105/957 (10.97%)

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
