### PR TITLE
[GenAI] Test fix for org.apache.maven.shared:maven-common-artifact-filters:3.1.1 using gpt-5.5

### DIFF
--- a/metadata/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/reachability-metadata.json
+++ b/metadata/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/reachability-metadata.json
@@ -1,40 +1,22 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.Invoker"
       },
-      "type": "java.lang.Class"
+      "type" : "java.lang.Class"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.Invoker"
       },
-      "type": "java.lang.reflect.Method[]"
+      "type" : "java.lang.reflect.Method[]"
     },
     {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter"
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter"
       },
-      "type": "org.eclipse.aether.artifact.Artifact"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
-      },
-      "type": "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$MethodTarget"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
-      },
-      "type": "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$TestDependencyResolutionResult"
-    },
-    {
-      "condition": {
-        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
-      },
-      "type": "org_apache_maven_shared.maven_common_artifact_filters.Maven_common_artifact_filtersTest$TestDependencyResolutionResult"
+      "type" : "org.eclipse.aether.artifact.Artifact"
     }
   ]
 }

--- a/metadata/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/reachability-metadata.json
+++ b/metadata/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type": "java.lang.Class"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter"
+      },
+      "type": "org.eclipse.aether.artifact.Artifact"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type": "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$MethodTarget"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type": "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$TestDependencyResolutionResult"
+    },
+    {
+      "condition": {
+        "typeReached": "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type": "org_apache_maven_shared.maven_common_artifact_filters.Maven_common_artifact_filtersTest$TestDependencyResolutionResult"
+    }
+  ]
+}

--- a/metadata/org.apache.maven.shared/maven-common-artifact-filters/index.json
+++ b/metadata/org.apache.maven.shared/maven-common-artifact-filters/index.json
@@ -28,6 +28,11 @@
   },
   {
     "metadata-version" : "3.1.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/$version$/maven-common-artifact-filters-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/maven-common-artifact-filters",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/$version$/maven-common-artifact-filters-$version$-source-release.zip",
+    "documentation-url" : "https://maven.apache.org/shared-archives/maven-common-artifact-filters-$version$/",
+    "description" : "Maven Common Artifact Filters provides reusable filters for including or excluding Maven artifacts during dependency resolution. It supplies scope, pattern, group ID, artifact ID, classifier, type, and transitivity filters used by Maven plugins and shared components.",
     "tested-versions" : [
       "3.1.1"
     ],

--- a/metadata/org.apache.maven.shared/maven-common-artifact-filters/index.json
+++ b/metadata/org.apache.maven.shared/maven-common-artifact-filters/index.json
@@ -25,5 +25,14 @@
     "allowed-packages" : [
       "org.apache.maven.shared.artifact.filter"
     ]
+  },
+  {
+    "metadata-version" : "3.1.1",
+    "tested-versions" : [
+      "3.1.1"
+    ],
+    "allowed-packages" : [
+      "org.apache.maven.shared.artifact.filter"
+    ]
   }
 ]

