### PR TITLE
[GenAI] Add support for org.springframework.shell:spring-shell-core-autoconfigure:4.0.2 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/reachability-metadata.json
+++ b/metadata/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/reachability-metadata.json
@@ -1,0 +1,604 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "boolean[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "java.lang.Class",
+      "methods" : [
+        {
+          "name" : "getModule",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration"
+      },
+      "type" : "java.lang.Iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "java.lang.Module",
+      "methods" : [
+        {
+          "name" : "isNativeAccessEnabled",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "java.lang.ProcessBuilder$RedirectPipeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.TerminalUIAutoConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ThemingAutoConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org.jline.terminal.impl.exec.ExecTerminalProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org.jline.terminal.impl.ffm.FfmTerminalProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org.jline.terminal.impl.jni.JniTerminalProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.Aware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration"
+      },
+      "type" : "org.springframework.boot.info.BuildProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration"
+      },
+      "type" : "org.springframework.boot.info.InfoProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.context.annotation.Bean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.context.annotation.Conditional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration"
+      },
+      "type" : "org.springframework.context.annotation.ImportRuntimeHints"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.context.annotation.Scope"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.core.annotation.AliasFor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration$CommonComponentFlowCustomizer"
+      },
+      "type" : "org.springframework.core.annotation.Order"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "commandRegistry",
+          "parameterTypes" : [
+            "org.springframework.context.ApplicationContext"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "componentFlowBuilder",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration$ComponentFlowConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "shellCommonComponentFlowCustomizer",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "fields" : [
+        {
+          "name" : "fallbackHistoryFileName"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "commandCompleter",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "commandHighlighter",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "inputProvider",
+          "parameterTypes" : [
+            "org.jline.reader.LineReader",
+            "org.springframework.shell.jline.PromptProvider"
+          ]
+        },
+        {
+          "name" : "historyCommand",
+          "parameterTypes" : [
+            "org.jline.reader.History"
+          ]
+        },
+        {
+          "name" : "jlineNonInteractiveShellRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandParser",
+            "org.springframework.shell.core.command.CommandRegistry",
+            "org.jline.terminal.Terminal"
+          ]
+        },
+        {
+          "name" : "jlineShellRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.JLineInputProvider",
+            "org.springframework.shell.core.command.CommandParser",
+            "org.springframework.shell.core.command.CommandRegistry",
+            "org.springframework.core.env.Environment"
+          ]
+        },
+        {
+          "name" : "lineReader",
+          "parameterTypes" : [
+            "org.jline.terminal.Terminal",
+            "org.jline.reader.Parser",
+            "org.springframework.shell.jline.CommandCompleter",
+            "org.springframework.shell.jline.CommandHighlighter"
+          ]
+        },
+        {
+          "name" : "onContextClosedEvent",
+          "parameterTypes" : [
+            "org.springframework.context.event.ContextClosedEvent"
+          ]
+        },
+        {
+          "name" : "parser",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "promptProvider",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "terminal",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0",
+      "fields" : [
+        {
+          "name" : "$$beanFactory"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0",
+      "allDeclaredConstructors" : true,
+      "allDeclaredFields" : true,
+      "methods" : [
+        {
+          "name" : "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes" : [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ShellRunnerAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "commandParser",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "consoleInputProvider",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "springShellApplicationRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.core.ShellRunner"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "helpCommand",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "versionCommand",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.TerminalCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.TerminalUIAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "terminalUIBuilder",
+          "parameterTypes" : [
+            "org.jline.terminal.Terminal",
+            "org.springframework.shell.jline.tui.style.ThemeResolver",
+            "org.springframework.shell.jline.tui.style.ThemeActive",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "viewComponentExecutor",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ThemingAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "shellThemeResolver",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.tui.style.ThemeRegistry",
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+            "org.springframework.shell.jline.tui.style.ThemeActive"
+          ]
+        },
+        {
+          "name" : "templateExecutor",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.tui.style.ThemeResolver"
+          ]
+        },
+        {
+          "name" : "themeActive",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "themeRegistry",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.beans.factory.support.SimpleInstantiationStrategy"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration",
+      "allDeclaredConstructors" : true,
+      "methods" : [
+        {
+          "name" : "userConfigPathProvider",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration"
+      },
+      "type" : "org.springframework.shell.core.command.AbstractCommand"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration"
+      },
+      "type" : "org.springframework.shell.core.command.Command"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.stereotype.Component"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$JLineSupportConfiguration",
+          "interfaces" : [
+            "org.springframework.shell.core.autoconfigure.TerminalCustomizer"
+          ]
+        }
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "META-INF/jline/providers/exec"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "META-INF/jline/providers/ffm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "META-INF/jline/providers/jansi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "META-INF/jline/providers/jna"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "META-INF/jline/providers/jni"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "glob" : "org/jline/utils/capabilities.txt"
+    }
+  ]
+}

--- a/metadata/org.springframework.shell/spring-shell-core-autoconfigure/index.json
+++ b/metadata/org.springframework.shell/spring-shell-core-autoconfigure/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.0.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-shell",
+    "test-code-url" : "https://github.com/spring-projects/spring-shell/tree/v$version$/spring-shell-core-autoconfigure/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-javadoc.jar",
+    "description" : "Spring Shell Core Autoconfigure provides Spring Boot auto-configuration for Spring Shell's core module. It registers the core shell infrastructure and related configuration properties so Spring Boot applications can expose interactive or scripted command-line commands with minimal manual setup.",
+    "tested-versions" : [
+      "4.0.2"
+    ],
+    "allowed-packages" : [
+      "org.springframework.shell.core.autoconfigure"
+    ]
+  }
+]

