### PR TITLE
[GenAI] Mark org.springframework.shell:spring-shell-starter as not for Native Image

### DIFF
--- a/metadata/org.springframework.shell/spring-shell-starter/index.json
+++ b/metadata/org.springframework.shell/spring-shell-starter/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The 4.0.2 JAR contains only META-INF Maven metadata and no JVM .class files.",
+    "replacement": "org.springframework.shell:spring-shell-core-autoconfigure:4.0.2"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8407

This PR records `org.springframework.shell:spring-shell-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The 4.0.2 JAR contains only META-INF Maven metadata and no JVM .class files.

Replacement guidance:
- org.springframework.shell:spring-shell-core-autoconfigure:4.0.2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