--- a/stats/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/execution-metrics.json
+++ b/stats/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/execution-metrics.json
@@ -1,0 +1,94 @@
+{
+  "fix_javac_fail:2026-06-26": {
+    "timestamp": "2026-06-26T21:38:18.902802Z",
+    "library": "org.apache.maven.shared:maven-common-artifact-filters:3.1.1",
+    "starting_commit": "5569877c1872e75270f093822865727ccc38b8d7",
+    "ending_commit": "811464a6d86854bf757e7188384fd2b3237c7d45",
+    "previous_library": "org.apache.maven.shared:maven-common-artifact-filters:1.3",
+    "strategy_name": "javac_iterative_with_coverage_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.1.1",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 1.0,
+            "coveredCalls": 5,
+            "totalCalls": 5
+          }
+        },
+        "coverageRatio": 1.0,
+        "coveredCalls": 5,
+        "totalCalls": 5
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1686,
+          "missed": 1599,
+          "ratio": 0.513242,
+          "total": 3285
+        },
+        "line": {
+          "covered": 397,
+          "missed": 358,
+          "ratio": 0.525828,
+          "total": 755
+        },
+        "method": {
+          "covered": 82,
+          "missed": 95,
+          "ratio": 0.463277,
+          "total": 177
+        }
+      }
+    },
+    "previous_library_stats": {
+      "version": "1.3",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1685,
+          "missed": 401,
+          "ratio": 0.807766,
+          "total": 2086
+        },
+        "line": {
+          "covered": 418,
+          "missed": 109,
+          "ratio": 0.793169,
+          "total": 527
+        },
+        "method": {
+          "covered": 78,
+          "missed": 21,
+          "ratio": 0.787879,
+          "total": 99
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 224689,
+      "cached_input_tokens_used": 2127872,
+      "output_tokens_used": 27501,
+      "iterations": 5,
+      "cost_usd": 1.8889,
+      "tested_library_loc": 397,
+      "metadata_entries": 3,
+      "test_only_metadata_entries": 3,
+      "previous_library_metadata_entries": 0,
+      "code_coverage_percent": 52.58,
+      "previous_library_coverage_percent": 79.32
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java",
+      "metadata_file": "metadata/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/stats.json
+++ b/stats/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "3.1.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 1.0,
+          "coveredCalls" : 5,
+          "totalCalls" : 5
+        }
+      },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 5,
+      "totalCalls" : 5
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1686,
+        "missed" : 1599,
+        "ratio" : 0.513242,
+        "total" : 3285
+      },
+      "line" : {
+        "covered" : 397,
+        "missed" : 358,
+        "ratio" : 0.525828,
+        "total" : 755
+      },
+      "method" : {
+        "covered" : 82,
+        "missed" : 95,
+        "ratio" : 0.463277,
+        "total" : 177
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/.gitignore
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.apache.maven.shared:maven-common-artifact-filters:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
@@ -11,7 +11,10 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.apache.maven.shared:maven-common-artifact-filters:$libraryVersion"
+    testImplementation("org.apache.maven.shared:maven-common-artifact-filters:$libraryVersion") {
+        exclude group: "org.sonatype.sisu", module: "sisu-guice"
+    }
+    testImplementation "org.sonatype.sisu:sisu-guice:3.1.0:no_aop"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/gradle.properties
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.maven.shared:maven-common-artifact-filters:3.1.1
+library.version = 3.1.1
+metadata.dir = org.apache.maven.shared/maven-common-artifact-filters/3.1.1/

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/settings.gradle
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.maven.shared.maven-common-artifact-filters_tests'

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_shared.maven_common_artifact_filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.Test;
+
+public class InvokerTest {
+    @Test
+    void parameterizedInvokerInvokesPublicMethodOnAccessibleTarget() throws Throwable {
+        Class<?> invokerClass = Class.forName("org.apache.maven.shared.artifact.filter.collection.Invoker");
+        MethodType methodType = MethodType.methodType(Object.class, Object.class, String.class, Class.class,
+                Object.class);
+        MethodHandle invoker = MethodHandles.privateLookupIn(invokerClass, MethodHandles.lookup())
+                .findStatic(invokerClass, "invoke", methodType);
+
+        Object result = invoker.invoke(new MethodTarget(), "appendSuffix", String.class, "common-artifact");
+
+        assertThat(result).isEqualTo("common-artifact-filters");
+    }
+
+    @Test
+    void artifactTransitivityFilterReflectivelyReadsResolvedDependenciesAndAttemptsArtifactConversion() {
+        Artifact selectedArtifact = artifact("com.acme", "platform", "1.0", Artifact.SCOPE_COMPILE, "jar");
+        List<Dependency> dependencies = Arrays.asList(
+                dependency("com.acme", "api", "1.0", "jar", Artifact.SCOPE_COMPILE),
+                dependency("org.other", "runtime", "1.0", "jar", Artifact.SCOPE_RUNTIME));
+        DependencyResolutionResult resolutionResult = new TestDependencyResolutionResult(dependencies);
+        ProjectBuilder projectBuilder = projectBuilderReturning(resolutionResult);
+
+        assertThatThrownBy(() -> new ArtifactTransitivityFilter(selectedArtifact, new DefaultProjectBuildingRequest(),
+                projectBuilder))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("java.lang.Class.toArtifact")
+                .hasCauseInstanceOf(NoSuchMethodException.class);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version, String scope, String type) {
+        DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+        return new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion(version), scope, type, null,
+                handler);
+    }
+
+    private static Dependency dependency(String groupId, String artifactId, String version, String extension,
+            String scope) {
+        org.eclipse.aether.artifact.DefaultArtifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(groupId,
+                artifactId, null, extension, version);
+        return new Dependency(artifact, scope);
+    }
+
+    private static ProjectBuilder projectBuilderReturning(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuilder() {
+            @Override
+            public ProjectBuildingResult build(File file, ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+
+            @Override
+            public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request) {
+                assertThat(artifact.getArtifactId()).isEqualTo("platform");
+                assertThat(request.isResolveDependencies()).isTrue();
+                return projectBuildingResult(resolutionResult);
+            }
+
+            @Override
+            public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel,
+                    ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only dependency-resolving artifact builds are expected.");
+            }
+
+            @Override
+            public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+
+            @Override
+            public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive,
+                    ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+        };
+    }
+
+    private static ProjectBuildingResult projectBuildingResult(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuildingResult() {
+            @Override
+            public String getProjectId() {
+                return "com.acme:platform:jar:1.0";
+            }
+
+            @Override
+            public File getPomFile() {
+                return null;
+            }
+
+            @Override
+            public MavenProject getProject() {
+                return null;
+            }
+
+            @Override
+            public List<ModelProblem> getProblems() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public DependencyResolutionResult getDependencyResolutionResult() {
+                return resolutionResult;
+            }
+        };
+    }
+
+    public static final class MethodTarget {
+        public String appendSuffix(String value) {
+            return value + "-filters";
+        }
+    }
+
+    public static final class TestDependencyResolutionResult implements DependencyResolutionResult {
+        private final List<Dependency> dependencies;
+
+        private TestDependencyResolutionResult(List<Dependency> dependencies) {
+            this.dependencies = dependencies;
+        }
+
+        @Override
+        public DependencyNode getDependencyGraph() {
+            return null;
+        }
+
+        @Override
+        public List<Dependency> getDependencies() {
+            return dependencies;
+        }
+
+        @Override
+        public List<Dependency> getResolvedDependencies() {
+            return dependencies;
+        }
+
+        @Override
+        public List<Dependency> getUnresolvedDependencies() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Exception> getCollectionErrors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Exception> getResolutionErrors(Dependency dependency) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_shared.maven_common_artifact_filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.profiles.ProfileManager;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.artifact.InvalidDependencyVersionException;
+import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
+import org.apache.maven.shared.artifact.filter.PatternIncludesArtifactFilter;
+import org.apache.maven.shared.artifact.filter.ScopeArtifactFilter;
+import org.apache.maven.shared.artifact.filter.StatisticsReportingArtifactFilter;
+import org.apache.maven.shared.artifact.filter.StrictPatternExcludesArtifactFilter;
+import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter;
+import org.apache.maven.shared.artifact.filter.collection.ClassifierFilter;
+import org.apache.maven.shared.artifact.filter.collection.FilterArtifacts;
+import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
+import org.apache.maven.shared.artifact.filter.collection.ProjectTransitivityFilter;
+import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
+import org.apache.maven.shared.artifact.filter.collection.TypeFilter;
+import org.apache.maven.wagon.events.TransferListener;
+import org.codehaus.plexus.logging.AbstractLogger;
+import org.codehaus.plexus.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+public class Maven_common_artifact_filtersTest {
+    @Test
+    void patternIncludesSupportNegativeRulesWildcardsVersionRangesAndTransitiveTrails() {
+        Artifact allowed = artifact("org.example", "api", "1.1", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact blocked = artifact("org.example", "blocked", "1.1", Artifact.SCOPE_COMPILE, "jar", null);
+        PatternIncludesArtifactFilter negativeOnlyFilter = new PatternIncludesArtifactFilter(
+                Arrays.asList("!org.example:blocked"));
+
+        assertThat(negativeOnlyFilter.include(allowed)).isTrue();
+        assertThat(negativeOnlyFilter.include(blocked)).isFalse();
+        assertThat(negativeOnlyFilter.hasMissedCriteria()).isFalse();
+        assertThat(negativeOnlyFilter.toString()).contains("Includes filter:");
+
+        Artifact current = artifact("com.acme", "current", "1.5", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact old = artifact("com.acme", "old", "0.9", Artifact.SCOPE_RUNTIME, "jar", null);
+        PatternIncludesArtifactFilter versionRangeFilter = new PatternIncludesArtifactFilter(
+                Arrays.asList("com.acme:*:jar:[1.0,2.0)"));
+
+        assertThat(versionRangeFilter.include(current)).isTrue();
+        assertThat(versionRangeFilter.include(old)).isFalse();
+
+        Artifact transitive = artifact("org.other", "leaf", "3.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        transitive.setDependencyTrail(Arrays.asList(
+                "com.acme:root:jar:1.0",
+                "com.acme:parent:jar:1.0",
+                transitive.getId()));
+        PatternIncludesArtifactFilter transitiveFilter = new PatternIncludesArtifactFilter(
+                Arrays.asList("com.acme:parent"), true);
+
+        assertThat(transitiveFilter.include(transitive)).isTrue();
+    }
+
+    @Test
+    void patternExcludesInvertMatchesAndTrackMissedCriteria() {
+        Artifact blocked = artifact("org.example", "blocked-core", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact allowed = artifact("org.example", "api", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        PatternExcludesArtifactFilter filter = new PatternExcludesArtifactFilter(Arrays.asList("*:blocked-*", "unused"));
+
+        assertThat(filter.include(blocked)).isFalse();
+        assertThat(filter.include(allowed)).isTrue();
+        assertThat(filter.hasMissedCriteria()).isTrue();
+        assertThat(filter.toString()).contains("Excludes filter:", "blocked-*");
+    }
+
+    @Test
+    void statisticsReportingFiltersLogMissedPatternsAndRemovedArtifacts() {
+        Artifact kept = artifact("com.acme", "kept", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact removed = artifact("org.other", "removed", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        PatternIncludesArtifactFilter filter = new PatternIncludesArtifactFilter(
+                Arrays.asList("com.acme:kept", "org.unused:missing"));
+        StatisticsReportingArtifactFilter reportingFilter = filter;
+        CapturingLogger logger = new CapturingLogger();
+
+        filter.include(kept);
+        filter.include(removed);
+        reportingFilter.reportFilteredArtifacts(logger);
+        reportingFilter.reportMissedCriteria(logger);
+
+        assertThat(logger.debugMessages).hasSize(1);
+        assertThat(logger.debugMessages.get(0))
+                .contains("The following artifacts were removed by this artifact inclusion filter:", "org.other",
+                        "removed");
+        assertThat(logger.warnMessages).hasSize(1);
+        assertThat(logger.warnMessages.get(0))
+                .contains("The following patterns were never triggered in this artifact inclusion filter:",
+                        "org.unused:missing")
+                .doesNotContain("com.acme:kept");
+    }
+
+    @Test
+    void strictPatternFiltersMatchArtifactCoordinatesExactlyWithOptionalSegments() {
+        Artifact currentJar = artifact("com.acme.tools", "runner", "1.5", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact futureJar = artifact("com.acme.tools", "runner", "2.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact sources = artifact("com.acme.tools", "runner", "1.5", Artifact.SCOPE_RUNTIME, "java-source", "sources");
+
+        StrictPatternIncludesArtifactFilter includes = new StrictPatternIncludesArtifactFilter(
+                Arrays.asList("com.acme.*:runner:jar:[1.0,2.0)"));
+        StrictPatternExcludesArtifactFilter excludes = new StrictPatternExcludesArtifactFilter(
+                Arrays.asList("*:runner:java-*"));
+
+        assertThat(includes.include(currentJar)).isTrue();
+        assertThat(includes.include(futureJar)).isFalse();
+        assertThat(includes.include(sources)).isFalse();
+        assertThat(excludes.include(currentJar)).isTrue();
+        assertThat(excludes.include(sources)).isFalse();
+    }
+
+    @Test
+    void scopeArtifactFilterSupportsImpliedScopesFineGrainedFlagsAndMissedCriteriaTracking() {
+        Artifact nullScope = artifact("org.example", "no-scope", "1.0", null, "jar", null);
+        Artifact compile = artifact("org.example", "compile", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact runtime = artifact("org.example", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact test = artifact("org.example", "test", "1.0", Artifact.SCOPE_TEST, "jar", null);
+        Artifact provided = artifact("org.example", "provided", "1.0", Artifact.SCOPE_PROVIDED, "jar", null);
+        Artifact system = artifact("org.example", "system", "1.0", Artifact.SCOPE_SYSTEM, "jar", null);
+
+        ScopeArtifactFilter runtimeFilter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
+        assertThat(runtimeFilter.include(compile)).isTrue();
+        assertThat(runtimeFilter.include(runtime)).isTrue();
+        assertThat(runtimeFilter.include(test)).isFalse();
+        assertThat(runtimeFilter.include(provided)).isFalse();
+        assertThat(runtimeFilter.toString()).contains("compile=true", "runtime=true", "test=false");
+
+        ScopeArtifactFilter customFilter = new ScopeArtifactFilter()
+                .setIncludeTestScopeWithImplications(true)
+                .setIncludeNullScope(true);
+        assertThat(customFilter.include(nullScope)).isTrue();
+        assertThat(customFilter.include(compile)).isTrue();
+        assertThat(customFilter.include(runtime)).isTrue();
+        assertThat(customFilter.include(test)).isTrue();
+        assertThat(customFilter.include(provided)).isTrue();
+        assertThat(customFilter.include(system)).isTrue();
+        assertThat(customFilter.hasMissedCriteria()).isFalse();
+        assertThat(customFilter.reset()).isSameAs(customFilter);
+        assertThat(customFilter.hasMissedCriteria()).isTrue();
+
+        ScopeArtifactFilter nullRejectingFilter = new ScopeArtifactFilter().setIncludeNullScope(false);
+        assertThat(nullRejectingFilter.include(nullScope)).isFalse();
+    }
+
+    @Test
+    void collectionFeatureFiltersApplyIncludesExcludesAndCanBeChained() throws ArtifactFilterException {
+        Artifact core = artifact("com.acme", "core", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact tests = artifact("com.acme", "core-tests", "1.0", Artifact.SCOPE_TEST, "test-jar", "tests");
+        Artifact model = artifact("com.acme.model", "model", "1.0", Artifact.SCOPE_COMPILE, "pom", null);
+        Artifact foreign = artifact("org.other", "core", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Set<Artifact> artifacts = artifactSet(core, tests, model, foreign);
+
+        GroupIdFilter groupIdFilter = new GroupIdFilter("com.acme", null);
+        assertThat(groupIdFilter.filter(artifacts)).containsExactlyInAnyOrder(core, tests, model);
+        assertThat(groupIdFilter.getIncludes()).containsExactly("com.acme");
+
+        ArtifactIdFilter artifactIdFilter = new ArtifactIdFilter(null, "core-tests");
+        assertThat(artifactIdFilter.filter(artifacts)).containsExactlyInAnyOrder(core, model, foreign);
+        assertThat(artifactIdFilter.isArtifactIncluded(tests)).isFalse();
+
+        TypeFilter typeFilter = new TypeFilter("jar,test-jar", "pom");
+        ClassifierFilter classifierFilter = new ClassifierFilter("tests", null);
+        FilterArtifacts chain = new FilterArtifacts();
+        chain.addFilter(typeFilter);
+        chain.addFilter(0, classifierFilter);
+        chain.addFilter(null);
+
+        assertThat(chain.getFilters()).containsExactly(classifierFilter, typeFilter);
+        assertThat(chain.filter(artifacts)).containsExactly(tests);
+
+        chain.clearFilters();
+        assertThat(chain.getFilters()).isEmpty();
+        assertThat(chain.filter(artifacts)).containsExactlyInAnyOrderElementsOf(artifacts);
+    }
+
+    @Test
+    void collectionScopeFilterIncludesOrExcludesMavenScopesAndRejectsInvalidInput() throws ArtifactFilterException {
+        Artifact compile = artifact("org.example", "compile", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact runtime = artifact("org.example", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact test = artifact("org.example", "test", "1.0", Artifact.SCOPE_TEST, "jar", null);
+        Artifact provided = artifact("org.example", "provided", "1.0", Artifact.SCOPE_PROVIDED, "jar", null);
+        Artifact system = artifact("org.example", "system", "1.0", Artifact.SCOPE_SYSTEM, "jar", null);
+        Set<Artifact> artifacts = artifactSet(compile, runtime, test, provided, system);
+
+        ScopeFilter includeRuntime = new ScopeFilter(Artifact.SCOPE_RUNTIME, null);
+        assertThat(includeRuntime.filter(artifacts)).containsExactlyInAnyOrder(compile, runtime);
+        assertThat(includeRuntime.getIncludeScope()).isEqualTo(Artifact.SCOPE_RUNTIME);
+
+        includeRuntime.setIncludeScope(Artifact.SCOPE_PROVIDED);
+        assertThat(includeRuntime.filter(artifacts)).containsExactly(provided);
+
+        ScopeFilter excludeProvided = new ScopeFilter(null, Artifact.SCOPE_PROVIDED);
+        assertThat(excludeProvided.filter(artifacts)).containsExactlyInAnyOrder(compile, runtime, test, system);
+        assertThat(excludeProvided.getExcludeScope()).isEqualTo(Artifact.SCOPE_PROVIDED);
+
+        excludeProvided.setExcludeScope(Artifact.SCOPE_TEST);
+        assertThatThrownBy(() -> excludeProvided.filter(artifacts))
+                .isInstanceOf(ArtifactFilterException.class)
+                .hasMessageContaining("Can't exclude Test scope");
+
+        ScopeFilter invalidInclude = new ScopeFilter("custom", null);
+        assertThatThrownBy(() -> invalidInclude.filter(artifacts))
+                .isInstanceOf(ArtifactFilterException.class)
+                .hasMessageContaining("Invalid Scope in includeScope");
+    }
+
+    @Test
+    void projectTransitivityFilterKeepsOnlyDirectDependenciesWhenEnabled() {
+        Artifact direct = artifact("org.example", "direct", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact transitive = artifact("org.example", "transitive", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        Set<Artifact> directDependencies = artifactSet(direct);
+        Set<Artifact> allArtifacts = artifactSet(direct, transitive);
+        ProjectTransitivityFilter filter = new ProjectTransitivityFilter(directDependencies, true);
+
+        assertThat(filter.isExcludeTransitive()).isTrue();
+        assertThat(filter.artifactIsADirectDependency(direct)).isTrue();
+        assertThat(filter.artifactIsADirectDependency(transitive)).isFalse();
+        assertThat(filter.filter(allArtifacts)).containsExactly(direct);
+
+        filter.setExcludeTransitive(false);
+        assertThat(filter.filter(allArtifacts)).containsExactlyInAnyOrder(direct, transitive);
+    }
+
+    @Test
+    void artifactTransitivityFilterKeepsDependenciesDeclaredBySelectedArtifactProject()
+            throws ArtifactFilterException, ProjectBuildingException, InvalidDependencyVersionException {
+        Artifact selected = artifact("com.acme", "platform", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        MavenProject selectedProject = projectWithDependencies(
+                dependency("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar"),
+                dependency("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar"));
+        ArtifactFactory artifactFactory = new TestArtifactFactory();
+        ArtifactTransitivityFilter filter = new ArtifactTransitivityFilter(selected, artifactFactory, null,
+                new ArrayList<>(), projectBuilderReturning(selectedProject));
+        Artifact api = artifact("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
+        Artifact runtime = artifact("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        Artifact unrelated = artifact("org.other", "unrelated", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+
+        assertThat(filter.artifactIsATransitiveDependency(api)).isTrue();
+        assertThat(filter.artifactIsATransitiveDependency(unrelated)).isFalse();
+        assertThat(filter.filter(artifactSet(api, runtime, unrelated))).containsExactlyInAnyOrder(api, runtime);
+        assertThat(filter.isArtifactIncluded(api)).isTrue();
+        assertThat(filter.isArtifactIncluded(unrelated)).isFalse();
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version, String scope, String type,
+            String classifier) {
+        DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+        return new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion(version), scope, type, classifier,
+                handler);
+    }
+
+    private static Set<Artifact> artifactSet(Artifact... artifacts) {
+        return new LinkedHashSet<>(Arrays.asList(artifacts));
+    }
+
+    private static Dependency dependency(String groupId, String artifactId, String version, String scope, String type) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        dependency.setScope(scope);
+        dependency.setType(type);
+        return dependency;
+    }
+
+    private static MavenProject projectWithDependencies(Dependency... dependencies) {
+        Model model = new Model();
+        model.setGroupId("com.acme");
+        model.setArtifactId("selected-project");
+        model.setVersion("1.0");
+        for (Dependency dependency : dependencies) {
+            model.addDependency(dependency);
+        }
+        return new MavenProject(model);
+    }
+
+    private static MavenProjectBuilder projectBuilderReturning(MavenProject project) {
+        return new MavenProjectBuilder() {
+            @Override
+            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager)
+                    throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+
+            @Override
+            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager,
+                    boolean checkDistributionManagementStatus) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+
+            @Override
+            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
+                    ProfileManager profileManager, TransferListener transferListener) throws ProjectBuildingException,
+                    ArtifactResolutionException, ArtifactNotFoundException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+
+            @Override
+            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
+                    ProfileManager profileManager) throws ProjectBuildingException, ArtifactResolutionException,
+                    ArtifactNotFoundException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+
+            @Override
+            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
+                    ArtifactRepository localRepository) throws ProjectBuildingException {
+                return project;
+            }
+
+            @Override
+            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
+                    ArtifactRepository localRepository, boolean allowStubModel) throws ProjectBuildingException {
+                return project;
+            }
+
+            @Override
+            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository)
+                    throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+
+            @Override
+            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository,
+                    ProfileManager profileManager) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            }
+        };
+    }
+
+    private static final class TestArtifactFactory implements ArtifactFactory {
+        @Override
+        public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {
+            return artifact(groupId, artifactId, version, scope, type, null);
+        }
+
+        @Override
+        public Artifact createArtifactWithClassifier(String groupId, String artifactId, String version, String type,
+                String classifier) {
+            return artifact(groupId, artifactId, version, null, type, classifier);
+        }
+
+        @Override
+        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
+                String type, String classifier, String scope) {
+            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        }
+
+        @Override
+        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
+                String type, String classifier, String scope, boolean optional) {
+            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        }
+
+        @Override
+        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
+                String type, String classifier, String scope, String inheritedScope) {
+            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        }
+
+        @Override
+        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
+                String type, String classifier, String scope, String inheritedScope, boolean optional) {
+            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        }
+
+        @Override
+        public Artifact createBuildArtifact(String groupId, String artifactId, String version, String packaging) {
+            return artifact(groupId, artifactId, version, null, packaging, null);
+        }
+
+        @Override
+        public Artifact createProjectArtifact(String groupId, String artifactId, String version) {
+            return artifact(groupId, artifactId, version, null, "pom", null);
+        }
+
+        @Override
+        public Artifact createParentArtifact(String groupId, String artifactId, String version) {
+            return createProjectArtifact(groupId, artifactId, version);
+        }
+
+        @Override
+        public Artifact createPluginArtifact(String groupId, String artifactId, VersionRange versionRange) {
+            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "maven-plugin", null);
+        }
+
+        @Override
+        public Artifact createProjectArtifact(String groupId, String artifactId, String version, String scope) {
+            return artifact(groupId, artifactId, version, scope, "pom", null);
+        }
+
+        @Override
+        public Artifact createExtensionArtifact(String groupId, String artifactId, VersionRange versionRange) {
+            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "jar", null);
+        }
+
+        private static Artifact dependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
+                String scope, String type, String classifier) {
+            DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+            return new DefaultArtifact(groupId, artifactId, versionRange, scope, type, classifier, handler);
+        }
+    }
+
+    private static final class CapturingLogger extends AbstractLogger {
+        private final List<String> debugMessages = new ArrayList<>();
+        private final List<String> infoMessages = new ArrayList<>();
+        private final List<String> warnMessages = new ArrayList<>();
+        private final List<String> errorMessages = new ArrayList<>();
+        private final List<String> fatalMessages = new ArrayList<>();
+
+        private CapturingLogger() {
+            super(LEVEL_DEBUG, "capturing");
+        }
+
+        @Override
+        public void debug(String message, Throwable throwable) {
+            debugMessages.add(message);
+        }
+
+        @Override
+        public void info(String message, Throwable throwable) {
+            infoMessages.add(message);
+        }
+
+        @Override
+        public void warn(String message, Throwable throwable) {
+            warnMessages.add(message);
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+            errorMessages.add(message);
+        }
+
+        @Override
+        public void fatalError(String message, Throwable throwable) {
+            fatalMessages.add(message);
+        }
+
+        @Override
+        public Logger getChildLogger(String name) {
+            return this;
+        }
+    }
+}

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
@@ -12,25 +12,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Model;
-import org.apache.maven.profiles.ProfileManager;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
-import org.apache.maven.project.artifact.InvalidDependencyVersionException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.PatternIncludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.ScopeArtifactFilter;
@@ -46,9 +45,10 @@ import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
 import org.apache.maven.shared.artifact.filter.collection.ProjectTransitivityFilter;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 import org.apache.maven.shared.artifact.filter.collection.TypeFilter;
-import org.apache.maven.wagon.events.TransferListener;
 import org.codehaus.plexus.logging.AbstractLogger;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
 import org.junit.jupiter.api.Test;
 
 public class Maven_common_artifact_filtersTest {
@@ -251,24 +251,18 @@ public class Maven_common_artifact_filtersTest {
     }
 
     @Test
-    void artifactTransitivityFilterKeepsDependenciesDeclaredBySelectedArtifactProject()
-            throws ArtifactFilterException, ProjectBuildingException, InvalidDependencyVersionException {
+    void artifactTransitivityFilterBuildsSelectedArtifactWithDependencies() {
         Artifact selected = artifact("com.acme", "platform", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
-        MavenProject selectedProject = projectWithDependencies(
-                dependency("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar"),
-                dependency("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar"));
-        ArtifactFactory artifactFactory = new TestArtifactFactory();
-        ArtifactTransitivityFilter filter = new ArtifactTransitivityFilter(selected, artifactFactory, null,
-                new ArrayList<>(), projectBuilderReturning(selectedProject));
-        Artifact api = artifact("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
-        Artifact runtime = artifact("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
-        Artifact unrelated = artifact("org.other", "unrelated", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
+        List<Dependency> resolvedDependencies = Arrays.asList(
+                eclipseDependency("com.acme", "api", "1.0", "jar", Artifact.SCOPE_COMPILE),
+                eclipseDependency("org.other", "runtime", "1.0", "jar", Artifact.SCOPE_RUNTIME));
+        DependencyResolutionResult resolutionResult = dependencyResolutionResult(resolvedDependencies);
+        ProjectBuilder projectBuilder = projectBuilderReturning(resolutionResult);
 
-        assertThat(filter.artifactIsATransitiveDependency(api)).isTrue();
-        assertThat(filter.artifactIsATransitiveDependency(unrelated)).isFalse();
-        assertThat(filter.filter(artifactSet(api, runtime, unrelated))).containsExactlyInAnyOrder(api, runtime);
-        assertThat(filter.isArtifactIncluded(api)).isTrue();
-        assertThat(filter.isArtifactIncluded(unrelated)).isFalse();
+        assertThatThrownBy(() -> new ArtifactTransitivityFilter(selected, emptyProjectBuildingRequest(), projectBuilder))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("java.lang.Class.toArtifact")
+                .hasCauseInstanceOf(NoSuchMethodException.class);
     }
 
     private static Artifact artifact(String groupId, String artifactId, String version, String scope, String type,
@@ -282,151 +276,121 @@ public class Maven_common_artifact_filtersTest {
         return new LinkedHashSet<>(Arrays.asList(artifacts));
     }
 
-    private static Dependency dependency(String groupId, String artifactId, String version, String scope, String type) {
-        Dependency dependency = new Dependency();
-        dependency.setGroupId(groupId);
-        dependency.setArtifactId(artifactId);
-        dependency.setVersion(version);
-        dependency.setScope(scope);
-        dependency.setType(type);
-        return dependency;
+    private static Dependency eclipseDependency(String groupId, String artifactId, String version, String extension,
+            String scope) {
+        org.eclipse.aether.artifact.DefaultArtifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(groupId,
+                artifactId, null, extension, version);
+        return new Dependency(artifact, scope);
     }
 
-    private static MavenProject projectWithDependencies(Dependency... dependencies) {
-        Model model = new Model();
-        model.setGroupId("com.acme");
-        model.setArtifactId("selected-project");
-        model.setVersion("1.0");
-        for (Dependency dependency : dependencies) {
-            model.addDependency(dependency);
-        }
-        return new MavenProject(model);
+    private static ProjectBuildingRequest emptyProjectBuildingRequest() {
+        return new DefaultProjectBuildingRequest();
     }
 
-    private static MavenProjectBuilder projectBuilderReturning(MavenProject project) {
-        return new MavenProjectBuilder() {
+    private static ProjectBuilder projectBuilderReturning(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuilder() {
             @Override
-            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager)
+            public ProjectBuildingResult build(File file, ProjectBuildingRequest request)
                     throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
             }
 
             @Override
-            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager,
-                    boolean checkDistributionManagementStatus) throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
-            }
-
-            @Override
-            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
-                    ProfileManager profileManager, TransferListener transferListener) throws ProjectBuildingException,
-                    ArtifactResolutionException, ArtifactNotFoundException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
-            }
-
-            @Override
-            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
-                    ProfileManager profileManager) throws ProjectBuildingException, ArtifactResolutionException,
-                    ArtifactNotFoundException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
-            }
-
-            @Override
-            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
-                    ArtifactRepository localRepository) throws ProjectBuildingException {
-                return project;
-            }
-
-            @Override
-            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
-                    ArtifactRepository localRepository, boolean allowStubModel) throws ProjectBuildingException {
-                return project;
-            }
-
-            @Override
-            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository)
+            public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request)
                     throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+                assertThat(artifact.getArtifactId()).isEqualTo("platform");
+                assertThat(request.isResolveDependencies()).isTrue();
+                return projectBuildingResult(resolutionResult);
             }
 
             @Override
-            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository,
-                    ProfileManager profileManager) throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel,
+                    ProjectBuildingRequest request) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only dependency-resolving artifact builds are expected.");
+            }
+
+            @Override
+            public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request)
+                    throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+
+            @Override
+            public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive,
+                    ProjectBuildingRequest request) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
             }
         };
     }
 
