### PR TITLE
[GenAI] Test fix for jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1 using gpt-5.5

### DIFF
--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
@@ -1,32 +1,32 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "UnqualifiedJaxbContextFactory",
-      "methods": [
+      "type" : "UnqualifiedJaxbContextFactory",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "UnqualifiedJaxbContextFactory"
+      "type" : "UnqualifiedJaxbContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "UnqualifiedLegacyContextFactory",
-      "methods": [
+      "type" : "UnqualifiedLegacyContextFactory",
+      "methods" : [
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.ClassLoader"
           ]
@@ -34,28 +34,28 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "UnqualifiedLegacyContextFactory"
+      "type" : "UnqualifiedLegacyContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "UnqualifiedPropertiesContextFactory",
-      "methods": [
+      "type" : "UnqualifiedPropertiesContextFactory",
+      "methods" : [
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.ClassLoader",
             "java.util.Map"
           ]
         },
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.Class[]",
             "java.util.Map"
           ]
@@ -63,20 +63,20 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "UnqualifiedPropertiesContextFactory"
+      "type" : "UnqualifiedPropertiesContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "UnqualifiedWrongTypeContextFactory",
-      "methods": [
+      "type" : "UnqualifiedWrongTypeContextFactory",
+      "methods" : [
         {
-          "name": "createContext",
-          "parameterTypes": [
+          "name" : "createContext",
+          "parameterTypes" : [
             "java.lang.Class[]",
             "java.util.Map"
           ]
@@ -84,84 +84,66 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "UnqualifiedWrongTypeContextFactory"
+      "type" : "UnqualifiedWrongTypeContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "jakarta.xml.bind.JAXBContextFactory"
+      "type" : "jakarta.xml.bind.JAXBContextFactory"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ModuleUtil"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "java.lang.String[]"
-    },
-    {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
-      },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.ContextFinder"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
       },
-      "glob": "jakarta/xml/bind/JAXBContext.class"
+      "glob" : "jakarta/xml/bind/JAXBContext.class"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.Messages"
       },
-      "bundle": "jakarta.xml.bind.Messages"
+      "bundle" : "jakarta.xml.bind.Messages"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.helpers.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.helpers.Messages"
       },
-      "bundle": "jakarta.xml.bind.helpers.Messages"
+      "bundle" : "jakarta.xml.bind.helpers.Messages"
     },
     {
-      "condition": {
-        "typeReached": "jakarta.xml.bind.util.Messages"
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.util.Messages"
       },
-      "bundle": "jakarta.xml.bind.util.Messages"
+      "bundle" : "jakarta.xml.bind.util.Messages"
     }
   ]
 }

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json
@@ -1,0 +1,167 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "UnqualifiedJaxbContextFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "UnqualifiedJaxbContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "UnqualifiedLegacyContextFactory",
+      "methods": [
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "UnqualifiedLegacyContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "UnqualifiedPropertiesContextFactory",
+      "methods": [
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "UnqualifiedPropertiesContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "UnqualifiedWrongTypeContextFactory",
+      "methods": [
+        {
+          "name": "createContext",
+          "parameterTypes": [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "UnqualifiedWrongTypeContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta.xml.bind.JAXBContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ModuleUtil"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "type": "java.lang.reflect.Method[]"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.ContextFinder"
+      },
+      "glob": "jakarta/xml/bind/JAXBContext.class"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.Messages"
+      },
+      "bundle": "jakarta.xml.bind.Messages"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.helpers.Messages"
+      },
+      "bundle": "jakarta.xml.bind.helpers.Messages"
+    },
+    {
+      "condition": {
+        "typeReached": "jakarta.xml.bind.util.Messages"
+      },
+      "bundle": "jakarta.xml.bind.util.Messages"
+    }
+  ]
+}

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "4.1.0-M1",
+    "tested-versions" : [
+      "4.1.0-M1"
+    ],
+    "allowed-packages" : [
+      "jakarta.xml.bind"
+    ]
+  },
+  {
     "metadata-version" : "4.0.0",
     "tested-versions" : [
       "4.0.0",

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "4.1.0-M1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/$version$/jakarta.xml.bind-api-$version$-sources.jar",
+    "repository-url" : "https://github.com/jakartaee/jaxb-api",
+    "test-code-url" : "https://github.com/jakartaee/jaxb-api/tree/$version$/jaxb-api-test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/$version$/jakarta.xml.bind-api-$version$-javadoc.jar",
+    "description" : "Jakarta XML Binding API defines the standard Jakarta API for binding Java classes to XML representations. It provides annotations and runtime interfaces for marshalling, unmarshalling, and validating XML content in Java applications.",
     "tested-versions" : [
       "4.1.0-M1"
     ],

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/execution-metrics.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-26": {
+    "timestamp": "2026-06-26T18:10:56.367255Z",
+    "library": "jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1",
+    "starting_commit": "94f5a1c0f3ef4d11971923508701eb76a3365c8a",
+    "ending_commit": "c095ffa20d6dcd6085d345843f30c9b5e7d12e6a",
+    "previous_library": "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0-M1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 19,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 25,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 835,
+          "missed": 6000,
+          "ratio": 0.122165,
+          "total": 6835
+        },
+        "line": {
+          "covered": 197,
+          "missed": 1519,
+          "ratio": 0.114802,
+          "total": 1716
+        },
+        "method": {
+          "covered": 45,
+          "missed": 409,
+          "ratio": 0.099119,
+          "total": 454
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "4.0.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.947368,
+            "coveredCalls": 18,
+            "totalCalls": 19
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 0.96,
+        "coveredCalls": 24,
+        "totalCalls": 25
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 822,
+          "missed": 6066,
+          "ratio": 0.119338,
+          "total": 6888
+        },
+        "line": {
+          "covered": 196,
+          "missed": 1489,
+          "ratio": 0.11632,
+          "total": 1685
+        },
+        "method": {
+          "covered": 49,
+          "missed": 417,
+          "ratio": 0.10515,
+          "total": 466
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 214085,
+      "cached_input_tokens_used": 1643008,
+      "output_tokens_used": 17338,
+      "iterations": 3,
+      "cost_usd": 1.3416,
+      "tested_library_loc": 197,
+      "metadata_entries": 22,
+      "test_only_metadata_entries": 31,
+      "previous_library_metadata_entries": 20,
+      "previous_library_test_only_metadata_entries": 29,
+      "code_coverage_percent": 11.48,
+      "previous_library_coverage_percent": 11.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java",
+      "metadata_file": "metadata/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/stats.json
+++ b/stats/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0-M1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 19,
+          "totalCalls" : 19
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 25,
+      "totalCalls" : 25
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 835,
+        "missed" : 6000,
+        "ratio" : 0.122165,
+        "total" : 6835
+      },
+      "line" : {
+        "covered" : 197,
+        "missed" : 1519,
+        "ratio" : 0.114802,
+        "total" : 1716
+      },
+      "method" : {
+        "covered" : 45,
+        "missed" : 409,
+        "ratio" : 0.099119,
+        "total" : 454
+      }
+    }
+  } ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/.gitignore
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "jakarta.xml.bind:jakarta.xml.bind-api:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}
+
+tasks.named("test") {
+    if ((JavaVersion.current().majorVersion as int) < 24) {
+        jvmArgs += ["-Djava.security.manager=allow"]
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/gradle.properties
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1
+library.version = 4.1.0-M1
+metadata.dir = jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/settings.gradle
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'jakarta.xml.bind.jakarta.xml.bind-api_tests'

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedJaxbContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedJaxbContextFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class UnqualifiedJaxbContextFactory extends FactoryBackedContextFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedLegacyContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedLegacyContextFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+
+public final class UnqualifiedLegacyContextFactory {
+    private UnqualifiedLegacyContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader) {
+        return LegacyContextFactory.createContext(contextPath, classLoader);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedPropertiesContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedPropertiesContextFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+
+public final class UnqualifiedPropertiesContextFactory {
+    private UnqualifiedPropertiesContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<?, ?> properties) {
+        return PropertiesContextFactory.createContext(contextPath, classLoader, properties);
+    }
+
+    public static JAXBContext createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return PropertiesContextFactory.createContext(classes, properties);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import java.util.Map;
+
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
+
+public final class UnqualifiedWrongTypeContextFactory {
+    private UnqualifiedWrongTypeContextFactory() {
+    }
+
+    public static Object createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return WrongTypeContextFactory.createContext(classes, properties);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta/xml/bind/ServiceLoaderUtilInvoker.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta.xml.bind;
+
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class ServiceLoaderUtilInvoker {
+    private static final ServiceLoaderUtil.ExceptionHandler<JAXBException> EXCEPTION_HANDLER =
+            new ServiceLoaderUtil.ExceptionHandler<>() {
+                @Override
+                public JAXBException createException(Throwable throwable, String message) {
+                    return new JAXBException(message, throwable);
+                }
+            };
+
+    private ServiceLoaderUtilInvoker() {
+    }
+
+    public static FactoryBackedContextFactory instantiateFactoryBackedContextFactory() throws JAXBException {
+        return (FactoryBackedContextFactory) ServiceLoaderUtil.newInstance(
+                FactoryBackedContextFactory.class.getName(),
+                FactoryBackedContextFactory.class.getName(),
+                EXCEPTION_HANDLER);
+    }
+
+    public static Class<?> loadFactoryBackedContextFactory(ClassLoader classLoader) throws ClassNotFoundException {
+        return ServiceLoaderUtil.safeLoadClass(
+                FactoryBackedContextFactory.class.getName(),
+                FactoryBackedContextFactory.class.getName(),
+                classLoader);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ContextFinderTest {
+    private static final String PROPERTIES_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties";
+    private static final String SERVICE_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
+
+    @Test
+    public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                PROPERTIES_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(
+                        JAXBContext.JAXB_CONTEXT_FACTORY,
+                        PropertiesContextFactory.class.getName(),
+                        "trigger",
+                        "jaxb-properties"));
+
+        assertContextSource(context, "properties-context-path-factory");
+    }
+
+    @Test
+    public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                new Class<?>[] {PropertiesBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+
+        assertContextSource(context, "properties-classes-factory");
+    }
+
+    @Test
+    public void loadsServiceProviderForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                SERVICE_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of());
+
+        assertContextSource(context, "service-context-factory-string");
+    }
+
+    @Test
+    public void loadsLegacyTwoArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                PROPERTIES_CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+
+        assertContextSource(context, "legacy-context-path-factory");
+    }
+
+    @Test
+    public void instantiatesJaxbContextFactoryImplementations() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                new Class<?>[] {FactoryBackedBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+
+        assertContextSource(context, "factory-backed-classes-factory");
+    }
+
+    @Test
+    public void loadsServiceProviderForBoundClassesWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertContextSource(context, "service-context-factory-classes");
+    }
+
+    @Test
+    public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
+        assertThatThrownBy(() -> JAXBContext.newInstance(
+                new Class<?>[] {WrongTypeBoundType.class},
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                .isInstanceOf(JAXBException.class)
+                .hasMessageContaining("ClassCastException");
+    }
+
+    private static void assertContextSource(JAXBContext context, String expectedSource) {
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo(expectedSource);
+    }
+
+    private static <T> T withContextClassLoader(
+            ClassLoader classLoader,
+            ThrowingSupplier<T> supplier) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            return supplier.get();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -13,11 +13,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +25,11 @@ public class ContextFinderTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties";
     private static final String SERVICE_CONTEXT_PATH =
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
+    // JAXB 4.1 checks package access for qualified provider class names before loading them.
+    private static final String PROPERTIES_CONTEXT_FACTORY = "UnqualifiedPropertiesContextFactory";
+    private static final String LEGACY_CONTEXT_FACTORY = "UnqualifiedLegacyContextFactory";
+    private static final String JAXB_CONTEXT_FACTORY = "UnqualifiedJaxbContextFactory";
+    private static final String WRONG_TYPE_CONTEXT_FACTORY = "UnqualifiedWrongTypeContextFactory";
 
     @Test
     public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
@@ -37,7 +38,7 @@ public class ContextFinderTest {
                 getClass().getClassLoader(),
                 Map.of(
                         JAXBContext.JAXB_CONTEXT_FACTORY,
-                        PropertiesContextFactory.class.getName(),
+                        PROPERTIES_CONTEXT_FACTORY,
                         "trigger",
                         "jaxb-properties"));
 
@@ -48,7 +49,7 @@ public class ContextFinderTest {
     public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 new Class<?>[] {PropertiesBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PROPERTIES_CONTEXT_FACTORY));
 
         assertContextSource(context, "properties-classes-factory");
     }
@@ -68,7 +69,7 @@ public class ContextFinderTest {
         JAXBContext context = JAXBContext.newInstance(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LEGACY_CONTEXT_FACTORY));
 
         assertContextSource(context, "legacy-context-path-factory");
     }
