### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-jdbc as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-jdbc/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-jdbc/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published spring-boot-starter-jdbc-4.1.0-RC1 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-jdbc:4.1.0-RC1 and com.zaxxer:HikariCP:7.0.2 for reachability metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8465

This PR records `org.springframework.boot:spring-boot-starter-jdbc` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published spring-boot-starter-jdbc-4.1.0-RC1 JAR contains only META-INF/MANIFEST.MF, LICENSE.txt, and NOTICE.txt and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-jdbc:4.1.0-RC1 and com.zaxxer:HikariCP:7.0.2 for reachability metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `beff17b2aff10b776bba944be7c0ad4ca847ac3b`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