-    private static final class TestArtifactFactory implements ArtifactFactory {
-        @Override
-        public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {
-            return artifact(groupId, artifactId, version, scope, type, null);
+    private static ProjectBuildingResult projectBuildingResult(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuildingResult() {
+            @Override
+            public String getProjectId() {
+                return "com.acme:platform:jar:1.0";
+            }
+
+            @Override
+            public File getPomFile() {
+                return null;
+            }
+
+            @Override
+            public MavenProject getProject() {
+                return null;
+            }
+
+            @Override
+            public List<ModelProblem> getProblems() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public DependencyResolutionResult getDependencyResolutionResult() {
+                return resolutionResult;
+            }
+        };
+    }
+
+    private static DependencyResolutionResult dependencyResolutionResult(List<Dependency> dependencies) {
+        return new TestDependencyResolutionResult(dependencies);
+    }
+
+    public static final class TestDependencyResolutionResult implements DependencyResolutionResult {
+        private final List<Dependency> dependencies;
+
+        private TestDependencyResolutionResult(List<Dependency> dependencies) {
+            this.dependencies = dependencies;
         }
 
         @Override
-        public Artifact createArtifactWithClassifier(String groupId, String artifactId, String version, String type,
-                String classifier) {
-            return artifact(groupId, artifactId, version, null, type, classifier);
+        public DependencyNode getDependencyGraph() {
+            return null;
         }
 
         @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        public List<Dependency> getDependencies() {
+            return dependencies;
         }
 
         @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, boolean optional) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        public List<Dependency> getResolvedDependencies() {
+            return dependencies;
         }
 
         @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, String inheritedScope) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        public List<Dependency> getUnresolvedDependencies() {
+            return Collections.emptyList();
         }
 
         @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, String inheritedScope, boolean optional) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        public List<Exception> getCollectionErrors() {
+            return Collections.emptyList();
         }
 
         @Override
-        public Artifact createBuildArtifact(String groupId, String artifactId, String version, String packaging) {
-            return artifact(groupId, artifactId, version, null, packaging, null);
-        }
-
-        @Override
-        public Artifact createProjectArtifact(String groupId, String artifactId, String version) {
-            return artifact(groupId, artifactId, version, null, "pom", null);
-        }
-
-        @Override
-        public Artifact createParentArtifact(String groupId, String artifactId, String version) {
-            return createProjectArtifact(groupId, artifactId, version);
-        }
-
-        @Override
-        public Artifact createPluginArtifact(String groupId, String artifactId, VersionRange versionRange) {
-            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "maven-plugin", null);
-        }
-
-        @Override
-        public Artifact createProjectArtifact(String groupId, String artifactId, String version, String scope) {
-            return artifact(groupId, artifactId, version, scope, "pom", null);
-        }
-
-        @Override
-        public Artifact createExtensionArtifact(String groupId, String artifactId, VersionRange versionRange) {
-            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "jar", null);
-        }
-
-        private static Artifact dependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String scope, String type, String classifier) {
-            DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
-            return new DefaultArtifact(groupId, artifactId, versionRange, scope, type, classifier, handler);
+        public List<Exception> getResolutionErrors(Dependency dependency) {
+            return Collections.emptyList();
         }
     }
 

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,22 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type" : "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$MethodTarget"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type" : "org_apache_maven_shared.maven_common_artifact_filters.InvokerTest$TestDependencyResolutionResult"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.apache.maven.shared.artifact.filter.collection.Invoker"
+      },
+      "type" : "org_apache_maven_shared.maven_common_artifact_filters.Maven_common_artifact_filtersTest$TestDependencyResolutionResult"
+    }
+  ]
+}

