### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-webclient as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-webclient/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-webclient/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-webclient:4.1.0-RC1 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-webclient:4.1.0-RC1, org.springframework.boot:spring-boot-reactor:4.1.0-RC1, and io.projectreactor.netty:reactor-netty-http:1.3.5."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8434

This PR records `org.springframework.boot:spring-boot-starter-webclient` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-webclient:4.1.0-RC1 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-webclient:4.1.0-RC1, org.springframework.boot:spring-boot-reactor:4.1.0-RC1, and io.projectreactor.netty:reactor-netty-http:1.3.5.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
