### PR TITLE
[GenAI] Test fix for com.mchange:mchange-commons-java:0.4.0 using gpt-5.5

### DIFF
--- a/metadata/com.mchange/mchange-commons-java/0.4.0/reachability-metadata.json
+++ b/metadata/com.mchange/mchange-commons-java/0.4.0/reachability-metadata.json
@@ -1,0 +1,1999 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type": "byte[][]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type": "com.mchange.sc.v1.decode.ScalaMapDecoderFinder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.db.sql.SchemaManager"
+      },
+      "type": "com.mchange.v1.db.sql.XmlSchema",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.MConfig"
+      },
+      "type": "com.mchange.v2.log.MLevel",
+      "fields": [
+        {
+          "name": "ALL"
+        },
+        {
+          "name": "CONFIG"
+        },
+        {
+          "name": "FINE"
+        },
+        {
+          "name": "FINER"
+        },
+        {
+          "name": "FINEST"
+        },
+        {
+          "name": "INFO"
+        },
+        {
+          "name": "OFF"
+        },
+        {
+          "name": "SEVERE"
+        },
+        {
+          "name": "WARNING"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.MLog"
+      },
+      "type": "com.mchange.v2.log.PackageNames",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.MLog"
+      },
+      "type": "com.mchange.v2.log.jdk14logging.Jdk14MLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.MLog"
+      },
+      "type": "com.mchange.v2.log.log4j.Log4jMLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.MLog"
+      },
+      "type": "com.mchange.v2.log.log4j2.Log4j2MLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.MLog"
+      },
+      "type": "com.mchange.v2.log.slf4j.Slf4jMLog",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.BeansUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.BeansUtilsTest$TestStringEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.IoSerializableUtilsTest$SerializablePayload"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.naming.JavaBeanObjectFactory"
+      },
+      "type": "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.lang.ObjectUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.ObjectUtilsTest$SerializablePayload"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.naming.ReferenceableUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.ReferenceableUtilsTest$CapturingObjectFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.ReflectUtilsTest$Describable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.ReflectUtilsTest$PublicParent"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.ser.SerializableUtils"
+      },
+      "type": "com_mchange.mchange_commons_java.SerializableUtilsTest$SerializablePayload"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.lang.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.Integer",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.lang.Iterable"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.Number",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.lang.ObjectUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.ser.SerializableUtils"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      },
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      },
+      "type": "java.lang.ObjectCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.BeansUtils"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.AbstractList"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.ArrayList",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.util.ArrayList"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.util.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.io.SerializableUtils"
+      },
+      "type": "java.util.LinkedHashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      },
+      "type": "java.util.String"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "type": "java.util.logging.ConsoleHandler"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "type": "java.util.logging.Handler[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "type": "java.util.logging.SimpleFormatter"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "type": "sun.util.logging.resources.logging"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.cachedstore.CachedStoreFactory"
+      },
+      "type": {
+        "proxy": [
+          "com.mchange.v1.cachedstore.TweakableCachedStore"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.Synchronizer"
+      },
+      "type": {
+        "proxy": [
+          "com.mchange.v1.cachedstore.TweakableCachedStore"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type": {
+        "proxy": [
+          "com_mchange.mchange_commons_java.ReflectUtilsTest$ProxyContract"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.lang.Synchronizer"
+      },
+      "type": {
+        "proxy": [
+          "com_mchange.mchange_commons_java.SynchronizerDollar1Test$EchoService"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.cachedstore.SoftSetFactory"
+      },
+      "type": {
+        "proxy": [
+          "java.util.Set"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
+      },
+      "type": {
+        "proxy": [
+          "org.graalvm.nativeimage.Platforms"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.lang.ThreadUtils"
+      },
+      "type": {
+        "proxy": [
+          "org.graalvm.nativeimage.Platforms"
+        ]
+      }
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type": "com.sun.beans.editors.StringEditor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "com.sun.swing.internal.plaf.basic.resources.basic"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "com.sun.swing.internal.plaf.metal.resources.metal"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.GraphicsEnvironment",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "isHeadless",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type": "java.beans.PropertyChangeListener"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.lang.System",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "load",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.naming.ReferenceableUtils"
+      },
+      "type": "com.mchange.v2.naming.ApparentlyLocalNameGuard",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type": "java.lang.StringEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type": "java.util.EventListener"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "javax.swing.plaf.metal.MetalComboBoxUI",
+      "methods": [
+        {
+          "name": "createUI",
+          "parameterTypes": [
+            "javax.swing.JComponent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.awt.SunToolkit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "awtLock",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockNotify",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockNotifyAll",
+          "parameterTypes": []
+        },
+        {
+          "name": "awtLockWait",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "awtUnlock",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.awt.X11.XErrorHandlerUtil",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "init",
+          "parameterTypes": [
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.awt.X11.XToolkit",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "modLockIsShiftLock"
+        },
+        {
+          "name": "numLockMask"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.AlphaComposite",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "extraAlpha"
+        },
+        {
+          "name": "rule"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.Component",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "appContext"
+        },
+        {
+          "name": "background"
+        },
+        {
+          "name": "font"
+        },
+        {
+          "name": "foreground"
+        },
+        {
+          "name": "graphicsConfig"
+        },
+        {
+          "name": "height"
+        },
+        {
+          "name": "isPacked"
+        },
+        {
+          "name": "name"
+        },
+        {
+          "name": "peer"
+        },
+        {
+          "name": "width"
+        },
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getLocationOnScreen_NoTreeLock",
+          "parameterTypes": []
+        },
+        {
+          "name": "getParent_NoClientCode",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.Color",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getRGB",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.Rectangle",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "int",
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.event.KeyEvent",
+      "allPublicFields": true,
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "isProxyActive"
+        },
+        {
+          "name": "VK_A"
+        },
+        {
+          "name": "VK_BACK_SLASH"
+        },
+        {
+          "name": "VK_BACK_SPACE"
+        },
+        {
+          "name": "VK_C"
+        },
+        {
+          "name": "VK_COPY"
+        },
+        {
+          "name": "VK_CUT"
+        },
+        {
+          "name": "VK_DELETE"
+        },
+        {
+          "name": "VK_END"
+        },
+        {
+          "name": "VK_ENTER"
+        },
+        {
+          "name": "VK_H"
+        },
+        {
+          "name": "VK_HOME"
+        },
+        {
+          "name": "VK_INSERT"
+        },
+        {
+          "name": "VK_KP_LEFT"
+        },
+        {
+          "name": "VK_KP_RIGHT"
+        },
+        {
+          "name": "VK_LEFT"
+        },
+        {
+          "name": "VK_O"
+        },
+        {
+          "name": "VK_PASTE"
+        },
+        {
+          "name": "VK_RIGHT"
+        },
+        {
+          "name": "VK_V"
+        },
+        {
+          "name": "VK_X"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.geom.AffineTransform",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "m00"
+        },
+        {
+          "name": "m01"
+        },
+        {
+          "name": "m02"
+        },
+        {
+          "name": "m10"
+        },
+        {
+          "name": "m11"
+        },
+        {
+          "name": "m12"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "java.awt.geom.GeneralPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int",
+            "byte[]",
+            "int",
+            "float[]",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.geom.Path2D",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "numTypes"
+        },
+        {
+          "name": "pointTypes"
+        },
+        {
+          "name": "windingRule"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.geom.Path2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "floatCoords"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "java.awt.geom.Point2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "java.awt.geom.Rectangle2D$Float",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "height"
+        },
+        {
+          "name": "width"
+        },
+        {
+          "name": "x"
+        },
+        {
+          "name": "y"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float",
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.image.ColorModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "colorSpace"
+        },
+        {
+          "name": "colorSpaceType"
+        },
+        {
+          "name": "isAlphaPremultiplied"
+        },
+        {
+          "name": "is_sRGB"
+        },
+        {
+          "name": "nBits"
+        },
+        {
+          "name": "numComponents"
+        },
+        {
+          "name": "supportsAlpha"
+        },
+        {
+          "name": "transparency"
+        }
+      ],
+      "methods": [
+        {
+          "name": "getRGBdefault",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "java.awt.image.IndexColorModel",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "allgrayopaque"
+        },
+        {
+          "name": "map_size"
+        },
+        {
+          "name": "rgb"
+        },
+        {
+          "name": "transparent_index"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.awt.SunHints",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "INTVAL_STROKE_PURE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.awt.X11GraphicsConfig",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "aData"
+        },
+        {
+          "name": "bitsPerPixel"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.awt.X11GraphicsDevice",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "addDoubleBufferVisual",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.CharToGlyphMapper",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "charToGlyph",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.Font2D",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "canDisplay",
+          "parameterTypes": [
+            "char"
+          ]
+        },
+        {
+          "name": "charToGlyphRaw",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "charToVariationGlyphRaw",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name": "getMapper",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTableBytes",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.FontStrike",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getGlyphMetrics",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.FontUtilities",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "debugFonts",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.FreetypeFontScaler",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "invalidateScaler",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.GlyphList",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "gposx"
+        },
+        {
+          "name": "gposy"
+        },
+        {
+          "name": "images"
+        },
+        {
+          "name": "lcdRGBOrder"
+        },
+        {
+          "name": "lcdSubPixPos"
+        },
+        {
+          "name": "len"
+        },
+        {
+          "name": "positions"
+        },
+        {
+          "name": "usePositions"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.PhysicalStrike",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pScalerContext"
+        }
+      ],
+      "methods": [
+        {
+          "name": "adjustPoint",
+          "parameterTypes": [
+            "java.awt.geom.Point2D$Float"
+          ]
+        },
+        {
+          "name": "getGlyphPoint",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.StrikeMetrics",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float",
+            "float"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.TrueTypeFont",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "readBlock",
+          "parameterTypes": [
+            "java.nio.ByteBuffer",
+            "int",
+            "int"
+          ]
+        },
+        {
+          "name": "readBytes",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      },
+      "type": "sun.font.Type1Font",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "readFile",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.Disposer",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "addRecord",
+          "parameterTypes": [
+            "java.lang.Object",
+            "long",
+            "long"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.InvalidPipeException",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.NullSurfaceData",
+      "jniAccessible": true
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.SunGraphics2D",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "clipRegion"
+        },
+        {
+          "name": "composite"
+        },
+        {
+          "name": "eargb"
+        },
+        {
+          "name": "lcdTextContrast"
+        },
+        {
+          "name": "pixel"
+        },
+        {
+          "name": "strokeHint"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.SurfaceData",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pData"
+        },
+        {
+          "name": "valid"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.Blit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.BlitBg",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.CompositeType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "AnyAlpha"
+        },
+        {
+          "name": "Src"
+        },
+        {
+          "name": "SrcNoEa"
+        },
+        {
+          "name": "SrcOver"
+        },
+        {
+          "name": "SrcOverNoEa"
+        },
+        {
+          "name": "Xor"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawGlyphList",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawGlyphListAA",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawGlyphListLCD",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawLine",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawParallelogram",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawPolygons",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.DrawRect",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.FillParallelogram",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.FillPath",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.FillRect",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.FillSpans",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitive",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "pNativePrim"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitiveMgr",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "register",
+          "parameterTypes": [
+            "sun.java2d.loops.GraphicsPrimitive[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.GraphicsPrimitive[]"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.MaskBlit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.MaskFill",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.ScaledBlit",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.SurfaceType",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "Any3Byte"
+        },
+        {
+          "name": "Any4Byte"
+        },
+        {
+          "name": "AnyByte"
+        },
+        {
+          "name": "AnyColor"
+        },
+        {
+          "name": "AnyInt"
+        },
+        {
+          "name": "AnyShort"
+        },
+        {
+          "name": "ByteBinary1Bit"
+        },
+        {
+          "name": "ByteBinary2Bit"
+        },
+        {
+          "name": "ByteBinary4Bit"
+        },
+        {
+          "name": "ByteGray"
+        },
+        {
+          "name": "ByteIndexed"
+        },
+        {
+          "name": "ByteIndexedBm"
+        },
+        {
+          "name": "FourByteAbgr"
+        },
+        {
+          "name": "FourByteAbgrPre"
+        },
+        {
+          "name": "Index12Gray"
+        },
+        {
+          "name": "Index8Gray"
+        },
+        {
+          "name": "IntArgb"
+        },
+        {
+          "name": "IntArgbBm"
+        },
+        {
+          "name": "IntArgbPre"
+        },
+        {
+          "name": "IntBgr"
+        },
+        {
+          "name": "IntRgb"
+        },
+        {
+          "name": "IntRgbx"
+        },
+        {
+          "name": "OpaqueColor"
+        },
+        {
+          "name": "ThreeByteBgr"
+        },
+        {
+          "name": "Ushort4444Argb"
+        },
+        {
+          "name": "Ushort555Rgb"
+        },
+        {
+          "name": "Ushort555Rgbx"
+        },
+        {
+          "name": "Ushort565Rgb"
+        },
+        {
+          "name": "UshortGray"
+        },
+        {
+          "name": "UshortIndexed"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.TransformHelper",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "long",
+            "sun.java2d.loops.SurfaceType",
+            "sun.java2d.loops.CompositeType",
+            "sun.java2d.loops.SurfaceType"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.loops.XORComposite",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "alphaMask"
+        },
+        {
+          "name": "xorColor"
+        },
+        {
+          "name": "xorPixel"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.marlin.DMarlinRenderingEngine",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.pipe.Region",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "bands"
+        },
+        {
+          "name": "endIndex"
+        },
+        {
+          "name": "hix"
+        },
+        {
+          "name": "hiy"
+        },
+        {
+          "name": "lox"
+        },
+        {
+          "name": "loy"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.pipe.RegionIterator",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "curIndex"
+        },
+        {
+          "name": "numXbands"
+        },
+        {
+          "name": "region"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "type": "sun.java2d.xr.XRSurfaceData",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "picture"
+        },
+        {
+          "name": "xid"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.mchange.v1.db.sql.SchemaManager"
+      },
+      "glob": "META-INF/services/java.sql.Driver"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      },
+      "glob": "com/mchange/v2/cfg/vmConfigResourcePaths.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      },
+      "glob": "com/mchange/v2/log/default-mchange-log.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      },
+      "glob": "mchange-commons.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      },
+      "glob": "mchange-config-resource-paths.txt"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      },
+      "glob": "mchange-log.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.cfg.BasicMultiPropertiesConfig"
+      },
+      "glob": "reference,/application,"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.FallbackMLog$FallbackMLogger"
+      },
+      "bundle": "com_mchange.mchange_commons_java.FallbackMLogDollarFallbackMLoggerTestMessages"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.log.LogUtils"
+      },
+      "bundle": "com_mchange.mchange_commons_java.LogUtilsTestMessages"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "module": "java.desktop",
+      "glob": "com/sun/swing/internal/plaf/basic/resources/basic_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "module": "java.desktop",
+      "glob": "com/sun/swing/internal/plaf/basic/resources/basic_en_US.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "module": "java.desktop",
+      "glob": "com/sun/swing/internal/plaf/metal/resources/metal_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      },
+      "module": "java.desktop",
+      "glob": "com/sun/swing/internal/plaf/metal/resources/metal_en_US.properties"
+    },
+    {
+      "bundle": "com.sun.swing.internal.plaf.basic.resources.basic"
+    },
+    {
+      "bundle": "com.sun.swing.internal.plaf.metal.resources.metal"
+    },
+    {
+      "module": "java.desktop",
+      "bundle": "sun.awt.resources.awt"
+    }
+  ]
+}

