### PR TITLE
[GenAI] Add support for org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/reachability-metadata.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/reachability-metadata.json
@@ -1,0 +1,396 @@
+{
+  "reflection": [
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "chatClientBuilderConfigurer",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "toolCallingAdvisorBuilder",
+          "parameterTypes": [
+            "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties",
+            "org.springframework.ai.model.tool.ToolCallingManager",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "chatClientBuilder",
+          "parameterTypes": [
+            "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties",
+            "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderConfigurer",
+            "org.springframework.ai.chat.model.ChatModel",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration$TracerNotPresentObservationConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "chatClientPromptContentObservationHandler",
+          "parameterTypes": []
+        },
+        {
+          "name": "chatClientCompletionObservationHandler",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration$TracerPresentObservationConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "chatClientPromptContentObservationHandler",
+          "parameterTypes": [
+            "io.micrometer.tracing.Tracer"
+          ]
+        },
+        {
+          "name": "chatClientCompletionObservationHandler",
+          "parameterTypes": [
+            "io.micrometer.tracing.Tracer"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderConfigurer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "configure",
+          "parameterTypes": [
+            "org.springframework.ai.chat.client.ChatClient$Builder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getObservations",
+          "parameterTypes": []
+        },
+        {
+          "name": "getToolCalling",
+          "parameterTypes": []
+        },
+        {
+          "name": "isEnabled",
+          "parameterTypes": []
+        },
+        {
+          "name": "setEnabled",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties$Observations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isLogPrompt",
+          "parameterTypes": []
+        },
+        {
+          "name": "isLogCompletion",
+          "parameterTypes": []
+        },
+        {
+          "name": "setLogPrompt",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setLogCompletion",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties$ToolCalling",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isEnabled",
+          "parameterTypes": []
+        },
+        {
+          "name": "setEnabled",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "getAdvisorOrder",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAdvisorOrder",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "isStreamToolCallResponses",
+          "parameterTypes": []
+        },
+        {
+          "name": "setStreamToolCallResponses",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "toolCallbackResolver",
+          "parameterTypes": [
+            "org.springframework.context.support.GenericApplicationContext",
+            "java.util.List",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "toolExecutionExceptionProcessor",
+          "parameterTypes": [
+            "org.springframework.ai.model.tool.autoconfigure.ToolCallingProperties"
+          ]
+        },
+        {
+          "name": "toolCallingManager",
+          "parameterTypes": [
+            "org.springframework.ai.tool.resolution.ToolCallbackResolver",
+            "org.springframework.ai.tool.execution.ToolExecutionExceptionProcessor",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "toolCallingContentObservationFilter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.tool.autoconfigure.ToolCallingProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getObservations",
+          "parameterTypes": []
+        },
+        {
+          "name": "isThrowExceptionOnError",
+          "parameterTypes": []
+        },
+        {
+          "name": "setThrowExceptionOnError",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.ai.model.tool.autoconfigure.ToolCallingProperties$Observations",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "isIncludeContent",
+          "parameterTypes": []
+        },
+        {
+          "name": "setIncludeContent",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.AutoConfiguration"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.EnableConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    }
+  ],
+  "resources": [
+    {
+      "glob": "org/springframework/ai/model/chat/client/autoconfigure/*.class"
+    },
+    {
+      "glob": "org/springframework/ai/model/tool/autoconfigure/*.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    }
+  ]
+}

--- a/metadata/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/index.json
+++ b/metadata/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.0.0-RC2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-chat-client/$version$/spring-ai-autoconfigure-model-chat-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-ai",
+    "test-code-url" : "https://github.com/spring-projects/spring-ai/tree/v$version$/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/ai/spring-ai-autoconfigure-model-chat-client/$version$/spring-ai-autoconfigure-model-chat-client-$version$-javadoc.jar",
+    "description" : "This library auto-configures Spring AI's ChatClient support in Spring Boot applications, creating a prototype ChatClient builder when a ChatModel is available. It also wires ChatClient customizers, tool-calling advisor defaults, and optional observation logging for prompts and completions.",
+    "tested-versions" : [
+      "2.0.0-RC2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.ai.model.chat.client.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/execution-metrics.json
@@ -1,0 +1,138 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T04:46:55.261713Z",
+    "library": "org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2",
+    "starting_commit": "ca1bab161b737eaf7a79c2824016c62c11955b04",
+    "ending_commit": "1c23eb7448111049b437a6379e3ef10f7f6e449e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.0.0-RC2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 214,
+          "missed": 41,
+          "ratio": 0.839216,
+          "total": 255
+        },
+        "line": {
+          "covered": 69,
+          "missed": 11,
+          "ratio": 0.8625,
+          "total": 80
+        },
+        "method": {
+          "covered": 31,
+          "missed": 5,
+          "ratio": 0.861111,
+          "total": 36
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 8414,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2",
+      "summary": "The artifact is a Spring AI auto-configuration module whose core usable classes depend on optional Spring AI and Spring Boot modules that are not pulled in by the normal single-library scaffold.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-client-chat:2.0.0-RC2",
+          "scope": "testImplementation",
+          "reason": "ChatClientAutoConfiguration creates and configures ChatClient.Builder and references ChatClient, ChatModel, advisors, and observation types supplied by spring-ai-client-chat and its transitive Spring AI model dependencies."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-autoconfigure-model-tool:2.0.0-RC2",
+          "scope": "testImplementation",
+          "reason": "The chat client auto-configuration is ordered after ToolCallingAutoConfiguration and its meaningful tool-calling advisor path uses Spring AI tool auto-configuration types that are optional in the published POM."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1",
+          "scope": "testImplementation",
+          "reason": "The library is a Spring Boot auto-configuration JAR and its classes use Boot auto-configuration annotations, conditions, and AutoConfigurations support from Spring Boot 4.1.0-RC1."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-test:4.1.0-RC1",
+          "scope": "testImplementation",
+          "reason": "Upstream tests validate this module with ApplicationContextRunner, which is the practical in-process way to exercise conditional Spring Boot auto-configuration without starting an application or external service."
+        }
+      ],
+      "agent_guidance": "No Docker image, API key, environment variable, or system property is required. Use an in-process Spring Boot ApplicationContextRunner-style test with a local fake or stub ChatModel bean; do not call a real model provider. Meaningful coverage should assert that ChatClientAutoConfiguration creates ChatClient.Builder, applies spring.ai.chat.client.tool-calling.* property values, and wires or backs off from ToolCallingAdvisor.Builder/ToolCallingManager as appropriate.",
+      "risks": [
+        "Without the optional Spring AI and Spring Boot modules, generated tests may compile only superficial metadata/resource checks or fail when loading the auto-configuration class.",
+        "Adding a real provider starter such as OpenAI/Anthropic would introduce API-key and network concerns and is not necessary for this auto-configuration module.",
+        "Micrometer tracing is optional; only add it later if local verification shows the tracer-present observation branch must be covered."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-client-chat:2.0.0-RC2",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.ai:spring-ai-autoconfigure-model-tool:2.0.0-RC2",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.springframework.boot:spring-boot-test:4.1.0-RC1",
+          "result": "applied",
+          "target": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8414 Support for org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 45937,
+      "output_tokens_used": 5476,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T04-19-47-259888Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 246917,
+      "cached_input_tokens_used": 3376128,
+      "output_tokens_used": 22742,
+      "iterations": 3,
+      "cost_usd": 2.3704,
+      "generated_loc": 214,
+      "tested_library_loc": 69,
+      "metadata_entries": 79,
+      "code_coverage_percent": 86.25
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java",
+      "metadata_file": "metadata/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/stats.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.0.0-RC2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 214,
+        "missed" : 41,
+        "ratio" : 0.839216,
+        "total" : 255
+      },
+      "line" : {
+        "covered" : 69,
+        "missed" : 11,
+        "ratio" : 0.8625,
+        "total" : 80
+      },
+      "method" : {
+        "covered" : 31,
+        "missed" : 5,
+        "ratio" : 0.861111,
+        "total" : 36
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/.gitignore
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.ai:spring-ai-autoconfigure-model-chat-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.springframework.ai:spring-ai-client-chat:2.0.0-RC2"
+    testImplementation "org.springframework.ai:spring-ai-autoconfigure-model-tool:2.0.0-RC2"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:4.1.0-RC1"
+    testImplementation "org.springframework.boot:spring-boot-test:4.1.0-RC1"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/gradle.properties
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2
+library.version = 2.0.0-RC2
+metadata.dir = org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/settings.gradle
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.ai.spring-ai-autoconfigure-model-chat-client_tests'

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_ai.spring_ai_autoconfigure_model_chat_client;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_ai_autoconfigure_model_chat_clientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
@@ -21,6 +21,8 @@ import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.observation.ChatClientCompletionObservationHandler;
+import org.springframework.ai.chat.client.observation.ChatClientPromptContentObservationHandler;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
@@ -67,6 +69,20 @@ public class Spring_ai_autoconfigure_model_chat_clientTest {
 
                     ToolCallingAdvisor advisor = context.getBean(ToolCallingAdvisor.Builder.class).build();
                     assertThat(advisor.getOrder()).isEqualTo(42);
+                });
+    }
+
+    @Test
+    void bindsObservationPropertiesAndRegistersContentObservationHandlers() {
+        this.contextRunner.withPropertyValues("spring.ai.chat.client.observations.log-prompt=true",
+                "spring.ai.chat.client.observations.log-completion=true").run(context -> {
+                    assertThat(context).hasSingleBean(ChatClientBuilderProperties.class);
+                    assertThat(context).hasSingleBean(ChatClientPromptContentObservationHandler.class);
+                    assertThat(context).hasSingleBean(ChatClientCompletionObservationHandler.class);
+
+                    ChatClientBuilderProperties properties = context.getBean(ChatClientBuilderProperties.class);
+                    assertThat(properties.getObservations().isLogPrompt()).isTrue();
+                    assertThat(properties.getObservations().isLogCompletion()).isTrue();
                 });
     }
 

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
@@ -15,18 +15,21 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientBuilderCustomizer;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderConfigurer;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
@@ -123,6 +126,35 @@ public class Spring_ai_autoconfigure_model_chat_clientTest {
         });
     }
 
+    @Test
+    void appliesChatClientBuilderCustomizersToEachPrototypeBuilder() {
+        AtomicInteger customizations = new AtomicInteger();
+        ApplicationContextRunner runner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ChatClientAutoConfiguration.class))
+                .withBean(RecordingChatModel.class)
+                .withBean(ChatClientBuilderCustomizer.class, () -> builder -> {
+                    customizations.incrementAndGet();
+                    builder.defaultSystem("configured system").defaultUser("configured user");
+                });
+
+        runner.run(context -> {
+            assertThat(context).hasSingleBean(ChatClientBuilderConfigurer.class);
+
+            ChatClient.Builder firstBuilder = context.getBean(ChatClient.Builder.class);
+            ChatClient.Builder secondBuilder = context.getBean(ChatClient.Builder.class);
+
+            assertThat(secondBuilder).isNotSameAs(firstBuilder);
+            assertThat(customizations).hasValue(2);
+
+            String content = firstBuilder.build().prompt().call().content();
+
+            assertThat(content).isEqualTo("customized response");
+            assertThat(context.getBean(RecordingChatModel.class).lastPrompt().getInstructions())
+                    .extracting(Message::getText)
+                    .containsExactly("configured system", "configured user");
+        });
+    }
+
     private static ChatClientRequest toolRequest() {
         return ChatClientRequest.builder()
                 .prompt(new Prompt("run the local tool", ToolCallingChatOptions.builder().build()))
@@ -148,6 +180,20 @@ public class Spring_ai_autoconfigure_model_chat_clientTest {
         @Bean
         public ChatModel chatModel() {
             return prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        }
+    }
+
+    public static class RecordingChatModel implements ChatModel {
+        private Prompt lastPrompt;
+
+        @Override
+        public ChatResponse call(Prompt prompt) {
+            this.lastPrompt = prompt;
+            return new ChatResponse(List.of(new Generation(new AssistantMessage("customized response"))));
+        }
+
+        public Prompt lastPrompt() {
+            return this.lastPrompt;
         }
     }
 

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/src/test/java/org_springframework_ai/spring_ai_autoconfigure_model_chat_client/Spring_ai_autoconfigure_model_chat_clientTest.java
@@ -6,11 +6,186 @@
  */
 package org_springframework_ai.spring_ai_autoconfigure_model_chat_client;
 
-import org.junit.jupiter.api.Test;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-class Spring_ai_autoconfigure_model_chat_clientTest {
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientBuilderProperties;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityChecker;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_ai_autoconfigure_model_chat_clientTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ChatClientAutoConfiguration.class))
+            .withUserConfiguration(ChatModelConfiguration.class);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void createsChatClientBuilderAndBindsToolCallingProperties() {
+        this.contextRunner.withConfiguration(AutoConfigurations.of(ToolCallingAutoConfiguration.class))
+                .withPropertyValues("spring.ai.chat.client.tool-calling.advisor-order=42",
+                        "spring.ai.chat.client.tool-calling.enabled=false",
+                        "spring.ai.chat.client.tool-calling.stream-tool-call-responses=true")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ChatClient.Builder.class);
+                    assertThat(context).hasSingleBean(ChatClientBuilderProperties.class);
+                    assertThat(context).hasSingleBean(ToolCallingManager.class);
+                    assertThat(context).hasSingleBean(ToolCallingAdvisor.Builder.class);
+
+                    ChatClientBuilderProperties properties = context.getBean(ChatClientBuilderProperties.class);
+                    assertThat(properties.getToolCalling().isEnabled()).isFalse();
+                    assertThat(properties.getToolCalling().getAdvisorOrder()).isEqualTo(42);
+                    assertThat(properties.getToolCalling().isStreamToolCallResponses()).isTrue();
+
+                    ToolCallingAdvisor advisor = context.getBean(ToolCallingAdvisor.Builder.class).build();
+                    assertThat(advisor.getOrder()).isEqualTo(42);
+                });
+    }
+
+    @Test
+    void toolCallingStreamResponsesPropertyChangesAdvisorStreamingBehavior() {
+        ApplicationContextRunner runner = this.contextRunner
+                .withBean(ToolCallingManager.class, RecordingToolCallingManager::new)
+                .withBean(ToolExecutionEligibilityChecker.class,
+                        () -> response -> "model requested a tool".equals(responseText(response)));
+
+        runner.withPropertyValues("spring.ai.chat.client.tool-calling.stream-tool-call-responses=true")
+                .run(context -> {
+                    ToolCallingAdvisor advisor = context.getBean(ToolCallingAdvisor.Builder.class).build();
+                    RecordingToolCallingManager toolCallingManager = (RecordingToolCallingManager) context
+                            .getBean(ToolCallingManager.class);
+
+                    List<String> responses = advisor.adviseStream(toolRequest(), new SingleResponseStreamAdvisorChain())
+                            .map(response -> response.chatResponse().getResult().getOutput().getText())
+                            .collectList()
+                            .block(Duration.ofSeconds(10));
+
+                    assertThat(responses).containsExactly("model requested a tool", "tool result");
+                    assertThat(toolCallingManager.executions).hasValue(1);
+                });
+
+        runner.withPropertyValues("spring.ai.chat.client.tool-calling.stream-tool-call-responses=false")
+                .run(context -> {
+                    ToolCallingAdvisor advisor = context.getBean(ToolCallingAdvisor.Builder.class).build();
+
+                    List<String> responses = advisor.adviseStream(toolRequest(), new SingleResponseStreamAdvisorChain())
+                            .map(response -> response.chatResponse().getResult().getOutput().getText())
+                            .collectList()
+                            .block(Duration.ofSeconds(10));
+
+                    assertThat(responses).containsExactly("tool result");
+                });
+    }
+
+    @Test
+    void backsOffToolCallingAdvisorBuilderWhenNoToolCallingManagerIsAvailable() {
+        this.contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ChatClient.Builder.class);
+            assertThat(context).doesNotHaveBean(ToolCallingManager.class);
+            assertThat(context).doesNotHaveBean(ToolCallingAdvisor.Builder.class);
+        });
+    }
+
+    @Test
+    void usesUserProvidedToolCallingAdvisorBuilderInsteadOfCreatingAnotherOne() {
+        ToolCallingAdvisor.Builder<?> customBuilder = ToolCallingAdvisor.builder().advisorOrder(77);
+
+        this.contextRunner.withBean(ToolCallingAdvisor.Builder.class, () -> customBuilder).run(context -> {
+            assertThat(context).hasSingleBean(ToolCallingAdvisor.Builder.class);
+            assertThat(context.getBean(ToolCallingAdvisor.Builder.class)).isSameAs(customBuilder);
+            assertThat(context.getBean(ToolCallingAdvisor.Builder.class).build().getOrder()).isEqualTo(77);
+            assertThat(context).hasSingleBean(ChatClient.Builder.class);
+        });
+    }
+
+    private static ChatClientRequest toolRequest() {
+        return ChatClientRequest.builder()
+                .prompt(new Prompt("run the local tool", ToolCallingChatOptions.builder().build()))
+                .context(Map.of())
+                .build();
+    }
+
+    private static ChatClientResponse response(String content) {
+        return ChatClientResponse.builder()
+                .chatResponse(new ChatResponse(List.of(new Generation(new AssistantMessage(content)))))
+                .context(Map.of())
+                .build();
+    }
+
+    private static String responseText(ChatResponse response) {
+        if (response == null || response.getResult() == null) {
+            return "";
+        }
+        return response.getResult().getOutput().getText();
+    }
+
+    public static class ChatModelConfiguration {
+        @Bean
+        public ChatModel chatModel() {
+            return prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        }
+    }
+
+    public static class RecordingToolCallingManager implements ToolCallingManager {
+        private final AtomicInteger executions = new AtomicInteger();
+
+        @Override
+        public List<ToolDefinition> resolveToolDefinitions(ToolCallingChatOptions options) {
+            return List.of();
+        }
+
+        @Override
+        public ToolExecutionResult executeToolCalls(Prompt prompt, ChatResponse chatResponse) {
+            this.executions.incrementAndGet();
+            return ToolExecutionResult.builder()
+                    .conversationHistory(List.of(ToolResponseMessage.builder()
+                            .responses(List.of(
+                                    new ToolResponseMessage.ToolResponse("tool-id", "tool-name", "tool result")))
+                            .build()))
+                    .returnDirect(true)
+                    .build();
+        }
+    }
+
+    public static class SingleResponseStreamAdvisorChain implements StreamAdvisorChain {
+        @Override
+        public Flux<ChatClientResponse> nextStream(ChatClientRequest chatClientRequest) {
+            return Flux.just(response("model requested a tool"));
+        }
+
+        @Override
+        public List<StreamAdvisor> getStreamAdvisors() {
+            return List.of();
+        }
+
+        @Override
+        public StreamAdvisorChain copy(StreamAdvisor advisor) {
+            return this;
+        }
     }
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.ai.model.chat.client.autoconfigure.**"
+      "includeClasses" : "org.springframework.ai.model.chat.client.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_ai.spring_ai_autoconfigure_model_chat_client.**"
     }
   ]
 }

--- a/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/user-code-filter.json
+++ b/tests/src/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.ai.model.chat.client.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8414

This PR introduces tests and metadata for org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 246917
- Cached input tokens: 3376128
- Output tokens: 22742
- Metadata entries: 79
- Iterations: 3
- Library coverage percentage: 86.25
- Generated lines of code: 214
- Tested library lines of code: 69

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 214/255 (83.92%)
- Line: 69/80 (86.25%)
- Method: 31/36 (86.11%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
