### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-liquibase as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-liquibase/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-liquibase/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-liquibase:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-liquibase:4.1.0, org.springframework.boot:spring-boot-jdbc:4.1.0, and org.liquibase:liquibase-core:5.0.3."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8461

This PR records `org.springframework.boot:spring-boot-starter-liquibase` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-liquibase:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-liquibase:4.1.0, org.springframework.boot:spring-boot-jdbc:4.1.0, and org.liquibase:liquibase-core:5.0.3.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