--- a/metadata/com.mchange/mchange-commons-java/0.4.0/reachability-metadata.json
+++ b/metadata/com.mchange/mchange-commons-java/0.4.0/reachability-metadata.json
@@ -1,706 +1,632 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
       },
-      "type": "byte[][]"
+      "type" : "byte[][]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v3.decode.DecodeUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
       },
-      "type": "com.mchange.sc.v1.decode.ScalaMapDecoderFinder"
+      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.db.sql.SchemaManager"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.db.sql.SchemaManager"
       },
-      "type": "com.mchange.v1.db.sql.XmlSchema",
-      "methods": [
+      "type" : "com.mchange.v1.db.sql.XmlSchema",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.MConfig"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.MConfig"
       },
-      "type": "com.mchange.v2.log.MLevel",
-      "fields": [
+      "type" : "com.mchange.v2.log.MLevel",
+      "fields" : [
         {
-          "name": "ALL"
+          "name" : "ALL"
         },
         {
-          "name": "CONFIG"
+          "name" : "CONFIG"
         },
         {
-          "name": "FINE"
+          "name" : "FINE"
         },
         {
-          "name": "FINER"
+          "name" : "FINER"
         },
         {
-          "name": "FINEST"
+          "name" : "FINEST"
         },
         {
-          "name": "INFO"
+          "name" : "INFO"
         },
         {
-          "name": "OFF"
+          "name" : "OFF"
         },
         {
-          "name": "SEVERE"
+          "name" : "SEVERE"
         },
         {
-          "name": "WARNING"
+          "name" : "WARNING"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.MLog"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.MLog"
       },
-      "type": "com.mchange.v2.log.PackageNames",
-      "methods": [
+      "type" : "com.mchange.v2.log.PackageNames",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.MLog"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.MLog"
       },
-      "type": "com.mchange.v2.log.jdk14logging.Jdk14MLog",
-      "methods": [
+      "type" : "com.mchange.v2.log.jdk14logging.Jdk14MLog",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.MLog"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.MLog"
       },
-      "type": "com.mchange.v2.log.log4j.Log4jMLog",
-      "methods": [
+      "type" : "com.mchange.v2.log.log4j.Log4jMLog",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.MLog"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.MLog"
       },
-      "type": "com.mchange.v2.log.log4j2.Log4j2MLog",
-      "methods": [
+      "type" : "com.mchange.v2.log.log4j2.Log4j2MLog",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.MLog"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.MLog"
       },
-      "type": "com.mchange.v2.log.slf4j.Slf4jMLog",
-      "methods": [
+      "type" : "com.mchange.v2.log.slf4j.Slf4jMLog",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.BeansUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "com_mchange.mchange_commons_java.BeansUtilsTest$TestStringEditor"
+      "type" : "java.lang.Date"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v3.decode.DecodeUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder"
+      "type" : "java.lang.Integer",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "com_mchange.mchange_commons_java.IoSerializableUtilsTest$SerializablePayload"
+      "type" : "java.lang.Iterable"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.naming.JavaBeanObjectFactory"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean"
+      "type" : "java.lang.Number",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.lang.ObjectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "com_mchange.mchange_commons_java.ObjectUtilsTest$SerializablePayload"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.naming.ReferenceableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.lang.ObjectUtils"
       },
-      "type": "com_mchange.mchange_commons_java.ReferenceableUtilsTest$CapturingObjectFactory"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
       },
-      "type": "com_mchange.mchange_commons_java.ReflectUtilsTest$Describable"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.ser.SerializableUtils"
       },
-      "type": "com_mchange.mchange_commons_java.ReflectUtilsTest$PublicParent"
+      "type" : "java.lang.Object"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.ser.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanReferenceMaker"
       },
-      "type": "com_mchange.mchange_commons_java.SerializableUtilsTest$SerializablePayload"
+      "type" : "java.lang.ObjectBeanInfo"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanReferenceMaker"
       },
-      "type": "java.lang.Date"
+      "type" : "java.lang.ObjectCustomizer"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.ConfigUtils"
       },
-      "type": "java.lang.Integer",
-      "serializable": true
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.Iterable"
+      "type" : "java.lang.String",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "type": "java.lang.Number",
-      "serializable": true
+      "type" : "java.lang.String[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Constructor[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.lang.ObjectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Field[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.ser.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.ObjectBeanInfo"
+      "type" : "java.util.AbstractCollection"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.ObjectCustomizer"
+      "type" : "java.util.AbstractList"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.StackTraceElement[]"
+      "type" : "java.util.AbstractMap"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.String",
-      "serializable": true
+      "type" : "java.util.ArrayList",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "java.lang.String[]"
+      "type" : "java.util.ArrayList"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "java.lang.reflect.Constructor[]"
+      "type" : "java.util.Date"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.reflect.Field[]"
+      "type" : "java.util.HashMap",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.util.LinkedHashMap",
+      "serializable" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.BeansUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.ClassUtils"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.util.String"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "type": "java.util.AbstractCollection"
+      "type" : "java.util.logging.ConsoleHandler"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "type": "java.util.AbstractList"
+      "type" : "java.util.logging.Handler[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "type": "java.util.AbstractMap"
+      "type" : "java.util.logging.SimpleFormatter"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "type": "java.util.ArrayList",
-      "serializable": true
+      "type" : "sun.util.logging.resources.logging"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
       },
-      "type": "java.util.ArrayList"
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
       },
-      "type": "java.util.Date"
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.cachedstore.CachedStoreFactory"
       },
-      "type": "java.util.HashMap",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.io.SerializableUtils"
-      },
-      "type": "java.util.LinkedHashMap",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.ClassUtils"
-      },
-      "type": "java.util.String"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
-      },
-      "type": "java.util.logging.ConsoleHandler"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
-      },
-      "type": "java.util.logging.Handler[]"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
-      },
-      "type": "java.util.logging.SimpleFormatter"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
-      },
-      "type": "sun.util.logging.resources.logging"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
-      },
-      "type": "sun.util.resources.cldr.TimeZoneNames"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.codegen.intfc.DelegatorGenerator"
-      },
-      "type": "sun.util.resources.cldr.TimeZoneNames_en"
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v1.cachedstore.CachedStoreFactory"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.mchange.v1.cachedstore.TweakableCachedStore"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.Synchronizer"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.Synchronizer"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "com.mchange.v1.cachedstore.TweakableCachedStore"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.reflect.ReflectUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
       },
-      "type": {
-        "proxy": [
-          "com_mchange.mchange_commons_java.ReflectUtilsTest$ProxyContract"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v1.lang.Synchronizer"
-      },
-      "type": {
-        "proxy": [
-          "com_mchange.mchange_commons_java.SynchronizerDollar1Test$EchoService"
-        ]
-      }
-    },
-    {
-      "condition": {
-        "typeReached": "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.cachedstore.SoftSetFactory"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.cachedstore.SoftSetFactory"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.util.Set"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.async.ThreadPoolAsynchronousRunner"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.graalvm.nativeimage.Platforms"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.lang.ThreadUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.lang.ThreadUtils"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.graalvm.nativeimage.Platforms"
         ]
       }
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
       },
-      "type": "com.sun.beans.editors.StringEditor",
-      "methods": [
+      "type" : "com.sun.beans.editors.StringEditor",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "com.sun.swing.internal.plaf.basic.resources.basic"
+      "type" : "com.sun.swing.internal.plaf.basic.resources.basic"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "com.sun.swing.internal.plaf.metal.resources.metal"
+      "type" : "com.sun.swing.internal.plaf.metal.resources.metal"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.GraphicsEnvironment",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.awt.GraphicsEnvironment",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "isHeadless",
-          "parameterTypes": []
+          "name" : "isHeadless",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
       },
-      "type": "java.beans.PropertyChangeListener"
+      "type" : "java.beans.PropertyChangeListener"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.lang.System",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.lang.System",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "load",
-          "parameterTypes": [
+          "name" : "load",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.naming.ReferenceableUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.ReferenceableUtils"
       },
-      "type": "com.mchange.v2.naming.ApparentlyLocalNameGuard",
-      "methods": [
+      "type" : "com.mchange.v2.naming.ApparentlyLocalNameGuard",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
       },
-      "type": "java.lang.StringEditor"
+      "type" : "java.lang.StringEditor"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
       },
