### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-cache as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-cache/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-cache/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-cache:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework.boot:spring-boot-cache:4.1.0, org.springframework.boot:spring-boot:4.1.0, and org.springframework:spring-context-support:7.0.8."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8404

This PR records `org.springframework.boot:spring-boot-starter-cache` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-cache:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework.boot:spring-boot-cache:4.1.0, org.springframework.boot:spring-boot:4.1.0, and org.springframework:spring-context-support:7.0.8.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
