### PR TITLE
[GenAI] Add support for com.typesafe.akka:akka-slf4j_2.13:2.6.21 using gpt-5.5

### DIFF
--- a/metadata/com.typesafe.akka/akka-slf4j_2.13/2.6.21/reachability-metadata.json
+++ b/metadata/com.typesafe.akka/akka-slf4j_2.13/2.6.21/reachability-metadata.json
@@ -1,0 +1,383 @@
+{
+  "reflection" : [
+    {
+      "type" : "akka.event.slf4j.Slf4jLoggingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "akka.event.EventStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.slf4j.Slf4jLogger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LightArrayRevolverScheduler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config",
+            "akka.event.LoggingAdapter",
+            "java.util.concurrent.ThreadFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "akka.actor.ActorSystem$Settings",
+            "akka.event.EventStream",
+            "akka.actor.DynamicAccess"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.routing.ConsistentHashingPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.routing.RoundRobinPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.Props$EmptyActor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedDequeBasedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.BoundedDequeBasedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.MultipleConsumerSemantics"
+    },
+    {
+      "type" : "akka.dispatch.ControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.BoundedControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.event.LoggerMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.LoggerMailboxType",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider$Guardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.SupervisorStrategy"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider$SystemGuardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.SupervisorStrategy",
+            "akka.actor.ActorRef"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.DefaultSupervisorStrategy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.DeadLetterListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.EventStreamUnsubscriber",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.event.EventStream",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.SerializationExtension$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.ByteArraySerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.LongSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.IntSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.StringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.ByteStringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.BooleanSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.JavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.DisabledJavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.util.ByteString$ByteString1C"
+    },
+    {
+      "type" : "akka.util.ByteString$ByteString1"
+    },
+    {
+      "type" : "akka.util.ByteString$ByteStrings"
+    },
+    {
+      "type" : "scala.Long"
+    },
+    {
+      "type" : "scala.Int"
+    },
+    {
+      "type" : "scala.Boolean"
+    },
+    {
+      "type" : "akka.io.InetAddressDnsProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "reference.conf"
+    },
+    {
+      "glob" : "version.conf"
+    }
+  ]
+}

--- a/metadata/com.typesafe.akka/akka-slf4j_2.13/index.json
+++ b/metadata/com.typesafe.akka/akka-slf4j_2.13/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.6.21",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-slf4j_2.13/$version$/akka-slf4j_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/akka/akka-core",
+    "test-code-url" : "https://github.com/akka/akka-core/tree/v$version$/akka-slf4j/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/typesafe/akka/akka-slf4j_2.13/$version$/akka-slf4j_2.13-$version$-javadoc.jar",
+    "description" : "akka-slf4j_2.13 provides the SLF4J logger implementation for Akka event logging, letting Akka applications route logs through SLF4J backends such as Logback. It also includes SLF4J marker and diagnostic logging helpers so actor logs can carry marker and MDC context through the standard SLF4J API.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "2.6.21"
+    ],
+    "allowed-packages" : [
+      "akka.event.slf4j"
+    ]
+  }
+]

