### PR TITLE
[GenAI] Add support for org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/reachability-metadata.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/reachability-metadata.json
@@ -1,0 +1,74 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.ai.model.embedding.observation.autoconfigure.EmbeddingObservationAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "embeddingModelMeterObservationHandler",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.embedding.EmbeddingModel"
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/ai/model/embedding/observation/autoconfigure/*.class"
+    },
+    {
+      "glob": "org/springframework/ai/embedding/EmbeddingModel.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    }
+  ]
+}

--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/index.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.0-RC2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-embedding-observation/$version$/spring-ai-autoconfigure-model-embedding-observation-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-ai",
+    "test-code-url" : "https://github.com/spring-projects/spring-ai/tree/v$version$/auto-configurations/models/embedding/observation/spring-ai-autoconfigure-model-embedding-observation/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-embedding-observation/$version$/spring-ai-autoconfigure-model-embedding-observation-$version$-javadoc.jar",
+    "description" : "This Spring AI module provides Spring Boot auto-configuration for observation support around embedding models. It registers the Micrometer observation handler for embedding model metrics when Spring AI embedding and meter registry infrastructure are present.",
+    "tested-versions" : [
+      "2.0.0-RC2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.ai.model.embedding.observation.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/execution-metrics.json
@@ -1,0 +1,126 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T03:08:46.074561Z",
+    "library": "org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2",
+    "starting_commit": "e4ae42b650021b5892aa031cff25ebe8d6206717",
+    "ending_commit": "d1819e8773e0c87eb9fddb7aace11a5d2e41b7b2",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-RC2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 10,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 10
+        },
+        "line": {
+          "covered": 2,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 2
+        },
+        "method": {
+          "covered": 2,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 2
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8417,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2",
+      "summary": "The artifact is only a Spring Boot auto-configuration class and its meaningful path depends on optional Spring AI, Spring Boot autoconfigure, and Micrometer types that are not pulled transitively by the target POM.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-model:2.0.0-RC2",
+          "scope": "testImplementation",
+          "reason": "Provides the EmbeddingModel condition class and EmbeddingModelMeterObservationHandler returned by the auto-configuration; it is declared optional by the target artifact and is not transitively resolved."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1",
+          "scope": "testImplementation",
+          "reason": "Provides the Spring Boot auto-configuration and conditional annotations needed to exercise the library as an auto-configuration component; it is optional in the target POM."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "io.micrometer:micrometer-core:1.17.0-RC1",
+          "scope": "testImplementation",
+          "reason": "Provides MeterRegistry and simple/composite registry implementations needed to satisfy the conditional bean path and instantiate the observation handler."
+        }
+      ],
+      "agent_guidance": "No Docker image, environment variable, or system property is indicated. Meaningful tests should exercise the auto-configuration in a Spring application context with and without a MeterRegistry bean. If directly invoking the bean factory method, place tests in package org.springframework.ai.model.embedding.observation.autoconfigure because the method is package-private.",
+      "risks": [
+        "With only the target artifact on the classpath, Maven resolves no transitive dependencies because the important compile dependencies are optional; generated tests may otherwise degrade to constructor/reflection-only coverage.",
+        "Upstream tests use Spring Boot's ApplicationContextRunner; if the generated tests choose that exact style, additional test-helper/assertion dependencies may be needed, but equivalent coverage is reachable with core Spring context APIs and the deterministic dependencies above.",
+        "The target POM also lists Spring Boot configuration/autoconfigure processors, but they are annotation processors and not needed for runtime test coverage."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-model:2.0.0-RC2",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "io.micrometer:micrometer-core:1.17.0-RC1",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8417 Support for org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 71250,
+      "output_tokens_used": 8786,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T02-46-38-432052Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 110160,
+      "cached_input_tokens_used": 1370112,
+      "output_tokens_used": 17397,
+      "iterations": 3,
+      "cost_usd": 1.207,
+      "generated_loc": 173,
+      "tested_library_loc": 2,
+      "metadata_entries": 16,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java",
+      "metadata_file": "metadata/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/stats.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0-RC2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 10,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 10
+      },
+      "line" : {
+        "covered" : 2,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 2
+      },
+      "method" : {
+        "covered" : 2,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 2
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/.gitignore
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/build.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.springframework.ai:spring-ai-model:2.0.0-RC2"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1"
+    testImplementation "io.micrometer:micrometer-core:1.17.0-RC1"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/gradle.properties
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2
+library.version = 2.0.0-RC2
+metadata.dir = org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/settings.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.ai.spring-ai-autoconfigure-model-embedding-observation_tests'

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_ai.spring_ai_autoconfigure_model_embedding_observation;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_ai_autoconfigure_model_embedding_observationTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
@@ -29,6 +29,9 @@ import org.springframework.ai.observation.conventions.AiTokenType;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,6 +87,26 @@ public class Spring_ai_autoconfigure_model_embedding_observationTest {
         }
     }
 
+    @Test
+    void autoConfigurationUsesPrimaryMeterRegistryWhenMultipleRegistriesAreAvailable() {
+        try (AnnotationConfigApplicationContext context = contextWithMultipleMeterRegistries()) {
+            EmbeddingModelMeterObservationHandler handler = context.getBean(
+                    EmbeddingModelMeterObservationHandler.class);
+            SimpleMeterRegistry primaryMeterRegistry = context.getBean("primaryMeterRegistry",
+                    SimpleMeterRegistry.class);
+            SimpleMeterRegistry secondaryMeterRegistry = context.getBean("secondaryMeterRegistry",
+                    SimpleMeterRegistry.class);
+
+            EmbeddingModelObservationContext observationContext = embeddingObservationContext();
+            observationContext.setResponse(embeddingResponseWithUsage(2, 3));
+
+            handler.onStop(observationContext);
+
+            assertTokenCounter(primaryMeterRegistry, AiTokenType.TOTAL, 5.0);
+            assertNoTokenCounter(secondaryMeterRegistry, AiTokenType.TOTAL);
+        }
+    }
+
     private static EmbeddingModelObservationContext embeddingObservationContext() {
         EmbeddingRequest request = new EmbeddingRequest(List.of("Spring AI observations"),
                 DefaultEmbeddingOptions.builder().model("test-embedding-model").dimensions(3).build());
@@ -109,6 +132,13 @@ public class Spring_ai_autoconfigure_model_embedding_observationTest {
         assertThat(counter.count()).isEqualTo(expectedCount);
     }
 
+    private static void assertNoTokenCounter(SimpleMeterRegistry meterRegistry, AiTokenType tokenType) {
+        Counter counter = meterRegistry.find(AiObservationMetricNames.TOKEN_USAGE.value())
+                .tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), tokenType.value())
+                .counter();
+        assertThat(counter).isNull();
+    }
+
     private static AnnotationConfigApplicationContext contextWithMeterRegistry() {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
         context.getBeanFactory().registerSingleton("simpleMeterRegistry", new SimpleMeterRegistry());
@@ -126,6 +156,30 @@ public class Spring_ai_autoconfigure_model_embedding_observationTest {
         context.register(EmbeddingObservationAutoConfiguration.class);
         context.refresh();
         return context;
+    }
+
+    private static AnnotationConfigApplicationContext contextWithMultipleMeterRegistries() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(MultipleMeterRegistryConfiguration.class);
+        context.register(EmbeddingObservationAutoConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MultipleMeterRegistryConfiguration {
+
+        @Bean
+        @Primary
+        SimpleMeterRegistry primaryMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        SimpleMeterRegistry secondaryMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
     }
 
     static class TestUsage implements Usage {

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
@@ -117,7 +117,7 @@ public class Spring_ai_autoconfigure_model_embedding_observationTest {
     }
 
     private static EmbeddingResponse embeddingResponseWithUsage(int promptTokens, int completionTokens) {
-        Embedding embedding = new Embedding(new float[] { 0.1F, 0.2F, 0.3F }, 0);
+        Embedding embedding = new Embedding(new float[] {0.1F, 0.2F, 0.3F}, 0);
         EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata("test-embedding-model",
                 new TestUsage(promptTokens, completionTokens));
         return new EmbeddingResponse(List.of(embedding), metadata);

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
@@ -26,11 +26,22 @@ import org.springframework.ai.model.embedding.observation.autoconfigure.Embeddin
 import org.springframework.ai.observation.conventions.AiObservationMetricAttributes;
 import org.springframework.ai.observation.conventions.AiObservationMetricNames;
 import org.springframework.ai.observation.conventions.AiTokenType;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Spring_ai_autoconfigure_model_embedding_observationTest {
+
+    @Test
+    void autoConfigurationIsRegisteredForSpringBootDiscovery() {
+        ClassLoader classLoader = Spring_ai_autoconfigure_model_embedding_observationTest.class
+                .getClassLoader();
+        List<String> candidates = ImportCandidates.load(AutoConfiguration.class, classLoader).getCandidates();
+
+        assertThat(candidates).contains(EmbeddingObservationAutoConfiguration.class.getName());
+    }
 
     @Test
     void autoConfigurationCreatesMeterObservationHandlerWhenMeterRegistryIsPresent() {

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_embedding_observation/Spring_ai_autoconfigure_model_embedding_observationTest.java
@@ -6,11 +6,143 @@
  */
 package org_springframework_ai.spring_ai_autoconfigure_model_embedding_observation;
 