@@ -77,7 +78,7 @@ public class ContextFinderTest {
     public void instantiatesJaxbContextFactoryImplementations() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 new Class<?>[] {FactoryBackedBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, JAXB_CONTEXT_FACTORY));
 
         assertContextSource(context, "factory-backed-classes-factory");
     }
@@ -93,7 +94,7 @@ public class ContextFinderTest {
     public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
         assertThatThrownBy(() -> JAXBContext.newInstance(
                 new Class<?>[] {WrongTypeBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WRONG_TYPE_CONTEXT_FACTORY)))
                 .isInstanceOf(JAXBException.class)
                 .hasMessageContaining("ClassCastException");
     }

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/HelpersMessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/HelpersMessagesTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.helpers.ValidationEventLocatorImpl;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.Locator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class HelpersMessagesTest {
+    @Test
+    public void formatsHelperMessagesFromTheResourceBundle() {
+        assertThatThrownBy(() -> new ValidationEventLocatorImpl((Locator) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("loc");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/MessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/MessagesTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.PropertyException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessagesTest {
+    @Test
+    public void formatsPropertyExceptionMessagesFromTheResourceBundle() {
+        PropertyException exception = new PropertyException("example.property", 7);
+
+        assertThat(exception.getMessage()).contains("example.property").contains("7");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModuleUtilTest {
+    private static final String CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties"
+                    + ":jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed";
+
+    @Test
+    public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(
+                CONTEXT_PATH,
+                getClass().getClassLoader(),
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -9,7 +9,6 @@ package jakarta_xml_bind.jakarta_xml_bind_api;
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +18,14 @@ public class ModuleUtilTest {
     private static final String CONTEXT_PATH =
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties"
                     + ":jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed";
+    private static final String PROPERTIES_CONTEXT_FACTORY = "UnqualifiedPropertiesContextFactory";
 
     @Test
     public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PROPERTIES_CONTEXT_FACTORY));
 
         assertThat(context).isInstanceOf(StubJaxbContext.class);
         assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.Permission;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.ServiceLoaderUtilInvoker;
+import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServiceLoaderUtilTest {
+    private static final String OSGI_CONTEXT_PATH =
+            "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi";
+    private static final String JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE =
+            "META-INF/services/jakarta.xml.bind.JAXBContextFactory";
+
+    @Test
+    public void loadsProviderClassUsingContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(
+                getClass().getClassLoader(),
+                () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("service-context-factory-classes");
+    }
+
+    @Test
+    public void loadsProviderClassWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(null, () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("service-context-factory-classes");
+    }
+
+    @Test
+    public void instantiatesProviderClassByName() throws Exception {
+        Object provider = withContextClassLoader(
+                null,
+                ServiceLoaderUtilInvoker::instantiateFactoryBackedContextFactory);
+
+        assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void fallsBackToClassForNameWhenDefaultImplementationPackageAccessIsDenied() throws Exception {
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        PackageAccessDenyingSecurityManager securityManager =
+                new PackageAccessDenyingSecurityManager(FactoryBackedContextFactory.class.getPackage().getName());
+        boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+
+        try {
+            Class<?> providerClass = ServiceLoaderUtilInvoker.loadFactoryBackedContextFactory(
+                    getClass().getClassLoader());
+
+            assertThat(providerClass).isEqualTo(FactoryBackedContextFactory.class);
+            if (securityManagerInstalled) {
+                assertThat(securityManager.wasCheckPackageAccessCalled()).isTrue();
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
+    @Test
+    public void loadsContextPathProviderFromOsgiLocatorWhenServiceResourceIsAbsent() throws Exception {
+        ClassLoader classLoader = new ServiceResourceHidingClassLoader(getClass().getClassLoader());
+
+        JAXBContext context = withContextClassLoader(
+                classLoader,
+                () -> JAXBContext.newInstance(OSGI_CONTEXT_PATH, classLoader, Map.of()));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-context-path-factory");
+    }
+
+    @Test
+    public void loadsClassProviderFromOsgiLocatorWhenServiceResourceIsAbsent() throws Exception {
+        ClassLoader classLoader = new ServiceResourceHidingClassLoader(getClass().getClassLoader());
+
+        JAXBContext context = withContextClassLoader(
+                classLoader,
+                () -> JAXBContext.newInstance(ServiceBoundType.class));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-classes-factory");
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
+    private static <T> T withContextClassLoader(
+            ClassLoader classLoader,
+            ThrowingSupplier<T> supplier) throws Exception {
+        Thread currentThread = Thread.currentThread();
+        ClassLoader previousClassLoader = currentThread.getContextClassLoader();
+        currentThread.setContextClassLoader(classLoader);
+        try {
+            return supplier.get();
+        } finally {
+            currentThread.setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @SuppressWarnings("removal")
+    private static final class PackageAccessDenyingSecurityManager extends SecurityManager {
+        private final String deniedPackageName;
+        private boolean checkPackageAccessCalled;
+
+        private PackageAccessDenyingSecurityManager(String deniedPackageName) {
+            this.deniedPackageName = deniedPackageName;
+        }
+
+        @Override
+        public void checkPermission(Permission permission) {
+        }
+
+        @Override
+        public void checkPackageAccess(String packageName) {
+            if (deniedPackageName.equals(packageName)) {
+                checkPackageAccessCalled = true;
+                throw new SecurityException(packageName);
+            }
+        }
+
+        private boolean wasCheckPackageAccessCalled() {
+            return checkPackageAccessCalled;
+        }
+    }
+
+    private static final class ServiceResourceHidingClassLoader extends ClassLoader {
+        private ServiceResourceHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return Collections.emptyEnumeration();
+            }
+            return super.getResources(name);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (JAXB_CONTEXT_FACTORY_SERVICE_RESOURCE.equals(name)) {
+                return null;
+            }
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.ServiceLoaderUtilInvoker;
+import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
@@ -54,6 +55,18 @@ public class ServiceLoaderUtilTest {
                 ServiceLoaderUtilInvoker::instantiateFactoryBackedContextFactory);
 
         assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
+    }
+
+    @Test
+    public void loadsProviderClassByNameWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(
+                null,
+                () -> JAXBContext.newInstance(
+                        new Class<?>[] {FactoryBackedBoundType.class},
+                        Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, "UnqualifiedJaxbContextFactory")));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-classes-factory");
     }
 
     @Test

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/UtilMessagesTest.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/UtilMessagesTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.util.JAXBResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class UtilMessagesTest {
+    @Test
+    public void formatsUtilMessagesFromTheResourceBundle() {
+        assertThatThrownBy(() -> new JAXBResult((JAXBContext) null))
+                .isInstanceOf(JAXBException.class);
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/classproperties/PropertiesBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/classproperties/PropertiesBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.classproperties;
+
+public final class PropertiesBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/IndexedBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/IndexedBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed;
+
+public final class IndexedBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/osgi/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/osgi/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/properties/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/properties/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/service/ObjectFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/service/ObjectFactory.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service;
+
+public class ObjectFactory {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/factorybacked/FactoryBackedBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/factorybacked/FactoryBackedBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.factorybacked;
+
+public final class FactoryBackedBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/servicebound/ServiceBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/servicebound/ServiceBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.servicebound;
+
+public final class ServiceBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/FactoryBackedContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/FactoryBackedContextFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta.xml.bind.JAXBException;
+
+public class FactoryBackedContextFactory implements JAXBContextFactory {
+    @Override
+    public JAXBContext createContext(Class<?>[] classesToBeBound, Map<String, ?> properties) throws JAXBException {
+        return new StubJaxbContext("factory-backed-classes-factory");
+    }
+
+    @Override
+    public JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<String, ?> properties)
+            throws JAXBException {
+        return new StubJaxbContext("factory-backed-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/LegacyContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/LegacyContextFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import jakarta.xml.bind.JAXBContext;
+
+public final class LegacyContextFactory {
+    private LegacyContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader) {
+        return new StubJaxbContext("legacy-context-path-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/PropertiesContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/PropertiesContextFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+
+public final class PropertiesContextFactory {
+    private PropertiesContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<?, ?> properties) {
+        return new StubJaxbContext("properties-context-path-factory");
+    }
+
+    public static JAXBContext createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return new StubJaxbContext("properties-classes-factory");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/ServiceContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/ServiceContextFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta.xml.bind.JAXBException;
+
+public final class ServiceContextFactory implements JAXBContextFactory {
+    @Override
+    public JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<String, ?> properties)
+            throws JAXBException {
+        return new StubJaxbContext("service-context-factory-string");
+    }
+
+    @Override
+    public JAXBContext createContext(Class<?>[] classes, Map<String, ?> properties) throws JAXBException {
+        return new StubJaxbContext("service-context-factory-classes");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/StubJaxbContext.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/StubJaxbContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+public class StubJaxbContext extends JAXBContext {
+    private final String source;
+
+    public StubJaxbContext(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public Unmarshaller createUnmarshaller() throws JAXBException {
+        throw new UnsupportedOperationException("Unmarshaller is not needed for this test");
+    }
+
+    @Override
+    public Marshaller createMarshaller() throws JAXBException {
+        throw new UnsupportedOperationException("Marshaller is not needed for this test");
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeContextFactory.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeContextFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+import java.util.Map;
+
+public final class WrongTypeContextFactory {
+    private WrongTypeContextFactory() {
+    }
+
+    public static Object createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return new WrongTypeReturnValue();
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeReturnValue.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/support/WrongTypeReturnValue.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.support;
+
+public final class WrongTypeReturnValue {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/wrongtype/WrongTypeBoundType.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/wrongtype/WrongTypeBoundType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package jakarta_xml_bind.jakarta_xml_bind_api.wrongtype;
+
+public final class WrongTypeBoundType {
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/org/glassfish/hk2/osgiresourcelocator/ServiceLoader.java
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/org/glassfish/hk2/osgiresourcelocator/ServiceLoader.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.glassfish.hk2.osgiresourcelocator;
+
+import java.util.Collections;
+
+import jakarta.xml.bind.JAXBContextFactory;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class ServiceLoader {
+    private ServiceLoader() {
+    }
+
+    public static <T> Iterable<Class<? extends T>> lookupProviderClasses(Class<T> serviceClass) {
+        if (serviceClass != JAXBContextFactory.class) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(FactoryBackedContextFactory.class.asSubclass(serviceClass));
+    }
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,197 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        },
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.ClassLoader",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.IndexedBoundType"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.ObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "createContext",
+          "parameterTypes" : [
+            "java.lang.Class[]",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder$2"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtilInvoker"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "glob" : "META-INF/services/jakarta.xml.bind.JAXBContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ModuleUtil"
+      },
+      "glob" : "jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "glob" : "META-INF/services/jakarta.xml.bind.JAXBContextFactory"
+    }
+  ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -172,6 +172,18 @@
         "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
       },
       "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ContextFinder"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "jakarta.xml.bind.ServiceLoaderUtil"
+      },
+      "type" : "jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory"
     }
   ],
   "resources" : [

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
@@ -1,0 +1,1 @@
+jakarta_xml_bind.jakarta_xml_bind_api.support.ServiceContextFactory

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/resources/jakarta_xml_bind/jakarta_xml_bind_api/contextpath/indexed/jaxb.index
@@ -1,0 +1,1 @@
+IndexedBoundType

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "jakarta.xml.bind.**"
+    }
+  ]
+}

--- a/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
+++ b/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -5,6 +5,39 @@
     },
     {
       "includeClasses" : "jakarta.xml.bind.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.servicebound.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.classproperties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.support.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.osgiresourcelocator.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #4422

This PR provides test fixes and new metadata for jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 214085
- Cached input tokens: 1643008
- Output tokens: 17338
- Metadata entries: 22
- Test-only metadata entries: 31
- Iterations: 3
- Library coverage percentage: 11.48
- Previous library version metadata entries: 20
- Previous library version test-only metadata entries: 29
- Previous library version coverage percentage: 11.63

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 24/25 covered calls (96.00%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 25/25 covered calls (100.00%)

**Reflection:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 18/19 covered calls (94.74%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 19/19 covered calls (100.00%)

**Resources:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 6/6 covered calls (100.00%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 822/6888 (11.93%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 835/6835 (12.22%)

**Line:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 196/1685 (11.63%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 197/1716 (11.48%)

**Method:**
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.0: 49/466 (10.51%)
- jakarta.xml.bind:jakarta.xml.bind-api:4.1.0-M1: 45/454 (9.91%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/build.gradle 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
index ca0d90b568..48e8527e44 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/build.gradle
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/build.gradle
@@ -25,3 +25,9 @@ graalvmNative {
         }
     }
 }
+
+tasks.named("test") {
+    if ((JavaVersion.current().majorVersion as int) < 24) {
+        jvmArgs += ["-Djava.security.manager=allow"]
+    }
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedJaxbContextFactory.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedJaxbContextFactory.java
new file mode 100644
index 0000000000..78a86b4daa
--- /dev/null
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedJaxbContextFactory.java
@@ -0,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
+
+public final class UnqualifiedJaxbContextFactory extends FactoryBackedContextFactory {
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedLegacyContextFactory.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedLegacyContextFactory.java
new file mode 100644
index 0000000000..3850187876
--- /dev/null
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedLegacyContextFactory.java
@@ -0,0 +1,17 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
+
+public final class UnqualifiedLegacyContextFactory {
+    private UnqualifiedLegacyContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader) {
+        return LegacyContextFactory.createContext(contextPath, classLoader);
+    }
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedPropertiesContextFactory.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedPropertiesContextFactory.java
new file mode 100644
index 0000000000..327b370a6f
--- /dev/null
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedPropertiesContextFactory.java
@@ -0,0 +1,23 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import java.util.Map;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
+
+public final class UnqualifiedPropertiesContextFactory {
+    private UnqualifiedPropertiesContextFactory() {
+    }
+
+    public static JAXBContext createContext(String contextPath, ClassLoader classLoader, Map<?, ?> properties) {
+        return PropertiesContextFactory.createContext(contextPath, classLoader, properties);
+    }
+
+    public static JAXBContext createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return PropertiesContextFactory.createContext(classes, properties);
+    }
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java
new file mode 100644
index 0000000000..b868d73ad6
--- /dev/null
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/UnqualifiedWrongTypeContextFactory.java
@@ -0,0 +1,18 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+import java.util.Map;
+
+import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
+
+public final class UnqualifiedWrongTypeContextFactory {
+    private UnqualifiedWrongTypeContextFactory() {
+    }
+
+    public static Object createContext(Class<?>[] classes, Map<?, ?> properties) {
+        return WrongTypeContextFactory.createContext(classes, properties);
+    }
+}
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
index 34f5daa1a3..90b8462791 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ContextFinderTest.java
@@ -13,11 +13,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta_xml_bind.jakarta_xml_bind_api.classproperties.PropertiesBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.LegacyContextFactory;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.WrongTypeContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.WrongTypeBoundType;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +25,11 @@ public class ContextFinderTest {
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties";
     private static final String SERVICE_CONTEXT_PATH =
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service";
+    // JAXB 4.1 checks package access for qualified provider class names before loading them.
+    private static final String PROPERTIES_CONTEXT_FACTORY = "UnqualifiedPropertiesContextFactory";
+    private static final String LEGACY_CONTEXT_FACTORY = "UnqualifiedLegacyContextFactory";
+    private static final String JAXB_CONTEXT_FACTORY = "UnqualifiedJaxbContextFactory";
+    private static final String WRONG_TYPE_CONTEXT_FACTORY = "UnqualifiedWrongTypeContextFactory";
 
     @Test
     public void loadsThreeArgumentFactoryFromPropertiesMapForContextPath() throws Exception {
@@ -37,7 +38,7 @@ public class ContextFinderTest {
                 getClass().getClassLoader(),
                 Map.of(
                         JAXBContext.JAXB_CONTEXT_FACTORY,
-                        PropertiesContextFactory.class.getName(),
+                        PROPERTIES_CONTEXT_FACTORY,
                         "trigger",
                         "jaxb-properties"));
 
@@ -48,7 +49,7 @@ public class ContextFinderTest {
     public void loadsFactoryFromPropertiesMapForBoundClasses() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 new Class<?>[] {PropertiesBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PROPERTIES_CONTEXT_FACTORY));
 
         assertContextSource(context, "properties-classes-factory");
     }
@@ -68,7 +69,7 @@ public class ContextFinderTest {
         JAXBContext context = JAXBContext.newInstance(
                 PROPERTIES_CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LegacyContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, LEGACY_CONTEXT_FACTORY));
 
         assertContextSource(context, "legacy-context-path-factory");
     }
@@ -77,7 +78,7 @@ public class ContextFinderTest {
     public void instantiatesJaxbContextFactoryImplementations() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 new Class<?>[] {FactoryBackedBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, FactoryBackedContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, JAXB_CONTEXT_FACTORY));
 
         assertContextSource(context, "factory-backed-classes-factory");
     }
@@ -93,7 +94,7 @@ public class ContextFinderTest {
     public void throwsHelpfulExceptionWhenProviderReturnsWrongType() {
         assertThatThrownBy(() -> JAXBContext.newInstance(
                 new Class<?>[] {WrongTypeBoundType.class},
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WrongTypeContextFactory.class.getName())))
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, WRONG_TYPE_CONTEXT_FACTORY)))
                 .isInstanceOf(JAXBException.class)
                 .hasMessageContaining("ClassCastException");
     }
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
index 4074763a76..5371940720 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ModuleUtilTest.java
@@ -9,7 +9,6 @@ package jakarta_xml_bind.jakarta_xml_bind_api;
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
-import jakarta_xml_bind.jakarta_xml_bind_api.support.PropertiesContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
 import org.junit.jupiter.api.Test;
 
@@ -19,13 +18,14 @@ public class ModuleUtilTest {
     private static final String CONTEXT_PATH =
             "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties"
                     + ":jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed";
+    private static final String PROPERTIES_CONTEXT_FACTORY = "UnqualifiedPropertiesContextFactory";
 
     @Test
     public void resolvesObjectFactoryAndJaxbIndexEntriesFromTheContextPath() throws Exception {
         JAXBContext context = JAXBContext.newInstance(
                 CONTEXT_PATH,
                 getClass().getClassLoader(),
-                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PropertiesContextFactory.class.getName()));
+                Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, PROPERTIES_CONTEXT_FACTORY));
 
         assertThat(context).isInstanceOf(StubJaxbContext.class);
         assertThat(((StubJaxbContext) context).getSource()).isEqualTo("properties-context-path-factory");
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
index 76060ff313..eb7a828a40 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/src/test/java/jakarta_xml_bind/jakarta_xml_bind_api/ServiceLoaderUtilTest.java
@@ -9,12 +9,14 @@ package jakarta_xml_bind.jakarta_xml_bind_api;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.security.Permission;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.ServiceLoaderUtilInvoker;
+import jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.FactoryBackedBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.servicebound.ServiceBoundType;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.FactoryBackedContextFactory;
 import jakarta_xml_bind.jakarta_xml_bind_api.support.StubJaxbContext;
@@ -55,6 +57,41 @@ public class ServiceLoaderUtilTest {
         assertThat(provider).isInstanceOf(FactoryBackedContextFactory.class);
     }
 
+    @Test
+    public void loadsProviderClassByNameWithoutContextClassLoader() throws Exception {
+        JAXBContext context = withContextClassLoader(
+                null,
+                () -> JAXBContext.newInstance(
+                        new Class<?>[] {FactoryBackedBoundType.class},
+                        Map.of(JAXBContext.JAXB_CONTEXT_FACTORY, "UnqualifiedJaxbContextFactory")));
+
+        assertThat(context).isInstanceOf(StubJaxbContext.class);
+        assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-classes-factory");
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    public void fallsBackToClassForNameWhenDefaultImplementationPackageAccessIsDenied() throws Exception {
+        SecurityManager previousSecurityManager = System.getSecurityManager();
+        PackageAccessDenyingSecurityManager securityManager =
+                new PackageAccessDenyingSecurityManager(FactoryBackedContextFactory.class.getPackage().getName());
+        boolean securityManagerInstalled = installSecurityManagerIfSupported(securityManager);
+
+        try {
+            Class<?> providerClass = ServiceLoaderUtilInvoker.loadFactoryBackedContextFactory(
+                    getClass().getClassLoader());
+
+            assertThat(providerClass).isEqualTo(FactoryBackedContextFactory.class);
+            if (securityManagerInstalled) {
+                assertThat(securityManager.wasCheckPackageAccessCalled()).isTrue();
+            }
+        } finally {
+            if (securityManagerInstalled) {
+                System.setSecurityManager(previousSecurityManager);
+            }
+        }
+    }
+
     @Test
     public void loadsContextPathProviderFromOsgiLocatorWhenServiceResourceIsAbsent() throws Exception {
         ClassLoader classLoader = new ServiceResourceHidingClassLoader(getClass().getClassLoader());
@@ -79,6 +116,16 @@ public class ServiceLoaderUtilTest {
         assertThat(((StubJaxbContext) context).getSource()).isEqualTo("factory-backed-classes-factory");
     }
 
+    @SuppressWarnings("removal")
+    private static boolean installSecurityManagerIfSupported(SecurityManager securityManager) {
+        try {
+            System.setSecurityManager(securityManager);
+            return System.getSecurityManager() == securityManager;
+        } catch (UnsupportedOperationException unsupportedOperationException) {
+            return false;
+        }
+    }
+
     private static <T> T withContextClassLoader(
             ClassLoader classLoader,
             ThrowingSupplier<T> supplier) throws Exception {
@@ -97,6 +144,32 @@ public class ServiceLoaderUtilTest {
         T get() throws Exception;
     }
 
+    @SuppressWarnings("removal")
+    private static final class PackageAccessDenyingSecurityManager extends SecurityManager {
+        private final String deniedPackageName;
+        private boolean checkPackageAccessCalled;
+
+        private PackageAccessDenyingSecurityManager(String deniedPackageName) {
+            this.deniedPackageName = deniedPackageName;
+        }
+
+        @Override
+        public void checkPermission(Permission permission) {
+        }
+
+        @Override
+        public void checkPackageAccess(String packageName) {
+            if (deniedPackageName.equals(packageName)) {
+                checkPackageAccessCalled = true;
+                throw new SecurityException(packageName);
+            }
+        }
+
+        private boolean wasCheckPackageAccessCalled() {
+            return checkPackageAccessCalled;
+        }
+    }
+
     private static final class ServiceResourceHidingClassLoader extends ClassLoader {
         private ServiceResourceHidingClassLoader(ClassLoader parent) {
             super(parent);
diff --git 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/user-code-filter.json 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
index d2d90d9f1a..5100f6f133 100644
--- 1/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0/user-code-filter.json
+++ 2/tests/src/jakarta.xml.bind/jakarta.xml.bind-api/4.1.0-M1/user-code-filter.json
@@ -5,6 +5,39 @@
     },
     {
       "includeClasses" : "jakarta.xml.bind.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.servicebound.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.classproperties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.osgi.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.properties.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.service.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.contextpath.indexed.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.factorybacked.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.wrongtype.**"
+    },
+    {
+      "includeClasses" : "jakarta_xml_bind.jakarta_xml_bind_api.support.**"
+    },
+    {
+      "includeClasses" : "org.glassfish.hk2.osgiresourcelocator.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