--- a/metadata/org.springframework.shell/spring-shell-core-autoconfigure/index.json
+++ b/metadata/org.springframework.shell/spring-shell-core-autoconfigure/index.json
@@ -1,17 +1,18 @@
 [
   {
-    "latest" : true,
-    "metadata-version" : "4.0.2",
-    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-sources.jar",
-    "repository-url" : "https://github.com/spring-projects/spring-shell",
-    "test-code-url" : "https://github.com/spring-projects/spring-shell/tree/v$version$/spring-shell-core-autoconfigure/src/test",
-    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-javadoc.jar",
-    "description" : "Spring Shell Core Autoconfigure provides Spring Boot auto-configuration for Spring Shell's core module. It registers the core shell infrastructure and related configuration properties so Spring Boot applications can expose interactive or scripted command-line commands with minimal manual setup.",
-    "tested-versions" : [
+    "latest": true,
+    "metadata-version": "4.0.2",
+    "source-code-url": "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-sources.jar",
+    "repository-url": "https://github.com/spring-projects/spring-shell",
+    "test-code-url": "https://github.com/spring-projects/spring-shell/tree/v$version$/spring-shell-core-autoconfigure/src/test",
+    "documentation-url": "https://repo.maven.apache.org/maven2/org/springframework/shell/spring-shell-core-autoconfigure/$version$/spring-shell-core-autoconfigure-$version$-javadoc.jar",
+    "description": "Spring Shell Core Autoconfigure provides Spring Boot auto-configuration for Spring Shell's core module. It registers the core shell infrastructure and related configuration properties so Spring Boot applications can expose interactive or scripted command-line commands with minimal manual setup.",
+    "tested-versions": [
       "4.0.2"
     ],
-    "allowed-packages" : [
-      "org.springframework.shell.core.autoconfigure"
+    "allowed-packages": [
+      "org.springframework.shell.core.autoconfigure",
+      "org.springframework.beans.factory.support"
     ]
   }
 ]

--- a/stats/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/execution-metrics.json
@@ -1,0 +1,57 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T05:07:52.452732Z",
+    "library": "org.springframework.shell:spring-shell-core-autoconfigure:4.0.2",
+    "starting_commit": "acd2b6cace74edcef075df90dfa2d286c6edd454",
+    "ending_commit": "b29e542cf45d39225eeb47dc3abc07c0cc87bc7f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "4.0.2",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 937,
+          "missed": 233,
+          "ratio": 0.800855,
+          "total": 1170
+        },
+        "line": {
+          "covered": 267,
+          "missed": 60,
+          "ratio": 0.816514,
+          "total": 327
+        },
+        "method": {
+          "covered": 122,
+          "missed": 30,
+          "ratio": 0.802632,
+          "total": 152
+        }
+      }
+    },
+    "metrics": {
+      "input_tokens_used": 306382,
+      "cached_input_tokens_used": 2660864,
+      "output_tokens_used": 31087,
+      "iterations": 4,
+      "cost_usd": 2.263,
+      "generated_loc": 383,
+      "tested_library_loc": 267,
+      "metadata_entries": 101,
+      "test_only_metadata_entries": 308,
+      "code_coverage_percent": 81.65
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/PredefinedConfigurationClassProxyGenerator.java",
+      "metadata_file": "metadata/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/stats.json
+++ b/stats/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.0.2",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 937,
+        "missed" : 233,
+        "ratio" : 0.800855,
+        "total" : 1170
+      },
+      "line" : {
+        "covered" : 267,
+        "missed" : 60,
+        "ratio" : 0.816514,
+        "total" : 327
+      },
+      "method" : {
+        "covered" : 122,
+        "missed" : 30,
+        "ratio" : 0.802632,
+        "total" : 152
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/.gitignore
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.shell:spring-shell-core-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.shell:spring-shell-jline:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.shell:spring-shell-core-autoconfigure:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/build.gradle
@@ -9,11 +9,40 @@ plugins {
 }
 
 String libraryVersion = tck.testedLibraryVersion.get()
+File compiledTestClassesDir = layout.buildDirectory.dir("classes/java/test").get().asFile
+File processedTestResourcesDir = layout.buildDirectory.dir("resources/test").get().asFile
+File generatedCglibProxyMarkerFile = layout.buildDirectory.dir("generated/cglib-proxy-test-classes")
+        .get().file("done.marker").asFile
+String javaHome = System.getenv("JAVA_HOME")
 
 dependencies {
     testImplementation "org.springframework.shell:spring-shell-core-autoconfigure:$libraryVersion"
     testImplementation "org.springframework.shell:spring-shell-jline:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+tasks.register("generatePredefinedConfigurationProxyClasses", JavaExec) { JavaExec task ->
+    task.dependsOn(tasks.named("testClasses"))
+    task.inputs.files(compiledTestClassesDir, processedTestResourcesDir, configurations.testRuntimeClasspath)
+    task.outputs.file(generatedCglibProxyMarkerFile)
+    task.classpath = files(compiledTestClassesDir, processedTestResourcesDir, configurations.testRuntimeClasspath)
+    task.mainClass = "org_springframework_shell.spring_shell_core_autoconfigure.PredefinedConfigurationClassProxyGenerator"
+    task.args(compiledTestClassesDir.absolutePath)
+    task.executable = new File(javaHome, "bin/java").absolutePath
+    task.environment("JAVA_HOME", javaHome)
+    task.environment("GRAALVM_HOME", System.getenv("GRAALVM_HOME"))
+    task.doLast {
+        generatedCglibProxyMarkerFile.parentFile.mkdirs()
+        generatedCglibProxyMarkerFile.text = "generated"
+    }
+}
+
+tasks.named("nativeTestCompile") {
+    dependsOn("generatePredefinedConfigurationProxyClasses")
+}
+
+tasks.named("nativeTraceImage") {
+    dependsOn("generatePredefinedConfigurationProxyClasses")
 }
 
 graalvmNative {

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/gradle.properties
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.shell:spring-shell-core-autoconfigure:4.0.2
+library.version = 4.0.2
+metadata.dir = org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/settings.gradle
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.shell.spring-shell-core-autoconfigure_tests'

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/PredefinedConfigurationClassProxyGenerator.java
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/PredefinedConfigurationClassProxyGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_shell.spring_shell_core_autoconfigure;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration.JLineHistoryConfiguration;
+
+public final class PredefinedConfigurationClassProxyGenerator {
+    private static final String DEBUG_LOCATION_PROPERTY = "cglib.debugLocation";
+    private static final List<String> EXPECTED_CLASS_FILES = List.of(
+            "org/springframework/shell/core/autoconfigure/JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0.class",
+            "org/springframework/shell/core/autoconfigure/JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$FastClass$$0.class",
+            "org/springframework/shell/core/autoconfigure/JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$FastClass$$1.class"
+    );
+
+    private PredefinedConfigurationClassProxyGenerator() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Expected a single output directory argument");
+        }
+        Path outputDirectory = Path.of(args[0]).toAbsolutePath().normalize();
+        Files.createDirectories(outputDirectory);
+
+        String previousDebugLocation = System.getProperty(DEBUG_LOCATION_PROPERTY);
+        try {
+            System.setProperty(DEBUG_LOCATION_PROPERTY, outputDirectory.toString());
+            generateProxyClasses();
+            verifyExpectedClassFiles(outputDirectory);
+        } finally {
+            restoreSystemProperty(DEBUG_LOCATION_PROPERTY, previousDebugLocation);
+        }
+    }
+
+    private static void generateProxyClasses() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(JLineHistoryConfiguration.class)) {
+            context.getBean(JLineHistoryConfiguration.class);
+        }
+    }
+
+    private static void verifyExpectedClassFiles(Path outputDirectory) throws IOException {
+        List<String> missingClassFiles = EXPECTED_CLASS_FILES.stream()
+                .filter(relativePath -> !Files.isRegularFile(outputDirectory.resolve(relativePath)))
+                .toList();
+        if (missingClassFiles.isEmpty()) {
+            return;
+        }
+
+        List<String> availableClassFiles;
+        try (Stream<Path> stream = Files.walk(outputDirectory)) {
+            availableClassFiles = stream
+                    .filter(Files::isRegularFile)
+                    .map(outputDirectory::relativize)
+                    .map(Path::toString)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+        throw new IOException("Missing generated configuration proxy classes: " + missingClassFiles
+                + "; available=" + availableClassFiles);
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+            return;
+        }
+        System.setProperty(key, value);
+    }
+}

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
@@ -6,11 +6,254 @@
  */
 package org_springframework_shell.spring_shell_core_autoconfigure;
 