+import java.util.List;
+import java.util.Map;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
 import org.junit.jupiter.api.Test;
 
-class Spring_ai_autoconfigure_model_embedding_observationTest {
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.embedding.DefaultEmbeddingOptions;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.embedding.EmbeddingResponseMetadata;
+import org.springframework.ai.embedding.observation.EmbeddingModelMeterObservationHandler;
+import org.springframework.ai.embedding.observation.EmbeddingModelObservationContext;
+import org.springframework.ai.model.embedding.observation.autoconfigure.EmbeddingObservationAutoConfiguration;
+import org.springframework.ai.observation.conventions.AiObservationMetricAttributes;
+import org.springframework.ai.observation.conventions.AiObservationMetricNames;
+import org.springframework.ai.observation.conventions.AiTokenType;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_ai_autoconfigure_model_embedding_observationTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void autoConfigurationCreatesMeterObservationHandlerWhenMeterRegistryIsPresent() {
+        try (AnnotationConfigApplicationContext context = contextWithMeterRegistry()) {
+            EmbeddingModelMeterObservationHandler handler = context.getBean(EmbeddingModelMeterObservationHandler.class);
+            SimpleMeterRegistry meterRegistry = context.getBean(SimpleMeterRegistry.class);
+
+            assertThat(handler.supportsContext(new Observation.Context())).isFalse();
+
+            EmbeddingModelObservationContext observationContext = embeddingObservationContext();
+            observationContext.setResponse(embeddingResponseWithUsage(7, 5));
+
+            assertThat(handler.supportsContext(observationContext)).isTrue();
+
+            handler.onStop(observationContext);
+
+            assertTokenCounter(meterRegistry, AiTokenType.INPUT, 7.0);
+            assertTokenCounter(meterRegistry, AiTokenType.OUTPUT, 5.0);
+            assertTokenCounter(meterRegistry, AiTokenType.TOTAL, 12.0);
+        }
     }
+
+    @Test
+    void autoConfigurationDoesNotCreateHandlerWithoutMeterRegistry() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+                EmbeddingObservationAutoConfiguration.class)) {
+            assertThat(context.getBeansOfType(EmbeddingModelMeterObservationHandler.class)).isEmpty();
+        }
+    }
+
+    @Test
+    void autoConfigurationBacksOffWhenUserSuppliesHandler() {
+        try (AnnotationConfigApplicationContext context = contextWithMeterRegistryAndUserHandler()) {
+            Map<String, EmbeddingModelMeterObservationHandler> handlers = context.getBeansOfType(
+                    EmbeddingModelMeterObservationHandler.class);
+
+            assertThat(handlers).containsOnlyKeys("userEmbeddingModelMeterObservationHandler");
+            assertThat(context.getBean(EmbeddingModelMeterObservationHandler.class))
+                    .isSameAs(context.getBean("userEmbeddingModelMeterObservationHandler"));
+        }
+    }
+
+    private static EmbeddingModelObservationContext embeddingObservationContext() {
+        EmbeddingRequest request = new EmbeddingRequest(List.of("Spring AI observations"),
+                DefaultEmbeddingOptions.builder().model("test-embedding-model").dimensions(3).build());
+        return EmbeddingModelObservationContext.builder()
+                .embeddingRequest(request)
+                .provider("test-provider")
+                .build();
+    }
+
+    private static EmbeddingResponse embeddingResponseWithUsage(int promptTokens, int completionTokens) {
+        Embedding embedding = new Embedding(new float[] { 0.1F, 0.2F, 0.3F }, 0);
+        EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata("test-embedding-model",
+                new TestUsage(promptTokens, completionTokens));
+        return new EmbeddingResponse(List.of(embedding), metadata);
+    }
+
+    private static void assertTokenCounter(SimpleMeterRegistry meterRegistry, AiTokenType tokenType,
+            double expectedCount) {
+        Counter counter = meterRegistry.find(AiObservationMetricNames.TOKEN_USAGE.value())
+                .tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), tokenType.value())
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(expectedCount);
+    }
+
+    private static AnnotationConfigApplicationContext contextWithMeterRegistry() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getBeanFactory().registerSingleton("simpleMeterRegistry", new SimpleMeterRegistry());
+        context.register(EmbeddingObservationAutoConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    private static AnnotationConfigApplicationContext contextWithMeterRegistryAndUserHandler() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        EmbeddingModelMeterObservationHandler handler = new EmbeddingModelMeterObservationHandler(meterRegistry);
+        context.getBeanFactory().registerSingleton("simpleMeterRegistry", meterRegistry);
+        context.getBeanFactory().registerSingleton("userEmbeddingModelMeterObservationHandler", handler);
+        context.register(EmbeddingObservationAutoConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    static class TestUsage implements Usage {
+
+        private final Integer promptTokens;
+
+        private final Integer completionTokens;
+
+        TestUsage(Integer promptTokens, Integer completionTokens) {
+            this.promptTokens = promptTokens;
+            this.completionTokens = completionTokens;
+        }
+
+        @Override
+        public Integer getPromptTokens() {
+            return this.promptTokens;
+        }
+
+        @Override
+        public Integer getCompletionTokens() {
+            return this.completionTokens;
+        }
+
+        @Override
+        public Object getNativeUsage() {
+            return Map.of("promptTokens", this.promptTokens, "completionTokens", this.completionTokens);
+        }
+
+    }
+
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.ai.model.embedding.observation.autoconfigure.**"
+      "includeClasses" : "org.springframework.ai.model.embedding.observation.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_ai.spring_ai_autoconfigure_model_embedding_observation.**"
     }
   ]
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0-RC2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.ai.model.embedding.observation.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8417

This PR introduces tests and metadata for org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 110160
- Cached input tokens: 1370112
- Output tokens: 17397
- Metadata entries: 16
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 173
- Tested library lines of code: 2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 10/10 (100.00%)
- Line: 2/2 (100.00%)
- Method: 2/2 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
