### PR TITLE
[GenAI] Add support for org.jruby.joni:joni:2.2.6 using gpt-5.5

### DIFF
--- a/metadata/org.jruby.joni/joni/2.2.6/reachability-metadata.json
+++ b/metadata/org.jruby.joni/joni/2.2.6/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.joni.Parser"
+      },
+      "glob": "tables/*.bin"
+    }
+  ]
+}

--- a/metadata/org.jruby.joni/joni/index.json
+++ b/metadata/org.jruby.joni/joni/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.2.6",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/jruby/joni/joni/$version$/joni-$version$-sources.jar",
+    "repository-url" : "https://github.com/jruby/joni",
+    "test-code-url" : "https://github.com/jruby/joni/tree/joni-$version$/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/jruby/joni/joni/$version$/joni-$version$-javadoc.jar",
+    "description" : "Joni is a Java port of the Oniguruma regular expression engine. It matches byte-array based regular expressions for JVM applications, including JRuby, without routing patterns through Java String and char APIs.",
+    "tested-versions" : [
+      "2.2.6"
+    ],
+    "allowed-packages" : [
+      "org.joni"
+    ]
+  }
+]

--- a/stats/org.jruby.joni/joni/2.2.6/execution-metrics.json
+++ b/stats/org.jruby.joni/joni/2.2.6/execution-metrics.json
@@ -1,0 +1,86 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T05:35:06.907747Z",
+    "library": "org.jruby.joni:joni:2.2.6",
+    "starting_commit": "c20074b7d630af378de0fb7f108dce1f615313d8",
+    "ending_commit": "8a96b9339cdedcdb732271391370a1d8d8c59825",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.2.6",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 14114,
+          "missed": 29683,
+          "ratio": 0.32226,
+          "total": 43797
+        },
+        "line": {
+          "covered": 2823,
+          "missed": 5600,
+          "ratio": 0.335154,
+          "total": 8423
+        },
+        "method": {
+          "covered": 515,
+          "missed": 590,
+          "ratio": 0.466063,
+          "total": 1105
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 8411,
+      "issue_label": "library-new-request",
+      "library": "org.jruby.joni:joni:2.2.6",
+      "summary": "Joni is a pure Java byte-array regular expression engine. Its normal documented usage only needs the library artifact plus its transitive org.jruby.jcodings:jcodings dependency, which Maven/Gradle will resolve automatically; no Docker service, extra test dependency, or required environment/system property is needed for meaningful coverage.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Joni has optional static joni.* system properties for internal configuration/debugging, but they are not required for normal API use or coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8411 Support for org.jruby.joni:joni:2.2.6; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 21485,
+      "output_tokens_used": 1805,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.jruby.joni:joni:2.2.6/library-preparation-preflight/pi-generation-2026-06-27T05-15-22-584924Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 154962,
+      "cached_input_tokens_used": 1580032,
+      "output_tokens_used": 20954,
+      "iterations": 5,
+      "cost_usd": 1.4186,
+      "generated_loc": 198,
+      "tested_library_loc": 2823,
+      "metadata_entries": 1,
+      "code_coverage_percent": 33.52
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java",
+      "metadata_file": "metadata/org.jruby.joni/joni/2.2.6/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jruby.joni/joni/2.2.6/stats.json
+++ b/stats/org.jruby.joni/joni/2.2.6/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.2.6",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 14114,
+        "missed" : 29683,
+        "ratio" : 0.32226,
+        "total" : 43797
+      },
+      "line" : {
+        "covered" : 2823,
+        "missed" : 5600,
+        "ratio" : 0.335154,
+        "total" : 8423
+      },
+      "method" : {
+        "covered" : 515,
+        "missed" : 590,
+        "ratio" : 0.466063,
+        "total" : 1105
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jruby.joni/joni/2.2.6/.gitignore
+++ b/tests/src/org.jruby.joni/joni/2.2.6/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jruby.joni/joni/2.2.6/build.gradle
+++ b/tests/src/org.jruby.joni/joni/2.2.6/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jruby.joni:joni:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jruby.joni/joni/2.2.6/gradle.properties
+++ b/tests/src/org.jruby.joni/joni/2.2.6/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jruby.joni:joni:2.2.6
+library.version = 2.2.6
+metadata.dir = org.jruby.joni/joni/2.2.6/

--- a/tests/src/org.jruby.joni/joni/2.2.6/settings.gradle
+++ b/tests/src/org.jruby.joni/joni/2.2.6/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jruby.joni.joni_tests'

--- a/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
+++ b/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
@@ -71,6 +71,26 @@ public class JoniTest {
     }
 
     @Test
+    void lookaroundAssertionsConstrainMatchesWithoutConsumingText() {
+        Regex regex = regex("(?<=USD )\\d+(?![\\dA-Z])");
+        byte[] input = bytes("EUR 100 USD 123 USD 456X USD 789.");
+        int firstAmount = bytes("EUR 100 USD ").length;
+        int secondAmount = bytes("EUR 100 USD 123 USD 456X USD ").length;
+
+        Matcher matcher = regex.matcher(input);
+        int matchStart = matcher.search(0, input.length, Option.DEFAULT);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(matchStart).isEqualTo(firstAmount);
+        assertThat(matcher.getBegin()).isEqualTo(firstAmount);
+        assertThat(extract(input, region, 0)).isEqualTo("123");
+
+        assertThat(matcher.search(matcher.getEnd(), input.length, Option.DEFAULT))
+                .isEqualTo(secondAmount);
+        assertThat(extract(input, matcher.getEagerRegion(), 0)).isEqualTo("789");
+    }
+
+    @Test
     void rubyNamedGroupsCanBeResolvedIteratedAndUsedAsBackReferences() {
         Regex regex = regex("\\A(?<token>[A-Za-z]+)-\\k<token>\\z");
         byte[] good = bytes("repeat-repeat");

--- a/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
+++ b/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
@@ -6,11 +6,200 @@
  */
 package org_jruby_joni.joni;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Matcher;
+import org.joni.NameEntry;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Region;
+import org.joni.Syntax;
+import org.joni.exception.SyntaxException;
 import org.junit.jupiter.api.Test;
 
-class JoniTest {
+public class JoniTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void searchFindsMatchesAndExposesNumberedCaptureRegions() {
+        Regex regex = regex("([A-Z]{2})(\\d{3})(?:-([a-z]+))?");
+        byte[] input = bytes("xx AB123-test yy");
+        int expectedStart = bytes("xx ").length;
+
+        Matcher matcher = regex.matcher(input);
+        int matchStart = matcher.search(0, input.length, Option.DEFAULT);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(matchStart).isEqualTo(expectedStart);
+        assertThat(matcher.getBegin()).isEqualTo(expectedStart);
+        assertThat(matcher.getEnd()).isEqualTo(expectedStart + bytes("AB123-test").length);
+        assertThat(regex.numberOfCaptures()).isEqualTo(3);
+        assertThat(region.getNumRegs()).isEqualTo(4);
+        assertThat(extract(input, region, 0)).isEqualTo("AB123-test");
+        assertThat(extract(input, region, 1)).isEqualTo("AB");
+        assertThat(extract(input, region, 2)).isEqualTo("123");
+        assertThat(extract(input, region, 3)).isEqualTo("test");
+
+        Region clone = region.clone();
+        clone.setBeg(1, 0);
+        clone.setEnd(1, 2);
+        assertThat(extract(input, clone, 1)).isEqualTo("xx");
+        assertThat(extract(input, region, 1)).isEqualTo("AB");
+    }
+
+    @Test
+    void matchAnchorsThePatternAtTheRequestedPosition() {
+        Regex regex = regex("\\A([a-z]+)(\\d+)\\z");
+        byte[] matching = bytes("abc123");
+        byte[] nonMatching = bytes("abc123x");
+
+        Matcher matcher = regex.matcher(matching);
+        int matchLength = matcher.match(0, matching.length, Option.DEFAULT);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(matchLength).isEqualTo(matching.length);
+        assertThat(extract(matching, region, 1)).isEqualTo("abc");
+        assertThat(extract(matching, region, 2)).isEqualTo("123");
+        assertThat(regex.matcher(nonMatching).match(0, nonMatching.length, Option.DEFAULT))
+                .isEqualTo(Matcher.FAILED);
+    }
+
+    @Test
+    void rubyNamedGroupsCanBeResolvedIteratedAndUsedAsBackReferences() {
+        Regex regex = regex("\\A(?<token>[A-Za-z]+)-\\k<token>\\z");
+        byte[] good = bytes("repeat-repeat");
+        byte[] bad = bytes("repeat-repeal");
+        byte[] name = bytes("token");
+
+        Matcher matcher = regex.matcher(good);
+        assertThat(matcher.match(0, good.length, Option.DEFAULT)).isEqualTo(good.length);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(regex.numberOfNames()).isEqualTo(1);
+        assertThat(regex.nameToBackrefNumber(name, 0, name.length, region)).isEqualTo(1);
+        assertThat(extract(good, region, 1)).isEqualTo("repeat");
+        assertThat(namedBackReferences(regex)).containsExactly("token=[1]");
+        assertThat(regex.matcher(bad).match(0, bad.length, Option.DEFAULT))
+                .isEqualTo(Matcher.FAILED);
+    }
+
+    @Test
+    void optionsControlCaseSensitivityLineAnchorsAndDotNewlineMatching() {
+        Regex caseInsensitiveRegex = regex("^status: (ok|warn).+$", Option.IGNORECASE, Syntax.RUBY);
+        byte[] input = bytes("header\nSTATUS: Warn disk\nfooter");
+        int expectedStart = bytes("header\n").length;
+
+        Matcher matcher = caseInsensitiveRegex.matcher(input);
+        int matchStart = matcher.search(0, input.length, Option.DEFAULT);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(Option.isIgnoreCase(caseInsensitiveRegex.getOptions())).isTrue();
+        assertThat(matchStart).isEqualTo(expectedStart);
+        assertThat(extract(input, region, 0)).isEqualTo("STATUS: Warn disk");
+        assertThat(extract(input, region, 1)).isEqualTo("Warn");
+
+        Regex multilineRegex = regex("start.+finish", Option.MULTILINE, Syntax.RUBY);
+        byte[] acrossLines = bytes("start\nmiddle\nfinish");
+        assertThat(multilineRegex.matcher(acrossLines)
+                .search(0, acrossLines.length, Option.DEFAULT)).isEqualTo(0);
+        assertThat(Option.isMultiline(multilineRegex.getOptions())).isTrue();
+
+        Regex singleLineRegex = regex("^STATUS", Option.SINGLELINE, Syntax.RUBY);
+        assertThat(singleLineRegex.matcher(input).search(0, input.length, Option.DEFAULT))
+                .isEqualTo(Matcher.FAILED);
+        assertThat(Option.isSingleline(singleLineRegex.getOptions())).isTrue();
+    }
+
+    @Test
+    void utf8EncodingMatchesUnicodeLiteralsAndReportsByteOffsets() {
+        Regex regex = regex("café\\s+(世界)");
+        byte[] input = bytes("prefix café 世界 suffix");
+        int expectedStart = bytes("prefix ").length;
+        int expectedGroupStart = bytes("prefix café ").length;
+
+        Matcher matcher = regex.matcher(input);
+        int matchStart = matcher.search(0, input.length, Option.DEFAULT);
+        Region region = matcher.getEagerRegion();
+
+        assertThat(regex.getEncoding()).isSameAs(UTF8Encoding.INSTANCE);
+        assertThat(matchStart).isEqualTo(expectedStart);
+        assertThat(region.getBeg(1)).isEqualTo(expectedGroupStart);
+        assertThat(extract(input, region, 0)).isEqualTo("café 世界");
+        assertThat(extract(input, region, 1)).isEqualTo("世界");
+    }
+
+    @Test
+    void matcherWithoutRegionStillReportsSearchBoundsForRepeatedRangeSearches() {
+        Regex regex = regex("\\bcat\\b");
+        byte[] input = bytes("concatenate cat category cat");
+        int firstCat = "concatenate cat category cat".indexOf(" cat ") + 1;
+        int secondCat = "concatenate cat category cat".lastIndexOf("cat");
+
+        Matcher matcher = regex.matcherNoRegion(input, 0, input.length);
+        assertThat(matcher.search(0, input.length, Option.DEFAULT)).isEqualTo(firstCat);
+        assertThat(matcher.getBegin()).isEqualTo(firstCat);
+        assertThat(matcher.getEnd()).isEqualTo(firstCat + bytes("cat").length);
+        assertThat(matcher.getRegion()).isNull();
+
+        assertThat(matcher.search(matcher.getEnd(), input.length, Option.DEFAULT))
+                .isEqualTo(secondCat);
+        assertThat(matcher.getBegin()).isEqualTo(secondCat);
+        assertThat(matcher.getEnd()).isEqualTo(secondCat + bytes("cat").length);
+    }
+
+    @Test
+    void regexStoresApplicationOptionsAndUserObject() {
+        Regex regex = regex("color");
+        Object marker = new Object();
+
+        regex.setUserOptions(Option.IGNORECASE | Option.FIND_LONGEST);
+        regex.setUserObject(marker);
+
+        assertThat(regex.getUserOptions()).isEqualTo(Option.IGNORECASE | Option.FIND_LONGEST);
+        assertThat(regex.getUserObject()).isSameAs(marker);
+        assertThat(regex.isLinear()).isTrue();
+        assertThat(regex.optimizeInfoToString()).contains("optimize");
+    }
+
+    @Test
+    void invalidPatternThrowsSyntaxException() {
+        assertThatThrownBy(() -> regex("([unterminated"))
+                .isInstanceOf(SyntaxException.class);
+    }
+
+    private static Regex regex(String pattern) {
+        return regex(pattern, Option.DEFAULT, Syntax.RUBY);
+    }
+
+    private static Regex regex(String pattern, int options, Syntax syntax) {
+        byte[] patternBytes = bytes(pattern);
+        return new Regex(patternBytes, 0, patternBytes.length, options,
+                UTF8Encoding.INSTANCE, syntax);
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(UTF_8);
+    }
+
+    private static String extract(byte[] input, Region region, int group) {
+        int begin = region.getBeg(group);
+        return new String(input, begin, region.getEnd(group) - begin, UTF_8);
+    }
+
+    private static List<String> namedBackReferences(Regex regex) {
+        List<String> entries = new ArrayList<>();
+        Iterator<NameEntry> iterator = regex.namedBackrefIterator();
+        while (iterator.hasNext()) {
+            NameEntry entry = iterator.next();
+            String name = new String(entry.name, entry.nameP, entry.nameEnd - entry.nameP, UTF_8);
+            entries.add(name + "=" + Arrays.toString(entry.getBackRefs()));
+        }
+        return entries;
     }
 }

--- a/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
+++ b/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
@@ -174,6 +174,18 @@ public class JoniTest {
     }
 
     @Test
+    void posixBracketClassesMatchCharacterCategories() {
+        Regex regex = regex("\\A[[:alpha:]]+[[:space:]]+[[:digit:]]+\\z");
+        byte[] matching = bytes("Order 12345");
+        byte[] nonMatching = bytes("Order ABCDE");
+
+        assertThat(regex.matcher(matching).match(0, matching.length, Option.DEFAULT))
+                .isEqualTo(matching.length);
+        assertThat(regex.matcher(nonMatching).match(0, nonMatching.length, Option.DEFAULT))
+                .isEqualTo(Matcher.FAILED);
+    }
+
+    @Test
     void regexStoresApplicationOptionsAndUserObject() {
         Regex regex = regex("color");
         Object marker = new Object();

--- a/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
+++ b/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
@@ -138,10 +138,10 @@ public class JoniTest {
 
     @Test
     void utf8EncodingMatchesUnicodeLiteralsAndReportsByteOffsets() {
-        Regex regex = regex("café\\s+(世界)");
-        byte[] input = bytes("prefix café 世界 suffix");
+        Regex regex = regex("caf\u00e9\\s+(\u4e16\u754c)");
+        byte[] input = bytes("prefix caf\u00e9 \u4e16\u754c suffix");
         int expectedStart = bytes("prefix ").length;
-        int expectedGroupStart = bytes("prefix café ").length;
+        int expectedGroupStart = bytes("prefix caf\u00e9 ").length;
 
         Matcher matcher = regex.matcher(input);
         int matchStart = matcher.search(0, input.length, Option.DEFAULT);
@@ -150,8 +150,8 @@ public class JoniTest {
         assertThat(regex.getEncoding()).isSameAs(UTF8Encoding.INSTANCE);
         assertThat(matchStart).isEqualTo(expectedStart);
         assertThat(region.getBeg(1)).isEqualTo(expectedGroupStart);
-        assertThat(extract(input, region, 0)).isEqualTo("café 世界");
-        assertThat(extract(input, region, 1)).isEqualTo("世界");
+        assertThat(extract(input, region, 0)).isEqualTo("caf\u00e9 \u4e16\u754c");
+        assertThat(extract(input, region, 1)).isEqualTo("\u4e16\u754c");
     }
 
     @Test

--- a/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
+++ b/tests/src/org.jruby.joni/joni/2.2.6/src/test/java/org_jruby_joni/joni/JoniTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jruby_joni.joni;
+
+import org.junit.jupiter.api.Test;
+
+class JoniTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jruby.joni/joni/2.2.6/user-code-filter.json
+++ b/tests/src/org.jruby.joni/joni/2.2.6/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.joni.**"
+    }
+  ]
+}

--- a/tests/src/org.jruby.joni/joni/2.2.6/user-code-filter.json
+++ b/tests/src/org.jruby.joni/joni/2.2.6/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.joni.**"
+      "includeClasses" : "org.joni.**"
+    },
+    {
+      "includeClasses" : "org_jruby_joni.joni.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #8411

This PR introduces tests and metadata for org.jruby.joni:joni:2.2.6, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 154962
- Cached input tokens: 1580032
- Output tokens: 20954
- Metadata entries: 1
- Iterations: 5
- Library coverage percentage: 33.52
- Generated lines of code: 198
- Tested library lines of code: 2823

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 14114/43797 (32.23%)
- Line: 2823/8423 (33.52%)
- Method: 515/1105 (46.61%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
