### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-restclient as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-restclient/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-restclient/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-restclient:4.1.0-RC1 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use the class-bearing dependency org.springframework.boot:spring-boot-restclient:4.1.0-RC1 for RestClient and RestTemplate support."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8433

This PR records `org.springframework.boot:spring-boot-starter-restclient` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-restclient:4.1.0-RC1 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use the class-bearing dependency org.springframework.boot:spring-boot-restclient:4.1.0-RC1 for RestClient and RestTemplate support.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
