### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-h2console:4.1.0 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-h2console/4.1.0/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-h2console/4.1.0/reachability-metadata.json
@@ -1,0 +1,178 @@
+{
+  "reflection" : [
+    {
+      "type" : "org.springframework.boot.h2console.autoconfigure.H2ConsoleAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "allDeclaredMethods" : true
+    },
+    {
+      "type" : "org.springframework.boot.h2console.autoconfigure.H2ConsoleProperties",
+      "allDeclaredConstructors" : true,
+      "allPublicMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "type" : "org.springframework.boot.h2console.autoconfigure.H2ConsoleProperties$Settings",
+      "allDeclaredConstructors" : true,
+      "allPublicMethods" : true,
+      "allDeclaredFields" : true
+    },
+    {
+      "type" : "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods" : [
+        {
+          "name" : "byAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.web.context.ConfigurableWebApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableWebApplicationContext"
+        ]
+      }
+    },
+    {
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "org/springframework/boot/h2console/autoconfigure/*.class"
+    },
+    {
+      "glob" : "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob" : "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnBooleanProperty.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnWebApplication.class"
+    },
+    {
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnWebApplication$Type.class"
+    },
+    {
+      "glob" : "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "glob" : "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-h2console/index.json
+++ b/metadata/org.springframework.boot/spring-boot-h2console/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-h2console/$version$/spring-boot-h2console-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-h2console/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-h2console/$version$/spring-boot-h2console-$version$-javadoc.jar",
+    "description" : "Spring Boot H2 Console provides auto-configuration for exposing the H2 database web console in servlet-based Spring Boot applications. It contributes configuration properties and auto-configuration that register the console when H2, Servlet APIs, and the required web environment are available.",
+    "tested-versions" : [
+      "4.1.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.h2console.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-h2console/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-h2console/4.1.0/execution-metrics.json
@@ -1,0 +1,125 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T00:08:44.993874Z",
+    "library": "org.springframework.boot:spring-boot-h2console:4.1.0",
+    "starting_commit": "316c42d9c6606490a1232f8af2ba8443131377f1",
+    "ending_commit": "00decffd0e52ed1bbf1cb592b912826e7496acfb",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 218,
+          "missed": 5,
+          "ratio": 0.977578,
+          "total": 223
+        },
+        "line": {
+          "covered": 60,
+          "missed": 2,
+          "ratio": 0.967742,
+          "total": 62
+        },
+        "method": {
+          "covered": 24,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 24
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8405,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.boot:spring-boot-h2console:4.1.0",
+      "summary": "The artifact is a Spring Boot servlet auto-configuration module; meaningful coverage requires Spring Boot auto-configuration/test support and a servlet web context beyond the target artifact's normal transitive dependencies.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0",
+          "scope": "testImplementation",
+          "reason": "spring-boot-h2console declares Spring Boot auto-configuration types as optional; tests need them to exercise H2ConsoleAutoConfiguration through AutoConfigurations and its conditional annotations."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-test:4.1.0",
+          "scope": "testImplementation",
+          "reason": "Spring Boot's own tests use WebApplicationContextRunner/ApplicationContextRunner to exercise this auto-configuration without starting a real server."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework:spring-web:7.0.8",
+          "scope": "testImplementation",
+          "reason": "A servlet web application context is required for @ConditionalOnWebApplication(type = SERVLET); WebApplicationContextRunner needs Spring Web servlet context types."
+        }
+      ],
+      "agent_guidance": "Use a servlet web application context and set `spring.h2.console.enabled=true` in test properties to activate the console, since it is disabled by default unless devtools is present. Cover path and settings properties such as `spring.h2.console.path`, `spring.h2.console.settings.trace`, `web-allow-others`, and `web-admin-password`; avoid starting a real embedded server unless local verification shows it is necessary.",
+      "risks": [
+        "The H2 console is development-only and disabled by default, so tests that do not enable it may produce scaffold-level coverage only.",
+        "If tests choose to start an embedded servlet container instead of using a context runner, they may need additional server dependencies such as Tomcat and should use a random port."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0",
+          "result": "applied",
+          "target": "tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-test:4.1.0",
+          "result": "applied",
+          "target": "tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework:spring-web:7.0.8",
+          "result": "applied",
+          "target": "tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8405 Support for org.springframework.boot:spring-boot-h2console:4.1.0; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 61162,
+      "output_tokens_used": 6801,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-h2console:4.1.0/library-preparation-preflight/pi-generation-2026-06-26T23-46-19-840996Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 231730,
+      "cached_input_tokens_used": 2036224,
+      "output_tokens_used": 20598,
+      "iterations": 5,
+      "cost_usd": 1.636,
+      "generated_loc": 188,
+      "tested_library_loc": 60,
+      "metadata_entries": 44,
+      "code_coverage_percent": 96.77
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java",
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-h2console/4.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-h2console/4.1.0/stats.json
+++ b/stats/org.springframework.boot/spring-boot-h2console/4.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 218,
+        "missed" : 5,
+        "ratio" : 0.977578,
+        "total" : 223
+      },
+      "line" : {
+        "covered" : 60,
+        "missed" : 2,
+        "ratio" : 0.967742,
+        "total" : 62
+      },
+      "method" : {
+        "covered" : 24,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 24
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-h2console:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:4.1.0"
+    testImplementation "org.springframework.boot:spring-boot-test:4.1.0"
+    testImplementation "org.springframework:spring-web:7.0.8"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-h2console:4.1.0
+library.version = 4.1.0
+metadata.dir = org.springframework.boot/spring-boot-h2console/4.1.0/

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-h2console_tests'

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_h2console;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_h2consoleTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
@@ -6,11 +6,115 @@
  */
 package org_springframework_boot.spring_boot_h2console;
 
+import java.util.Map;
+
+import org.h2.server.web.JakartaWebServlet;
 import org.junit.jupiter.api.Test;
 
-class Spring_boot_h2consoleTest {
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.h2console.autoconfigure.H2ConsoleAutoConfiguration;
+import org.springframework.boot.h2console.autoconfigure.H2ConsoleProperties;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public class Spring_boot_h2consoleTest {
+
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(H2ConsoleAutoConfiguration.class));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void h2ConsolePropertiesExposeDefaultsAndValidatePath() {
+        H2ConsoleProperties properties = new H2ConsoleProperties();
+
+        assertThat(properties.getPath()).isEqualTo("/h2-console");
+        assertThat(properties.isEnabled()).isFalse();
+        assertThat(properties.getSettings().isTrace()).isFalse();
+        assertThat(properties.getSettings().isWebAllowOthers()).isFalse();
+        assertThat(properties.getSettings().getWebAdminPassword()).isNull();
+
+        properties.setEnabled(true);
+        properties.setPath("/database-console");
+        properties.getSettings().setTrace(true);
+        properties.getSettings().setWebAllowOthers(true);
+        properties.getSettings().setWebAdminPassword("admin-secret");
+
+        assertThat(properties.isEnabled()).isTrue();
+        assertThat(properties.getPath()).isEqualTo("/database-console");
+        assertThat(properties.getSettings().isTrace()).isTrue();
+        assertThat(properties.getSettings().isWebAllowOthers()).isTrue();
+        assertThat(properties.getSettings().getWebAdminPassword()).isEqualTo("admin-secret");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> properties.setPath(null))
+                .withMessageContaining("'path' must not be null");
+        assertThatIllegalArgumentException().isThrownBy(() -> properties.setPath("/"))
+                .withMessageContaining("'path' must have length greater than 1");
+        assertThatIllegalArgumentException().isThrownBy(() -> properties.setPath("h2-console"))
+                .withMessageContaining("'path' must start with '/'");
     }
+
+    @Test
+    void autoConfigurationDoesNotCreateConsoleWhenConsoleIsDisabled() {
+        this.contextRunner.run((context) -> {
+            assertThat(context).doesNotHaveBean(H2ConsoleProperties.class);
+            assertThat(context).doesNotHaveBean("h2Console");
+            assertThat(context).doesNotHaveBean(ServletRegistrationBean.class);
+        });
+    }
+
+    @Test
+    void enabledConsoleCreatesRegistrationForDefaultPath() {
+        this.contextRunner.withPropertyValues("spring.h2.console.enabled=true").run((context) -> {
+            assertThat(context).hasSingleBean(H2ConsoleProperties.class);
+            assertThat(context).hasSingleBean(ServletRegistrationBean.class);
+
+            ServletRegistrationBean<?> registration = context.getBean(ServletRegistrationBean.class);
+            H2ConsoleProperties properties = context.getBean(H2ConsoleProperties.class);
+
+            assertThat(properties.isEnabled()).isTrue();
+            assertThat(properties.getPath()).isEqualTo("/h2-console");
+            assertThat(registration.getServlet()).isInstanceOf(JakartaWebServlet.class);
+            assertThat(registration.getServletName()).isEqualTo("h2Console");
+            assertThat(registration.getUrlMappings()).containsExactly("/h2-console/*");
+            assertThat(registration.getInitParameters()).isEmpty();
+        });
+    }
+
+    @Test
+    void enabledConsoleBindsPathAndSettingsIntoServletRegistration() {
+        this.contextRunner
+                .withPropertyValues("spring.h2.console.enabled=true", "spring.h2.console.path=/database/",
+                        "spring.h2.console.settings.trace=true",
+                        "spring.h2.console.settings.web-allow-others=true",
+                        "spring.h2.console.settings.web-admin-password=admin-secret")
+                .run((context) -> {
+                    H2ConsoleProperties properties = context.getBean(H2ConsoleProperties.class);
+                    ServletRegistrationBean<?> registration = context.getBean(ServletRegistrationBean.class);
+
+                    assertThat(properties.getPath()).isEqualTo("/database/");
+                    assertThat(properties.getSettings().isTrace()).isTrue();
+                    assertThat(properties.getSettings().isWebAllowOthers()).isTrue();
+                    assertThat(properties.getSettings().getWebAdminPassword()).isEqualTo("admin-secret");
+                    assertThat(registration.getUrlMappings()).containsExactly("/database/*");
+                    assertThat(registration.getServlet()).isInstanceOf(JakartaWebServlet.class);
+                    assertThat(registration.getServletName()).isEqualTo("h2Console");
+                    assertThat(registration.getInitParameters()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                            "trace", "", "webAllowOthers", "", "webAdminPassword", "admin-secret"));
+                });
+    }
+
+    @Test
+    void customPathWithoutTrailingSlashUsesWildcardChildMapping() {
+        this.contextRunner
+                .withPropertyValues("spring.h2.console.enabled=true", "spring.h2.console.path=/tools/h2")
+                .run((context) -> {
+                    ServletRegistrationBean<?> registration = context.getBean(ServletRegistrationBean.class);
+
+                    assertThat(registration.getUrlMappings()).containsExactly("/tools/h2/*");
+                    assertThat(registration.toString()).contains("/tools/h2/*");
+                });
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.h2console.autoconfigure.H2ConsoleAutoConfiguration;
 import org.springframework.boot.h2console.autoconfigure.H2ConsoleProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 
@@ -23,6 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 public class Spring_boot_h2consoleTest {
 
     private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(H2ConsoleAutoConfiguration.class));
+
+    private final ApplicationContextRunner nonWebContextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(H2ConsoleAutoConfiguration.class));
 
     @Test
@@ -58,6 +62,15 @@ public class Spring_boot_h2consoleTest {
     @Test
     void autoConfigurationDoesNotCreateConsoleWhenConsoleIsDisabled() {
         this.contextRunner.run((context) -> {
+            assertThat(context).doesNotHaveBean(H2ConsoleProperties.class);
+            assertThat(context).doesNotHaveBean("h2Console");
+            assertThat(context).doesNotHaveBean(ServletRegistrationBean.class);
+        });
+    }
+
+    @Test
+    void enabledConsoleDoesNotCreateRegistrationForNonWebApplication() {
+        this.nonWebContextRunner.withPropertyValues("spring.h2.console.enabled=true").run((context) -> {
             assertThat(context).doesNotHaveBean(H2ConsoleProperties.class);
             assertThat(context).doesNotHaveBean("h2Console");
             assertThat(context).doesNotHaveBean(ServletRegistrationBean.class);

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/src/test/java/org_springframework_boot/spring_boot_h2console/Spring_boot_h2consoleTest.java
@@ -6,8 +6,17 @@
  */
 package org_springframework_boot.spring_boot_h2console;
 
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcDataSource;
 import org.h2.server.web.JakartaWebServlet;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +26,8 @@ import org.springframework.boot.h2console.autoconfigure.H2ConsoleProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -128,6 +139,93 @@ public class Spring_boot_h2consoleTest {
                     assertThat(registration.getUrlMappings()).containsExactly("/tools/h2/*");
                     assertThat(registration.toString()).contains("/tools/h2/*");
                 });
+    }
+
+    @Test
+    void enabledConsoleInspectsAvailableDataSourcesForStartupLogging() {
+        this.contextRunner.withPropertyValues("spring.h2.console.enabled=true")
+                .withUserConfiguration(TestDataSourceConfiguration.class)
+                .run((context) -> {
+                    assertThat(context).hasBean("h2ConsoleLogger");
+
+                    CountingDataSource dataSource = context.getBean(CountingDataSource.class);
+                    assertThat(dataSource.getConnectionCount()).isPositive();
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    public static class TestDataSourceConfiguration {
+
+        @Bean
+        public CountingDataSource h2DataSource() {
+            return new CountingDataSource("jdbc:h2:mem:h2consolelogger");
+        }
+
+    }
+
+    static final class CountingDataSource implements DataSource {
+
+        private final JdbcDataSource delegate = new JdbcDataSource();
+
+        private final AtomicInteger connectionCount = new AtomicInteger();
+
+        CountingDataSource(String url) {
+            this.delegate.setURL(url);
+            this.delegate.setUser("sa");
+            this.delegate.setPassword("");
+        }
+
+        int getConnectionCount() {
+            return this.connectionCount.get();
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            this.connectionCount.incrementAndGet();
+            return this.delegate.getConnection();
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            this.connectionCount.incrementAndGet();
+            return this.delegate.getConnection(username, password);
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return this.delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            this.delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            this.delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return this.delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return this.delegate.getParentLogger();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return this.delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return this.delegate.isWrapperFor(iface);
+        }
+
     }
 
 }

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.h2console.autoconfigure.**"
+      "includeClasses" : "org.springframework.boot.h2console.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_h2console.**"
     }
   ]
 }

--- a/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-h2console/4.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.h2console.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8405

This PR introduces tests and metadata for org.springframework.boot:spring-boot-h2console:4.1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 231730
- Cached input tokens: 2036224
- Output tokens: 20598
- Metadata entries: 44
- Iterations: 5
- Library coverage percentage: 96.77
- Generated lines of code: 188
- Tested library lines of code: 60

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 218/223 (97.76%)
- Line: 60/62 (96.77%)
- Method: 24/24 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
