### PR TITLE
[GenAI] Mark org.springframework.ai:spring-ai-starter-model-openai as not for Native Image

### DIFF
--- a/metadata/org.springframework.ai/spring-ai-starter-model-openai/index.json
+++ b/metadata/org.springframework.ai/spring-ai-starter-model-openai/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8399

This PR records `org.springframework.ai:spring-ai-starter-model-openai` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