--- a/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/execution-metrics.json
+++ b/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T09:08:45.557379Z",
+    "library": "com.typesafe.akka:akka-slf4j_2.13:2.6.21",
+    "starting_commit": "75b8e5d6217f869a5488a51dcb0bc18b68e3bd5b",
+    "ending_commit": "74d56b3083d9c08d94db668b541dd4f6125417ba",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success_with_intervention",
+    "stats": {
+      "version": "2.6.21",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 668,
+          "missed": 289,
+          "ratio": 0.698015,
+          "total": 957
+        },
+        "line": {
+          "covered": 73,
+          "missed": 13,
+          "ratio": 0.848837,
+          "total": 86
+        },
+        "method": {
+          "covered": 49,
+          "missed": 19,
+          "ratio": 0.720588,
+          "total": 68
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 5418,
+      "issue_label": "library-new-request",
+      "library": "com.typesafe.akka:akka-slf4j_2.13:2.6.21",
+      "summary": "akka-slf4j is only the Akka SLF4J adapter; Akka documentation and the artifact POM show that meaningful runtime use requires an SLF4J backend, with Logback recommended and used by the artifact's own tests.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "ch.qos.logback:logback-classic:1.2.11",
+          "scope": "testImplementation",
+          "reason": "Akka 2.6.21 logging documentation says akka-slf4j has only slf4j-api at runtime and needs an SLF4J backend; the 2.6.21 docs and POM recommend/use logback-classic 1.2.11."
+        }
+      ],
+      "agent_guidance": "Use an in-test Typesafe Config when creating the ActorSystem so the SLF4J adapter is actually exercised, e.g. set akka.loggers=[\"akka.event.slf4j.Slf4jLogger\"], akka.logging-filter=\"akka.event.slf4j.Slf4jLoggingFilter\", akka.loglevel=\"DEBUG\", and optionally akka.stdout-loglevel=\"OFF\". Exercise the akka.event.slf4j classes through normal Akka logging/event-bus usage and terminate the ActorSystem cleanly.",
+      "risks": [
+        "Without enabling Slf4jLogger/Slf4jLoggingFilter in the ActorSystem configuration, tests may only cover default Akka stdout logging rather than the requested akka-slf4j adapter.",
+        "Without an SLF4J backend, SLF4J calls can become no-op/default-provider behavior, reducing meaningful coverage of the adapter path."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "ch.qos.logback:logback-classic:1.2.11",
+          "result": "applied",
+          "target": "tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5418 Support for com.typesafe.akka:akka-slf4j_2.13:2.6.21; label=library-new-request; body_chars=290"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 22414,
+      "output_tokens_used": 2012,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.typesafe.akka:akka-slf4j_2.13:2.6.21/library-preparation-preflight/pi-generation-2026-06-27T08-30-50-586016Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 208768,
+      "cached_input_tokens_used": 1509888,
+      "output_tokens_used": 19126,
+      "iterations": 4,
+      "cost_usd": 1.3287,
+      "generated_loc": 205,
+      "tested_library_loc": 73,
+      "metadata_entries": 76,
+      "code_coverage_percent": 84.88
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala",
+      "metadata_file": "metadata/com.typesafe.akka/akka-slf4j_2.13/2.6.21/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/stats.json
+++ b/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.6.21",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 668,
+        "missed" : 289,
+        "ratio" : 0.698015,
+        "total" : 957
+      },
+      "line" : {
+        "covered" : 73,
+        "missed" : 13,
+        "ratio" : 0.848837,
+        "total" : 86
+      },
+      "method" : {
+        "covered" : 49,
+        "missed" : 19,
+        "ratio" : 0.720588,
+        "total" : 68
+      }
+    }
+  } ]
+}

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/.gitignore
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/build.gradle
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
+
+dependencies {
+    testImplementation "com.typesafe.akka:akka-slf4j_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
+    testImplementation "ch.qos.logback:logback-classic:1.2.11"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/gradle.properties
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.typesafe.akka:akka-slf4j_2.13:2.6.21
+library.version = 2.6.21
+metadata.dir = com.typesafe.akka/akka-slf4j_2.13/2.6.21/

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/settings.gradle
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.typesafe.akka.akka-slf4j_2.13_tests'

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_akka.akka_slf4j_2_13
+
+import org.junit.jupiter.api.Test
+
+class Akka_slf4j_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
@@ -17,6 +17,7 @@ import akka.actor.Props
 import akka.actor.DiagnosticActorLogging
 import akka.event.Logging
 import akka.event.Logging.MDC
+import akka.event.slf4j.Slf4jLogMarker
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
@@ -29,6 +30,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
+import org.slf4j.Marker
+import org.slf4j.MarkerFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
@@ -83,6 +86,27 @@ class Akka_slf4j_2_13Test {
         appender.awaitExpectedMessages()
         val event: ILoggingEvent = assertCaptured(appender, Level.INFO, message)
         assertEquals(correlationId, event.getMDCPropertyMap.get("correlationId"))
+      }
+    }
+  }
+
+  @Test
+  def markerLoggingPublishesSlf4jMarkerThroughAdapter(): Unit = {
+    val message: String = "marker message routed through akka-slf4j"
+    val markerName: String = "akka-slf4j-functional-marker"
+    val slf4jMarker: Marker = MarkerFactory.getMarker(markerName)
+    val logMarker: Slf4jLogMarker = Slf4jLogMarker(slf4jMarker)
+
+    withCapturingAppender(Set(message)) { appender =>
+      withActorSystem("Slf4jAdapterMarkerLoggingTest") { system =>
+        val log = Logging.withMarker(system, "marker-logging-source")
+
+        log.info(logMarker, message)
+
+        appender.awaitExpectedMessages()
+        val event: ILoggingEvent = assertCaptured(appender, Level.INFO, message)
+        assertNotNull(event.getMarker)
+        assertEquals(markerName, event.getMarker.getName)
       }
     }
   }

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
@@ -17,7 +17,9 @@ import akka.actor.Props
 import akka.actor.DiagnosticActorLogging
 import akka.event.Logging
 import akka.event.Logging.MDC