-      "type": "java.util.EventListener"
+      "type" : "java.util.EventListener"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "javax.swing.plaf.metal.MetalComboBoxUI",
-      "methods": [
+      "type" : "javax.swing.plaf.metal.MetalComboBoxUI",
+      "methods" : [
         {
-          "name": "createUI",
-          "parameterTypes": [
+          "name" : "createUI",
+          "parameterTypes" : [
             "javax.swing.JComponent"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.awt.SunToolkit",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.awt.SunToolkit",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "awtLock",
-          "parameterTypes": []
+          "name" : "awtLock",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "awtLockNotify",
-          "parameterTypes": []
+          "name" : "awtLockNotify",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "awtLockNotifyAll",
-          "parameterTypes": []
+          "name" : "awtLockNotifyAll",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "awtLockWait",
-          "parameterTypes": [
+          "name" : "awtLockWait",
+          "parameterTypes" : [
             "long"
           ]
         },
         {
-          "name": "awtUnlock",
-          "parameterTypes": []
+          "name" : "awtUnlock",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.awt.X11.XErrorHandlerUtil",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.awt.X11.XErrorHandlerUtil",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "init",
-          "parameterTypes": [
+          "name" : "init",
+          "parameterTypes" : [
             "long"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.awt.X11.XToolkit",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.awt.X11.XToolkit",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "modLockIsShiftLock"
+          "name" : "modLockIsShiftLock"
         },
         {
-          "name": "numLockMask"
+          "name" : "numLockMask"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.AlphaComposite",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.AlphaComposite",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "extraAlpha"
+          "name" : "extraAlpha"
         },
         {
-          "name": "rule"
+          "name" : "rule"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.Component",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.Component",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "appContext"
+          "name" : "appContext"
         },
         {
-          "name": "background"
+          "name" : "background"
         },
         {
-          "name": "font"
+          "name" : "font"
         },
         {
-          "name": "foreground"
+          "name" : "foreground"
         },
         {
-          "name": "graphicsConfig"
+          "name" : "graphicsConfig"
         },
         {
-          "name": "height"
+          "name" : "height"
         },
         {
-          "name": "isPacked"
+          "name" : "isPacked"
         },
         {
-          "name": "name"
+          "name" : "name"
         },
         {
-          "name": "peer"
+          "name" : "peer"
         },
         {
-          "name": "width"
+          "name" : "width"
         },
         {
-          "name": "x"
+          "name" : "x"
         },
         {
-          "name": "y"
+          "name" : "y"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "getLocationOnScreen_NoTreeLock",
-          "parameterTypes": []
+          "name" : "getLocationOnScreen_NoTreeLock",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getParent_NoClientCode",
-          "parameterTypes": []
+          "name" : "getParent_NoClientCode",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.Color",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.awt.Color",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getRGB",
-          "parameterTypes": []
+          "name" : "getRGB",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.Rectangle",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.awt.Rectangle",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "int",
             "int",
             "int",
@@ -710,119 +636,119 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.event.KeyEvent",
-      "allPublicFields": true,
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.event.KeyEvent",
+      "allPublicFields" : true,
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "isProxyActive"
+          "name" : "isProxyActive"
         },
         {
-          "name": "VK_A"
+          "name" : "VK_A"
         },
         {
-          "name": "VK_BACK_SLASH"
+          "name" : "VK_BACK_SLASH"
         },
         {
-          "name": "VK_BACK_SPACE"
+          "name" : "VK_BACK_SPACE"
         },
         {
-          "name": "VK_C"
+          "name" : "VK_C"
         },
         {
-          "name": "VK_COPY"
+          "name" : "VK_COPY"
         },
         {
-          "name": "VK_CUT"
+          "name" : "VK_CUT"
         },
         {
-          "name": "VK_DELETE"
+          "name" : "VK_DELETE"
         },
         {
-          "name": "VK_END"
+          "name" : "VK_END"
         },
         {
-          "name": "VK_ENTER"
+          "name" : "VK_ENTER"
         },
         {
-          "name": "VK_H"
+          "name" : "VK_H"
         },
         {
-          "name": "VK_HOME"
+          "name" : "VK_HOME"
         },
         {
-          "name": "VK_INSERT"
+          "name" : "VK_INSERT"
         },
         {
-          "name": "VK_KP_LEFT"
+          "name" : "VK_KP_LEFT"
         },
         {
-          "name": "VK_KP_RIGHT"
+          "name" : "VK_KP_RIGHT"
         },
         {
-          "name": "VK_LEFT"
+          "name" : "VK_LEFT"
         },
         {
-          "name": "VK_O"
+          "name" : "VK_O"
         },
         {
-          "name": "VK_PASTE"
+          "name" : "VK_PASTE"
         },
         {
-          "name": "VK_RIGHT"
+          "name" : "VK_RIGHT"
         },
         {
-          "name": "VK_V"
+          "name" : "VK_V"
         },
         {
-          "name": "VK_X"
+          "name" : "VK_X"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.geom.AffineTransform",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.geom.AffineTransform",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "m00"
+          "name" : "m00"
         },
         {
-          "name": "m01"
+          "name" : "m01"
         },
         {
-          "name": "m02"
+          "name" : "m02"
         },
         {
-          "name": "m10"
+          "name" : "m10"
         },
         {
-          "name": "m11"
+          "name" : "m11"
         },
         {
-          "name": "m12"
+          "name" : "m12"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "java.awt.geom.GeneralPath",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "java.awt.geom.GeneralPath",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "int",
             "byte[]",
             "int",
@@ -833,53 +759,53 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.geom.Path2D",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.geom.Path2D",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "numTypes"
+          "name" : "numTypes"
         },
         {
-          "name": "pointTypes"
+          "name" : "pointTypes"
         },
         {
-          "name": "windingRule"
+          "name" : "windingRule"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.geom.Path2D$Float",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.geom.Path2D$Float",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "floatCoords"
+          "name" : "floatCoords"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "java.awt.geom.Point2D$Float",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.geom.Point2D$Float",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "x"
+          "name" : "x"
         },
         {
-          "name": "y"
+          "name" : "y"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "float",
             "float"
           ]
@@ -887,33 +813,33 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "java.awt.geom.Rectangle2D$Float",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.geom.Rectangle2D$Float",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "height"
+          "name" : "height"
         },
         {
-          "name": "width"
+          "name" : "width"
         },
         {
-          "name": "x"
+          "name" : "x"
         },
         {
-          "name": "y"
+          "name" : "y"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "float",
             "float",
             "float",
@@ -923,255 +849,255 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.image.ColorModel",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.image.ColorModel",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "colorSpace"
+          "name" : "colorSpace"
         },
         {
-          "name": "colorSpaceType"
+          "name" : "colorSpaceType"
         },
         {
-          "name": "isAlphaPremultiplied"
+          "name" : "isAlphaPremultiplied"
         },
         {
-          "name": "is_sRGB"
+          "name" : "is_sRGB"
         },
         {
-          "name": "nBits"
+          "name" : "nBits"
         },
         {
-          "name": "numComponents"
+          "name" : "numComponents"
         },
         {
-          "name": "supportsAlpha"
+          "name" : "supportsAlpha"
         },
         {
-          "name": "transparency"
+          "name" : "transparency"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "getRGBdefault",
-          "parameterTypes": []
+          "name" : "getRGBdefault",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "java.awt.image.IndexColorModel",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "java.awt.image.IndexColorModel",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "allgrayopaque"
+          "name" : "allgrayopaque"
         },
         {
-          "name": "map_size"
+          "name" : "map_size"
         },
         {
-          "name": "rgb"
+          "name" : "rgb"
         },
         {
-          "name": "transparent_index"
+          "name" : "transparent_index"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.awt.SunHints",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.awt.SunHints",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "INTVAL_STROKE_PURE"
+          "name" : "INTVAL_STROKE_PURE"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.awt.X11GraphicsConfig",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.awt.X11GraphicsConfig",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "aData"
+          "name" : "aData"
         },
         {
-          "name": "bitsPerPixel"
+          "name" : "bitsPerPixel"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.awt.X11GraphicsDevice",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.awt.X11GraphicsDevice",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "addDoubleBufferVisual",
-          "parameterTypes": [
+          "name" : "addDoubleBufferVisual",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.CharToGlyphMapper",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.CharToGlyphMapper",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "charToGlyph",
-          "parameterTypes": [
+          "name" : "charToGlyph",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.Font2D",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.Font2D",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "canDisplay",
-          "parameterTypes": [
+          "name" : "canDisplay",
+          "parameterTypes" : [
             "char"
           ]
         },
         {
-          "name": "charToGlyphRaw",
-          "parameterTypes": [
+          "name" : "charToGlyphRaw",
+          "parameterTypes" : [
             "int"
           ]
         },
         {
-          "name": "charToVariationGlyphRaw",
-          "parameterTypes": [
+          "name" : "charToVariationGlyphRaw",
+          "parameterTypes" : [
             "int",
             "int"
           ]
         },
         {
-          "name": "getMapper",
-          "parameterTypes": []
+          "name" : "getMapper",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getTableBytes",
-          "parameterTypes": [
+          "name" : "getTableBytes",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.FontStrike",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.FontStrike",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "getGlyphMetrics",
-          "parameterTypes": [
+          "name" : "getGlyphMetrics",
+          "parameterTypes" : [
             "int"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.FontUtilities",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.FontUtilities",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "debugFonts",
-          "parameterTypes": []
+          "name" : "debugFonts",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.FreetypeFontScaler",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.FreetypeFontScaler",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "invalidateScaler",
-          "parameterTypes": []
+          "name" : "invalidateScaler",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.GlyphList",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.font.GlyphList",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "gposx"
+          "name" : "gposx"
         },
         {
-          "name": "gposy"
+          "name" : "gposy"
         },
         {
-          "name": "images"
+          "name" : "images"
         },
         {
-          "name": "lcdRGBOrder"
+          "name" : "lcdRGBOrder"
         },
         {
-          "name": "lcdSubPixPos"
+          "name" : "lcdSubPixPos"
         },
         {
-          "name": "len"
+          "name" : "len"
         },
         {
-          "name": "positions"
+          "name" : "positions"
         },
         {
-          "name": "usePositions"
+          "name" : "usePositions"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.PhysicalStrike",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.font.PhysicalStrike",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "pScalerContext"
+          "name" : "pScalerContext"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "adjustPoint",
-          "parameterTypes": [
+          "name" : "adjustPoint",
+          "parameterTypes" : [
             "java.awt.geom.Point2D$Float"
           ]
         },
         {
-          "name": "getGlyphPoint",
-          "parameterTypes": [
+          "name" : "getGlyphPoint",
+          "parameterTypes" : [
             "int",
             "int"
           ]
@@ -1179,15 +1105,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.StrikeMetrics",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.StrikeMetrics",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "float",
             "float",
             "float",
@@ -1203,23 +1129,23 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.TrueTypeFont",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.TrueTypeFont",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "readBlock",
-          "parameterTypes": [
+          "name" : "readBlock",
+          "parameterTypes" : [
             "java.nio.ByteBuffer",
             "int",
             "int"
           ]
         },
         {
-          "name": "readBytes",
-          "parameterTypes": [
+          "name" : "readBytes",
+          "parameterTypes" : [
             "int",
             "int"
           ]
@@ -1227,30 +1153,30 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox$MyHbi"
       },
-      "type": "sun.font.Type1Font",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.font.Type1Font",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "readFile",
-          "parameterTypes": [
+          "name" : "readFile",
+          "parameterTypes" : [
             "java.nio.ByteBuffer"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.Disposer",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.Disposer",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "addRecord",
-          "parameterTypes": [
+          "name" : "addRecord",
+          "parameterTypes" : [
             "java.lang.Object",
             "long",
             "long"
@@ -1259,71 +1185,71 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.InvalidPipeException",
-      "jniAccessible": true
+      "type" : "sun.java2d.InvalidPipeException",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.NullSurfaceData",
-      "jniAccessible": true
+      "type" : "sun.java2d.NullSurfaceData",
+      "jniAccessible" : true
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.SunGraphics2D",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.SunGraphics2D",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "clipRegion"
+          "name" : "clipRegion"
         },
         {
-          "name": "composite"
+          "name" : "composite"
         },
         {
-          "name": "eargb"
+          "name" : "eargb"
         },
         {
-          "name": "lcdTextContrast"
+          "name" : "lcdTextContrast"
         },
         {
-          "name": "pixel"
+          "name" : "pixel"
         },
         {
-          "name": "strokeHint"
+          "name" : "strokeHint"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.SurfaceData",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.SurfaceData",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "pData"
+          "name" : "pData"
         },
         {
-          "name": "valid"
+          "name" : "valid"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.Blit",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.Blit",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1333,15 +1259,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.BlitBg",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.BlitBg",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1351,42 +1277,42 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.CompositeType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.loops.CompositeType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "AnyAlpha"
+          "name" : "AnyAlpha"
         },
         {
-          "name": "Src"
+          "name" : "Src"
         },
         {
-          "name": "SrcNoEa"
+          "name" : "SrcNoEa"
         },
         {
-          "name": "SrcOver"
+          "name" : "SrcOver"
         },
         {
-          "name": "SrcOverNoEa"
+          "name" : "SrcOverNoEa"
         },
         {
-          "name": "Xor"
+          "name" : "Xor"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawGlyphList",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawGlyphList",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1396,15 +1322,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawGlyphListAA",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawGlyphListAA",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1414,15 +1340,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawGlyphListLCD",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawGlyphListLCD",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1432,15 +1358,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawLine",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawLine",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1450,15 +1376,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawParallelogram",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawParallelogram",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1468,15 +1394,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawPath",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawPath",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1486,15 +1412,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawPolygons",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawPolygons",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1504,15 +1430,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.DrawRect",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.DrawRect",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1522,15 +1448,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.FillParallelogram",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.FillParallelogram",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1540,15 +1466,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.FillPath",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.FillPath",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1558,15 +1484,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.FillRect",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.FillRect",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1576,15 +1502,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.FillSpans",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.FillSpans",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1594,48 +1520,48 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.GraphicsPrimitive",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.loops.GraphicsPrimitive",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "pNativePrim"
+          "name" : "pNativePrim"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.GraphicsPrimitiveMgr",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.GraphicsPrimitiveMgr",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "register",
-          "parameterTypes": [
+          "name" : "register",
+          "parameterTypes" : [
             "sun.java2d.loops.GraphicsPrimitive[]"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.GraphicsPrimitive[]"
+      "type" : "sun.java2d.loops.GraphicsPrimitive[]"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.MaskBlit",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.MaskBlit",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1645,15 +1571,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.MaskFill",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.MaskFill",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1663,15 +1589,15 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.ScaledBlit",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.ScaledBlit",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1681,114 +1607,114 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.SurfaceType",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.loops.SurfaceType",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "Any3Byte"
+          "name" : "Any3Byte"
         },
         {
-          "name": "Any4Byte"
+          "name" : "Any4Byte"
         },
         {
-          "name": "AnyByte"
+          "name" : "AnyByte"
         },
         {
-          "name": "AnyColor"
+          "name" : "AnyColor"
         },
         {
-          "name": "AnyInt"
+          "name" : "AnyInt"
         },
         {
-          "name": "AnyShort"
+          "name" : "AnyShort"
         },
         {
-          "name": "ByteBinary1Bit"
+          "name" : "ByteBinary1Bit"
         },
         {
-          "name": "ByteBinary2Bit"
+          "name" : "ByteBinary2Bit"
         },
         {
-          "name": "ByteBinary4Bit"
+          "name" : "ByteBinary4Bit"
         },
         {
-          "name": "ByteGray"
+          "name" : "ByteGray"
         },
         {
-          "name": "ByteIndexed"
+          "name" : "ByteIndexed"
         },
         {
-          "name": "ByteIndexedBm"
+          "name" : "ByteIndexedBm"
         },
         {
-          "name": "FourByteAbgr"
+          "name" : "FourByteAbgr"
         },
         {
-          "name": "FourByteAbgrPre"
+          "name" : "FourByteAbgrPre"
         },
         {
-          "name": "Index12Gray"
+          "name" : "Index12Gray"
         },
         {
-          "name": "Index8Gray"
+          "name" : "Index8Gray"
         },
         {
-          "name": "IntArgb"
+          "name" : "IntArgb"
         },
         {
-          "name": "IntArgbBm"
+          "name" : "IntArgbBm"
         },
         {
-          "name": "IntArgbPre"
+          "name" : "IntArgbPre"
         },
         {
-          "name": "IntBgr"
+          "name" : "IntBgr"
         },
         {
-          "name": "IntRgb"
+          "name" : "IntRgb"
         },
         {
-          "name": "IntRgbx"
+          "name" : "IntRgbx"
         },
         {
-          "name": "OpaqueColor"
+          "name" : "OpaqueColor"
         },
         {
-          "name": "ThreeByteBgr"
+          "name" : "ThreeByteBgr"
         },
         {
-          "name": "Ushort4444Argb"
+          "name" : "Ushort4444Argb"
         },
         {
-          "name": "Ushort555Rgb"
+          "name" : "Ushort555Rgb"
         },
         {
-          "name": "Ushort555Rgbx"
+          "name" : "Ushort555Rgbx"
         },
         {
-          "name": "Ushort565Rgb"
+          "name" : "Ushort565Rgb"
         },
         {
-          "name": "UshortGray"
+          "name" : "UshortGray"
         },
         {
-          "name": "UshortIndexed"
+          "name" : "UshortIndexed"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.TransformHelper",
-      "jniAccessible": true,
-      "methods": [
+      "type" : "sun.java2d.loops.TransformHelper",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "long",
             "sun.java2d.loops.SurfaceType",
             "sun.java2d.loops.CompositeType",
@@ -1798,202 +1724,202 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.loops.XORComposite",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.loops.XORComposite",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "alphaMask"
+          "name" : "alphaMask"
         },
         {
-          "name": "xorColor"
+          "name" : "xorColor"
         },
         {
-          "name": "xorPixel"
+          "name" : "xorPixel"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.marlin.DMarlinRenderingEngine",
-      "methods": [
+      "type" : "sun.java2d.marlin.DMarlinRenderingEngine",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.pipe.Region",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.pipe.Region",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "bands"
+          "name" : "bands"
         },
         {
-          "name": "endIndex"
+          "name" : "endIndex"
         },
         {
-          "name": "hix"
+          "name" : "hix"
         },
         {
-          "name": "hiy"
+          "name" : "hiy"
         },
         {
-          "name": "lox"
+          "name" : "lox"
         },
         {
-          "name": "loy"
+          "name" : "loy"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.pipe.RegionIterator",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.pipe.RegionIterator",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "curIndex"
+          "name" : "curIndex"
         },
         {
-          "name": "numXbands"
+          "name" : "numXbands"
         },
         {
-          "name": "region"
+          "name" : "region"
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "type": "sun.java2d.xr.XRSurfaceData",
-      "jniAccessible": true,
-      "fields": [
+      "type" : "sun.java2d.xr.XRSurfaceData",
+      "jniAccessible" : true,
+      "fields" : [
         {
-          "name": "picture"
+          "name" : "picture"
         },
         {
-          "name": "xid"
+          "name" : "xid"
         }
       ]
     }
   ],
-  "resources": [
+  "resources" : [
     {
-      "condition": {
-        "typeReached": "com.mchange.v1.db.sql.SchemaManager"
+      "condition" : {
+        "typeReached" : "com.mchange.v1.db.sql.SchemaManager"
       },
-      "glob": "META-INF/services/java.sql.Driver"
+      "glob" : "META-INF/services/java.sql.Driver"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.ConfigUtils"
       },
-      "glob": "com/mchange/v2/cfg/vmConfigResourcePaths.txt"
+      "glob" : "com/mchange/v2/cfg/vmConfigResourcePaths.txt"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.BasicPropertiesConfigSource"
       },
-      "glob": "com/mchange/v2/log/default-mchange-log.properties"
+      "glob" : "com/mchange/v2/log/default-mchange-log.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.BasicPropertiesConfigSource"
       },
-      "glob": "mchange-commons.properties"
+      "glob" : "mchange-commons.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.ConfigUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.ConfigUtils"
       },
-      "glob": "mchange-config-resource-paths.txt"
+      "glob" : "mchange-config-resource-paths.txt"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.BasicPropertiesConfigSource"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.BasicPropertiesConfigSource"
       },
-      "glob": "mchange-log.properties"
+      "glob" : "mchange-log.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.cfg.BasicMultiPropertiesConfig"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.cfg.BasicMultiPropertiesConfig"
       },
-      "glob": "reference,/application,"
+      "glob" : "reference,/application,"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.jdk14logging.Jdk14MLog$Jdk14MLogger"
       },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en_US.properties"
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.FallbackMLog$FallbackMLogger"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.FallbackMLog$FallbackMLogger"
       },
-      "bundle": "com_mchange.mchange_commons_java.FallbackMLogDollarFallbackMLoggerTestMessages"
+      "bundle" : "com_mchange.mchange_commons_java.FallbackMLogDollarFallbackMLoggerTestMessages"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.log.LogUtils"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.LogUtils"
       },
-      "bundle": "com_mchange.mchange_commons_java.LogUtilsTestMessages"
+      "bundle" : "com_mchange.mchange_commons_java.LogUtilsTestMessages"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "module": "java.desktop",
-      "glob": "com/sun/swing/internal/plaf/basic/resources/basic_en.properties"
+      "module" : "java.desktop",
+      "glob" : "com/sun/swing/internal/plaf/basic/resources/basic_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "module": "java.desktop",
-      "glob": "com/sun/swing/internal/plaf/basic/resources/basic_en_US.properties"
+      "module" : "java.desktop",
+      "glob" : "com/sun/swing/internal/plaf/basic/resources/basic_en_US.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "module": "java.desktop",
-      "glob": "com/sun/swing/internal/plaf/metal/resources/metal_en.properties"
+      "module" : "java.desktop",
+      "glob" : "com/sun/swing/internal/plaf/metal/resources/metal_en.properties"
     },
     {
-      "condition": {
-        "typeReached": "com.mchange.v2.beans.swing.PropertyBoundComboBox"
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyBoundComboBox"
       },
-      "module": "java.desktop",
-      "glob": "com/sun/swing/internal/plaf/metal/resources/metal_en_US.properties"
+      "module" : "java.desktop",
+      "glob" : "com/sun/swing/internal/plaf/metal/resources/metal_en_US.properties"
     },
     {
-      "bundle": "com.sun.swing.internal.plaf.basic.resources.basic"
+      "bundle" : "com.sun.swing.internal.plaf.basic.resources.basic"
     },
     {
-      "bundle": "com.sun.swing.internal.plaf.metal.resources.metal"
+      "bundle" : "com.sun.swing.internal.plaf.metal.resources.metal"
     },
     {
-      "module": "java.desktop",
-      "bundle": "sun.awt.resources.awt"
+      "module" : "java.desktop",
+      "bundle" : "sun.awt.resources.awt"
     }
   ]
 }

--- a/metadata/com.mchange/mchange-commons-java/index.json
+++ b/metadata/com.mchange/mchange-commons-java/index.json
@@ -2,6 +2,11 @@
   {
     "latest" : true,
     "metadata-version" : "0.4.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/mchange/mchange-commons-java/$version$/mchange-commons-java-$version$-sources.jar",
+    "repository-url" : "https://github.com/swaldman/mchange-commons-java",
+    "test-code-url" : "https://github.com/swaldman/mchange-commons-java/tree/v$version$/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/mchange/mchange-commons-java/$version$/mchange-commons-java-$version$-javadoc.jar",
+    "description" : "mchange-commons-java is a general-purpose Java utility library that provides reusable support code for configuration, concurrency, I/O, logging, reflection, SQL, and related infrastructure tasks. It supplies low-level helper components used across mchange projects rather than a standalone end-user framework.",
     "tested-versions" : [
       "0.4.0"
     ],

--- a/metadata/com.mchange/mchange-commons-java/index.json
+++ b/metadata/com.mchange/mchange-commons-java/index.json
@@ -1,6 +1,15 @@
 [
   {
     "latest" : true,
+    "metadata-version" : "0.4.0",
+    "tested-versions" : [
+      "0.4.0"
+    ],
+    "allowed-packages" : [
+      "com.mchange"
+    ]
+  },
+  {
     "metadata-version" : "0.2.15",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/mchange/mchange-commons-java/$version$/mchange-commons-java-$version$-sources.jar",
     "repository-url" : "https://github.com/swaldman/mchange-commons-java",

--- a/stats/com.mchange/mchange-commons-java/0.4.0/execution-metrics.json
+++ b/stats/com.mchange/mchange-commons-java/0.4.0/execution-metrics.json
@@ -1,0 +1,111 @@
+{
+  "fix_java_run_fail:2026-06-26": {
+    "timestamp": "2026-06-26T21:04:59.355780Z",
+    "library": "com.mchange:mchange-commons-java:0.4.0",
+    "starting_commit": "1749cc322a11e2fb2e00f6db94d4e7c4e0c2561d",
+    "ending_commit": "a95947dee371cd7c792b7fd4cfcb6ca99608d38e",
+    "previous_library": "com.mchange:mchange-commons-java:0.2.15",
+    "strategy_name": "java_run_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "0.4.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 87,
+            "totalCalls": 87
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 93,
+        "totalCalls": 93
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8288,
+          "missed": 50560,
+          "ratio": 0.140837,
+          "total": 58848
+        },
+        "line": {
+          "covered": 1910,
+          "missed": 11388,
+          "ratio": 0.143631,
+          "total": 13298
+        },
+        "method": {
+          "covered": 372,
+          "missed": 4220,
+          "ratio": 0.08101,
+          "total": 4592
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "0.2.15",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.952381,
+            "coveredCalls": 80,
+            "totalCalls": 84
+          },
+          "resources": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 6,
+            "totalCalls": 6
+          }
+        },
+        "coverageRatio": 0.955556,
+        "coveredCalls": 86,
+        "totalCalls": 90
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 7688,
+          "missed": 49063,
+          "ratio": 0.135469,
+          "total": 56751
+        },
+        "line": {
+          "covered": 1753,
+          "missed": 11111,
+          "ratio": 0.136272,
+          "total": 12864
+        },
+        "method": {
+          "covered": 340,
+          "missed": 4098,
+          "ratio": 0.076611,
+          "total": 4438
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 149798,
+      "cached_input_tokens_used": 621568,
+      "output_tokens_used": 15685,
+      "iterations": 5,
+      "cost_usd": 0.7814,
+      "tested_library_loc": 1910,
+      "metadata_entries": 422,
+      "test_only_metadata_entries": 107,
+      "previous_library_metadata_entries": 453,
+      "previous_library_test_only_metadata_entries": 104,
+      "code_coverage_percent": 14.36,
+      "previous_library_coverage_percent": 13.63
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com/mchange/sc/v1/decode/ScalaMapDecoderFinder.java",
+      "metadata_file": "metadata/com.mchange/mchange-commons-java/0.4.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.mchange/mchange-commons-java/0.4.0/stats.json
+++ b/stats/com.mchange/mchange-commons-java/0.4.0/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "0.4.0",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 87,
+          "totalCalls" : 87
+        },
+        "resources" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 6,
+          "totalCalls" : 6
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 93,
+      "totalCalls" : 93
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8288,
+        "missed" : 50560,
+        "ratio" : 0.140837,
+        "total" : 58848
+      },
+      "line" : {
+        "covered" : 1910,
+        "missed" : 11388,
+        "ratio" : 0.143631,
+        "total" : 13298
+      },
+      "method" : {
+        "covered" : 372,
+        "missed" : 4220,
+        "ratio" : 0.08101,
+        "total" : 4592
+      }
+    }
+  } ]
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/.gitignore
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/build.gradle
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.mchange:mchange-commons-java:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/gradle.properties
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.mchange:mchange-commons-java:0.4.0
+library.version = 0.4.0
+metadata.dir = com.mchange/mchange-commons-java/0.4.0/

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/settings.gradle
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.mchange.mchange-commons-java_tests'

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com/mchange/sc/v1/decode/ScalaMapDecoderFinder.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com/mchange/sc/v1/decode/ScalaMapDecoderFinder.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com.mchange.sc.v1.decode;
+
+import com.mchange.v3.decode.CannotDecodeException;
+import com.mchange.v3.decode.DecoderFinder;
+import com_mchange.mchange_commons_java.DecodeUtilsTest.PrefixingDecoder;
+
+public class ScalaMapDecoderFinder implements DecoderFinder {
+    public ScalaMapDecoderFinder() {
+    }
+
+    @Override
+    public String decoderClassName(Object encoded) throws CannotDecodeException {
+        if (encoded instanceof String text && text.startsWith("finder:")) {
+            return PrefixingDecoder.class.getName();
+        }
+        return null;
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/BeansUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/BeansUtilsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.beans.BeansUtils;
+import org.junit.jupiter.api.Test;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.beans.PropertyEditor;
+import java.beans.PropertyEditorSupport;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeansUtilsTest {
+    @Test
+    void findPropertyEditorInstantiatesConfiguredEditorClass() throws IntrospectionException {
+        PropertyDescriptor propertyDescriptor = new PropertyDescriptor("name", MutableBean.class);
+        propertyDescriptor.setPropertyEditorClass(TestStringEditor.class);
+
+        PropertyEditor propertyEditor = BeansUtils.findPropertyEditor(propertyDescriptor);
+
+        assertThat(propertyEditor).isInstanceOf(TestStringEditor.class);
+    }
+
+    @Test
+    void extractAccessiblePropertiesToMapReadsBeanProperties() throws IntrospectionException {
+        MutableBean bean = new MutableBean();
+        bean.setName("alpha");
+        bean.setCount(3);
+        Map<String, Object> properties = new HashMap<>();
+
+        BeansUtils.extractAccessiblePropertiesToMap(properties, bean);
+
+        assertThat(properties)
+                .containsEntry("count", 3)
+                .containsEntry("name", "alpha");
+    }
+
+    @Test
+    void overwriteAccessiblePropertiesCopiesBeanValues() throws IntrospectionException {
+        MutableBean source = new MutableBean();
+        source.setName("alpha");
+        source.setCount(7);
+        MutableBean destination = new MutableBean();
+        destination.setName("before");
+        destination.setCount(1);
+
+        BeansUtils.overwriteAccessibleProperties(source, destination);
+
+        assertThat(destination.getName()).isEqualTo("alpha");
+        assertThat(destination.getCount()).isEqualTo(7);
+    }
+
+    @Test
+    void overwriteAccessiblePropertiesFromMapAppliesDirectAndCoercedValues() throws IntrospectionException {
+        MutableBean destination = new MutableBean();
+        Map<String, Object> source = new HashMap<>();
+        source.put("count", "9");
+        source.put("name", "bravo");
+
+        BeansUtils.overwriteAccessiblePropertiesFromMap(source, destination, false, List.of(), true, null, null, true);
+
+        assertThat(destination.getName()).isEqualTo("bravo");
+        assertThat(destination.getCount()).isEqualTo(9);
+    }
+
+    @Test
+    void overwriteSpecificAccessiblePropertiesUsesSetterFromCompatibleTargetType() throws IntrospectionException {
+        MutableBean source = new MutableBean();
+        source.setName("charlie");
+        CompatibleTargetBean destination = new CompatibleTargetBean();
+
+        BeansUtils.overwriteSpecificAccessibleProperties(source, destination, List.of("name"));
+
+        assertThat(destination.getName()).isEqualTo("charlie");
+    }
+
+    @Test
+    void overwriteSpecificAccessiblePropertiesFindsMatchingSetterOnDifferentTargetType() throws IntrospectionException {
+        MutableBean source = new MutableBean();
+        source.setName("delta");
+        AlternateBean destination = new AlternateBean();
+
+        BeansUtils.overwriteSpecificAccessibleProperties(source, destination, List.of("name"));
+
+        assertThat(destination.getName()).isEqualTo("delta");
+    }
+
+    public static class TestStringEditor extends PropertyEditorSupport {
+        public TestStringEditor() {
+        }
+    }
+
+    public static class MutableBean {
+        private Integer count;
+        private String name;
+
+        public MutableBean() {
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+
+        public void setCount(Integer count) {
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class CompatibleTargetBean extends MutableBean {
+        public CompatibleTargetBean() {
+        }
+    }
+
+    public static class AlternateBean {
+        private String name;
+
+        public AlternateBean() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CachedStoreFactoryTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CachedStoreFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.cachedstore.CachedStore;
+import com.mchange.v1.cachedstore.CachedStoreException;
+import com.mchange.v1.cachedstore.CachedStoreFactory;
+import com.mchange.v1.cachedstore.TweakableCachedStore;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CachedStoreFactoryTest {
+    @Test
+    void createSynchronousCleanupSoftKeyCachedStoreCachesAndRefreshesValues() throws CachedStoreException {
+        CountingManager manager = new CountingManager();
+        TweakableCachedStore store = CachedStoreFactory.createSynchronousCleanupSoftKeyCachedStore(manager);
+
+        CacheValue first = (CacheValue) store.find("alpha");
+        CacheValue second = (CacheValue) store.find("alpha");
+        manager.markDirty();
+        CacheValue refreshed = (CacheValue) store.find("alpha");
+
+        assertThat(first.sequence).isEqualTo(1);
+        assertThat(second).isSameAs(first);
+        assertThat(refreshed.sequence).isEqualTo(2);
+        assertThat(refreshed).isNotSameAs(first);
+        assertThat(manager.recreateCalls).isEqualTo(2);
+        assertThat(manager.dirtyChecks).isEqualTo(2);
+    }
+
+    private static final class CountingManager implements CachedStore.Manager {
+        private int recreateCalls;
+        private int dirtyChecks;
+        private boolean dirty;
+
+        @Override
+        public boolean isDirty(Object key, Object cached) {
+            dirtyChecks++;
+            return dirty;
+        }
+
+        @Override
+        public Object recreateFromKey(Object key) {
+            recreateCalls++;
+            dirty = false;
+            return new CacheValue(String.valueOf(key), recreateCalls);
+        }
+
+        void markDirty() {
+            dirty = true;
+        }
+    }
+
+    private static final class CacheValue {
+        private final String key;
+        private final int sequence;
+
+        private CacheValue(String key, int sequence) {
+            this.key = key;
+            this.sequence = sequence;
+        }
+
+        @Override
+        public String toString() {
+            return key + ":" + sequence;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ClassUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ClassUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.lang.AmbiguousClassNameException;
+import com.mchange.v1.lang.ClassUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClassUtilsTest {
+    @Test
+    void containsMethodAsSupertypeFindsMatchingInterfaceMethod() throws NoSuchMethodException {
+        Method iteratorMethod = Collection.class.getMethod("iterator");
+
+        boolean containsMethod = ClassUtils.containsMethodAsSupertype(Iterable.class, iteratorMethod);
+
+        assertThat(containsMethod).isTrue();
+    }
+
+    @Test
+    void forNameResolvesPrimitiveAndFullyQualifiedClassNames() throws ClassNotFoundException {
+        assertThat(ClassUtils.forName("int")).isSameAs(int.class);
+        assertThat(ClassUtils.forName("java.util.ArrayList")).isSameAs(ArrayList.class);
+    }
+
+    @Test
+    void forNameWithImportsReturnsFullyQualifiedClassBeforeTryingImports()
+            throws AmbiguousClassNameException, ClassNotFoundException {
+        Class<?> resolvedClass = ClassUtils.forName(
+                "java.util.Map",
+                new String[]{"java.sql"},
+                new String[]{"java.util.List"});
+
+        assertThat(resolvedClass).isSameAs(Map.class);
+    }
+
+    @Test
+    void classForSimpleNameResolvesExplicitImportedClass()
+            throws AmbiguousClassNameException, ClassNotFoundException {
+        Class<?> resolvedClass = ClassUtils.classForSimpleName("Map", null, new String[]{"java.util.Map"});
+
+        assertThat(resolvedClass).isSameAs(Map.class);
+    }
+
+    @Test
+    void classForSimpleNameResolvesJavaLangClassBeforeImportedPackages()
+            throws AmbiguousClassNameException, ClassNotFoundException {
+        Class<?> resolvedClass = ClassUtils.classForSimpleName("String", new String[]{"java.util"}, null);
+
+        assertThat(resolvedClass).isSameAs(String.class);
+    }
+
+    @Test
+    void classForSimpleNameResolvesClassFromImportedPackage()
+            throws AmbiguousClassNameException, ClassNotFoundException {
+        Class<?> resolvedClass = ClassUtils.classForSimpleName("Date", new String[]{"java.util"}, null);
+
+        assertThat(resolvedClass).isSameAs(Date.class);
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.util.CollectionUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionUtilsTest {
+    @Test
+    void attemptCloneClonesArrayListUsingBuiltInPath() throws NoSuchMethodException {
+        ArrayList<String> original = new ArrayList<>();
+        original.add("alpha");
+        original.add("beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(ArrayList.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesTreeSetUsingBuiltInPath() throws NoSuchMethodException {
+        TreeSet<String> original = new TreeSet<>();
+        original.add("beta");
+        original.add("alpha");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(TreeSet.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesHashMapUsingBuiltInPath() throws NoSuchMethodException {
+        HashMap<String, Integer> original = new HashMap<>();
+        original.put("one", 1);
+        original.put("two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(HashMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesTreeMapUsingBuiltInPath() throws NoSuchMethodException {
+        TreeMap<String, Integer> original = new TreeMap<>();
+        original.put("two", 2);
+        original.put("one", 1);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(TreeMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
@@ -9,10 +9,16 @@ package com_mchange.mchange_commons_java;
 import com.mchange.v2.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.AbstractList;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -77,5 +83,198 @@ public class CollectionUtilsTest {
         assertThat(cloned.get("one")).isEqualTo(1);
         assertThat(cloned.get("two")).isEqualTo(2);
         assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesCollectionUsingPublicCloneMethod() throws NoSuchMethodException {
+        CloneableCollection original = new CloneableCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CloneableCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesCollectionUsingCollectionCopyConstructor() throws NoSuchMethodException {
+        CollectionCopyConstructorCollection original =
+                new CollectionCopyConstructorCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CollectionCopyConstructorCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesCollectionUsingExactClassCopyConstructor() throws NoSuchMethodException {
+        ExactCopyConstructorCollection original =
+                new ExactCopyConstructorCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(ExactCopyConstructorCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingPublicCloneMethod() throws NoSuchMethodException {
+        CloneableMap original = new CloneableMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CloneableMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingMapCopyConstructor() throws NoSuchMethodException {
+        MapCopyConstructorMap original = new MapCopyConstructorMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(MapCopyConstructorMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingExactClassCopyConstructor() throws NoSuchMethodException {
+        ExactCopyConstructorMap original = new ExactCopyConstructorMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(ExactCopyConstructorMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    public static class CloneableCollection extends TestCollection {
+        public CloneableCollection(String... elements) {
+            super(elements);
+        }
+
+        private CloneableCollection(Collection<String> elements) {
+            super(elements);
+        }
+
+        @Override
+        public CloneableCollection clone() {
+            return new CloneableCollection(values);
+        }
+    }
+
+    public static class CollectionCopyConstructorCollection extends TestCollection {
+        public CollectionCopyConstructorCollection(String... elements) {
+            super(elements);
+        }
+
+        public CollectionCopyConstructorCollection(Collection<String> elements) {
+            super(elements);
+        }
+    }
+
+    public static class ExactCopyConstructorCollection extends TestCollection {
+        public ExactCopyConstructorCollection(String... elements) {
+            super(elements);
+        }
+
+        public ExactCopyConstructorCollection(ExactCopyConstructorCollection source) {
+            super(source.values);
+        }
+    }
+
+    public static class CloneableMap extends TestMap {
+        public CloneableMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        private CloneableMap(Map<String, Integer> entries) {
+            super(entries);
+        }
+
+        @Override
+        public CloneableMap clone() {
+            return new CloneableMap(values);
+        }
+    }
+
+    public static class MapCopyConstructorMap extends TestMap {
+        public MapCopyConstructorMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        public MapCopyConstructorMap(Map<String, Integer> entries) {
+            super(entries);
+        }
+    }
+
+    public static class ExactCopyConstructorMap extends TestMap {
+        public ExactCopyConstructorMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        public ExactCopyConstructorMap(ExactCopyConstructorMap source) {
+            super(source.values);
+        }
+    }
+
+    private abstract static class TestCollection extends AbstractList<String> {
+        protected final List<String> values = new ArrayList<>();
+
+        TestCollection(String... elements) {
+            Collections.addAll(values, elements);
+        }
+
+        TestCollection(Collection<String> elements) {
+            values.addAll(elements);
+        }
+
+        @Override
+        public String get(int index) {
+            return values.get(index);
+        }
+
+        @Override
+        public int size() {
+            return values.size();
+        }
+    }
+
+    private abstract static class TestMap extends AbstractMap<String, Integer> {
+        protected final Map<String, Integer> values = new LinkedHashMap<>();
+
+        TestMap(String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            values.put(firstKey, firstValue);
+            values.put(secondKey, secondValue);
+        }
+
+        TestMap(Map<String, Integer> entries) {
+            values.putAll(entries);
+        }
+
+        @Override
+        public Set<Entry<String, Integer>> entrySet() {
+            return values.entrySet();
+        }
     }
 }

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ConnectionBundlePoolBeanTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ConnectionBundlePoolBeanTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.db.sql.ConnectionBundlePoolBean;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectionBundlePoolBeanTest {
+    @Test
+    void initLoadsConfiguredJdbcDriverClassBeforeCreatingThePool() throws Exception {
+        InitializationTracker.reset();
+
+        ConnectionBundlePoolBean bean = new ConnectionBundlePoolBean();
+        bean.init(TrackingJdbcDriver.class.getName(), "jdbc:connection-bundle-pool:test", "user", "password", 0, 0, 0);
+        bean.close();
+
+        assertThat(InitializationTracker.loadCount()).isEqualTo(1);
+    }
+
+    public static final class TrackingJdbcDriver implements Driver {
+        static {
+            InitializationTracker.recordLoad();
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) {
+            return null;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return false;
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException();
+        }
+    }
+
+    private static final class InitializationTracker {
+        private static final AtomicInteger LOAD_COUNT = new AtomicInteger();
+
+        private InitializationTracker() {
+        }
+
+        private static void reset() {
+            LOAD_COUNT.set(0);
+        }
+
+        private static void recordLoad() {
+            LOAD_COUNT.incrementAndGet();
+        }
+
+        private static int loadCount() {
+            return LOAD_COUNT.get();
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/DecodeUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/DecodeUtilsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v3.decode.CannotDecodeException;
+import com.mchange.v3.decode.DecodeUtils;
+import com.mchange.v3.decode.Decoder;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DecodeUtilsTest {
+    @Test
+    void decodeUsesDecoderClassDeclaredInEncodedMap() throws CannotDecodeException {
+        Map<String, Object> encoded = new HashMap<>();
+        encoded.put(DecodeUtils.DECODER_CLASS_DOT_KEY, PrefixingDecoder.class.getName());
+        encoded.put("value", "payload");
+
+        Object decoded = DecodeUtils.decode(encoded);
+
+        assertThat(decoded).isEqualTo("decoded:payload");
+    }
+
+    @Test
+    void decodeUsesOptionalFinderLoadedDuringStaticInitialization() throws CannotDecodeException {
+        Object decoded = DecodeUtils.decode("finder:payload");
+
+        assertThat(decoded).isEqualTo("decoded:payload");
+    }
+
+    public static class PrefixingDecoder implements Decoder {
+        public PrefixingDecoder() {
+        }
+
+        @Override
+        public Object decode(Object obj) throws CannotDecodeException {
+            if (obj instanceof Map<?, ?> encoded) {
+                return "decoded:" + encoded.get("value");
+            }
+            if (obj instanceof String text && text.startsWith("finder:")) {
+                return "decoded:" + text.substring("finder:".length());
+            }
+            throw new CannotDecodeException("Unsupported encoded value: " + obj);
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/DelegatorGeneratorTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/DelegatorGeneratorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.codegen.intfc.DelegatorGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DelegatorGeneratorTest {
+    @Test
+    void writeDelegatorIncludesInheritedInterfaceMethods() throws IOException {
+        DelegatorGenerator generator = new DelegatorGenerator();
+        StringWriter writer = new StringWriter();
+
+        generator.writeDelegator(ChildContract.class, "com_mchange.mchange_commons_java.GeneratedDelegator", writer);
+
+        String generatedSource = writer.toString();
+
+        assertThat(generatedSource).contains("package com_mchange.mchange_commons_java;");
+        assertThat(generatedSource)
+                .contains("abstract class GeneratedDelegator implements DelegatorGeneratorTest.ChildContract");
+        assertThat(generatedSource).contains("parentMessage()");
+        assertThat(generatedSource).contains("return inner.parentMessage();");
+        assertThat(generatedSource).contains("childValue()");
+        assertThat(generatedSource).contains("return inner.childValue();");
+    }
+
+    public interface ParentContract {
+        String parentMessage();
+    }
+
+    public interface ChildContract extends ParentContract {
+        int childValue();
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/FallbackMLogDollarFallbackMLoggerTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/FallbackMLogDollarFallbackMLoggerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.log.FallbackMLog;
+import com.mchange.v2.log.MLevel;
+import com.mchange.v2.log.MLogger;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FallbackMLogDollarFallbackMLoggerTest {
+    private static final String BUNDLE_NAME = "com_mchange.mchange_commons_java.FallbackMLogDollarFallbackMLoggerTestMessages";
+
+    @Test
+    void logrbResolvesMessagesFromResourceBundle() {
+        MLogger logger = new FallbackMLog().getMLogger();
+        ByteArrayOutputStream capturedErr = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+
+        try (PrintStream redirectedErr = new PrintStream(capturedErr, true, StandardCharsets.UTF_8)) {
+            System.setErr(redirectedErr);
+
+            logger.logrb(
+                    MLevel.INFO,
+                    FallbackMLogDollarFallbackMLoggerTest.class.getName(),
+                    "logrbResolvesMessagesFromResourceBundle",
+                    BUNDLE_NAME,
+                    "message.template",
+                    new Object[]{"world"}
+            );
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        assertThat(capturedErr.toString(StandardCharsets.UTF_8))
+                .contains(FallbackMLogDollarFallbackMLoggerTest.class.getName())
+                .contains("logrbResolvesMessagesFromResourceBundle()")
+                .contains("Resource bundle says hello to world");
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ForwardingInvocationHandlerTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ForwardingInvocationHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.reflect.ForwardingInvocationHandler;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ForwardingInvocationHandlerTest {
+    @Test
+    void proxyInvocationHandlerForwardsCallsToInnerImplementation() {
+        GreetingService proxy = (GreetingService) Proxy.newProxyInstance(
+                GreetingService.class.getClassLoader(),
+                new Class<?>[]{GreetingService.class},
+                new ForwardingInvocationHandler(new GreetingServiceImpl("hello "))
+        );
+
+        assertThat(proxy.greet("metadata")).isEqualTo("hello metadata");
+    }
+
+    public interface GreetingService {
+        String greet(String name);
+    }
+
+    public static final class GreetingServiceImpl implements GreetingService {
+        private final String prefix;
+
+        public GreetingServiceImpl(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public String greet(String name) {
+            return prefix + name;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/IoSerializableUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/IoSerializableUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.io.SerializableUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class IoSerializableUtilsTest {
+    @Test
+    void marshallObjectToFileAndUnmarshallObjectFromFileRoundTripSerializablePayload(@TempDir Path tempDir) throws Exception {
+        SerializablePayload original = createPayload("legacy-io");
+        File serializedFile = tempDir.resolve("legacy-payload.ser").toFile();
+
+        SerializableUtils.marshallObjectToFile(original, serializedFile);
+        Object restored = SerializableUtils.unmarshallObjectFromFile(serializedFile);
+
+        assertThat(serializedFile).exists().isFile();
+        assertThat(serializedFile.length()).isGreaterThan(0L);
+        assertThat(restored).isInstanceOf(SerializablePayload.class);
+
+        SerializablePayload restoredPayload = (SerializablePayload) restored;
+
+        assertThat(restoredPayload.getName()).isEqualTo(original.getName());
+        assertThat(restoredPayload.getTags()).containsExactlyElementsOf(original.getTags());
+        assertThat(restoredPayload.getAttributes()).containsExactlyEntriesOf(original.getAttributes());
+    }
+
+    private static SerializablePayload createPayload(String name) {
+        List<String> tags = new ArrayList<>();
+        tags.add(name + "-first");
+        tags.add(name + "-second");
+
+        Map<String, Integer> attributes = new LinkedHashMap<>();
+        attributes.put("length", name.length());
+        attributes.put("tagCount", tags.size());
+
+        return new SerializablePayload(name, tags, attributes);
+    }
+
+    public static final class SerializablePayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> tags;
+        private final Map<String, Integer> attributes;
+
+        public SerializablePayload(String name, List<String> tags, Map<String, Integer> attributes) {
+            this.name = name;
+            this.tags = new ArrayList<>(tags);
+            this.attributes = new LinkedHashMap<>(attributes);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getTags() {
+            return new ArrayList<>(tags);
+        }
+
+        public Map<String, Integer> getAttributes() {
+            return new LinkedHashMap<>(attributes);
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/IteratorUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/IteratorUtilsTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.util.IteratorUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IteratorUtilsTest {
+    @Test
+    void toArrayCreatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        Object[] result = IteratorUtils.toArray(List.of("alpha", "beta").iterator(), 2, new String[0]);
+
+        assertThat(result).isInstanceOf(String[].class);
+        assertThat((String[]) result).containsExactly("alpha", "beta");
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/JavaBeanObjectFactoryTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/JavaBeanObjectFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.naming.JavaBeanObjectFactory;
+import com.mchange.v2.naming.JavaBeanReferenceMaker;
+import org.junit.jupiter.api.Test;
+
+import javax.naming.Reference;
+import java.util.Hashtable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaBeanObjectFactoryTest {
+    @Test
+    void getObjectInstanceRecreatesJavaBeanPropertiesFromReference() throws Exception {
+        ReferenceableBean bean = new ReferenceableBean();
+        bean.setCount(7);
+        bean.setName("alpha");
+
+        JavaBeanReferenceMaker referenceMaker = new JavaBeanReferenceMaker();
+        Reference reference = referenceMaker.createReference(bean);
+        JavaBeanObjectFactory objectFactory = new JavaBeanObjectFactory();
+
+        Object recreated = objectFactory.getObjectInstance(reference, null, null, new
+            Hashtable<>());
+        ReferenceableBean recreatedBean = (ReferenceableBean) recreated;
+
+        assertThat(recreated).isInstanceOf(ReferenceableBean.class);
+        assertThat(recreatedBean.getCount()).isEqualTo(7);
+        assertThat(recreatedBean.getName()).isEqualTo("alpha");
+    }
+
+    public static class ReferenceableBean {
+        private Integer count;
+        private String name;
+
+        public ReferenceableBean() {
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+
+        public void setCount(Integer count) {
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/LogUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/LogUtilsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.log.LogUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogUtilsTest {
+    private static final String BUNDLE_NAME = "com_mchange.mchange_commons_java.LogUtilsTestMessages";
+
+    @Test
+    void formatMessageLoadsMessagePatternFromResourceBundle() {
+        String formattedMessage = LogUtils.formatMessage(
+                BUNDLE_NAME,
+                "message.template",
+                new Object[]{"world"});
+
+        assertThat(formattedMessage).isEqualTo("Resource bundle says hello to world");
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/MLogTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/MLogTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.log.MLog;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MLogTest {
+    private static final String MLOG_PROPERTY = "com.mchange.v2.log.MLog";
+    private static final String NAME_TRANSFORMER_PROPERTY = "com.mchange.v2.log.NameTransformer";
+
+    @Test
+    void refreshConfigLoadsConfiguredNameTransformer() {
+        String previousMLog = System.getProperty(MLOG_PROPERTY);
+        String previousNameTransformer = System.getProperty(NAME_TRANSFORMER_PROPERTY);
+
+        try {
+            System.setProperty(MLOG_PROPERTY, "jdk14");
+            System.setProperty(NAME_TRANSFORMER_PROPERTY, "com.mchange.v2.log.PackageNames");
+
+            MLog.refreshConfig(null, null);
+
+            assertThat(MLog.getLogger(MLogTest.class).getName()).isEqualTo(MLogTest.class.getPackageName());
+        } finally {
+            restoreSystemProperty(MLOG_PROPERTY, previousMLog);
+            restoreSystemProperty(NAME_TRANSFORMER_PROPERTY, previousNameTransformer);
+            MLog.refreshConfig(null, null);
+        }
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ObjectUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ObjectUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.lang.ObjectUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class ObjectUtilsTest {
+    @Test
+    void objectToByteArrayAndObjectFromByteArrayRoundTripSerializablePayload() throws Exception {
+        SerializablePayload original = createPayload("legacy-object-utils");
+
+        byte[] serialized = ObjectUtils.objectToByteArray(original);
+        Object restored = ObjectUtils.objectFromByteArray(serialized);
+
+        assertThat(serialized).isNotEmpty();
+        assertThat(restored).isInstanceOf(SerializablePayload.class);
+
+        SerializablePayload restoredPayload = (SerializablePayload) restored;
+
+        assertThat(restoredPayload.getName()).isEqualTo(original.getName());
+        assertThat(restoredPayload.getTags()).containsExactlyElementsOf(original.getTags());
+        assertThat(restoredPayload.getAttributes()).containsExactlyEntriesOf(original.getAttributes());
+    }
+
+    private static SerializablePayload createPayload(String name) {
+        List<String> tags = new ArrayList<>();
+        tags.add(name + "-first");
+        tags.add(name + "-second");
+
+        Map<String, Integer> attributes = new LinkedHashMap<>();
+        attributes.put("length", name.length());
+        attributes.put("tagCount", tags.size());
+
+        return new SerializablePayload(name, tags, attributes);
+    }
+
+    public static final class SerializablePayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> tags;
+        private final Map<String, Integer> attributes;
+
+        public SerializablePayload(String name, List<String> tags, Map<String, Integer> attributes) {
+            this.name = name;
+            this.tags = new ArrayList<>(tags);
+            this.attributes = new LinkedHashMap<>(attributes);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getTags() {
+            return new ArrayList<>(tags);
+        }
+
+        public Map<String, Integer> getAttributes() {
+            return new LinkedHashMap<>(attributes);
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/PropertyComponentBindingUtilityTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/PropertyComponentBindingUtilityTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.beans.swing.PropertyBoundComboBox;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.SwingUtilities;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyComponentBindingUtilityTest {
+    @Test
+    void comboBoxBindingReadsAndWritesBeanPropertyThroughPublicSwingBinding() throws Exception {
+        ChoiceBean bean = new ChoiceBean("alpha");
+
+        PropertyBoundComboBox comboBox = onEventDispatchThread(() -> new PropertyBoundComboBox(
+                bean,
+                "choice",
+                new String[] {"alpha", "bravo", "none"},
+                "none"));
+        flushSwingEvents();
+
+        assertThat(bean.getPropertyChangeListenerAddCount()).isEqualTo(1);
+        assertThat(bean.getChoiceGetterInvocationCount()).isGreaterThanOrEqualTo(1);
+        assertThat(comboBox.getSelectedItem()).isEqualTo("alpha");
+
+        bean.resetAccessCounts();
+        onEventDispatchThread(() -> comboBox.setSelectedItem("bravo"));
+
+        assertThat(bean.choice()).isEqualTo("bravo");
+        assertThat(bean.getChoiceGetterInvocationCount()).isGreaterThanOrEqualTo(1);
+        assertThat(bean.getChoiceSetterInvocationCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    private static void flushSwingEvents() throws Exception {
+        onEventDispatchThread(() -> {
+        });
+    }
+
+    private static <T> T onEventDispatchThread(ThrowingSupplier<T> supplier) throws Exception {
+        Result<T> result = new Result<>();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                result.value = supplier.get();
+            } catch (Exception e) {
+                result.exception = e;
+            }
+        });
+        if (result.exception != null) {
+            throw result.exception;
+        }
+        return result.value;
+    }
+
+    private static void onEventDispatchThread(ThrowingRunnable runnable) throws Exception {
+        onEventDispatchThread(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    public static class ChoiceBean {
+        private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+        private String choice;
+        private int propertyChangeListenerAddCount;
+        private int choiceGetterInvocationCount;
+        private int choiceSetterInvocationCount;
+
+        public ChoiceBean(String choice) {
+            this.choice = choice;
+        }
+
+        public String getChoice() {
+            choiceGetterInvocationCount++;
+            return choice;
+        }
+
+        public void setChoice(String choice) {
+            choiceSetterInvocationCount++;
+            String oldChoice = this.choice;
+            this.choice = choice;
+            propertyChangeSupport.firePropertyChange("choice", oldChoice, choice);
+        }
+
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+            propertyChangeListenerAddCount++;
+            propertyChangeSupport.addPropertyChangeListener(listener);
+        }
+
+        public void removePropertyChangeListener(PropertyChangeListener listener) {
+            propertyChangeSupport.removePropertyChangeListener(listener);
+        }
+
+        public String choice() {
+            return choice;
+        }
+
+        public int getPropertyChangeListenerAddCount() {
+            return propertyChangeListenerAddCount;
+        }
+
+        public int getChoiceGetterInvocationCount() {
+            return choiceGetterInvocationCount;
+        }
+
+        public int getChoiceSetterInvocationCount() {
+            return choiceSetterInvocationCount;
+        }
+
+        public void resetAccessCounts() {
+            choiceGetterInvocationCount = 0;
+            choiceSetterInvocationCount = 0;
+        }
+    }
+
+    private static final class Result<T> {
+        private T value;
+        private Exception exception;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.naming.ReferenceableUtils;
+import org.junit.jupiter.api.Test;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+import javax.naming.spi.ObjectFactory;
+import java.util.Hashtable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReferenceableUtilsTest {
+    @Test
+    void referenceToObjectInstantiatesConfiguredFactoryAndDelegatesReferenceResolution() throws Exception {
+        Reference reference = new Reference(String.class.getName(), CapturingObjectFactory.class.getName(), null);
+        reference.add(new StringRefAddr("value", "alpha"));
+        Hashtable<String, Object> environment = new
+            Hashtable<>();
+        environment.put("prefix", "resolved");
+
+        Object resolved = ReferenceableUtils.referenceToObject(reference, null, null, environment);
+
+        assertThat(resolved).isEqualTo("resolved:alpha");
+    }
+
+    public static class CapturingObjectFactory implements ObjectFactory {
+        public CapturingObjectFactory() {
+        }
+
+        @Override
+        public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
+            Reference reference = (Reference) obj;
+            String prefix = (String) environment.get("prefix");
+            String value = (String) reference.get("value").getContent();
+            return prefix + ":" + value;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
@@ -15,6 +15,7 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +28,9 @@ public class ReferenceableUtilsTest {
             Hashtable<>();
         environment.put("prefix", "resolved");
 
-        Object resolved = ReferenceableUtils.referenceToObject(reference, null, null, environment);
+        Set<String> allowedFactoryClassNames = Set.of(CapturingObjectFactory.class.getName());
+
+        Object resolved = ReferenceableUtils.referenceToObject(reference, null, null, environment, allowedFactoryClassNames);
 
         assertThat(resolved).isEqualTo("resolved:alpha");
     }

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
@@ -18,8 +18,15 @@ import java.util.Hashtable;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class ReferenceableUtilsTest {
+    @Test
+    void assertAcceptableNameConstructsTheDefaultNameGuard() {
+        assertThatCode(() -> ReferenceableUtils.assertAcceptableName("java:comp/env/jdbc/example", null))
+            .doesNotThrowAnyException();
+    }
+
     @Test
     void referenceToObjectInstantiatesConfiguredFactoryAndDelegatesReferenceResolution() throws Exception {
         Reference reference = new Reference(String.class.getName(), CapturingObjectFactory.class.getName(), null);

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReflectUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReflectUtilsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.reflect.ReflectUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectUtilsTest {
+    @Test
+    void findProxyConstructorReturnsInvocationHandlerConstructorForProxyInterface() throws NoSuchMethodException {
+        Constructor<?> proxyConstructor = ReflectUtils.findProxyConstructor(ProxyContract.class.getClassLoader(), ProxyContract.class);
+
+        assertThat(proxyConstructor.getParameterTypes()).containsExactly(InvocationHandler.class);
+        assertThat(proxyConstructor.getDeclaringClass().getInterfaces()).contains(ProxyContract.class);
+    }
+
+    @Test
+    void findInPublicScopeReturnsPublicParentMethodForPackagePrivateOverride() throws NoSuchMethodException {
+        Method overridingMethod = PackagePrivateChild.class.getDeclaredMethod("message");
+
+        Method publicMethod = ReflectUtils.findInPublicScope(overridingMethod);
+
+        assertThat(publicMethod).isNotNull();
+        assertThat(publicMethod.getDeclaringClass()).isSameAs(PublicParent.class);
+        assertThat(publicMethod.getName()).isEqualTo("message");
+    }
+
+    @Test
+    void findInPublicScopeReturnsPublicInterfaceMethodWhenNoPublicParentDeclaresIt() throws NoSuchMethodException {
+        Method implementationMethod = PackagePrivateInterfaceImpl.class.getDeclaredMethod("describe");
+
+        Method publicMethod = ReflectUtils.findInPublicScope(implementationMethod);
+
+        assertThat(publicMethod).isNotNull();
+        assertThat(publicMethod.getDeclaringClass()).isSameAs(Describable.class);
+        assertThat(publicMethod.getName()).isEqualTo("describe");
+    }
+
+    public interface ProxyContract {
+        String message();
+    }
+
+    public static class PublicParent {
+        public String message() {
+            return "parent";
+        }
+    }
+
+    static class PackagePrivateChild extends PublicParent {
+        @Override
+        public String message() {
+            return "child";
+        }
+    }
+
+    public interface Describable {
+        String describe();
+    }
+
+    static class PackagePrivateInterfaceImpl implements Describable {
+        @Override
+        public String describe() {
+            return "implementation";
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ResourceEntityResolverTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ResourceEntityResolverTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.xml.ResourceEntityResolver;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceEntityResolverTest {
+    @Test
+    void resolveEntityLoadsSiblingPackageResourceFromSystemIdFileName() throws Exception {
+        ResourceEntityResolver resolver = new ResourceEntityResolver(ResourceEntityResolverTest.class);
+
+        InputSource inputSource = resolver.resolveEntity(null, "https://example.test/dtd/test-entity.dtd");
+
+        assertThat(inputSource).isNotNull();
+        try (InputStream stream = inputSource.getByteStream()) {
+            assertThat(stream).isNotNull();
+            assertThat(new String(stream.readAllBytes(), StandardCharsets.UTF_8))
+                    .contains("<!ELEMENT sample (#PCDATA)>");
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SchemaManagerTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SchemaManagerTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.db.sql.SchemaManager;
+import com.mchange.v1.db.sql.XmlSchema;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SchemaManagerTest {
+    private static final String JDBC_URL = "jdbc:schema-manager:test";
+
+    @Test
+    void mainCreatesSchemaUsingReflectedSchemaClass() throws SQLException {
+        TrackingDriver driver = new TrackingDriver();
+        DriverManager.registerDriver(driver);
+        try {
+            String output = invokeMainAndCaptureStdout(new String[]{"-create", JDBC_URL, XmlSchema.class.getName()});
+
+            assertThat(output).contains("Schema created.");
+            assertThat(driver.connection.autoCommit).isFalse();
+            assertThat(driver.connection.closed).isTrue();
+            assertThat(driver.lastUrl).isEqualTo(JDBC_URL);
+            assertThat(driver.lastProperties).doesNotContainKeys("user", "password");
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void mainDropsSchemaUsingCredentialsAndReflectedSchemaClass() throws SQLException {
+        TrackingDriver driver = new TrackingDriver();
+        DriverManager.registerDriver(driver);
+        try {
+            String output = invokeMainAndCaptureStdout(
+                    new String[]{"-drop", JDBC_URL, "scott", "tiger", XmlSchema.class.getName()}
+            );
+
+            assertThat(output).contains("Schema dropped.");
+            assertThat(driver.connection.autoCommit).isFalse();
+            assertThat(driver.connection.closed).isTrue();
+            assertThat(driver.lastUrl).isEqualTo(JDBC_URL);
+            assertThat(driver.lastProperties)
+                    .containsEntry("user", "scott")
+                    .containsEntry("password", "tiger");
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    private static String invokeMainAndCaptureStdout(String[] arguments) {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+            SchemaManager.main(arguments);
+        } finally {
+            System.setOut(originalOut);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private static final class TrackingDriver implements Driver {
+        private final TrackingConnection connection = new TrackingConnection();
+        private String lastUrl;
+        private Properties lastProperties;
+
+        @Override
+        public Connection connect(String url, Properties info) {
+            if (!acceptsUrl(url)) {
+                return null;
+            }
+            this.lastUrl = url;
+            this.lastProperties = copyOf(info);
+            return connection;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return acceptsUrl(url);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException();
+        }
+
+        private static boolean acceptsUrl(String url) {
+            return JDBC_URL.equals(url);
+        }
+
+        private static Properties copyOf(Properties original) {
+            Properties copy = new Properties();
+            if (original != null) {
+                copy.putAll(original);
+            }
+            return copy;
+        }
+    }
+
+    private static final class TrackingConnection implements Connection {
+        private boolean autoCommit = true;
+        private boolean closed;
+        private final Properties clientInfo = new Properties();
+        private String schema;
+        private String catalog;
+        private int transactionIsolation = Connection.TRANSACTION_NONE;
+        private int holdability;
+        private int networkTimeout;
+        private boolean readOnly;
+        private Map<String, Class<?>> typeMap;
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public String nativeSQL(String sql) {
+            return sql;
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) {
+            this.autoCommit = autoCommit;
+        }
+
+        @Override
+        public boolean getAutoCommit() {
+            return autoCommit;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public void rollback() {
+        }
+
+        @Override
+        public void close() {
+            this.closed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) {
+            this.readOnly = readOnly;
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return readOnly;
+        }
+
+        @Override
+        public void setCatalog(String catalog) {
+            this.catalog = catalog;
+        }
+
+        @Override
+        public String getCatalog() {
+            return catalog;
+        }
+
+        @Override
+        public void setTransactionIsolation(int level) {
+            this.transactionIsolation = level;
+        }
+
+        @Override
+        public int getTransactionIsolation() {
+            return transactionIsolation;
+        }
+
+        @Override
+        public SQLWarning getWarnings() {
+            return null;
+        }
+
+        @Override
+        public void clearWarnings() {
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() {
+            return typeMap;
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> map) {
+            this.typeMap = map;
+        }
+
+        @Override
+        public void setHoldability(int holdability) {
+            this.holdability = holdability;
+        }
+
+        @Override
+        public int getHoldability() {
+            return holdability;
+        }
+
+        @Override
+        public Savepoint setSavepoint() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public Savepoint setSavepoint(String name) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public void rollback(Savepoint savepoint) {
+        }
+
+        @Override
+        public void releaseSavepoint(Savepoint savepoint) {
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public Clob createClob() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public Blob createBlob() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public NClob createNClob() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public SQLXML createSQLXML() throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public boolean isValid(int timeout) {
+            return !closed;
+        }
+
+        @Override
+        public void setClientInfo(String name, String value) {
+            clientInfo.setProperty(name, value);
+        }
+
+        @Override
+        public void setClientInfo(Properties properties) {
+            clientInfo.clear();
+            clientInfo.putAll(properties);
+        }
+
+        @Override
+        public String getClientInfo(String name) {
+            return clientInfo.getProperty(name);
+        }
+
+        @Override
+        public Properties getClientInfo() {
+            Properties copy = new Properties();
+            copy.putAll(clientInfo);
+            return copy;
+        }
+
+        @Override
+        public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+            throw unsupported();
+        }
+
+        @Override
+        public void setSchema(String schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public String getSchema() {
+            return schema;
+        }
+
+        @Override
+        public void abort(Executor executor) {
+            this.closed = true;
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) {
+            this.networkTimeout = milliseconds;
+        }
+
+        @Override
+        public int getNetworkTimeout() {
+            return networkTimeout;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            if (iface.isInstance(this)) {
+                return iface.cast(this);
+            }
+            throw unsupported();
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return iface.isInstance(this);
+        }
+
+        private static SQLException unsupported() {
+            return new SQLFeatureNotSupportedException("Not needed for SchemaManager coverage tests.");
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SerializableUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SerializableUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.ser.SerializableUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializableUtilsTest {
+    @Test
+    void serializeToByteArrayAndDeserializeFromByteArrayRoundTripSerializablePayload() throws Exception {
+        SerializablePayload original = createPayload("byte-array");
+
+        byte[] serialized = SerializableUtils.serializeToByteArray(original);
+        Object restored = SerializableUtils.deserializeFromByteArray(serialized);
+
+        assertThat(serialized).isNotEmpty();
+        assertThat(restored).isInstanceOf(SerializablePayload.class);
+
+        SerializablePayload restoredPayload = (SerializablePayload) restored;
+
+        assertThat(restoredPayload.getName()).isEqualTo(original.getName());
+        assertThat(restoredPayload.getTags()).containsExactlyElementsOf(original.getTags());
+        assertThat(restoredPayload.getAttributes()).containsExactlyEntriesOf(original.getAttributes());
+    }
+
+    @Test
+    void marshallObjectToFileAndUnmarshallObjectFromFileRoundTripSerializablePayload(@TempDir Path tempDir) throws Exception {
+        SerializablePayload original = createPayload("file");
+        File serializedFile = tempDir.resolve("payload.ser").toFile();
+
+        SerializableUtils.marshallObjectToFile(original, serializedFile);
+        Object restored = SerializableUtils.unmarshallObjectFromFile(serializedFile);
+
+        assertThat(serializedFile).exists().isFile();
+        assertThat(serializedFile.length()).isGreaterThan(0L);
+        assertThat(restored).isInstanceOf(SerializablePayload.class);
+
+        SerializablePayload restoredPayload = (SerializablePayload) restored;
+
+        assertThat(restoredPayload.getName()).isEqualTo(original.getName());
+        assertThat(restoredPayload.getTags()).containsExactlyElementsOf(original.getTags());
+        assertThat(restoredPayload.getAttributes()).containsExactlyEntriesOf(original.getAttributes());
+    }
+
+    private static SerializablePayload createPayload(String name) {
+        List<String> tags = new ArrayList<>();
+        tags.add(name + "-first");
+        tags.add(name + "-second");
+
+        Map<String, Integer> attributes = new LinkedHashMap<>();
+        attributes.put("length", name.length());
+        attributes.put("tagCount", tags.size());
+
+        return new SerializablePayload(name, tags, attributes);
+    }
+
+    public static final class SerializablePayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final List<String> tags;
+        private final Map<String, Integer> attributes;
+
+        public SerializablePayload(String name, List<String> tags, Map<String, Integer> attributes) {
+            this.name = name;
+            this.tags = new ArrayList<>(tags);
+            this.attributes = new LinkedHashMap<>(attributes);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getTags() {
+            return new ArrayList<>(tags);
+        }
+
+        public Map<String, Integer> getAttributes() {
+            return new LinkedHashMap<>(attributes);
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SoftSetFactoryTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SoftSetFactoryTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.cachedstore.SoftSetFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SoftSetFactoryTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    void createSynchronousCleanupSoftSetReturnsWorkingSetProxy() {
+        Set<Object> set = (Set<Object>) SoftSetFactory.createSynchronousCleanupSoftSet();
+
+        assertThat(set.add("alpha")).isTrue();
+        assertThat(set.add("alpha")).isFalse();
+        assertThat(set.contains("alpha")).isTrue();
+        assertThat(set.size()).isEqualTo(1);
+        assertThat(set.remove("alpha")).isTrue();
+        assertThat(set.size()).isZero();
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SynchronizerDollar1Test.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/SynchronizerDollar1Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v1.lang.Synchronizer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SynchronizerDollar1Test {
+    @Test
+    void createSynchronizedWrapperDelegatesInterfaceMethodCallsToWrappedObject() {
+        EchoServiceImpl target = new EchoServiceImpl();
+
+        EchoService wrapper = (EchoService) Synchronizer.createSynchronizedWrapper(target);
+
+        assertThat(wrapper).isNotSameAs(target);
+        assertThat(wrapper).isInstanceOf(EchoService.class);
+        assertThat(wrapper.echo("hello")).isEqualTo("hello-1");
+        assertThat(target.invocations()).isEqualTo(1);
+    }
+
+    public interface EchoService {
+        String echo(String value);
+    }
+
+    public static final class EchoServiceImpl implements EchoService {
+        private int invocations;
+
+        @Override
+        public String echo(String value) {
+            invocations++;
+            return value + "-" + invocations;
+        }
+
+        public int invocations() {
+            return invocations;
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ThreadPoolAsynchronousRunnerTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ThreadPoolAsynchronousRunnerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.async.ThreadPoolAsynchronousRunner;
+import com.mchange.v2.log.MLevel;
+import com.mchange.v2.log.MLog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Timer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadPoolAsynchronousRunnerTest {
+    private static final String THREAD_POOL_LOGGER_NAME = "com.mchange.v2.async.ThreadPoolAsynchronousRunner";
+    private static final String FALLBACK_CUTOFF_PROPERTY = "com.mchange.v2.log.FallbackMLog.DEFAULT_CUTOFF_LEVEL";
+
+    private static Logger rootLogger;
+    private static Logger threadPoolLogger;
+    private static Level previousRootLevel;
+    private static Level previousThreadPoolLoggerLevel;
+    private static Map<Handler, Level> previousHandlerLevels;
+    private static String previousFallbackCutoffLevel;
+
+    @BeforeAll
+    static void enableFinestLogging() {
+        previousFallbackCutoffLevel = System.getProperty(FALLBACK_CUTOFF_PROPERTY);
+        System.setProperty(FALLBACK_CUTOFF_PROPERTY, "FINEST");
+        MLog.refreshConfig(null, null);
+
+        rootLogger = LogManager.getLogManager().getLogger("");
+        threadPoolLogger = Logger.getLogger(THREAD_POOL_LOGGER_NAME);
+        previousRootLevel = rootLogger.getLevel();
+        previousThreadPoolLoggerLevel = threadPoolLogger.getLevel();
+        previousHandlerLevels = new IdentityHashMap<>();
+        for (Handler handler : rootLogger.getHandlers()) {
+            previousHandlerLevels.put(handler, handler.getLevel());
+            handler.setLevel(Level.FINEST);
+        }
+        rootLogger.setLevel(Level.FINEST);
+        threadPoolLogger.setLevel(Level.FINEST);
+    }
+
+    @AfterAll
+    static void restoreLogging() {
+        if (rootLogger != null) {
+            rootLogger.setLevel(previousRootLevel);
+        }
+        if (threadPoolLogger != null) {
+            threadPoolLogger.setLevel(previousThreadPoolLoggerLevel);
+        }
+        if (previousHandlerLevels != null) {
+            for (Map.Entry<Handler, Level> entry : previousHandlerLevels.entrySet()) {
+                entry.getKey().setLevel(entry.getValue());
+            }
+        }
+
+        if (previousFallbackCutoffLevel == null) {
+            System.clearProperty(FALLBACK_CUTOFF_PROPERTY);
+        } else {
+            System.setProperty(FALLBACK_CUTOFF_PROPERTY, previousFallbackCutoffLevel);
+        }
+        MLog.refreshConfig(null, null);
+    }
+
+    @Test
+    void getStackTracesReturnsManagedWorkerThreadDump() throws InterruptedException {
+        Timer timer = new Timer(true);
+        ThreadPoolAsynchronousRunner runner = new ThreadPoolAsynchronousRunner(1, true, 0, 1000, 1000, timer, "stack-trace-runner");
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch releaseTask = new CountDownLatch(1);
+
+        try {
+            runner.postRunnable(() -> {
+                taskStarted.countDown();
+                awaitLatch(releaseTask);
+            });
+
+            assertThat(taskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            String stackTraces = runner.getStackTraces();
+
+            assertThat(stackTraces)
+                    .isNotBlank()
+                    .contains("stack-trace-runner-#0")
+                    .contains("java.util.concurrent.CountDownLatch");
+        } finally {
+            releaseTask.countDown();
+            runner.close(true);
+            timer.cancel();
+        }
+    }
+
+    @Test
+    void pendingTasksTriggerDeadlockDetectionAndRecovery() throws InterruptedException {
+        assertThat(MLog.getLogger(ThreadPoolAsynchronousRunner.class).isLoggable(MLevel.FINEST)).isTrue();
+
+        Timer timer = new Timer(true);
+        ThreadPoolAsynchronousRunner runner = new ThreadPoolAsynchronousRunner(1, true, 0, 25, 25, timer, "deadlock-runner");
+        CountDownLatch blockingTaskStarted = new CountDownLatch(1);
+        CountDownLatch releaseBlockingTask = new CountDownLatch(1);
+        CountDownLatch pendingTaskExecuted = new CountDownLatch(1);
+
+        try {
+            runner.postRunnable(() -> {
+                blockingTaskStarted.countDown();
+                awaitLatch(releaseBlockingTask);
+            });
+            assertThat(blockingTaskStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            runner.postRunnable(pendingTaskExecuted::countDown);
+
+            assertThat(pendingTaskExecuted.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            releaseBlockingTask.countDown();
+            runner.close(true);
+            timer.cancel();
+        }
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ThreadUtilsTest.java
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ThreadUtilsTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.lang.ThreadUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ThreadUtilsTest {
+    @Test
+    void reflectiveHoldsLockReportsWhetherCurrentThreadOwnsMonitor() {
+        Object lock = new Object();
+
+        synchronized (lock) {
+            assertThat(ThreadUtils.reflectiveHoldsLock(lock)).isTrue();
+        }
+
+        assertThat(ThreadUtils.reflectiveHoldsLock(lock)).isFalse();
+    }
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,608 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$TestStringEditor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$MutableBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$CompatibleTargetBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$AlternateBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type" : "com_mchange.mchange_commons_java.PropertyComponentBindingUtilityTest$ObservableValueBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "addPropertyChangeListener",
+          "parameterTypes" : [
+            "java.beans.PropertyChangeListener"
+          ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "decoderClassName",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "decode",
+          "parameterTypes" : [
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$PackagePrivateChild",
+      "methods" : [
+        {
+          "name" : "message",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$PackagePrivateInterfaceImpl",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$PublicParent",
+      "methods" : [
+        {
+          "name" : "message",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$Describable",
+      "methods" : [
+        {
+          "name" : "describe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type" : {
+        "proxy" : [
+          "com_mchange.mchange_commons_java.ReflectUtilsTest$ProxyContract"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ForwardingInvocationHandler"
+      },
+      "type" : "com_mchange.mchange_commons_java.ForwardingInvocationHandlerTest$GreetingService",
+      "methods" : [
+        {
+          "name" : "greet",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ForwardingInvocationHandler"
+      },
+      "type" : {
+        "proxy" : [
+          "com_mchange.mchange_commons_java.ForwardingInvocationHandlerTest$GreetingService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.ReferenceableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReferenceableUtilsTest$CapturingObjectFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getObjectInstance",
+          "parameterTypes" : [
+            "java.lang.Object",
+            "javax.naming.Name",
+            "javax.naming.Context",
+            "java.util.Hashtable"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanObjectFactory"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.ser.SerializableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.SerializableUtilsTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.IoSerializableUtilsTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.lang.ObjectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ObjectUtilsTest$SerializablePayload",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type" : "com_mchange.mchange_commons_java.DelegatorGeneratorTest$ParentContract",
+      "methods" : [
+        {
+          "name" : "parentMessage",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type" : "com_mchange.mchange_commons_java.DelegatorGeneratorTest$ChildContract",
+      "methods" : [
+        {
+          "name" : "childValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "parentMessage",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$AlternateBean",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$AlternateBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$AlternateBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$MutableBean",
+      "methods" : [
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$MutableBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$MutableBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.db.sql.ConnectionBundlePoolBean"
+      },
+      "type" : "com_mchange.mchange_commons_java.ConnectionBundlePoolBeanTest$TrackingJdbcDriver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.codegen.intfc.DelegatorGenerator"
+      },
+      "type" : "com_mchange.mchange_commons_java.DelegatorGeneratorTest$ChildContract"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanObjectFactory"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCount",
+          "parameterTypes" : [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean",
+      "methods" : [
+        {
+          "name" : "getCount",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getName",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanReferenceMaker"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type" : "com_mchange.mchange_commons_java.PropertyComponentBindingUtilityTest$ObservableValueBean",
+      "methods" : [
+        {
+          "name" : "addPropertyChangeListener",
+          "parameterTypes" : [
+            "java.beans.PropertyChangeListener"
+          ]
+        },
+        {
+          "name" : "getValue",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setValue",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type" : "com_mchange.mchange_commons_java.PropertyComponentBindingUtilityTest$ObservableValueBeanBeanInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.swing.PropertyComponentBindingUtility"
+      },
+      "type" : "com_mchange.mchange_commons_java.PropertyComponentBindingUtilityTest$ObservableValueBeanCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.ReferenceableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReferenceableUtilsTest$CapturingObjectFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$Describable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.reflect.ReflectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReflectUtilsTest$PublicParent"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.db.sql.SchemaManager"
+      },
+      "type" : "com_mchange.mchange_commons_java.SchemaManagerTest$TrackingDriver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.Synchronizer$1"
+      },
+      "type" : "com_mchange.mchange_commons_java.SynchronizerDollar1Test$EchoService",
+      "methods" : [
+        {
+          "name" : "echo",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.Synchronizer$1"
+      },
+      "type" : {
+        "proxy" : [
+          "com_mchange.mchange_commons_java.SynchronizerDollar1Test$EchoService"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.LogUtils"
+      },
+      "glob" : "com_mchange/mchange_commons_java/LogUtilsTestMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.log.FallbackMLog$FallbackMLogger"
+      },
+      "glob" : "com_mchange/mchange_commons_java/FallbackMLogDollarFallbackMLoggerTestMessages.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.xml.ResourceEntityResolver"
+      },
+      "glob" : "com_mchange/mchange_commons_java/test-entity.dtd"
+    }
+  ]
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -130,6 +130,18 @@
       "condition" : {
         "typeReached" : "com.mchange.v3.decode.DecodeUtils"
       },
+      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
       "type" : "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder",
       "methods" : [
         {

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -130,24 +130,6 @@
       "condition" : {
         "typeReached" : "com.mchange.v3.decode.DecodeUtils"
       },
-      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "decoderClassName",
-          "parameterTypes" : [
-            "java.lang.Object"
-          ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
-      },
       "type" : "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder",
       "methods" : [
         {
@@ -336,18 +318,6 @@
         },
         {
           "name" : "parentMessage",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
-      },
-      "type" : "com.mchange.sc.v1.decode.ScalaMapDecoderFinder",
-      "methods" : [
-        {
-          "name" : "<init>",
           "parameterTypes" : [ ]
         }
       ]
@@ -577,6 +547,58 @@
     {
       "condition" : {
         "typeReached" : "com.mchange.v1.lang.Synchronizer$1"
+      },
+      "type" : {
+        "proxy" : [
+          "com_mchange.mchange_commons_java.SynchronizerDollar1Test$EchoService"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.beans.BeansUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.BeansUtilsTest$TestStringEditor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v3.decode.DecodeUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.DecodeUtilsTest$PrefixingDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.io.SerializableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.IoSerializableUtilsTest$SerializablePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.JavaBeanObjectFactory"
+      },
+      "type" : "com_mchange.mchange_commons_java.JavaBeanObjectFactoryTest$ReferenceableBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.lang.ObjectUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ObjectUtilsTest$SerializablePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.naming.ReferenceableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.ReferenceableUtilsTest$CapturingObjectFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v2.ser.SerializableUtils"
+      },
+      "type" : "com_mchange.mchange_commons_java.SerializableUtilsTest$SerializablePayload"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mchange.v1.lang.Synchronizer"
       },
       "type" : {
         "proxy" : [

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/FallbackMLogDollarFallbackMLoggerTestMessages.properties
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/FallbackMLogDollarFallbackMLoggerTestMessages.properties
@@ -1,0 +1,1 @@
+message.template=Resource bundle says hello to {0}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/LogUtilsTestMessages.properties
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/LogUtilsTestMessages.properties
@@ -1,0 +1,1 @@
+message.template=Resource bundle says hello to {0}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/test-entity.dtd
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/resources/com_mchange/mchange_commons_java/test-entity.dtd
@@ -1,0 +1,1 @@
+<!ELEMENT sample (#PCDATA)>

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.mchange.**"
+    }
+  ]
+}

--- a/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
+++ b/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
@@ -1,10 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.mchange.**"
+      "includeClasses" : "com.mchange.**"
+    },
+    {
+      "includeClasses" : "com.mchange.sc.v1.decode.**"
+    },
+    {
+      "includeClasses" : "com_mchange.mchange_commons_java.**"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes: #2097

This PR provides test fixes and new metadata for com.mchange:mchange-commons-java:0.4.0, addressing runtime java test failures caused by changes in the updated library version.

Summary:
- Strategy: java_run_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 149798
- Cached input tokens: 621568
- Output tokens: 15685
- Metadata entries: 422
- Test-only metadata entries: 107
- Iterations: 5
- Library coverage percentage: 14.36
- Previous library version metadata entries: 453
- Previous library version test-only metadata entries: 104
- Previous library version coverage percentage: 13.63

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- com.mchange:mchange-commons-java:0.2.15: 86/90 covered calls (95.56%)
- com.mchange:mchange-commons-java:0.4.0: 93/93 covered calls (100.00%)

**Reflection:**
- com.mchange:mchange-commons-java:0.2.15: 80/84 covered calls (95.24%)
- com.mchange:mchange-commons-java:0.4.0: 87/87 covered calls (100.00%)

**Resources:**
- com.mchange:mchange-commons-java:0.2.15: 6/6 covered calls (100.00%)
- com.mchange:mchange-commons-java:0.4.0: 6/6 covered calls (100.00%)

#### Library coverage

**Instruction:**
- com.mchange:mchange-commons-java:0.2.15: 7688/56751 (13.55%)
- com.mchange:mchange-commons-java:0.4.0: 8288/58848 (14.08%)

**Line:**
- com.mchange:mchange-commons-java:0.2.15: 1753/12864 (13.63%)
- com.mchange:mchange-commons-java:0.4.0: 1910/13298 (14.36%)

**Method:**
- com.mchange:mchange-commons-java:0.2.15: 340/4438 (7.66%)
- com.mchange:mchange-commons-java:0.4.0: 372/4592 (8.10%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/com.mchange/mchange-commons-java/0.2.15/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
index be9e24ed80..c31f176467 100644
--- 1/tests/src/com.mchange/mchange-commons-java/0.2.15/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
+++ 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/CollectionUtilsTest.java
@@ -9,10 +9,16 @@ package com_mchange.mchange_commons_java;
 import com.mchange.v2.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.AbstractList;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -78,4 +84,197 @@ public class CollectionUtilsTest {
         assertThat(cloned.get("two")).isEqualTo(2);
         assertThat(cloned).isNotSameAs(original);
     }
+
+    @Test
+    void attemptCloneClonesCollectionUsingPublicCloneMethod() throws NoSuchMethodException {
+        CloneableCollection original = new CloneableCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CloneableCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesCollectionUsingCollectionCopyConstructor() throws NoSuchMethodException {
+        CollectionCopyConstructorCollection original =
+                new CollectionCopyConstructorCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CollectionCopyConstructorCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesCollectionUsingExactClassCopyConstructor() throws NoSuchMethodException {
+        ExactCopyConstructorCollection original =
+                new ExactCopyConstructorCollection("alpha", "beta");
+
+        Collection<?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(ExactCopyConstructorCollection.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.contains("alpha")).isTrue();
+        assertThat(cloned.contains("beta")).isTrue();
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingPublicCloneMethod() throws NoSuchMethodException {
+        CloneableMap original = new CloneableMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(CloneableMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingMapCopyConstructor() throws NoSuchMethodException {
+        MapCopyConstructorMap original = new MapCopyConstructorMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(MapCopyConstructorMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    @Test
+    void attemptCloneClonesMapUsingExactClassCopyConstructor() throws NoSuchMethodException {
+        ExactCopyConstructorMap original = new ExactCopyConstructorMap("one", 1, "two", 2);
+
+        Map<?, ?> cloned = CollectionUtils.attemptClone(original);
+
+        assertThat(cloned).isInstanceOf(ExactCopyConstructorMap.class);
+        assertThat(cloned).hasSize(2);
+        assertThat(cloned.get("one")).isEqualTo(1);
+        assertThat(cloned.get("two")).isEqualTo(2);
+        assertThat(cloned).isNotSameAs(original);
+    }
+
+    public static class CloneableCollection extends TestCollection {
+        public CloneableCollection(String... elements) {
+            super(elements);
+        }
+
+        private CloneableCollection(Collection<String> elements) {
+            super(elements);
+        }
+
+        @Override
+        public CloneableCollection clone() {
+            return new CloneableCollection(values);
+        }
+    }
+
+    public static class CollectionCopyConstructorCollection extends TestCollection {
+        public CollectionCopyConstructorCollection(String... elements) {
+            super(elements);
+        }
+
+        public CollectionCopyConstructorCollection(Collection<String> elements) {
+            super(elements);
+        }
+    }
+
+    public static class ExactCopyConstructorCollection extends TestCollection {
+        public ExactCopyConstructorCollection(String... elements) {
+            super(elements);
+        }
+
+        public ExactCopyConstructorCollection(ExactCopyConstructorCollection source) {
+            super(source.values);
+        }
+    }
+
+    public static class CloneableMap extends TestMap {
+        public CloneableMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        private CloneableMap(Map<String, Integer> entries) {
+            super(entries);
+        }
+
+        @Override
+        public CloneableMap clone() {
+            return new CloneableMap(values);
+        }
+    }
+
+    public static class MapCopyConstructorMap extends TestMap {
+        public MapCopyConstructorMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        public MapCopyConstructorMap(Map<String, Integer> entries) {
+            super(entries);
+        }
+    }
+
+    public static class ExactCopyConstructorMap extends TestMap {
+        public ExactCopyConstructorMap(
+                String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            super(firstKey, firstValue, secondKey, secondValue);
+        }
+
+        public ExactCopyConstructorMap(ExactCopyConstructorMap source) {
+            super(source.values);
+        }
+    }
+
+    private abstract static class TestCollection extends AbstractList<String> {
+        protected final List<String> values = new ArrayList<>();
+
+        TestCollection(String... elements) {
+            Collections.addAll(values, elements);
+        }
+
+        TestCollection(Collection<String> elements) {
+            values.addAll(elements);
+        }
+
+        @Override
+        public String get(int index) {
+            return values.get(index);
+        }
+
+        @Override
+        public int size() {
+            return values.size();
+        }
+    }
+
+    private abstract static class TestMap extends AbstractMap<String, Integer> {
+        protected final Map<String, Integer> values = new LinkedHashMap<>();
+
+        TestMap(String firstKey, Integer firstValue, String secondKey, Integer secondValue) {
+            values.put(firstKey, firstValue);
+            values.put(secondKey, secondValue);
+        }
+
+        TestMap(Map<String, Integer> entries) {
+            values.putAll(entries);
+        }
+
+        @Override
+        public Set<Entry<String, Integer>> entrySet() {
+            return values.entrySet();
+        }
+    }
 }
diff --git 1/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/PropertyComponentBindingUtilityTest.java 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/PropertyComponentBindingUtilityTest.java
new file mode 100644
index 0000000000..cbfebcf246
--- /dev/null
+++ 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/PropertyComponentBindingUtilityTest.java
@@ -0,0 +1,137 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mchange.mchange_commons_java;
+
+import com.mchange.v2.beans.swing.PropertyBoundComboBox;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.SwingUtilities;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyComponentBindingUtilityTest {
+    @Test
+    void comboBoxBindingReadsAndWritesBeanPropertyThroughPublicSwingBinding() throws Exception {
+        ChoiceBean bean = new ChoiceBean("alpha");
+
+        PropertyBoundComboBox comboBox = onEventDispatchThread(() -> new PropertyBoundComboBox(
+                bean,
+                "choice",
+                new String[] {"alpha", "bravo", "none"},
+                "none"));
+        flushSwingEvents();
+
+        assertThat(bean.getPropertyChangeListenerAddCount()).isEqualTo(1);
+        assertThat(bean.getChoiceGetterInvocationCount()).isGreaterThanOrEqualTo(1);
+        assertThat(comboBox.getSelectedItem()).isEqualTo("alpha");
+
+        bean.resetAccessCounts();
+        onEventDispatchThread(() -> comboBox.setSelectedItem("bravo"));
+
+        assertThat(bean.choice()).isEqualTo("bravo");
+        assertThat(bean.getChoiceGetterInvocationCount()).isGreaterThanOrEqualTo(1);
+        assertThat(bean.getChoiceSetterInvocationCount()).isGreaterThanOrEqualTo(1);
+    }
+
+    private static void flushSwingEvents() throws Exception {
+        onEventDispatchThread(() -> {
+        });
+    }
+
+    private static <T> T onEventDispatchThread(ThrowingSupplier<T> supplier) throws Exception {
+        Result<T> result = new Result<>();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                result.value = supplier.get();
+            } catch (Exception e) {
+                result.exception = e;
+            }
+        });
+        if (result.exception != null) {
+            throw result.exception;
+        }
+        return result.value;
+    }
+
+    private static void onEventDispatchThread(ThrowingRunnable runnable) throws Exception {
+        onEventDispatchThread(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    public static class ChoiceBean {
+        private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+        private String choice;
+        private int propertyChangeListenerAddCount;
+        private int choiceGetterInvocationCount;
+        private int choiceSetterInvocationCount;
+
+        public ChoiceBean(String choice) {
+            this.choice = choice;
+        }
+
+        public String getChoice() {
+            choiceGetterInvocationCount++;
+            return choice;
+        }
+
+        public void setChoice(String choice) {
+            choiceSetterInvocationCount++;
+            String oldChoice = this.choice;
+            this.choice = choice;
+            propertyChangeSupport.firePropertyChange("choice", oldChoice, choice);
+        }
+
+        public void addPropertyChangeListener(PropertyChangeListener listener) {
+            propertyChangeListenerAddCount++;
+            propertyChangeSupport.addPropertyChangeListener(listener);
+        }
+
+        public void removePropertyChangeListener(PropertyChangeListener listener) {
+            propertyChangeSupport.removePropertyChangeListener(listener);
+        }
+
+        public String choice() {
+            return choice;
+        }
+
+        public int getPropertyChangeListenerAddCount() {
+            return propertyChangeListenerAddCount;
+        }
+
+        public int getChoiceGetterInvocationCount() {
+            return choiceGetterInvocationCount;
+        }
+
+        public int getChoiceSetterInvocationCount() {
+            return choiceSetterInvocationCount;
+        }
+
+        public void resetAccessCounts() {
+            choiceGetterInvocationCount = 0;
+            choiceSetterInvocationCount = 0;
+        }
+    }
+
+    private static final class Result<T> {
+        private T value;
+        private Exception exception;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}
diff --git 1/tests/src/com.mchange/mchange-commons-java/0.2.15/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
index b8b61f01ef..37a0cda13d 100644
--- 1/tests/src/com.mchange/mchange-commons-java/0.2.15/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
+++ 2/tests/src/com.mchange/mchange-commons-java/0.4.0/src/test/java/com_mchange/mchange_commons_java/ReferenceableUtilsTest.java
@@ -15,10 +15,18 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class ReferenceableUtilsTest {
+    @Test
+    void assertAcceptableNameConstructsTheDefaultNameGuard() {
+        assertThatCode(() -> ReferenceableUtils.assertAcceptableName("java:comp/env/jdbc/example", null))
+            .doesNotThrowAnyException();
+    }
+
     @Test
     void referenceToObjectInstantiatesConfiguredFactoryAndDelegatesReferenceResolution() throws Exception {
         Reference reference = new Reference(String.class.getName(), CapturingObjectFactory.class.getName(), null);
@@ -27,7 +35,9 @@ public class ReferenceableUtilsTest {
             Hashtable<>();
         environment.put("prefix", "resolved");
 
-        Object resolved = ReferenceableUtils.referenceToObject(reference, null, null, environment);
+        Set<String> allowedFactoryClassNames = Set.of(CapturingObjectFactory.class.getName());
+
+        Object resolved = ReferenceableUtils.referenceToObject(reference, null, null, environment, allowedFactoryClassNames);
 
         assertThat(resolved).isEqualTo("resolved:alpha");
     }
diff --git 1/tests/src/com.mchange/mchange-commons-java/0.2.15/user-code-filter.json 2/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
index eaa93f0d88..d07ff1cba9 100644
--- 1/tests/src/com.mchange/mchange-commons-java/0.2.15/user-code-filter.json
+++ 2/tests/src/com.mchange/mchange-commons-java/0.4.0/user-code-filter.json
@@ -1,10 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.mchange.**"
+      "includeClasses" : "com.mchange.**"
+    },
+    {
+      "includeClasses" : "com.mchange.sc.v1.decode.**"
+    },
+    {
+      "includeClasses" : "com_mchange.mchange_commons_java.**"
     }
   ]
 }

```

### Local CI Verification

- Status: `success`
- Commands run: 17
- Fixup attempts: 1
