### PR TITLE
[GenAI] Add support for org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/reachability-metadata.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/reachability-metadata.json
@@ -1,0 +1,137 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.AbstractOpenAiProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.AbstractOpenAiProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiCommonProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties"
+      },
+      "type": "org.springframework.ai.openai.OpenAiChatModel$ResponseFormat",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties"
+      },
+      "type": "org.springframework.ai.openai.OpenAiChatOptions$AudioParameters",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiImageProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiImageProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiImageProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiModerationProperties",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.ai.model.openai.autoconfigure.OpenAiModerationProperties"
+      },
+      "type": "org.springframework.ai.model.openai.autoconfigure.OpenAiModerationProperties$Options",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true,
+      "allDeclaredFields": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "META-INF/spring-configuration-metadata.json"
+    }
+  ]
+}

--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-openai/index.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-openai/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.0-RC2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-openai/$version$/spring-ai-autoconfigure-model-openai-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-ai",
+    "test-code-url" : "https://github.com/spring-projects/spring-ai/tree/v$version$/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-openai/$version$/spring-ai-autoconfigure-model-openai-$version$-javadoc.jar",
+    "description" : "Spring AI OpenAI Auto Configuration provides Spring Boot auto-configuration for OpenAI-backed Spring AI model clients. It wires chat, embedding, image, audio, and moderation model beans from application properties and OpenAI client setup defaults.",
+    "tested-versions" : [
+      "2.0.0-RC2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.ai.model.openai.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T02:07:42.080241Z",
+    "library": "org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2",
+    "starting_commit": "81cd00097b3456e67fa597d6976eda5ca78f380e",
+    "ending_commit": "0af951f5ee1313e4ad776f9dd0141231a472fe13",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-RC2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1038,
+          "missed": 1016,
+          "ratio": 0.505355,
+          "total": 2054
+        },
+        "line": {
+          "covered": 363,
+          "missed": 277,
+          "ratio": 0.567188,
+          "total": 640
+        },
+        "method": {
+          "covered": 175,
+          "missed": 151,
+          "ratio": 0.53681,
+          "total": 326
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8422,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8422 Support for org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
+      "model": "oca/gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T01-29-40-322796Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 303319,
+      "cached_input_tokens_used": 3844096,
+      "output_tokens_used": 30322,
+      "iterations": 5,
+      "cost_usd": 2.8317,
+      "generated_loc": 435,
+      "tested_library_loc": 363,
+      "metadata_entries": 66,
+      "code_coverage_percent": 56.72
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java",
+      "metadata_file": "metadata/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/stats.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0-RC2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1038,
+        "missed" : 1016,
+        "ratio" : 0.505355,
+        "total" : 2054
+      },
+      "line" : {
+        "covered" : 363,
+        "missed" : 277,
+        "ratio" : 0.567188,
+        "total" : 640
+      },
+      "method" : {
+        "covered" : 175,
+        "missed" : 151,
+        "ratio" : 0.53681,
+        "total" : 326
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/.gitignore
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/build.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/build.gradle
@@ -9,9 +9,13 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+String springBootVersion = "4.1.0-RC1"
 
 dependencies {
     testImplementation "org.springframework.ai:spring-ai-autoconfigure-model-openai:$libraryVersion"
+    testImplementation "org.springframework.ai:spring-ai-openai:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot:$springBootVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/build.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.ai:spring-ai-autoconfigure-model-openai:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/gradle.properties
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2
+library.version = 2.0.0-RC2
+metadata.dir = org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/settings.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.ai.spring-ai-autoconfigure-model-openai_tests'

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
@@ -378,6 +378,78 @@ public class Spring_ai_autoconfigure_model_openaiTest {
     }
 
     @Test
+    void binderPopulatesNestedOptionsNamespaceForEveryOpenAiModel() {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry(OpenAiChatProperties.CONFIG_PREFIX + ".options.model", "gpt-options"),
+                Map.entry(OpenAiChatProperties.CONFIG_PREFIX + ".options.temperature", "0.35"),
+                Map.entry(OpenAiChatProperties.CONFIG_PREFIX + ".options.stop[0]", "HALT"),
+                Map.entry(OpenAiEmbeddingProperties.CONFIG_PREFIX + ".options.model", "embedding-options"),
+                Map.entry(OpenAiEmbeddingProperties.CONFIG_PREFIX + ".options.user", "nested-embedding-user"),
+                Map.entry(OpenAiEmbeddingProperties.CONFIG_PREFIX + ".options.encoding-format", "float"),
+                Map.entry(OpenAiEmbeddingProperties.CONFIG_PREFIX + ".options.dimensions", "384"),
+                Map.entry(OpenAiImageProperties.CONFIG_PREFIX + ".options.model", "image-options"),
+                Map.entry(OpenAiImageProperties.CONFIG_PREFIX + ".options.width", "512"),
+                Map.entry(OpenAiImageProperties.CONFIG_PREFIX + ".options.height", "512"),
+                Map.entry(OpenAiImageProperties.CONFIG_PREFIX + ".options.quality", "standard"),
+                Map.entry(OpenAiAudioSpeechProperties.CONFIG_PREFIX + ".options.model", "speech-options"),
+                Map.entry(OpenAiAudioSpeechProperties.CONFIG_PREFIX + ".options.input", "Nested speech"),
+                Map.entry(OpenAiAudioSpeechProperties.CONFIG_PREFIX + ".options.voice", "verse"),
+                Map.entry(OpenAiAudioSpeechProperties.CONFIG_PREFIX + ".options.response-format", "opus"),
+                Map.entry(OpenAiAudioSpeechProperties.CONFIG_PREFIX + ".options.speed", "0.85"),
+                Map.entry(OpenAiAudioTranscriptionProperties.CONFIG_PREFIX + ".options.model", "transcription-options"),
+                Map.entry(OpenAiAudioTranscriptionProperties.CONFIG_PREFIX + ".options.prompt", "Nested prompt"),
+                Map.entry(OpenAiAudioTranscriptionProperties.CONFIG_PREFIX + ".options.language", "fr"),
+                Map.entry(OpenAiAudioTranscriptionProperties.CONFIG_PREFIX + ".options.temperature", "0.1"),
+                Map.entry(OpenAiModerationProperties.CONFIG_PREFIX + ".options.model", "moderation-options"));
+
+        OpenAiChatProperties chatProperties = bind(properties, OpenAiChatProperties.CONFIG_PREFIX,
+                OpenAiChatProperties.class);
+        OpenAiEmbeddingProperties embeddingProperties = bind(properties, OpenAiEmbeddingProperties.CONFIG_PREFIX,
+                OpenAiEmbeddingProperties.class);
+        OpenAiImageProperties imageProperties = bind(properties, OpenAiImageProperties.CONFIG_PREFIX,
+                OpenAiImageProperties.class);
+        OpenAiAudioSpeechProperties speechProperties = bind(properties, OpenAiAudioSpeechProperties.CONFIG_PREFIX,
+                OpenAiAudioSpeechProperties.class);
+        OpenAiAudioTranscriptionProperties transcriptionProperties = bind(properties,
+                OpenAiAudioTranscriptionProperties.CONFIG_PREFIX, OpenAiAudioTranscriptionProperties.class);
+        OpenAiModerationProperties moderationProperties = bind(properties, OpenAiModerationProperties.CONFIG_PREFIX,
+                OpenAiModerationProperties.class);
+
+        assertThat(chatProperties.getOptions().getModel()).isEqualTo("gpt-options");
+        assertThat(chatProperties.toOptions().getModel()).isEqualTo("gpt-options");
+        assertThat(chatProperties.toOptions().getTemperature()).isEqualTo(0.35d);
+        assertThat(chatProperties.toOptions().getStopSequences()).containsExactly("HALT");
+
+        assertThat(embeddingProperties.getOptions().getModel()).isEqualTo("embedding-options");
+        assertThat(embeddingProperties.toOptions().getModel()).isEqualTo("embedding-options");
+        assertThat(embeddingProperties.toOptions().getUser()).isEqualTo("nested-embedding-user");
+        assertThat(embeddingProperties.toOptions().getEncodingFormat()).isEqualTo(EncodingFormat.FLOAT);
+        assertThat(embeddingProperties.toOptions().getDimensions()).isEqualTo(384);
+
+        assertThat(imageProperties.getOptions().getModel()).isEqualTo("image-options");
+        assertThat(imageProperties.toOptions().getModel()).isEqualTo("image-options");
+        assertThat(imageProperties.toOptions().getWidth()).isEqualTo(512);
+        assertThat(imageProperties.toOptions().getHeight()).isEqualTo(512);
+        assertThat(imageProperties.toOptions().getQuality()).isEqualTo("standard");
+
+        assertThat(speechProperties.getOptions().getModel()).isEqualTo("speech-options");
+        assertThat(speechProperties.toOptions().getModel()).isEqualTo("speech-options");
+        assertThat(speechProperties.toOptions().getInput()).isEqualTo("Nested speech");
+        assertThat(speechProperties.toOptions().getVoice()).isEqualTo("verse");
+        assertThat(speechProperties.toOptions().getResponseFormat()).isEqualTo("opus");
+        assertThat(speechProperties.toOptions().getSpeed()).isEqualTo(0.85d);
+
+        assertThat(transcriptionProperties.getOptions().getModel()).isEqualTo("transcription-options");
+        assertThat(transcriptionProperties.toOptions().getModel()).isEqualTo("transcription-options");
+        assertThat(transcriptionProperties.toOptions().getPrompt()).isEqualTo("Nested prompt");
+        assertThat(transcriptionProperties.toOptions().getLanguage()).isEqualTo("fr");
+        assertThat(transcriptionProperties.toOptions().getTemperature()).isEqualTo(0.1f);
+
+        assertThat(moderationProperties.getOptions().getModel()).isEqualTo("moderation-options");
+        assertThat(moderationProperties.toOptions().getModel()).isEqualTo("moderation-options");
+    }
+
+    @Test
     void defaultCommonPropertiesMatchDocumentedOpenAiClientDefaults() {
         OpenAiCommonProperties properties = new OpenAiCommonProperties();
 

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
@@ -166,6 +166,23 @@ public class Spring_ai_autoconfigure_model_openaiTest {
     }
 
     @Test
+    void binderPopulatesNestedChatResponseAndAudioOptions() {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry("spring.ai.openai.chat.response-format.type", "json_schema"),
+                Map.entry("spring.ai.openai.chat.response-format.json-schema", "{\"name\":\"answer\"}"),
+                Map.entry("spring.ai.openai.chat.output-audio.voice", "onyx"),
+                Map.entry("spring.ai.openai.chat.output-audio.format", "aac"));
+
+        OpenAiChatProperties chatProperties = bind(properties, OpenAiChatProperties.CONFIG_PREFIX,
+                OpenAiChatProperties.class);
+
+        assertThat(chatProperties.getResponseFormat().getType()).isEqualTo(Type.JSON_SCHEMA);
+        assertThat(chatProperties.getResponseFormat().getJsonSchema()).isEqualTo("{\"name\":\"answer\"}");
+        assertThat(chatProperties.getOutputAudio().voice()).isEqualTo(Voice.ONYX);
+        assertThat(chatProperties.getOutputAudio().format()).isEqualTo(AudioParameters.AudioResponseFormat.AAC);
+    }
+
+    @Test
     void resolvesConnectionPropertiesUsingModelOverridesAndCommonFallbacks() {
         OpenAiCommonProperties commonProperties = new OpenAiCommonProperties();
         commonProperties.setBaseUrl("https://common.example.test/v1");

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
@@ -6,11 +6,390 @@
  */
 package org_springframework_ai.spring_ai_autoconfigure_model_openai;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import com.openai.models.audio.AudioResponseFormat;
+import com.openai.models.audio.transcriptions.TranscriptionCreateParams.TimestampGranularity;
 import org.junit.jupiter.api.Test;
 
-class Spring_ai_autoconfigure_model_openaiTest {
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.model.openai.autoconfigure.AbstractOpenAiProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiAutoConfigurationUtil;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiChatProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiCommonProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiImageAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiImageProperties;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration;
+import org.springframework.ai.model.openai.autoconfigure.OpenAiModerationProperties;
+import org.springframework.ai.openai.OpenAiAudioSpeechOptions;
+import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
+import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat;
+import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat.Type;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiChatOptions.AudioParameters;
+import org.springframework.ai.openai.OpenAiChatOptions.AudioParameters.Voice;
+import org.springframework.ai.openai.OpenAiChatOptions.StreamOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions.EncodingFormat;
+import org.springframework.ai.openai.OpenAiImageOptions;
+import org.springframework.ai.openai.OpenAiModerationOptions;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+public class Spring_ai_autoconfigure_model_openaiTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void autoConfigurationImportsExposeEveryOpenAiModelAutoConfiguration() {
+        List<String> candidates = ImportCandidates
+                .load(AutoConfiguration.class, Spring_ai_autoconfigure_model_openaiTest.class.getClassLoader())
+                .getCandidates();
+
+        assertThat(candidates).contains(OpenAiChatAutoConfiguration.class.getName(),
+                OpenAiEmbeddingAutoConfiguration.class.getName(), OpenAiImageAutoConfiguration.class.getName(),
+                OpenAiAudioSpeechAutoConfiguration.class.getName(),
+                OpenAiAudioTranscriptionAutoConfiguration.class.getName(),
+                OpenAiModerationAutoConfiguration.class.getName());
     }
+
+    @Test
+    void binderPopulatesCurrentCommonAndModelSpecificProperties() {
+        Map<String, String> properties = Map.ofEntries(
+                Map.entry("spring.ai.openai.base-url", "https://common.example.test/v1"),
+                Map.entry("spring.ai.openai.api-key", "common-key"),
+                Map.entry("spring.ai.openai.model", "common-model"),
+                Map.entry("spring.ai.openai.organization-id", "org-common"),
+                Map.entry("spring.ai.openai.timeout", "45s"),
+                Map.entry("spring.ai.openai.max-retries", "7"),
+                Map.entry("spring.ai.openai.microsoft-foundry", "true"),
+                Map.entry("spring.ai.openai.git-hub-models", "false"),
+                Map.entry("spring.ai.openai.connection-pool-metrics-enabled", "true"),
+                Map.entry("spring.ai.openai.custom-headers.[x-tenant]", "tenant-a"),
+                Map.entry("spring.ai.openai.custom-headers.[x-trace]", "trace-a"),
+                Map.entry("spring.ai.openai.chat.base-url", "https://chat.example.test/v1"),
+                Map.entry("spring.ai.openai.chat.api-key", ""),
+                Map.entry("spring.ai.openai.chat.model", "gpt-chat"),
+                Map.entry("spring.ai.openai.chat.organization-id", "org-chat"),
+                Map.entry("spring.ai.openai.chat.timeout", "15s"),
+                Map.entry("spring.ai.openai.chat.max-retries", "2"),
+                Map.entry("spring.ai.openai.chat.custom-headers.[x-chat]", "chat-header"),
+                Map.entry("spring.ai.openai.chat.frequency-penalty", "0.5"),
+                Map.entry("spring.ai.openai.chat.logit-bias.[token-a]", "3"),
+                Map.entry("spring.ai.openai.chat.logprobs", "true"),
+                Map.entry("spring.ai.openai.chat.top-logprobs", "4"),
+                Map.entry("spring.ai.openai.chat.max-tokens", "64"),
+                Map.entry("spring.ai.openai.chat.max-completion-tokens", "96"),
+                Map.entry("spring.ai.openai.chat.n", "2"),
+                Map.entry("spring.ai.openai.chat.output-modalities[0]", "text"),
+                Map.entry("spring.ai.openai.chat.output-modalities[1]", "audio"),
+                Map.entry("spring.ai.openai.chat.presence-penalty", "0.25"),
+                Map.entry("spring.ai.openai.chat.seed", "1234"),
+                Map.entry("spring.ai.openai.chat.stop[0]", "END"),
+                Map.entry("spring.ai.openai.chat.stop[1]", "STOP"),
+                Map.entry("spring.ai.openai.chat.temperature", "0.7"),
+                Map.entry("spring.ai.openai.chat.top-p", "0.9"),
+                Map.entry("spring.ai.openai.chat.user", "chat-user"),
+                Map.entry("spring.ai.openai.chat.parallel-tool-calls", "false"),
+                Map.entry("spring.ai.openai.chat.store", "true"),
+                Map.entry("spring.ai.openai.chat.metadata.tenant", "acme"),
+                Map.entry("spring.ai.openai.chat.reasoning-effort", "medium"),
+                Map.entry("spring.ai.openai.chat.verbosity", "low"),
+                Map.entry("spring.ai.openai.chat.service-tier", "default"),
+                Map.entry("spring.ai.openai.embedding.metadata-mode", "none"),
+                Map.entry("spring.ai.openai.embedding.model", "text-embedding-3-large"),
+                Map.entry("spring.ai.openai.embedding.user", "embedding-user"),
+                Map.entry("spring.ai.openai.embedding.encoding-format", "base64"),
+                Map.entry("spring.ai.openai.embedding.dimensions", "1024"));
+
+        OpenAiCommonProperties commonProperties = bind(properties, OpenAiCommonProperties.CONFIG_PREFIX,
+                OpenAiCommonProperties.class);
+        OpenAiChatProperties chatProperties = bind(properties, OpenAiChatProperties.CONFIG_PREFIX,
+                OpenAiChatProperties.class);
+        OpenAiEmbeddingProperties embeddingProperties = bind(properties, OpenAiEmbeddingProperties.CONFIG_PREFIX,
+                OpenAiEmbeddingProperties.class);
+
+        assertThat(commonProperties.getBaseUrl()).isEqualTo("https://common.example.test/v1");
+        assertThat(commonProperties.getApiKey()).isEqualTo("common-key");
+        assertThat(commonProperties.getModel()).isEqualTo("common-model");
+        assertThat(commonProperties.getOrganizationId()).isEqualTo("org-common");
+        assertThat(commonProperties.getTimeout()).isEqualTo(Duration.ofSeconds(45));
+        assertThat(commonProperties.getMaxRetries()).isEqualTo(7);
+        assertThat(commonProperties.isMicrosoftFoundry()).isTrue();
+        assertThat(commonProperties.isGitHubModels()).isFalse();
+        assertThat(commonProperties.isConnectionPoolMetricsEnabled()).isTrue();
+        assertThat(commonProperties.getCustomHeaders()).containsEntry("x-tenant", "tenant-a")
+                .containsEntry("x-trace", "trace-a");
+
+        assertThat(chatProperties.getApiKey()).isEmpty();
+        assertThat(chatProperties.getModel()).isEqualTo("gpt-chat");
+        assertThat(chatProperties.getFrequencyPenalty()).isEqualTo(0.5d);
+        assertThat(chatProperties.getLogitBias()).containsEntry("token-a", 3);
+        assertThat(chatProperties.getLogprobs()).isTrue();
+        assertThat(chatProperties.getTopLogprobs()).isEqualTo(4);
+        assertThat(chatProperties.getMaxTokens()).isEqualTo(64);
+        assertThat(chatProperties.getMaxCompletionTokens()).isEqualTo(96);
+        assertThat(chatProperties.getN()).isEqualTo(2);
+        assertThat(chatProperties.getOutputModalities()).containsExactly("text", "audio");
+        assertThat(chatProperties.getPresencePenalty()).isEqualTo(0.25d);
+        assertThat(chatProperties.getSeed()).isEqualTo(1234);
+        assertThat(chatProperties.getStop()).containsExactly("END", "STOP");
+        assertThat(chatProperties.getTemperature()).isEqualTo(0.7d);
+        assertThat(chatProperties.getTopP()).isEqualTo(0.9d);
+        assertThat(chatProperties.getUser()).isEqualTo("chat-user");
+        assertThat(chatProperties.getParallelToolCalls()).isFalse();
+        assertThat(chatProperties.getStore()).isTrue();
+        assertThat(chatProperties.getMetadata()).containsEntry("tenant", "acme");
+        assertThat(chatProperties.getReasoningEffort()).isEqualTo("medium");
+        assertThat(chatProperties.getVerbosity()).isEqualTo("low");
+        assertThat(chatProperties.getServiceTier()).isEqualTo("default");
+
+        assertThat(embeddingProperties.getMetadataMode()).isEqualTo(MetadataMode.NONE);
+        assertThat(embeddingProperties.getModel()).isEqualTo("text-embedding-3-large");
+        assertThat(embeddingProperties.getUser()).isEqualTo("embedding-user");
+        assertThat(embeddingProperties.getEncodingFormat()).isEqualTo(EncodingFormat.BASE64);
+        assertThat(embeddingProperties.getDimensions()).isEqualTo(1024);
+    }
+
+    @Test
+    void resolvesConnectionPropertiesUsingModelOverridesAndCommonFallbacks() {
+        OpenAiCommonProperties commonProperties = new OpenAiCommonProperties();
+        commonProperties.setBaseUrl("https://common.example.test/v1");
+        commonProperties.setApiKey("common-key");
+        commonProperties.setModel("common-model");
+        commonProperties.setMicrosoftDeploymentName("common-deployment");
+        commonProperties.setOrganizationId("org-common");
+        commonProperties.setMicrosoftFoundry(true);
+        commonProperties.setGitHubModels(false);
+        commonProperties.setTimeout(Duration.ofSeconds(30));
+        commonProperties.setMaxRetries(6);
+        commonProperties.setCustomHeaders(Map.of("x-common", "common"));
+
+        OpenAiChatProperties chatProperties = new OpenAiChatProperties();
+        chatProperties.setBaseUrl("https://chat.example.test/v1");
+        chatProperties.setApiKey("");
+        chatProperties.setModel("chat-model");
+        chatProperties.setGitHubModels(true);
+        chatProperties.setTimeout(Duration.ofSeconds(12));
+        chatProperties.setMaxRetries(1);
+        chatProperties.setCustomHeaders(Map.of("x-chat", "chat"));
+
+        OpenAiAutoConfigurationUtil.ResolvedConnectionProperties resolved =
+                OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties, chatProperties);
+
+        assertThat(resolved.getBaseUrl()).isEqualTo("https://chat.example.test/v1");
+        assertThat(resolved.getApiKey()).isEmpty();
+        assertThat(resolved.getModel()).isEqualTo("chat-model");
+        assertThat(resolved.getMicrosoftDeploymentName()).isEqualTo("common-deployment");
+        assertThat(resolved.getOrganizationId()).isEqualTo("org-common");
+        assertThat(resolved.isMicrosoftFoundry()).isTrue();
+        assertThat(resolved.isGitHubModels()).isTrue();
+        assertThat(resolved.getTimeout()).isEqualTo(Duration.ofSeconds(12));
+        assertThat(resolved.getMaxRetries()).isEqualTo(1);
+        assertThat(resolved.getCustomHeaders()).containsOnly(Map.entry("x-chat", "chat"));
+    }
+
+    @Test
+    void resolvesConnectionPropertiesFallsBackWhenModelPropertiesUseDefaults() {
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved("proxy.example.test", 8080));
+        OpenAiCommonProperties commonProperties = new OpenAiCommonProperties();
+        commonProperties.setBaseUrl("https://common.example.test/v1");
+        commonProperties.setApiKey("common-key");
+        commonProperties.setModel("common-model");
+        commonProperties.setOrganizationId("org-common");
+        commonProperties.setTimeout(Duration.ofSeconds(20));
+        commonProperties.setMaxRetries(5);
+        commonProperties.setProxy(proxy);
+        commonProperties.setCustomHeaders(Map.of("x-common", "common"));
+
+        OpenAiEmbeddingProperties embeddingProperties = new OpenAiEmbeddingProperties();
+
+        OpenAiAutoConfigurationUtil.ResolvedConnectionProperties resolved =
+                OpenAiAutoConfigurationUtil.resolveCommonProperties(commonProperties, embeddingProperties);
+
+        assertThat(resolved.getBaseUrl()).isEqualTo("https://common.example.test/v1");
+        assertThat(resolved.getApiKey()).isEqualTo("common-key");
+        assertThat(resolved.getModel()).isEqualTo("common-model");
+        assertThat(resolved.getOrganizationId()).isEqualTo("org-common");
+        assertThat(resolved.getTimeout()).isEqualTo(Duration.ofSeconds(20));
+        assertThat(resolved.getMaxRetries()).isEqualTo(5);
+        assertThat(resolved.getProxy()).isSameAs(proxy);
+        assertThat(resolved.getCustomHeaders()).containsOnly(Map.entry("x-common", "common"));
+    }
+
+    @Test
+    void chatPropertiesCreateEquivalentChatOptions() {
+        ResponseFormat responseFormat = ResponseFormat.builder()
+                .type(Type.JSON_SCHEMA)
+                .jsonSchema("{\"name\":\"answer\"}")
+                .build();
+        StreamOptions streamOptions = StreamOptions.builder()
+                .includeObfuscation(true)
+                .includeUsage(true)
+                .additionalProperty("trace", "enabled")
+                .build();
+        AudioParameters audioParameters = new AudioParameters(Voice.ALLOY, AudioParameters.AudioResponseFormat.WAV);
+        OpenAiChatProperties properties = new OpenAiChatProperties();
+        properties.setModel("gpt-4.1-mini");
+        properties.setFrequencyPenalty(0.4d);
+        properties.setLogitBias(Map.of("token", 11));
+        properties.setLogprobs(true);
+        properties.setTopLogprobs(3);
+        properties.setMaxCompletionTokens(256);
+        properties.setN(2);
+        properties.setOutputModalities(List.of("text", "audio"));
+        properties.setOutputAudio(audioParameters);
+        properties.setPresencePenalty(0.2d);
+        properties.setResponseFormat(responseFormat);
+        properties.setStreamOptions(streamOptions);
+        properties.setSeed(42);
+        properties.setStop(List.of("END"));
+        properties.setTemperature(0.6d);
+        properties.setTopP(0.95d);
+        properties.setToolChoice("none");
+        properties.setUser("chat-user");
+        properties.setParallelToolCalls(false);
+        properties.setStore(true);
+        properties.setMetadata(Map.of("tenant", "acme"));
+        properties.setReasoningEffort("medium");
+        properties.setVerbosity("low");
+        properties.setServiceTier("default");
+        properties.setExtraBody(Map.of("trace", true));
+
+        OpenAiChatOptions options = properties.toOptions();
+
+        assertThat(options.getModel()).isEqualTo("gpt-4.1-mini");
+        assertThat(options.getFrequencyPenalty()).isEqualTo(0.4d);
+        assertThat(options.getLogitBias()).containsEntry("token", 11);
+        assertThat(options.getLogprobs()).isTrue();
+        assertThat(options.getTopLogprobs()).isEqualTo(3);
+        assertThat(options.getMaxCompletionTokens()).isEqualTo(256);
+        assertThat(options.getN()).isEqualTo(2);
+        assertThat(options.getOutputModalities()).containsExactly("text", "audio");
+        assertThat(options.getOutputAudio()).isEqualTo(audioParameters);
+        assertThat(options.getPresencePenalty()).isEqualTo(0.2d);
+        assertThat(options.getResponseFormat()).isEqualTo(responseFormat);
+        assertThat(options.getStreamOptions()).isEqualTo(streamOptions);
+        assertThat(options.getSeed()).isEqualTo(42);
+        assertThat(options.getStopSequences()).containsExactly("END");
+        assertThat(options.getTemperature()).isEqualTo(0.6d);
+        assertThat(options.getTopP()).isEqualTo(0.95d);
+        assertThat(options.getToolChoice()).isEqualTo("none");
+        assertThat(options.getUser()).isEqualTo("chat-user");
+        assertThat(options.getParallelToolCalls()).isFalse();
+        assertThat(options.getStore()).isTrue();
+        assertThat(options.getMetadata()).containsEntry("tenant", "acme");
+        assertThat(options.getReasoningEffort()).isEqualTo("medium");
+        assertThat(options.getVerbosity()).isEqualTo("low");
+        assertThat(options.getServiceTier()).isEqualTo("default");
+        assertThat(options.getExtraBody()).containsEntry("trace", true);
+    }
+
+    @Test
+    void embeddingImageAudioAndModerationPropertiesCreateEquivalentOptions() {
+        OpenAiEmbeddingProperties embeddingProperties = new OpenAiEmbeddingProperties();
+        embeddingProperties.setMetadataMode(MetadataMode.INFERENCE);
+        embeddingProperties.setModel("text-embedding-3-small");
+        embeddingProperties.setUser("embedding-user");
+        embeddingProperties.setEncodingFormat(EncodingFormat.FLOAT);
+        embeddingProperties.setDimensions(512);
+
+        OpenAiImageProperties imageProperties = new OpenAiImageProperties();
+        imageProperties.setModel("gpt-image-1");
+        imageProperties.setN(1);
+        imageProperties.setWidth(1024);
+        imageProperties.setHeight(768);
+        imageProperties.setQuality("high");
+        imageProperties.setResponseFormat("b64_json");
+        imageProperties.setSize("1024x768");
+        imageProperties.setStyle("vivid");
+        imageProperties.setUser("image-user");
+
+        OpenAiAudioSpeechProperties speechProperties = new OpenAiAudioSpeechProperties();
+        speechProperties.setModel("gpt-4o-mini-tts");
+        speechProperties.setInput("Spring AI speech");
+        speechProperties.setVoice("alloy");
+        speechProperties.setResponseFormat("mp3");
+        speechProperties.setSpeed(1.25d);
+
+        OpenAiAudioTranscriptionProperties transcriptionProperties = new OpenAiAudioTranscriptionProperties();
+        transcriptionProperties.setModel("gpt-4o-transcribe");
+        transcriptionProperties.setResponseFormat(AudioResponseFormat.VERBOSE_JSON);
+        transcriptionProperties.setPrompt("domain words");
+        transcriptionProperties.setLanguage("en");
+        transcriptionProperties.setTemperature(0.2f);
+        transcriptionProperties.setTimestampGranularities(
+                List.of(TimestampGranularity.WORD, TimestampGranularity.SEGMENT));
+
+        OpenAiModerationProperties moderationProperties = new OpenAiModerationProperties();
+        moderationProperties.setModel("omni-moderation-latest");
+
+        OpenAiEmbeddingOptions embeddingOptions = embeddingProperties.toOptions();
+        OpenAiImageOptions imageOptions = imageProperties.toOptions();
+        OpenAiAudioSpeechOptions speechOptions = speechProperties.toOptions();
+        OpenAiAudioTranscriptionOptions transcriptionOptions = transcriptionProperties.toOptions();
+        OpenAiModerationOptions moderationOptions = moderationProperties.toOptions();
+
+        assertThat(embeddingProperties.getMetadataMode()).isEqualTo(MetadataMode.INFERENCE);
+        assertThat(embeddingOptions.getModel()).isEqualTo("text-embedding-3-small");
+        assertThat(embeddingOptions.getUser()).isEqualTo("embedding-user");
+        assertThat(embeddingOptions.getEncodingFormat()).isEqualTo(EncodingFormat.FLOAT);
+        assertThat(embeddingOptions.getDimensions()).isEqualTo(512);
+
+        assertThat(imageOptions.getModel()).isEqualTo("gpt-image-1");
+        assertThat(imageOptions.getN()).isEqualTo(1);
+        assertThat(imageOptions.getWidth()).isEqualTo(1024);
+        assertThat(imageOptions.getHeight()).isEqualTo(768);
+        assertThat(imageOptions.getQuality()).isEqualTo("high");
+        assertThat(imageOptions.getResponseFormat()).isEqualTo("b64_json");
+        assertThat(imageOptions.getSize()).isEqualTo("1024x768");
+        assertThat(imageOptions.getStyle()).isEqualTo("vivid");
+        assertThat(imageOptions.getUser()).isEqualTo("image-user");
+
+        assertThat(speechOptions.getModel()).isEqualTo("gpt-4o-mini-tts");
+        assertThat(speechOptions.getInput()).isEqualTo("Spring AI speech");
+        assertThat(speechOptions.getVoice()).isEqualTo("alloy");
+        assertThat(speechOptions.getResponseFormat()).isEqualTo("mp3");
+        assertThat(speechOptions.getSpeed()).isEqualTo(1.25d);
+
+        assertThat(transcriptionOptions.getModel()).isEqualTo("gpt-4o-transcribe");
+        assertThat(transcriptionOptions.getResponseFormat()).isEqualTo(AudioResponseFormat.VERBOSE_JSON);
+        assertThat(transcriptionOptions.getPrompt()).isEqualTo("domain words");
+        assertThat(transcriptionOptions.getLanguage()).isEqualTo("en");
+        assertThat(transcriptionOptions.getTemperature()).isEqualTo(0.2f);
+        assertThat(transcriptionOptions.getTimestampGranularities())
+                .containsExactly(TimestampGranularity.WORD, TimestampGranularity.SEGMENT);
+
+        assertThat(moderationOptions.getModel()).isEqualTo("omni-moderation-latest");
+    }
+
+    @Test
+    void defaultCommonPropertiesMatchDocumentedOpenAiClientDefaults() {
+        OpenAiCommonProperties properties = new OpenAiCommonProperties();
+
+        assertThat(properties.getTimeout()).isEqualTo(AbstractOpenAiProperties.DEFAULT_TIMEOUT);
+        assertThat(properties.getMaxRetries()).isEqualTo(AbstractOpenAiProperties.DEFAULT_MAX_RETRIES);
+        assertThat(properties.getCustomHeaders()).isEmpty();
+        assertThat(properties.isConnectionPoolMetricsEnabled()).isFalse();
+    }
+
+    private static <T> T bind(Map<String, String> properties, String prefix, Class<T> type) {
+        Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+        return binder.bind(prefix, Bindable.of(type)).get();
+    }
+
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_openai/Spring_ai_autoconfigure_model_openaiTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_ai.spring_ai_autoconfigure_model_openai;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_ai_autoconfigure_model_openaiTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.ai.model.openai.autoconfigure.**"
+      "includeClasses" : "org.springframework.ai.model.openai.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_ai.spring_ai_autoconfigure_model_openai.**"
     }
   ]
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0-RC2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.ai.model.openai.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8422

This PR introduces tests and metadata for org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 303319
- Cached input tokens: 3844096
- Output tokens: 30322
- Metadata entries: 66
- Iterations: 5
- Library coverage percentage: 56.72
- Generated lines of code: 435
- Tested library lines of code: 363

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1038/2054 (50.54%)
- Line: 363/640 (56.72%)
- Method: 175/326 (53.68%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
