### PR TITLE
[GenAI] Add support for io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha using gpt-5.5

### DIFF
--- a/metadata/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/reachability-metadata.json
+++ b/metadata/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/reachability-metadata.json
@@ -1,0 +1,62 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "type": "io.opentelemetry.api.incubator.trace.ExtendedDefaultTracerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "type": "io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "type": "io.opentelemetry.instrumentation.api.internal.SpanKey[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry"
+      },
+      "type": {
+        "proxy": [
+          "org.apache.kafka.clients.consumer.Consumer"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry"
+      },
+      "type": {
+        "proxy": [
+          "org.apache.kafka.clients.producer.Producer"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "glob": "META-INF/io/opentelemetry/instrumentation/io.opentelemetry.kafka-clients-2.6.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetryBuilder"
+      },
+      "glob": "META-INF/services/io.opentelemetry.instrumentation.api.incubator.instrumenter.InstrumenterCustomizerProvider"
+    }
+  ]
+}

--- a/metadata/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/index.json
+++ b/metadata/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.28.1-alpha",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/instrumentation/opentelemetry-kafka-clients-2.6/$version$/opentelemetry-kafka-clients-2.6-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-java-instrumentation",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/v2.28.1/instrumentation/kafka/kafka-clients/kafka-clients-2.6/library/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/instrumentation/opentelemetry-kafka-clients-2.6/$version$/opentelemetry-kafka-clients-2.6-$version$-javadoc.jar",
+    "description" : "This library provides OpenTelemetry instrumentation for Apache Kafka clients, emitting messaging spans for producers and consumers. It can instrument clients through interceptors or wrappers and bridges internal Kafka client metrics into OpenTelemetry.",
+    "tested-versions" : [
+      "2.28.1-alpha"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.instrumentation.kafkaclients.v2_6"
+    ]
+  }
+]

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/execution-metrics.json
@@ -1,0 +1,107 @@
+{
+  "add_new_library_support:2026-06-26": {
+    "timestamp": "2026-06-26T16:00:19.152583Z",
+    "library": "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha",
+    "starting_commit": "32b43b96fa693f81d26bb28c7d0b2435d959d7cd",
+    "ending_commit": "115e614f6d96afe346114f03a0737278b433e9fc",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.28.1-alpha",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 4,
+            "totalCalls": 4
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 4,
+        "totalCalls": 4
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 269,
+          "missed": 611,
+          "ratio": 0.305682,
+          "total": 880
+        },
+        "line": {
+          "covered": 70,
+          "missed": 153,
+          "ratio": 0.313901,
+          "total": 223
+        },
+        "method": {
+          "covered": 16,
+          "missed": 32,
+          "ratio": 0.333333,
+          "total": 48
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8542,
+      "issue_label": "library-new-request",
+      "library": "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha",
+      "summary": "The artifact is OpenTelemetry library instrumentation for Kafka clients and does not transitively provide org.apache.kafka client classes; its public API and normal usage require a Kafka client dependency before meaningful tests can compile and exercise wrapping/interceptor behavior.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.kafka:kafka-clients:2.6.0",
+          "scope": "testImplementation",
+          "reason": "Upstream instrumentation declares kafka-clients 2.6.0 as the instrumented library dependency, while the published instrumentation artifact only carries OpenTelemetry/runtime instrumentation dependencies. KafkaTelemetry and related APIs reference Producer, Consumer, ProducerRecord, ConsumerRecords, i\n...[truncated]"
+        }
+      ],
+      "agent_guidance": "Prefer Kafka's in-memory MockProducer and MockConsumer plus ProducerRecord/ConsumerRecords to exercise KafkaTelemetry.wrap, producerInterceptorConfigProperties, consumerInterceptorConfigProperties, and metricConfigProperties without starting a Kafka broker. No environment variable or system property appears required for basic generated coverage.",
+      "risks": [
+        "Full end-to-end broker interaction would require Testcontainers/Kafka setup, but the Kafka client artifact includes mocks that should make meaningful reachability coverage possible without Docker.",
+        "Using newer kafka-clients versions may also work because the module targets Kafka clients 2.6+, but 2.6.0 is the concrete upstream library baseline for this instrumentation module."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.kafka:kafka-clients:2.6.0",
+          "result": "applied",
+          "target": "tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8542 Support for io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 65581,
+      "output_tokens_used": 2531,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T15-48-03-249062Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 59586,
+      "cached_input_tokens_used": 370688,
+      "output_tokens_used": 5972,
+      "iterations": 1,
+      "cost_usd": 0.3645,
+      "generated_loc": 73,
+      "tested_library_loc": 70,
+      "metadata_entries": 8,
+      "code_coverage_percent": 31.39
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/Opentelemetry_kafka_clients_2_6Test.java",
+      "metadata_file": "metadata/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/stats.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.28.1-alpha",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 4,
+          "totalCalls" : 4
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 4,
+      "totalCalls" : 4
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 269,
+        "missed" : 611,
+        "ratio" : 0.305682,
+        "total" : 880
+      },
+      "line" : {
+        "covered" : 70,
+        "missed" : 153,
+        "ratio" : 0.313901,
+        "total" : 223
+      },
+      "method" : {
+        "covered" : 16,
+        "missed" : 32,
+        "ratio" : 0.333333,
+        "total" : 48
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/.gitignore
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/build.gradle
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.apache.kafka:kafka-clients:2.6.0"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/gradle.properties
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha
+library.version = 2.28.1-alpha
+metadata.dir = io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/settings.gradle
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.instrumentation.opentelemetry-kafka-clients-2.6_tests'

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/KafkaTelemetryTest.java
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/KafkaTelemetryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry_instrumentation.opentelemetry_kafka_clients_2_6;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.kafkaclients.v2_6.KafkaTelemetry;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+public class KafkaTelemetryTest {
+    @Test
+    void wrapsProducerWithDynamicProxyAndDelegatesNonSendMethods() {
+        KafkaTelemetry kafkaTelemetry = KafkaTelemetry.create(OpenTelemetry.noop());
+        MockProducer<String, String> mockProducer = new MockProducer<>(
+                true,
+                new StringSerializer(),
+                new StringSerializer());
+
+        Producer<String, String> wrappedProducer = kafkaTelemetry.wrap(mockProducer);
+
+        assertThat(wrappedProducer).isNotSameAs(mockProducer);
+        Map<MetricName, ? extends Metric> metrics = wrappedProducer.metrics();
+
+        assertThat(metrics).isEmpty();
+    }
+
+    @Test
+    void wrapsConsumerWithDynamicProxyAndDelegatesNonPollMethods() {
+        KafkaTelemetry kafkaTelemetry = KafkaTelemetry.create(OpenTelemetry.noop());
+        MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.subscribe(Collections.singleton("telemetry-topic"));
+
+        Consumer<String, String> wrappedConsumer = kafkaTelemetry.wrap(mockConsumer);
+
+        assertThat(wrappedConsumer).isNotSameAs(mockConsumer);
+        Set<String> subscription = wrappedConsumer.subscription();
+
+        assertThat(subscription).containsExactly("telemetry-topic");
+    }
+
+    @Test
+    void exposesInterceptorAndMetricsConfigurationProperties() {
+        KafkaTelemetry kafkaTelemetry = KafkaTelemetry.create(OpenTelemetry.noop());
+
+        Map<String, ?> producerInterceptorConfig =
+                kafkaTelemetry.producerInterceptorConfigProperties();
+        Map<String, ?> consumerInterceptorConfig =
+                kafkaTelemetry.consumerInterceptorConfigProperties();
+        Map<String, ?> metricConfig = kafkaTelemetry.metricConfigProperties();
+
+        assertThat(producerInterceptorConfig)
+                .containsKeys(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG);
+        assertThat(consumerInterceptorConfig)
+                .containsKeys(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG);
+        assertThat(metricConfig)
+                .containsKeys(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG);
+    }
+}

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/Opentelemetry_kafka_clients_2_6Test.java
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/Opentelemetry_kafka_clients_2_6Test.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry_instrumentation.opentelemetry_kafka_clients_2_6;
+
+import org.junit.jupiter.api.Test;
+
+class Opentelemetry_kafka_clients_2_6Test {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/Opentelemetry_kafka_clients_2_6Test.java
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/src/test/java/io_opentelemetry_instrumentation/opentelemetry_kafka_clients_2_6/Opentelemetry_kafka_clients_2_6Test.java
@@ -6,11 +6,5 @@
  */
 package io_opentelemetry_instrumentation.opentelemetry_kafka_clients_2_6;
 
-import org.junit.jupiter.api.Test;
-
-class Opentelemetry_kafka_clients_2_6Test {
-    @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
-    }
+public class Opentelemetry_kafka_clients_2_6Test {
 }

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.opentelemetry.instrumentation.kafkaclients.v2_6.**"
+      "includeClasses" : "io.opentelemetry.instrumentation.kafkaclients.v2_6.**"
+    },
+    {
+      "includeClasses" : "io_opentelemetry_instrumentation.opentelemetry_kafka_clients_2_6.**"
     }
   ]
 }

--- a/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.instrumentation.kafkaclients.v2_6.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8542

This PR introduces tests and metadata for io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 59586
- Cached input tokens: 370688
- Output tokens: 5972
- Metadata entries: 8
- Iterations: 1
- Library coverage percentage: 31.39
- Generated lines of code: 73
- Tested library lines of code: 70

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `beff17b2aff10b776bba944be7c0ad4ca847ac3b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 4/4 covered calls (100.00%)
- Reflection: 4/4 covered calls (100.00%)

Library coverage:
- Instruction: 269/880 (30.57%)
- Line: 70/223 (31.39%)
- Method: 16/48 (33.33%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