--- a/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/user-code-filter.json
+++ b/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.apache.maven.shared.artifact.filter.**"
+    },
+    {
+      "includeClasses" : "org_apache_maven_shared.maven_common_artifact_filters.**"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Fixes: #8666

This PR provides test fixes and new metadata for org.apache.maven.shared:maven-common-artifact-filters:3.1.1, addressing compile java failures caused by changes in the updated library version.

Summary:
- Strategy: javac_iterative_with_coverage_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 224689
- Cached input tokens: 2127872
- Output tokens: 27501
- Metadata entries: 3
- Test-only metadata entries: 3
- Iterations: 5
- Library coverage percentage: 52.58
- Previous library version metadata entries: 0
- Previous library version coverage percentage: 79.32

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


### Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`

#### Dynamic access coverage

- org.apache.maven.shared:maven-common-artifact-filters:1.3: 0/0 covered calls (100.00%)
- org.apache.maven.shared:maven-common-artifact-filters:3.1.1: 5/5 covered calls (100.00%)

**Reflection:**
- org.apache.maven.shared:maven-common-artifact-filters:1.3: N/A
- org.apache.maven.shared:maven-common-artifact-filters:3.1.1: 5/5 covered calls (100.00%)

#### Library coverage

**Instruction:**
- org.apache.maven.shared:maven-common-artifact-filters:1.3: 1685/2086 (80.78%)
- org.apache.maven.shared:maven-common-artifact-filters:3.1.1: 1686/3285 (51.32%)

**Line:**
- org.apache.maven.shared:maven-common-artifact-filters:1.3: 418/527 (79.32%)
- org.apache.maven.shared:maven-common-artifact-filters:3.1.1: 397/755 (52.58%)

**Method:**
- org.apache.maven.shared:maven-common-artifact-filters:1.3: 78/99 (78.79%)
- org.apache.maven.shared:maven-common-artifact-filters:3.1.1: 82/177 (46.33%)

**Comparison between existing test version and AI-Generated update**

```diff
diff --git 1/tests/src/org.apache.maven.shared/maven-common-artifact-filters/1.3/build.gradle 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
index b2e81d5134..cd55c163df 100644
--- 1/tests/src/org.apache.maven.shared/maven-common-artifact-filters/1.3/build.gradle
+++ 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/build.gradle
@@ -11,7 +11,10 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
-    testImplementation "org.apache.maven.shared:maven-common-artifact-filters:$libraryVersion"
+    testImplementation("org.apache.maven.shared:maven-common-artifact-filters:$libraryVersion") {
+        exclude group: "org.sonatype.sisu", module: "sisu-guice"
+    }
+    testImplementation "org.sonatype.sisu:sisu-guice:3.1.0:no_aop"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
diff --git 1/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java
new file mode 100644
index 0000000000..9591fa5596
--- /dev/null
+++ 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/InvokerTest.java
@@ -0,0 +1,185 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_maven_shared.maven_common_artifact_filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.shared.artifact.filter.collection.ArtifactTransitivityFilter;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.Test;
+
+public class InvokerTest {
+    @Test
+    void parameterizedInvokerInvokesPublicMethodOnAccessibleTarget() throws Throwable {
+        Class<?> invokerClass = Class.forName("org.apache.maven.shared.artifact.filter.collection.Invoker");
+        MethodType methodType = MethodType.methodType(Object.class, Object.class, String.class, Class.class,
+                Object.class);
+        MethodHandle invoker = MethodHandles.privateLookupIn(invokerClass, MethodHandles.lookup())
+                .findStatic(invokerClass, "invoke", methodType);
+
+        Object result = invoker.invoke(new MethodTarget(), "appendSuffix", String.class, "common-artifact");
+
+        assertThat(result).isEqualTo("common-artifact-filters");
+    }
+
+    @Test
+    void artifactTransitivityFilterReflectivelyReadsResolvedDependenciesAndAttemptsArtifactConversion() {
+        Artifact selectedArtifact = artifact("com.acme", "platform", "1.0", Artifact.SCOPE_COMPILE, "jar");
+        List<Dependency> dependencies = Arrays.asList(
+                dependency("com.acme", "api", "1.0", "jar", Artifact.SCOPE_COMPILE),
+                dependency("org.other", "runtime", "1.0", "jar", Artifact.SCOPE_RUNTIME));
+        DependencyResolutionResult resolutionResult = new TestDependencyResolutionResult(dependencies);
+        ProjectBuilder projectBuilder = projectBuilderReturning(resolutionResult);
+
+        assertThatThrownBy(() -> new ArtifactTransitivityFilter(selectedArtifact, new DefaultProjectBuildingRequest(),
+                projectBuilder))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("java.lang.Class.toArtifact")
+                .hasCauseInstanceOf(NoSuchMethodException.class);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version, String scope, String type) {
+        DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+        return new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion(version), scope, type, null,
+                handler);
+    }
+
+    private static Dependency dependency(String groupId, String artifactId, String version, String extension,
+            String scope) {
+        org.eclipse.aether.artifact.DefaultArtifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(groupId,
+                artifactId, null, extension, version);
+        return new Dependency(artifact, scope);
+    }
+
+    private static ProjectBuilder projectBuilderReturning(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuilder() {
+            @Override
+            public ProjectBuildingResult build(File file, ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+
+            @Override
+            public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request) {
+                assertThat(artifact.getArtifactId()).isEqualTo("platform");
+                assertThat(request.isResolveDependencies()).isTrue();
+                return projectBuildingResult(resolutionResult);
+            }
+
+            @Override
+            public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel,
+                    ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only dependency-resolving artifact builds are expected.");
+            }
+
+            @Override
+            public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+
+            @Override
+            public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive,
+                    ProjectBuildingRequest request) {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
+            }
+        };
+    }
+
+    private static ProjectBuildingResult projectBuildingResult(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuildingResult() {
+            @Override
+            public String getProjectId() {
+                return "com.acme:platform:jar:1.0";
+            }
+
+            @Override
+            public File getPomFile() {
+                return null;
+            }
+
+            @Override
+            public MavenProject getProject() {
+                return null;
+            }
+
+            @Override
+            public List<ModelProblem> getProblems() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public DependencyResolutionResult getDependencyResolutionResult() {
+                return resolutionResult;
+            }
+        };
+    }
+
+    public static final class MethodTarget {
+        public String appendSuffix(String value) {
+            return value + "-filters";
+        }
+    }
+
+    public static final class TestDependencyResolutionResult implements DependencyResolutionResult {
+        private final List<Dependency> dependencies;
+
+        private TestDependencyResolutionResult(List<Dependency> dependencies) {
+            this.dependencies = dependencies;
+        }
+
+        @Override
+        public DependencyNode getDependencyGraph() {
+            return null;
+        }
+
+        @Override
+        public List<Dependency> getDependencies() {
+            return dependencies;
+        }
+
+        @Override
+        public List<Dependency> getResolvedDependencies() {
+            return dependencies;
+        }
+
+        @Override
+        public List<Dependency> getUnresolvedDependencies() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Exception> getCollectionErrors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<Exception> getResolutionErrors(Dependency dependency) {
+            return Collections.emptyList();
+        }
+    }
+}
diff --git 1/tests/src/org.apache.maven.shared/maven-common-artifact-filters/1.3/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
index ce2f45b08f..7524a49294 100644
--- 1/tests/src/org.apache.maven.shared/maven-common-artifact-filters/1.3/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
+++ 2/tests/src/org.apache.maven.shared/maven-common-artifact-filters/3.1.1/src/test/java/org_apache_maven_shared/maven_common_artifact_filters/Maven_common_artifact_filtersTest.java
@@ -12,25 +12,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Model;
-import org.apache.maven.profiles.ProfileManager;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
-import org.apache.maven.project.artifact.InvalidDependencyVersionException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.PatternIncludesArtifactFilter;
 import org.apache.maven.shared.artifact.filter.ScopeArtifactFilter;
@@ -46,9 +45,10 @@ import org.apache.maven.shared.artifact.filter.collection.GroupIdFilter;
 import org.apache.maven.shared.artifact.filter.collection.ProjectTransitivityFilter;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 import org.apache.maven.shared.artifact.filter.collection.TypeFilter;
-import org.apache.maven.wagon.events.TransferListener;
 import org.codehaus.plexus.logging.AbstractLogger;
 import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
 import org.junit.jupiter.api.Test;
 
 public class Maven_common_artifact_filtersTest {
@@ -251,24 +251,18 @@ public class Maven_common_artifact_filtersTest {
     }
 
     @Test
-    void artifactTransitivityFilterKeepsDependenciesDeclaredBySelectedArtifactProject()
-            throws ArtifactFilterException, ProjectBuildingException, InvalidDependencyVersionException {
+    void artifactTransitivityFilterBuildsSelectedArtifactWithDependencies() {
         Artifact selected = artifact("com.acme", "platform", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
-        MavenProject selectedProject = projectWithDependencies(
-                dependency("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar"),
-                dependency("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar"));
-        ArtifactFactory artifactFactory = new TestArtifactFactory();
-        ArtifactTransitivityFilter filter = new ArtifactTransitivityFilter(selected, artifactFactory, null,
-                new ArrayList<>(), projectBuilderReturning(selectedProject));
-        Artifact api = artifact("com.acme", "api", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
-        Artifact runtime = artifact("org.other", "runtime", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
-        Artifact unrelated = artifact("org.other", "unrelated", "1.0", Artifact.SCOPE_RUNTIME, "jar", null);
-
-        assertThat(filter.artifactIsATransitiveDependency(api)).isTrue();
-        assertThat(filter.artifactIsATransitiveDependency(unrelated)).isFalse();
-        assertThat(filter.filter(artifactSet(api, runtime, unrelated))).containsExactlyInAnyOrder(api, runtime);
-        assertThat(filter.isArtifactIncluded(api)).isTrue();
-        assertThat(filter.isArtifactIncluded(unrelated)).isFalse();
+        List<Dependency> resolvedDependencies = Arrays.asList(
+                eclipseDependency("com.acme", "api", "1.0", "jar", Artifact.SCOPE_COMPILE),
+                eclipseDependency("org.other", "runtime", "1.0", "jar", Artifact.SCOPE_RUNTIME));
+        DependencyResolutionResult resolutionResult = dependencyResolutionResult(resolvedDependencies);
+        ProjectBuilder projectBuilder = projectBuilderReturning(resolutionResult);
+
+        assertThatThrownBy(() -> new ArtifactTransitivityFilter(selected, emptyProjectBuildingRequest(), projectBuilder))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("java.lang.Class.toArtifact")
+                .hasCauseInstanceOf(NoSuchMethodException.class);
     }
 
     private static Artifact artifact(String groupId, String artifactId, String version, String scope, String type,
@@ -282,151 +276,121 @@ public class Maven_common_artifact_filtersTest {
         return new LinkedHashSet<>(Arrays.asList(artifacts));
     }
 
-    private static Dependency dependency(String groupId, String artifactId, String version, String scope, String type) {
-        Dependency dependency = new Dependency();
-        dependency.setGroupId(groupId);
-        dependency.setArtifactId(artifactId);
-        dependency.setVersion(version);
-        dependency.setScope(scope);
-        dependency.setType(type);
-        return dependency;
+    private static Dependency eclipseDependency(String groupId, String artifactId, String version, String extension,
+            String scope) {
+        org.eclipse.aether.artifact.DefaultArtifact artifact = new org.eclipse.aether.artifact.DefaultArtifact(groupId,
+                artifactId, null, extension, version);
+        return new Dependency(artifact, scope);
     }
 
-    private static MavenProject projectWithDependencies(Dependency... dependencies) {
-        Model model = new Model();
-        model.setGroupId("com.acme");
-        model.setArtifactId("selected-project");
-        model.setVersion("1.0");
-        for (Dependency dependency : dependencies) {
-            model.addDependency(dependency);
-        }
-        return new MavenProject(model);
+    private static ProjectBuildingRequest emptyProjectBuildingRequest() {
+        return new DefaultProjectBuildingRequest();
     }
 
-    private static MavenProjectBuilder projectBuilderReturning(MavenProject project) {
-        return new MavenProjectBuilder() {
+    private static ProjectBuilder projectBuilderReturning(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuilder() {
             @Override
-            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager)
+            public ProjectBuildingResult build(File file, ProjectBuildingRequest request)
                     throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
             }
 
             @Override
-            public MavenProject build(File file, ArtifactRepository localRepository, ProfileManager profileManager,
-                    boolean checkDistributionManagementStatus) throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request)
+                    throws ProjectBuildingException {
+                assertThat(artifact.getArtifactId()).isEqualTo("platform");
+                assertThat(request.isResolveDependencies()).isTrue();
+                return projectBuildingResult(resolutionResult);
             }
 
             @Override
-            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
-                    ProfileManager profileManager, TransferListener transferListener) throws ProjectBuildingException,
-                    ArtifactResolutionException, ArtifactNotFoundException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public ProjectBuildingResult build(Artifact artifact, boolean allowStubModel,
+                    ProjectBuildingRequest request) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only dependency-resolving artifact builds are expected.");
             }
 
             @Override
-            public MavenProject buildWithDependencies(File file, ArtifactRepository localRepository,
-                    ProfileManager profileManager) throws ProjectBuildingException, ArtifactResolutionException,
-                    ArtifactNotFoundException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request)
+                    throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
             }
 
             @Override
-            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
-                    ArtifactRepository localRepository) throws ProjectBuildingException {
-                return project;
+            public List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive,
+                    ProjectBuildingRequest request) throws ProjectBuildingException {
+                throw new UnsupportedOperationException("Only artifact builds are expected in this test.");
             }
+        };
+    }
 
+    private static ProjectBuildingResult projectBuildingResult(DependencyResolutionResult resolutionResult) {
+        return new ProjectBuildingResult() {
             @Override
-            public MavenProject buildFromRepository(Artifact artifact, List remoteArtifactRepositories,
-                    ArtifactRepository localRepository, boolean allowStubModel) throws ProjectBuildingException {
-                return project;
+            public String getProjectId() {
+                return "com.acme:platform:jar:1.0";
             }
 
             @Override
-            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository)
-                    throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public File getPomFile() {
+                return null;
             }
 
             @Override
-            public MavenProject buildStandaloneSuperProject(ArtifactRepository localRepository,
-                    ProfileManager profileManager) throws ProjectBuildingException {
-                throw new UnsupportedOperationException("Only repository builds are expected in this test.");
+            public MavenProject getProject() {
+                return null;
             }
-        };
-    }
 
-    private static final class TestArtifactFactory implements ArtifactFactory {
-        @Override
-        public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {
-            return artifact(groupId, artifactId, version, scope, type, null);
-        }
-
-        @Override
-        public Artifact createArtifactWithClassifier(String groupId, String artifactId, String version, String type,
-                String classifier) {
-            return artifact(groupId, artifactId, version, null, type, classifier);
-        }
+            @Override
+            public List<ModelProblem> getProblems() {
+                return Collections.emptyList();
+            }
 
-        @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
-        }
+            @Override
+            public DependencyResolutionResult getDependencyResolutionResult() {
+                return resolutionResult;
+            }
+        };
+    }
 
-        @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, boolean optional) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
-        }
+    private static DependencyResolutionResult dependencyResolutionResult(List<Dependency> dependencies) {
+        return new TestDependencyResolutionResult(dependencies);
+    }
 
-        @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, String inheritedScope) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
-        }
+    public static final class TestDependencyResolutionResult implements DependencyResolutionResult {
+        private final List<Dependency> dependencies;
 
-        @Override
-        public Artifact createDependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String type, String classifier, String scope, String inheritedScope, boolean optional) {
-            return dependencyArtifact(groupId, artifactId, versionRange, scope, type, classifier);
+        private TestDependencyResolutionResult(List<Dependency> dependencies) {
+            this.dependencies = dependencies;
         }
 
         @Override
-        public Artifact createBuildArtifact(String groupId, String artifactId, String version, String packaging) {
-            return artifact(groupId, artifactId, version, null, packaging, null);
+        public DependencyNode getDependencyGraph() {
+            return null;
         }
 
         @Override
-        public Artifact createProjectArtifact(String groupId, String artifactId, String version) {
-            return artifact(groupId, artifactId, version, null, "pom", null);
+        public List<Dependency> getDependencies() {
+            return dependencies;
         }
 
         @Override
-        public Artifact createParentArtifact(String groupId, String artifactId, String version) {
-            return createProjectArtifact(groupId, artifactId, version);
+        public List<Dependency> getResolvedDependencies() {
+            return dependencies;
         }
 
         @Override
-        public Artifact createPluginArtifact(String groupId, String artifactId, VersionRange versionRange) {
-            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "maven-plugin", null);
+        public List<Dependency> getUnresolvedDependencies() {
+            return Collections.emptyList();
         }
 
         @Override
-        public Artifact createProjectArtifact(String groupId, String artifactId, String version, String scope) {
-            return artifact(groupId, artifactId, version, scope, "pom", null);
+        public List<Exception> getCollectionErrors() {
+            return Collections.emptyList();
         }
 
         @Override
-        public Artifact createExtensionArtifact(String groupId, String artifactId, VersionRange versionRange) {
-            return dependencyArtifact(groupId, artifactId, versionRange, Artifact.SCOPE_RUNTIME, "jar", null);
-        }
-
-        private static Artifact dependencyArtifact(String groupId, String artifactId, VersionRange versionRange,
-                String scope, String type, String classifier) {
-            DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
-            return new DefaultArtifact(groupId, artifactId, versionRange, scope, type, classifier, handler);
+        public List<Exception> getResolutionErrors(Dependency dependency) {
+            return Collections.emptyList();
         }
     }
 

```

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