+import akka.event.slf4j.SLF4JLogging
 import akka.event.slf4j.Slf4jLogMarker
+import akka.event.slf4j.{Logger => AkkaSlf4jLogger}
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
@@ -111,6 +113,29 @@ class Akka_slf4j_2_13Test {
     }
   }
 
+  @Test
+  def publicSlf4jLoggerFactoriesCreateUsableNamedLoggers(): Unit = {
+    val namedLoggerName: String = "akka.slf4j.public.factory"
+    val namedLoggerMessage: String = "message written through akka slf4j logger name factory"
+    val classLoggerMessage: String = "message written through akka slf4j logger class factory"
+    val traitLoggerMessage: String = "message written through akka slf4j logging trait"
+    val component: ComponentUsingSlf4jLogging = new ComponentUsingSlf4jLogging
+
+    withCapturingAppender(Set(namedLoggerMessage, classLoggerMessage, traitLoggerMessage)) { appender =>
+      AkkaSlf4jLogger(namedLoggerName).info(namedLoggerMessage)
+      AkkaSlf4jLogger(classOf[ComponentUsingSlf4jLogging], "ignored-source-name").info(classLoggerMessage)
+      component.writeInfo(traitLoggerMessage)
+
+      appender.awaitExpectedMessages()
+      val namedEvent: ILoggingEvent = assertCaptured(appender, Level.INFO, namedLoggerMessage)
+      assertEquals(namedLoggerName, namedEvent.getLoggerName)
+      val classEvent: ILoggingEvent = assertCaptured(appender, Level.INFO, classLoggerMessage)
+      assertEquals(classOf[ComponentUsingSlf4jLogging].getName, classEvent.getLoggerName)
+      val traitEvent: ILoggingEvent = assertCaptured(appender, Level.INFO, traitLoggerMessage)
+      assertEquals(component.getClass.getName, traitEvent.getLoggerName)
+    }
+  }
+
   private def withActorSystem(name: String)(testBody: ActorSystem => Unit): Unit = {
     val system: ActorSystem = ActorSystem(name, slf4jLoggingConfig)
     try {
@@ -167,6 +192,10 @@ object Akka_slf4j_2_13Test {
   )
 
   final case class LogWithMdc(correlationId: String, message: String)
+
+  final class ComponentUsingSlf4jLogging extends SLF4JLogging {
+    def writeInfo(message: String): Unit = log.info(message)
+  }
 
   final class DiagnosticLoggingActor extends Actor with DiagnosticActorLogging {
     override def mdc(currentMessage: Any): MDC = currentMessage match {

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/src/test/scala/com_typesafe_akka/akka_slf4j_2_13/Akka_slf4j_2_13Test.scala
@@ -6,11 +6,180 @@
  */
 package com_typesafe_akka.akka_slf4j_2_13
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import akka.actor.Actor
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.actor.DiagnosticActorLogging
+import akka.event.Logging
+import akka.event.Logging.MDC
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 
 class Akka_slf4j_2_13Test {
+  import Akka_slf4j_2_13Test._
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def configuredActorSystemRoutesClassicLoggingThroughSlf4jAdapter(): Unit = {
+    val debugMessage: String = "debug message routed through akka-slf4j"
+    val infoMessage: String = "info message routed through akka-slf4j"
+    val warningMessage: String = "warning message routed through akka-slf4j"
+    val errorMessage: String = "error message routed through akka-slf4j"
+    val error: IllegalStateException =
+      new IllegalStateException("expected slf4j adapter failure marker")
+
+    withCapturingAppender(Set(debugMessage, infoMessage, warningMessage, errorMessage)) { appender =>
+      withActorSystem("Slf4jAdapterClassicLoggingTest") { system =>
+        val log = Logging(system, "classic-logging-source")
+
+        log.debug(debugMessage)
+        log.info(infoMessage)
+        log.warning(warningMessage)
+        log.error(error, errorMessage)
+
+        appender.awaitExpectedMessages()
+        assertCaptured(appender, Level.DEBUG, debugMessage)
+        assertCaptured(appender, Level.INFO, infoMessage)
+        assertCaptured(appender, Level.WARN, warningMessage)
+        val errorEvent: ILoggingEvent = assertCaptured(appender, Level.ERROR, errorMessage)
+        assertNotNull(errorEvent.getThrowableProxy)
+        assertEquals(
+          classOf[IllegalStateException].getName,
+          errorEvent.getThrowableProxy.getClassName
+        )
+      }
+    }
+  }
+
+  @Test
+  def diagnosticActorLoggingPublishesMdcThroughSlf4jAdapter(): Unit = {
+    val message: String = "diagnostic actor message routed through akka-slf4j"
+    val correlationId: String = "correlation-id-akka-slf4j"
+
+    withCapturingAppender(Set(message)) { appender =>
+      withActorSystem("Slf4jAdapterDiagnosticLoggingTest") { system =>
+        val actor = system.actorOf(Props(new DiagnosticLoggingActor), "diagnostic-logging-actor")
+
+        actor ! LogWithMdc(correlationId, message)
+
+        appender.awaitExpectedMessages()
+        val event: ILoggingEvent = assertCaptured(appender, Level.INFO, message)
+        assertEquals(correlationId, event.getMDCPropertyMap.get("correlationId"))
+      }
+    }
+  }
+
+  private def withActorSystem(name: String)(testBody: ActorSystem => Unit): Unit = {
+    val system: ActorSystem = ActorSystem(name, slf4jLoggingConfig)
+    try {
+      testBody(system)
+    } finally {
+      Await.result(system.terminate(), TestTimeout)
+    }
+  }
+
+  private def withCapturingAppender(
+    expectedMessages: Set[String]
+  )(testBody: CapturingAppender => Unit): Unit = {
+    val context: LoggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+    val rootLogger: Logger =
+      LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+    val previousLevel: Level = rootLogger.getLevel
+    val appender: CapturingAppender = new CapturingAppender(expectedMessages)
+    appender.setContext(context)
+    appender.start()
+    rootLogger.setLevel(Level.DEBUG)
+    rootLogger.addAppender(appender)
+    try {
+      testBody(appender)
+    } finally {
+      rootLogger.detachAppender(appender)
+      appender.stop()
+      rootLogger.setLevel(previousLevel)
+    }
+  }
+
+  private def assertCaptured(appender: CapturingAppender, level: Level, message: String): ILoggingEvent = {
+    val matchingEvents: Seq[ILoggingEvent] = appender.events.filter { event =>
+      level == event.getLevel && event.getFormattedMessage.contains(message)
+    }
+    assertTrue(
+      matchingEvents.nonEmpty,
+      s"Did not capture $level event containing '$message'."
+    )
+    matchingEvents.head
+  }
+}
+
+object Akka_slf4j_2_13Test {
+  private val TestTimeout = 10.seconds
+
+  private val slf4jLoggingConfig: Config = ConfigFactory.parseString(
+    """
+      |akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
+      |akka.logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+      |akka.loglevel = "DEBUG"
+      |akka.stdout-loglevel = "OFF"
+      |akka.actor.default-dispatcher.shutdown-timeout = 10s
+      |""".stripMargin
+  )
+
+  final case class LogWithMdc(correlationId: String, message: String)
+
+  final class DiagnosticLoggingActor extends Actor with DiagnosticActorLogging {
+    override def mdc(currentMessage: Any): MDC = currentMessage match {
+      case LogWithMdc(correlationId, _) => Map("correlationId" -> correlationId)
+      case _ => Map.empty
+    }
+
+    override def receive: Receive = {
+      case LogWithMdc(_, message) => log.info(message)
+    }
+  }
+
+  final class CapturingAppender(expectedMessages: Set[String]) extends AppenderBase[ILoggingEvent] {
+    private val remainingMessages = ConcurrentHashMap.newKeySet[String]()
+    remainingMessages.addAll(expectedMessages.asJava)
+
+    private val latch: CountDownLatch = new CountDownLatch(expectedMessages.size)
+    private val capturedEvents: CopyOnWriteArrayList[ILoggingEvent] =
+      new CopyOnWriteArrayList[ILoggingEvent]()
+
+    override protected def append(eventObject: ILoggingEvent): Unit = {
+      capturedEvents.add(eventObject)
+      expectedMessages.foreach { expectedMessage =>
+        val isExpectedMessage: Boolean = eventObject.getFormattedMessage.contains(expectedMessage)
+        if (isExpectedMessage && remainingMessages.remove(expectedMessage)) {
+          latch.countDown()
+        }
+      }
+    }
+
+    def events: Seq[ILoggingEvent] = capturedEvents.asScala.toSeq
+
+    def awaitExpectedMessages(): Unit = {
+      assertTrue(
+        latch.await(TestTimeout.toSeconds, TimeUnit.SECONDS),
+        s"Timed out waiting for messages: ${remainingMessages.asScala.mkString(", ")}"
+      )
+    }
   }
 }

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/user-code-filter.json
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "akka.event.slf4j.**"
+      "includeClasses" : "akka.event.slf4j.**"
+    },
+    {
+      "includeClasses" : "com_typesafe_akka.akka_slf4j_2_13.**"
     }
   ]
 }

--- a/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/user-code-filter.json
+++ b/tests/src/com.typesafe.akka/akka-slf4j_2.13/2.6.21/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "akka.event.slf4j.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5418

This PR introduces tests and metadata for com.typesafe.akka:akka-slf4j_2.13:2.6.21, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 208768
- Cached input tokens: 1509888
- Output tokens: 19126
- Metadata entries: 76
- Iterations: 4
- Library coverage percentage: 84.88
- Generated lines of code: 205
- Tested library lines of code: 73

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 668/957 (69.80%)
- Line: 73/86 (84.88%)
- Method: 49/68 (72.06%)

### Post-Generation Intervention

- Stage: `metadata_fix_failed`

- Intervention file: `post-gen-interventions/com.typesafe.akka_akka-slf4j_2.13_2.6.21.md`

# Post-generation intervention report

Library: com.typesafe.akka:akka-slf4j_2.13:2.6.21
Stage: metadata_fix_failed

## Summary

The native test run builds the image successfully, but `nativeTest` fails in three generated tests that create an Akka `ActorSystem` configured to route logging through `akka-slf4j`:

- `configuredActorSystemRoutesClassicLoggingThroughSlf4jAdapter()`
- `diagnosticActorLoggingPublishesMdcThroughSlf4jAdapter()`
- `markerLoggingPublishesSlf4jMarkerThroughAdapter()`

All three fail before exercising their assertions with `com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'akka.version'`. The fourth generated test, `publicSlf4jLoggerFactoriesCreateUsableNamedLoggers()`, succeeds because it only exercises the public `akka.event.slf4j.Logger`/`SLF4JLogging` factories and does not boot an `ActorSystem`.

## Root cause

This is metadata-related, not an unsupported native-image behavior and not a test that should be removed. Akka obtains required defaults such as `akka.version` from its packaged configuration resources (`reference.conf`/Akka configuration defaults). In the native image, the actor-system tests reach `ActorSystem$Settings` with those defaults unavailable, so the merged configuration lacks `akka.version`.

The Codex metadata-fix log shows a partial metadata repair loop rather than a non-metadata limitation. Codex repeatedly advanced through Akka startup by adding reachability entries for reflective constructors and class lookups, but it did not complete the full set of resources/classes needed for this actor-system path. The log also records that the repository metadata generator could not be used with the pinned GraalVM because `libnative-image-agent` was unavailable, leaving the repair manual and incomplete. Later iterations in the log had moved into further Akka serialization/bootstrap class lookup gaps, confirming that metadata was still incomplete.

## Action taken

No generated tests were removed. The failures are caused by missing or incomplete reachability metadata/resources, and the instructions require preserving metadata-related tests so the remaining missing metadata can be reported rather than hidden.

## Why preserve the remaining generated support

The generated support still covers meaningful `akka-slf4j` behavior:

- the passing logger-factory test validates public `akka-slf4j` APIs without requiring Akka system startup;
- the failing actor-system tests are legitimate coverage for classic Akka logging, diagnostic MDC propagation, and SLF4J marker propagation through the adapter;
- those tests expose real missing native-image reachability support for Akka configuration/bootstrap paths, so deleting them would mask incomplete metadata rather than remove an invalid scenario.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