-import org.junit.jupiter.api.Test;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
 
-class Spring_shell_core_autoconfigureTest {
+import org.jline.reader.History;
+import org.jline.reader.LineReader;
+import org.jline.reader.Parser;
+import org.jline.reader.impl.history.DefaultHistory;
+import org.jline.terminal.Terminal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.shell.core.command.Command;
+import org.springframework.shell.core.command.CommandContext;
+import org.springframework.shell.core.command.CommandOption;
+import org.springframework.shell.core.command.CommandParser;
+import org.springframework.shell.core.command.CommandRegistry;
+import org.springframework.shell.core.command.DefaultCommandParser;
+import org.springframework.shell.core.command.ExitStatus;
+import org.springframework.shell.core.command.ParsedInput;
+import org.springframework.shell.core.config.UserConfigPathProvider;
+import org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration;
+import org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration;
+import org.springframework.shell.core.autoconfigure.SpringShellProperties;
+import org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration;
+import org.springframework.shell.core.autoconfigure.TerminalCustomizer;
+import org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration;
+import org.springframework.shell.jline.PromptProvider;
+import org.springframework.shell.jline.tui.component.ViewComponentExecutor;
+import org.springframework.shell.jline.tui.component.flow.ComponentFlow;
+import org.springframework.shell.jline.tui.component.view.TerminalUIBuilder;
+import org.springframework.shell.jline.tui.style.TemplateExecutor;
+import org.springframework.shell.jline.tui.style.ThemeActive;
+import org.springframework.shell.jline.tui.style.ThemeRegistry;
+import org.springframework.shell.jline.tui.style.ThemeResolver;
+import org.springframework.stereotype.Component;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_shell_core_autoconfigureTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void commandRegistryAutoConfigurationRegistersProgrammaticAndAnnotatedCommands() throws Exception {
+        try (AnnotationConfigApplicationContext context = newContext(Collections.emptyMap(),
+                CommandRegistryAutoConfiguration.class, CommandConfiguration.class, GreetingCommands.class)) {
+            CommandRegistry registry = context.getBean(CommandRegistry.class);
+
+            Command programmatic = registry.getCommandByName("programmatic");
+            assertThat(programmatic).isNotNull();
+            assertThat(programmatic.getDescription()).isEqualTo("registered as a Command bean");
+
+            Command annotated = registry.getCommandByName("greet");
+            assertThat(annotated).isNotNull();
+            assertThat(annotated.getAliases()).containsExactly("hello");
+            assertThat(annotated.getOptions()).extracting(CommandOption::longName).containsExactly("name");
+
+            StringWriter output = new StringWriter();
+            CommandContext commandContext = new CommandContext(
+                    ParsedInput.builder()
+                        .commandName("greet")
+                        .addOption(CommandOption.with()
+                            .longName("name")
+                            .value("native image")
+                            .type(String.class)
+                            .build())
+                        .build(),
+                    registry, new PrintWriter(output), null);
+
+            ExitStatus exitStatus = annotated.execute(commandContext);
+
+            assertThat(exitStatus).isEqualTo(ExitStatus.OK);
+            assertThat(output.toString()).contains("Hello native image");
+            assertThat(registry.getCommandByName("quit")).isNotNull();
+        }
     }
+
+    @Test
+    void standardCommandsHonorConfigurationPropertiesAndBuildInformation() throws Exception {
+        Map<String, Object> properties = Map.of(
+                "spring.shell.command.clear.enabled", "false",
+                "spring.shell.command.script.enabled", "false",
+                "spring.shell.command.version.show-build-group", "true",
+                "spring.shell.command.version.show-build-artifact", "true",
+                "spring.shell.command.version.show-build-name", "true",
+                "spring.shell.command.version.show-build-version", "true",
+                "spring.shell.command.version.show-build-time", "false");
+
+        try (AnnotationConfigApplicationContext context = newContext(properties,
+                StandardCommandsAutoConfiguration.class, BuildInfoConfiguration.class)) {
+            assertThat(context.containsBean("helpCommand")).isTrue();
+            assertThat(context.containsBean("versionCommand")).isTrue();
+            assertThat(context.containsBean("clearCommand")).isFalse();
+            assertThat(context.containsBean("scriptCommand")).isFalse();
+
+            Command versionCommand = context.getBean("versionCommand", Command.class);
+            StringWriter output = new StringWriter();
+            CommandContext commandContext = new CommandContext(ParsedInput.builder().commandName("version").build(),
+                    new CommandRegistry(), new PrintWriter(output), null);
+
+            ExitStatus exitStatus = versionCommand.execute(commandContext);
+
+            assertThat(exitStatus).isEqualTo(ExitStatus.OK);
+            assertThat(output.toString())
+                .contains("Version: 9.9.9")
+                .contains("Build Group: example.group")
+                .contains("Build Artifact: example-artifact")
+                .contains("Build Name: Example Shell");
+        }
+    }
+
+    @Test
+    void springShellPropertiesBindNestedConfigurationAndResolveUserConfigLocation() {
+        Map<String, Object> properties = Map.ofEntries(
+                Map.entry("spring.shell.config.location", "build/test-user-config"),
+                Map.entry("spring.shell.history.enabled", "false"),
+                Map.entry("spring.shell.history.name", "commands.log"),
+                Map.entry("spring.shell.interactive.enabled", "false"),
+                Map.entry("spring.shell.debug.enabled", "true"),
+                Map.entry("spring.shell.theme.name", "dump"),
+                Map.entry("spring.shell.command.help.enabled", "false"),
+                Map.entry("spring.shell.command.version.show-git-short-commit-id", "true"),
+                Map.entry("spring.shell.context.close", "true"));
+
+        try (AnnotationConfigApplicationContext context = newContext(properties, UserConfigAutoConfiguration.class)) {
+            SpringShellProperties shellProperties = context.getBean(SpringShellProperties.class);
+
+            assertThat(shellProperties.getConfig().getLocation()).isEqualTo("build/test-user-config");
+            assertThat(shellProperties.getHistory().isEnabled()).isFalse();
+            assertThat(shellProperties.getHistory().getName()).isEqualTo("commands.log");
+            assertThat(shellProperties.getInteractive().isEnabled()).isFalse();
+            assertThat(shellProperties.getDebug().isEnabled()).isTrue();
+            assertThat(shellProperties.getTheme().getName()).isEqualTo("dump");
+            assertThat(shellProperties.getCommand().getHelp().isEnabled()).isFalse();
+            assertThat(shellProperties.getCommand().getVersion().isShowGitShortCommitId()).isTrue();
+            assertThat(shellProperties.getContext().isClose()).isTrue();
+            assertThat(context.getBean(UserConfigPathProvider.class).provide())
+                .isEqualTo(Path.of("build/test-user-config"));
+        }
+    }
+
+    @Test
+    void jlineAutoConfigurationCreatesShellInfrastructureWithTheming(@TempDir Path tempDirectory) {
+        Map<String, Object> properties = Map.of(
+                "spring.shell.config.location", tempDirectory.toString(),
+                "spring.shell.history.enabled", "true",
+                "spring.shell.history.name", "history.log",
+                "spring.shell.interactive.enabled", "true");
+
+        try (AnnotationConfigApplicationContext context = newContext(properties,
+                CommandRegistryAutoConfiguration.class, UserConfigAutoConfiguration.class,
+                JLineShellAutoConfiguration.class, JLineSupportConfiguration.class)) {
+            LineReader lineReader = context.getBean(LineReader.class);
+            Object historyFile = lineReader.getVariable(LineReader.HISTORY_FILE);
+
+            assertThat(historyFile).isEqualTo(tempDirectory.resolve("history.log").toAbsolutePath());
+            assertThat(context.getBean(Parser.class)).isNotNull();
+            assertThat(context.getBean(PromptProvider.class).getPrompt().toString()).contains("shell:>");
+            assertThat(context.getBean(Terminal.class).getType()).isNotBlank();
+            assertThat(context.getBean(ThemeActive.class).get()).isIn("default", "dump");
+            assertThat(context.getBean(ThemeRegistry.class)).isNotNull();
+            assertThat(context.getBean(ThemeResolver.class)).isNotNull();
+            assertThat(context.getBean(TemplateExecutor.class)).isNotNull();
+            assertThat(context.getBean(ComponentFlow.Builder.class)).isNotNull();
+            assertThat(context.getBean(TerminalUIBuilder.class)).isNotNull();
+            assertThat(context.getBean(ViewComponentExecutor.class)).isNotNull();
+        }
+    }
+
+    private static AnnotationConfigApplicationContext newContext(Map<String, Object> properties,
+            Class<?>... configurationClasses) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new MapPropertySource("test", properties));
+        context.register(configurationClasses);
+        context.refresh();
+        return context;
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CommandConfiguration {
+
+        @Bean
+        Command programmaticCommand() {
+            return Command.builder()
+                .name("programmatic")
+                .description("registered as a Command bean")
+                .execute(commandContext -> "programmatic result");
+        }
+
+    }
+
+    @Component
+    static class GreetingCommands {
+
+        @org.springframework.shell.core.command.annotation.Command(name = "greet", alias = "hello",
+                description = "Greet a named target")
+        String greet(@org.springframework.shell.core.command.annotation.Option(longName = "name",
+                defaultValue = "world") String name) {
+            return "Hello " + name;
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class BuildInfoConfiguration {
+
+        @Bean
+        BuildProperties buildProperties() {
+            Properties properties = new Properties();
+            properties.setProperty("group", "example.group");
+            properties.setProperty("artifact", "example-artifact");
+            properties.setProperty("name", "Example Shell");
+            properties.setProperty("version", "9.9.9");
+            return new BuildProperties(properties);
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class JLineSupportConfiguration {
+
+        @Bean
+        History history() {
+            return new DefaultHistory();
+        }
+
+        @Bean
+        TerminalCustomizer testTerminalCustomizer() {
+            return builder -> builder
+                .dumb(true)
+                .system(false)
+                .streams(new ByteArrayInputStream(new byte[0]), new ByteArrayOutputStream());
+        }
+
+        @Bean
+        CommandParser commandParser(CommandRegistry commandRegistry) {
+            return new DefaultCommandParser(commandRegistry);
+        }
+
+    }
+
 }

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
@@ -23,11 +23,14 @@ import org.jline.terminal.Terminal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.shell.core.ShellRunner;
 import org.springframework.shell.core.command.Command;
 import org.springframework.shell.core.command.CommandContext;
 import org.springframework.shell.core.command.CommandOption;
@@ -39,6 +42,7 @@ import org.springframework.shell.core.command.ParsedInput;
 import org.springframework.shell.core.config.UserConfigPathProvider;
 import org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration;
 import org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration;
+import org.springframework.shell.core.autoconfigure.ShellRunnerAutoConfiguration;
 import org.springframework.shell.core.autoconfigure.SpringShellProperties;
 import org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration;
 import org.springframework.shell.core.autoconfigure.TerminalCustomizer;
@@ -184,6 +188,20 @@ public class Spring_shell_core_autoconfigureTest {
         }
     }
 
+    @Test
+    void shellRunnerAutoConfigurationDelegatesApplicationArgumentsToShellRunner() throws Exception {
+        try (AnnotationConfigApplicationContext context = newContext(Collections.emptyMap(),
+                CommandRegistryAutoConfiguration.class, ShellRunnerAutoConfiguration.class,
+                RecordingShellRunnerConfiguration.class)) {
+            ApplicationRunner applicationRunner = context.getBean("springShellApplicationRunner", ApplicationRunner.class);
+            RecordingShellRunner shellRunner = context.getBean(RecordingShellRunner.class);
+
+            applicationRunner.run(new DefaultApplicationArguments("sample", "--name=native"));
+
+            assertThat(shellRunner.getArguments()).containsExactly("sample", "--name=native");
+        }
+    }
+
     private static AnnotationConfigApplicationContext newContext(Map<String, Object> properties,
             Class<?>... configurationClasses) {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -229,6 +247,31 @@ public class Spring_shell_core_autoconfigureTest {
             properties.setProperty("name", "Example Shell");
             properties.setProperty("version", "9.9.9");
             return new BuildProperties(properties);
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class RecordingShellRunnerConfiguration {
+
+        @Bean
+        RecordingShellRunner recordingShellRunner() {
+            return new RecordingShellRunner();
+        }
+
+    }
+
+    static class RecordingShellRunner implements ShellRunner {
+
+        private String[] arguments = new String[0];
+
+        @Override
+        public void run(String[] args) {
+            this.arguments = args.clone();
+        }
+
+        String[] getArguments() {
+            return this.arguments.clone();
         }
 
     }

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_shell.spring_shell_core_autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_shell_core_autoconfigureTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/java/org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest.java
@@ -11,12 +11,16 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.jline.reader.Candidate;
 import org.jline.reader.History;
 import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
@@ -47,6 +51,7 @@ import org.springframework.shell.core.autoconfigure.SpringShellProperties;
 import org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration;
 import org.springframework.shell.core.autoconfigure.TerminalCustomizer;
 import org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration;
+import org.springframework.shell.jline.CommandCompleter;
 import org.springframework.shell.jline.PromptProvider;
 import org.springframework.shell.jline.tui.component.ViewComponentExecutor;
 import org.springframework.shell.jline.tui.component.flow.ComponentFlow;
@@ -202,6 +207,51 @@ public class Spring_shell_core_autoconfigureTest {
         }
     }
 
+    @Test
+    void jlineCommandCompleterSuggestsNestedCommandsAndOptions(@TempDir Path tempDirectory) {
+        Map<String, Object> properties = Map.of(
+                "spring.shell.config.location", tempDirectory.toString(),
+                "spring.shell.history.enabled", "false",
+                "spring.shell.interactive.enabled", "true");
+
+        try (AnnotationConfigApplicationContext context = newContext(properties,
+                CommandRegistryAutoConfiguration.class, UserConfigAutoConfiguration.class,
+                JLineShellAutoConfiguration.class, JLineSupportConfiguration.class,
+                CompletionCommandConfiguration.class)) {
+            CommandCompleter completer = context.getBean(CommandCompleter.class);
+
+            assertThat(candidateValues(complete(completer, "admin ", "admin", ""))).contains("user");
+            assertThat(candidateValues(complete(completer, "admin user ", "admin", "user", "")))
+                .contains("--role", "-r");
+            assertThat(candidateValues(complete(completer, "admin user --role=operator ",
+                    "admin", "user", "--role=operator", "")))
+                .doesNotContain("--role", "-r");
+        }
+    }
+
+    private static List<Candidate> complete(CommandCompleter completer, String line, String... words) {
+        List<Candidate> candidates = new ArrayList<>();
+        List<String> parsedWords = List.of(words);
+        String word = parsedWords.get(parsedWords.size() - 1);
+        completer.complete(null, new CompletionLine(line, parsedWords, parsedWords.size() - 1, word, word.length()),
+                candidates);
+        return candidates;
+    }
+
+    private static List<String> candidateValues(List<Candidate> candidates) {
+        return candidates.stream().map(Candidate::value).toList();
+    }
+
+    private record CompletionLine(String line, List<String> words, int wordIndex, String word,
+            int wordCursor) implements ParsedLine {
+
+        @Override
+        public int cursor() {
+            return line().length();
+        }
+
+    }
+
     private static AnnotationConfigApplicationContext newContext(Map<String, Object> properties,
             Class<?>... configurationClasses) {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -232,6 +282,25 @@ public class Spring_shell_core_autoconfigureTest {
         String greet(@org.springframework.shell.core.command.annotation.Option(longName = "name",
                 defaultValue = "world") String name) {
             return "Hello " + name;
+        }
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CompletionCommandConfiguration {
+
+        @Bean
+        Command adminUserCommand() {
+            return Command.builder()
+                .name("admin user")
+                .description("Manage shell users")
+                .options(CommandOption.with()
+                    .longName("role")
+                    .shortName('r')
+                    .description("Assigned role")
+                    .type(String.class)
+                    .build())
+                .execute(commandContext -> "updated");
         }
 
     }

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,1923 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.annotation.PostConstruct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.inject.Inject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.inject.Named"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.inject.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.inject.Qualifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.persistence.EntityManagerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.validation.Validator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.validation.ValidatorFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "jakarta.validation.bootstrap.GenericBootstrap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.io.Closeable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.io.Flushable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.AutoCloseable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.ClassLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.Class[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.Iterable"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.annotation.Documented"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.annotation.Inherited"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.annotation.Retention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "java.lang.annotation.Target"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "javax.money.MonetaryAmount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "kotlinx.coroutines.reactor.MonoKt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$JLineSupportConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.eclipse.core.runtime.FileLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.hibernate.validator.internal.util.logging.Log_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.Completer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.Highlighter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.History"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.LineReader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.Parser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.impl.LineReaderImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.reader.impl.history.DefaultHistory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.terminal.Terminal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.terminal.impl.AbstractTerminal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.terminal.impl.ExternalTerminal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.terminal.impl.LineDisciplineTerminal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.jline.terminal.spi.TerminalExt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.reactivestreams.Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.aot.hint.annotation.Reflective"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.Aware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.FactoryBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.InitializingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.SmartInitializingSingleton"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.beans.factory.annotation.Value"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.ApplicationRunner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigurationImportSelector$AutoConfigurationGroup",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureAfter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureBefore"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.ImportAutoConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.ImportAutoConfigurationImportSelector",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionEvaluationReportAutoConfigurationImportListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnProperty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods" : [
+        {
+          "name" : "byAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.ApplicationContextAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.Bean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.Conditional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.Import"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.annotation.Scope"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.event.EventListener"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.core.annotation.AliasFor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.core.annotation.Order"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.ConsoleInputProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.InputProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.InteractiveShellRunner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.ShellRunner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.CommandRegistryAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "commandRegistry",
+          "parameterTypes" : [
+            "org.springframework.context.ApplicationContext"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "componentFlowBuilder",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration$CommonComponentFlowCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowAutoConfiguration$ComponentFlowConfiguration",
+      "methods" : [
+        {
+          "name" : "shellCommonComponentFlowCustomizer",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ComponentFlowCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration",
+      "fields" : [
+        {
+          "name" : "fallbackHistoryFileName"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jline.reader.History",
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+            "org.springframework.shell.core.config.UserConfigPathProvider"
+          ]
+        },
+        {
+          "name" : "commandCompleter",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "commandHighlighter",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "inputProvider",
+          "parameterTypes" : [
+            "org.jline.reader.LineReader",
+            "org.springframework.shell.jline.PromptProvider"
+          ]
+        },
+        {
+          "name" : "historyCommand",
+          "parameterTypes" : [
+            "org.jline.reader.History"
+          ]
+        },
+        {
+          "name" : "jlineNonInteractiveShellRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandParser",
+            "org.springframework.shell.core.command.CommandRegistry",
+            "org.jline.terminal.Terminal"
+          ]
+        },
+        {
+          "name" : "jlineShellRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.JLineInputProvider",
+            "org.springframework.shell.core.command.CommandParser",
+            "org.springframework.shell.core.command.CommandRegistry",
+            "org.springframework.core.env.Environment"
+          ]
+        },
+        {
+          "name" : "lineReader",
+          "parameterTypes" : [
+            "org.jline.terminal.Terminal",
+            "org.jline.reader.Parser",
+            "org.springframework.shell.jline.CommandCompleter",
+            "org.springframework.shell.jline.CommandHighlighter"
+          ]
+        },
+        {
+          "name" : "onContextClosedEvent",
+          "parameterTypes" : [
+            "org.springframework.context.event.ContextClosedEvent"
+          ]
+        },
+        {
+          "name" : "parser",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "promptProvider",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "terminal",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration$JLineHistoryConfiguration$$SpringCGLIB$$0",
+      "fields" : [
+        {
+          "name" : "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name" : "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes" : [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ShellRunnerAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "commandParser",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "consoleInputProvider",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "springShellApplicationRunner",
+          "parameterTypes" : [
+            "org.springframework.shell.core.ShellRunner"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getCommand",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getConfig",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getContext",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getDebug",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getHistory",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getInteractive",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getTheme",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setCommand",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Command"
+          ]
+        },
+        {
+          "name" : "setConfig",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Config"
+          ]
+        },
+        {
+          "name" : "setContext",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Context"
+          ]
+        },
+        {
+          "name" : "setDebug",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Debug"
+          ]
+        },
+        {
+          "name" : "setHistory",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$History"
+          ]
+        },
+        {
+          "name" : "setInteractive",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Interactive"
+          ]
+        },
+        {
+          "name" : "setTheme",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$Theme"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$ClearCommand",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Command",
+      "methods" : [
+        {
+          "name" : "getClear",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getHelp",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getScript",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getVersion",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setClear",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$ClearCommand"
+          ]
+        },
+        {
+          "name" : "setHelp",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$HelpCommand"
+          ]
+        },
+        {
+          "name" : "setScript",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$ScriptCommand"
+          ]
+        },
+        {
+          "name" : "setVersion",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties$VersionCommand"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Config",
+      "methods" : [
+        {
+          "name" : "setLocation",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Context",
+      "methods" : [
+        {
+          "name" : "setClose",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Debug",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$HelpCommand",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$History",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Interactive",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$ScriptCommand",
+      "methods" : [
+        {
+          "name" : "setEnabled",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$Theme",
+      "methods" : [
+        {
+          "name" : "setName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.SpringShellProperties$VersionCommand",
+      "methods" : [
+        {
+          "name" : "setShowBuildArtifact",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setShowBuildGroup",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setShowBuildName",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setShowBuildTime",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setShowBuildVersion",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        },
+        {
+          "name" : "setShowGitShortCommitId",
+          "parameterTypes" : [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "helpCommand",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "versionCommand",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.TerminalCustomizer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.TerminalUIAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "terminalUIBuilder",
+          "parameterTypes" : [
+            "org.jline.terminal.Terminal",
+            "org.springframework.shell.jline.tui.style.ThemeResolver",
+            "org.springframework.shell.jline.tui.style.ThemeActive",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "viewComponentExecutor",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.ThemingAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "shellThemeResolver",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.tui.style.ThemeRegistry",
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties",
+            "org.springframework.shell.jline.tui.style.ThemeActive"
+          ]
+        },
+        {
+          "name" : "templateExecutor",
+          "parameterTypes" : [
+            "org.springframework.shell.jline.tui.style.ThemeResolver"
+          ]
+        },
+        {
+          "name" : "themeActive",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "themeRegistry",
+          "parameterTypes" : [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "userConfigPathProvider",
+          "parameterTypes" : [
+            "org.springframework.shell.core.autoconfigure.SpringShellProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration$LocationResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.AbstractCommand"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.Command"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.CommandParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.CommandRegistry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.DefaultCommandParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.Help"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.Version"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.annotation.Command"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.command.annotation.Option"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.core.config.UserConfigPathProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.CommandCompleter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.CommandHighlighter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.DefaultJLineShellConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.ExtendedDefaultParser"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.JLineInputProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.JLineShellRunner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.PromptProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.ViewComponentExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.flow.ComponentFlow"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.flow.ComponentFlow$BaseBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.flow.ComponentFlow$Builder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.flow.ComponentFlow$DefaultBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.view.TerminalUI"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.component.view.TerminalUIBuilder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.style.TemplateExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.style.ThemeActive"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.style.ThemeRegistry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.shell.jline.tui.style.ThemeResolver"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.stereotype.Component"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.stereotype.Indexed"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.StandardCommandsAutoConfiguration"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$BuildInfoConfiguration",
+      "methods" : [
+        {
+          "name" : "buildProperties",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$BuildInfoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$CommandConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$CompletionCommandConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$GreetingCommands",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "greet",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$JLineSupportConfiguration",
+      "methods" : [
+        {
+          "name" : "testTerminalCustomizer",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$JLineSupportConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "commandParser",
+          "parameterTypes" : [
+            "org.springframework.shell.core.command.CommandRegistry"
+          ]
+        },
+        {
+          "name" : "history",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$RecordingShellRunner"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$RecordingShellRunnerConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "recordingShellRunner",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.context.properties.ConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.event.EventListener"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+          "interfaces" : [
+            "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.shell.core.autoconfigure.JLineShellAutoConfiguration",
+          "interfaces" : [
+            "org.springframework.shell.jline.PromptProvider"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.shell.core.autoconfigure.ShellRunnerAutoConfiguration",
+          "interfaces" : [
+            "org.springframework.boot.ApplicationRunner"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.shell.core.autoconfigure.ThemingAutoConfiguration",
+          "interfaces" : [
+            "org.springframework.shell.jline.tui.style.ThemeActive"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.shell.core.autoconfigure.UserConfigAutoConfiguration",
+          "interfaces" : [
+            "org.springframework.shell.core.config.UserConfigPathProvider"
+          ]
+        }
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest$JLineSupportConfiguration",
+          "interfaces" : [
+            "org.springframework.shell.core.autoconfigure.TerminalCustomizer"
+          ]
+        }
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/spring.components"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/spring.factories"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/autoconfigure/AutoConfigureAfter.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/autoconfigure/AutoConfigureBefore.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/context/annotation/Conditional.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/context/annotation/Configuration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/context/annotation/Import.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/context/annotation/ImportBeanDefinitionRegistrar.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/ComponentFlowAutoConfiguration$CommonComponentFlowCustomizer.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/ComponentFlowAutoConfiguration$ComponentFlowConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/ComponentFlowAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/JLineShellAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/ShellRunnerAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/StandardCommandsAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/TerminalUIAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org/springframework/shell/core/autoconfigure/ThemingAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "org_springframework_shell/spring_shell_core_autoconfigure/Spring_shell_core_autoconfigureTest$JLineSupportConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_shell.spring_shell_core_autoconfigure.Spring_shell_core_autoconfigureTest"
+      },
+      "glob" : "spring.properties"
+    }
+  ]
+}

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.shell.core.autoconfigure.**"
+      "includeClasses" : "org.springframework.shell.core.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_shell.spring_shell_core_autoconfigure.**"
     }
   ]
 }

--- a/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/user-code-filter.json
+++ b/tests/src/org.springframework.shell/spring-shell-core-autoconfigure/4.0.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.shell.core.autoconfigure.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8413

This PR introduces tests and metadata for org.springframework.shell:spring-shell-core-autoconfigure:4.0.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 306382
- Cached input tokens: 2660864
- Output tokens: 31087
- Metadata entries: 101
- Test-only metadata entries: 308
- Iterations: 4
- Library coverage percentage: 81.65
- Generated lines of code: 383
- Tested library lines of code: 267

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 937/1170 (80.09%)
- Line: 267/327 (81.65%)
- Method: 122/152 (80.26%)

### Local CI Verification

- Status: `success`
- Commands run: 14
- Fixup attempts: 0
