### PR TITLE
[GenAI] Add support for com.softwaremill.sttp.shared:pekko_3:1.5.1 using gpt-5.5

### DIFF
--- a/metadata/com.softwaremill.sttp.shared/pekko_3/1.5.1/reachability-metadata.json
+++ b/metadata/com.softwaremill.sttp.shared/pekko_3/1.5.1/reachability-metadata.json
@@ -1,0 +1,424 @@
+{
+  "reflection" : [
+    {
+      "type" : "org.apache.pekko.event.DefaultLoggingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "org.apache.pekko.event.EventStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.event.Logging$DefaultLogger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.SerializationExtension$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.stream.SystemMaterializer$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.DefaultSupervisorStrategy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.LightArrayRevolverScheduler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config",
+            "org.apache.pekko.event.LoggingAdapter",
+            "java.util.concurrent.ThreadFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.PekkoJdk9ForkJoinPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "int",
+            "java.util.concurrent.ForkJoinPool$ForkJoinWorkerThreadFactory",
+            "int",
+            "java.lang.Thread$UncaughtExceptionHandler",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.event.LoggerMailboxType",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.LocalActorRefProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "org.apache.pekko.event.EventStream",
+            "org.apache.pekko.actor.DynamicAccess"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.LocalActorRefProvider$Guardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.SupervisorStrategy"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.LocalActorRefProvider$SystemGuardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.SupervisorStrategy",
+            "org.apache.pekko.actor.ActorRef"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.routing.ConsistentHashingPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.routing.RoundRobinPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.actor.Props$EmptyActor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.event.DeadLetterListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.event.EventStreamUnsubscriber",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.event.EventStream",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.JavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.ByteArraySerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.LongSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.IntSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.StringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.ByteStringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.BooleanSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.serialization.DisabledJavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.stream.serialization.StreamRefSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.util.ByteString$ByteString1C"
+    },
+    {
+      "type" : "org.apache.pekko.util.ByteString$ByteString1"
+    },
+    {
+      "type" : "org.apache.pekko.util.ByteString$ByteStrings"
+    },
+    {
+      "type" : "scala.Long"
+    },
+    {
+      "type" : "scala.Int"
+    },
+    {
+      "type" : "scala.Boolean"
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.DequeBasedMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedDequeBasedMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedDequeBasedMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.MultipleConsumerSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.ControlAwareMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedControlAwareMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedControlAwareMessageQueueSemantics",
+      "allPublicMethods" : true
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.UnboundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.dispatch.BoundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.apache.pekko.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "reference.conf"
+    },
+    {
+      "glob" : "version.conf"
+    }
+  ]
+}

--- a/metadata/com.softwaremill.sttp.shared/pekko_3/index.json
+++ b/metadata/com.softwaremill.sttp.shared/pekko_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.5.1",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/softwaremill/sttp/shared/pekko_3/$version$/pekko_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/softwaremill/sttp-shared",
+    "test-code-url" : "https://github.com/softwaremill/sttp-shared/tree/v$version$/pekko/src/test/scala",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/softwaremill/sttp/shared/pekko_3/$version$/pekko_3-$version$-javadoc.jar",
+    "description" : "sttp-shared provides common abstractions used across the sttp Scala HTTP ecosystem, including capabilities and streaming support. The pekko_3 module supplies the Pekko Streams capability implementation, modeling binary streams and pipes with Pekko Source and Flow types.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.5.1"
+    ],
+    "allowed-packages" : [
+      "sttp.capabilities.pekko"
+    ]
+  }
+]

--- a/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/execution-metrics.json
+++ b/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T10:06:10.951812Z",
+    "library": "com.softwaremill.sttp.shared:pekko_3:1.5.1",
+    "starting_commit": "98aae6998fcc0594601ad76d54619371732a276a",
+    "ending_commit": "62dee2f5e3c6d7df23a8be5652d2b64475b9fe8c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success_with_intervention",
+    "stats": {
+      "version": "1.5.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 36,
+          "missed": 19,
+          "ratio": 0.654545,
+          "total": 55
+        },
+        "line": {
+          "covered": 5,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 5
+        },
+        "method": {
+          "covered": 4,
+          "missed": 3,
+          "ratio": 0.571429,
+          "total": 7
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 5432,
+      "issue_label": "library-new-request",
+      "library": "com.softwaremill.sttp.shared:pekko_3:1.5.1",
+      "summary": "The library's only meaningful API is Pekko-stream based, but `org.apache.pekko:pekko-stream_3:1.5.0` is declared as `provided` in the artifact POM and is not pulled transitively for tests.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.pekko:pekko-stream_3:1.5.0",
+          "scope": "testImplementation",
+          "reason": "`sttp.capabilities.pekko.PekkoStreams` exposes and calls `org.apache.pekko.stream.scaladsl.Source`, `FlowOps`, and `org.apache.pekko.util.ByteString`; the upstream build marks `pekko-stream` as provided, so generated tests need it explicitly to compile and exercise the API."
+        }
+      ],
+      "agent_guidance": "For meaningful coverage, create a small Pekko `Source` of `ByteString`, call `PekkoStreams.limitBytes`, materialize it using a short-lived `org.apache.pekko.actor.ActorSystem`, and terminate the actor system after the assertion. No Docker image, environment variable, or system property appears required.",
+      "risks": [
+        "The artifact is a Scala 3 module, so generated Java tests may need to use the Java-accessible forms of Scala/Pekko APIs carefully.",
+        "Pekko stream materialization may introduce native-image metadata needs, but local Gradle and Native Image verification should remain authoritative."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.pekko:pekko-stream_3:1.5.0",
+          "result": "applied",
+          "target": "tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5432 Support for com.softwaremill.sttp.shared:pekko_3:1.5.1; label=library-new-request; body_chars=111"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 25674,
+      "output_tokens_used": 2701,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.softwaremill.sttp.shared:pekko_3:1.5.1/library-preparation-preflight/pi-generation-2026-06-27T09-30-01-165014Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 134693,
+      "cached_input_tokens_used": 1504256,
+      "output_tokens_used": 19459,
+      "iterations": 4,
+      "cost_usd": 1.3359,
+      "generated_loc": 167,
+      "tested_library_loc": 5,
+      "metadata_entries": 90,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala",
+      "metadata_file": "metadata/com.softwaremill.sttp.shared/pekko_3/1.5.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/stats.json
+++ b/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.5.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 36,
+        "missed" : 19,
+        "ratio" : 0.654545,
+        "total" : 55
+      },
+      "line" : {
+        "covered" : 5,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 5
+      },
+      "method" : {
+        "covered" : 4,
+        "missed" : 3,
+        "ratio" : 0.571429,
+        "total" : 7
+      }
+    }
+  } ]
+}

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/.gitignore
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/build.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
+
+dependencies {
+    testImplementation "com.softwaremill.sttp.shared:pekko_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
+    testImplementation "org.apache.pekko:pekko-stream_3:1.5.0"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/gradle.properties
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.softwaremill.sttp.shared:pekko_3:1.5.1
+library.version = 1.5.1
+metadata.dir = com.softwaremill.sttp.shared/pekko_3/1.5.1/

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/settings.gradle
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.softwaremill.sttp.shared.pekko_3_tests'

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_softwaremill_sttp_shared.pekko_3
+
+import org.junit.jupiter.api.Test
+
+class Pekko_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
@@ -149,6 +149,27 @@ class Pekko_3Test {
     assertEquals(Right(Seq(ByteString("a"), ByteString("bc"))), secondRun)
   }
 
+  @Test
+  def limitBytesPreservesTheSourceMaterializedValueWhenTheLimitIsExceeded(): Unit = withActorSystem {
+    val expectedMaterializedValue: String = "source-materialized-value"
+    val source: Source[ByteString, String] = Source
+      .single(ByteString("too-large"))
+      .mapMaterializedValue(_ => expectedMaterializedValue)
+    val limited: Source[ByteString, Any] = PekkoStreams.limitBytes(source, 3L)
+
+    val (materializedValue: Any, collectedFuture: Future[Seq[ByteString]]) = limited
+      .toMat(Sink.seq[ByteString])(Keep.both)
+      .run()
+    val result: Either[Throwable, Seq[ByteString]] = try {
+      Right(Await.result(collectedFuture, 10.seconds))
+    } catch {
+      case NonFatal(error) => Left(error)
+    }
+
+    assertEquals(expectedMaterializedValue, materializedValue)
+    assertLimitExceeded(result, expectedMaxBytes = 3L)
+  }
+
   private def withActorSystem[A](body: Materializer ?=> A): A = {
     val system: ActorSystem = ActorSystem("Pekko_3Test")
     val materializer: Materializer = Materializer(system)

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
@@ -9,6 +9,7 @@ package com_softwaremill_sttp_shared.pekko_3
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Keep
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
@@ -78,6 +79,22 @@ class Pekko_3Test {
     val collected: Either[Throwable, Seq[String]] = collect(limited.map(_.utf8String))
 
     assertEquals(Right(Seq("a", "bb", "ccc")), collected)
+  }
+
+  @Test
+  def limitBytesPreservesTheSourceMaterializedValue(): Unit = withActorSystem {
+    val expectedMaterializedValue: String = "source-materialized-value"
+    val source: Source[ByteString, String] = Source
+      .single(ByteString("ok"))
+      .mapMaterializedValue(_ => expectedMaterializedValue)
+    val limited: Source[ByteString, Any] = PekkoStreams.limitBytes(source, 2L)
+
+    val (materializedValue: Any, collectedFuture: Future[Seq[ByteString]]) = limited
+      .toMat(Sink.seq[ByteString])(Keep.both)
+      .run()
+
+    assertEquals(expectedMaterializedValue, materializedValue)
+    assertEquals(Seq(ByteString("ok")), Await.result(collectedFuture, 10.seconds))
   }
 
   @Test

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/src/test/scala/com_softwaremill_sttp_shared/pekko_3/Pekko_3Test.scala
@@ -6,11 +6,165 @@
  */
 package com_softwaremill_sttp_shared.pekko_3
 
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import sttp.capabilities.StreamMaxLengthExceededException
+import sttp.capabilities.Streams
+import sttp.capabilities.pekko.PekkoStreams
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+import scala.util.control.NonFatal
 
 class Pekko_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def pekkoStreamsExposeTypedBinaryStreamAndFlowCapabilities(): Unit = withActorSystem {
+    val streamsCapability: Streams[PekkoStreams] = PekkoStreams
+    val binary: PekkoStreams.BinaryStream = Source.single(ByteString("pekko"))
+    val toUpperCase: PekkoStreams.Pipe[ByteString, String] = Flow[ByteString].map(_.utf8String.toUpperCase)
+
+    val collected: Either[Throwable, Seq[String]] = collect(binary.via(toUpperCase))
+
+    assertNotNull(streamsCapability)
+    assertEquals(Right(Seq("PEKKO")), collected)
+  }
+
+  @Test
+  def limitBytesAllowsEmptyStreamsAndStreamsUnderTheLimit(): Unit = withActorSystem {
+    val empty: Source[ByteString, Any] = Source.empty[ByteString]
+    val underLimit: Source[ByteString, Any] = Source(List(ByteString("ab"), ByteString("c")))
+
+    assertEquals(Right(Seq.empty[ByteString]), collect(PekkoStreams.limitBytes(empty, 0L)))
+    assertEquals(Right(Seq(ByteString("ab"), ByteString("c"))), collect(PekkoStreams.limitBytes(underLimit, 4L)))
+  }
+
+  @Test
+  def limitBytesAllowsExactlyTheMaximumNumberOfBytes(): Unit = withActorSystem {
+    val exactLimit: Source[ByteString, Any] = Source(List(ByteString("ab"), ByteString("cd"), ByteString("e")))
+
+    val collected: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(exactLimit, 5L))
+
+    assertEquals(Right(Seq(ByteString("ab"), ByteString("cd"), ByteString("e"))), collected)
+  }
+
+  @Test
+  def limitBytesPreservesOriginalByteStringChunksAndOrdering(): Unit = withActorSystem {
+    val chunked: Source[ByteString, Any] = Source(List(ByteString("one"), ByteString.empty, ByteString("two")))
+
+    val collected: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(chunked, 6L))
+
+    assertEquals(Right(Seq(ByteString("one"), ByteString.empty, ByteString("two"))), collected)
+  }
+
+  @Test
+  def limitBytesCanBeUsedWithOrdinaryPekkoFlowTransformations(): Unit = withActorSystem {
+    val transformed: Source[ByteString, Any] = Source(List("a", "bb", "ccc", "dddd"))
+      .filter(_.length <= 3)
+      .map(value => ByteString(value))
+    val limited: Source[ByteString, Any] = PekkoStreams.limitBytes(transformed, 6L)
+
+    val collected: Either[Throwable, Seq[String]] = collect(limited.map(_.utf8String))
+
+    assertEquals(Right(Seq("a", "bb", "ccc")), collected)
+  }
+
+  @Test
+  def limitBytesRaisesStreamMaxLengthExceededWhenAccumulatedChunksExceedTheLimit(): Unit = withActorSystem {
+    val source: Source[ByteString, Any] = Source(List(ByteString("ab"), ByteString("cd")))
+
+    val result: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(source, 3L))
+
+    assertLimitExceeded(result, expectedMaxBytes = 3L)
+  }
+
+  @Test
+  def limitBytesRaisesStreamMaxLengthExceededWhenASingleChunkIsTooLarge(): Unit = withActorSystem {
+    val source: Source[ByteString, Any] = Source.single(ByteString("abcd"))
+
+    val result: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(source, 2L))
+
+    assertLimitExceeded(result, expectedMaxBytes = 2L)
+  }
+
+  @Test
+  def limitBytesTreatsZeroAsOnlyAllowingEmptyStreams(): Unit = withActorSystem {
+    val nonEmpty: Source[ByteString, Any] = Source.single(ByteString("x"))
+
+    val result: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(nonEmpty, 0L))
+
+    assertLimitExceeded(result, expectedMaxBytes = 0L)
+  }
+
+  @Test
+  def limitBytesPropagatesUpstreamFailuresWithoutWrappingThem(): Unit = withActorSystem {
+    val upstreamFailure: IllegalStateException = new IllegalStateException("upstream failed")
+    val source: Source[ByteString, Any] = Source
+      .single(ByteString("ok"))
+      .concat(Source.failed[ByteString](upstreamFailure))
+
+    val result: Either[Throwable, Seq[ByteString]] = collect(PekkoStreams.limitBytes(source, 10L))
+
+    assertEquals(Left(upstreamFailure), result)
+    assertSame(upstreamFailure, failure(result))
+  }
+
+  @Test
+  def limitedStreamsCanBeMaterializedMoreThanOnceWithIndependentByteCounts(): Unit = withActorSystem {
+    val source: Source[ByteString, Any] = Source(List(ByteString("a"), ByteString("bc")))
+    val limited: Source[ByteString, Any] = PekkoStreams.limitBytes(source, 3L)
+
+    val firstRun: Either[Throwable, Seq[ByteString]] = collect(limited)
+    val secondRun: Either[Throwable, Seq[ByteString]] = collect(limited)
+
+    assertEquals(Right(Seq(ByteString("a"), ByteString("bc"))), firstRun)
+    assertEquals(Right(Seq(ByteString("a"), ByteString("bc"))), secondRun)
+  }
+
+  private def withActorSystem[A](body: Materializer ?=> A): A = {
+    val system: ActorSystem = ActorSystem("Pekko_3Test")
+    val materializer: Materializer = Materializer(system)
+    try {
+      given Materializer = materializer
+      body
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+    }
+  }
+
+  private def collect[A](source: Source[A, Any])(using materializer: Materializer): Either[Throwable, Seq[A]] = {
+    val collected: Future[Seq[A]] = source.runWith(Sink.seq[A])
+    try {
+      Right(Await.result(collected, 10.seconds))
+    } catch {
+      case NonFatal(error) => Left(error)
+    }
+  }
+
+  private def assertLimitExceeded[A](result: Either[Throwable, Seq[A]], expectedMaxBytes: Long): Unit = {
+    assertTrue(result.isLeft)
+    val exception: StreamMaxLengthExceededException = assertInstanceOf(
+      classOf[StreamMaxLengthExceededException],
+      failure(result)
+    )
+    assertEquals(expectedMaxBytes, exception.maxBytes)
+    assertEquals(s"Stream length limit of $expectedMaxBytes bytes exceeded", exception.getMessage)
+    assertFalse(result.isRight)
+  }
+
+  private def failure[A](result: Either[Throwable, A]): Throwable = result match {
+    case Left(error) => error
+    case Right(_)    => throw new AssertionError("Expected stream to fail")
   }
 }

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/user-code-filter.json
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "sttp.capabilities.pekko.**"
+    }
+  ]
+}

--- a/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/user-code-filter.json
+++ b/tests/src/com.softwaremill.sttp.shared/pekko_3/1.5.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "sttp.capabilities.pekko.**"
+      "includeClasses" : "sttp.capabilities.pekko.**"
+    },
+    {
+      "includeClasses" : "com_softwaremill_sttp_shared.pekko_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5432

This PR introduces tests and metadata for com.softwaremill.sttp.shared:pekko_3:1.5.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 134693
- Cached input tokens: 1504256
- Output tokens: 19459
- Metadata entries: 90
- Iterations: 4
- Library coverage percentage: 100.0
- Generated lines of code: 167
- Tested library lines of code: 5

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `d7c4a57b6eaa398346728e835861d1eff0e73849`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 36/55 (65.45%)
- Line: 5/5 (100.00%)
- Method: 4/7 (57.14%)

### Post-Generation Intervention

- Stage: `metadata_fix_failed`

- Intervention file: `post-gen-interventions/com.softwaremill.sttp.shared_pekko_3_1.5.1.md`

# Post-generation intervention report

Library: com.softwaremill.sttp.shared:pekko_3:1.5.1
Stage: metadata_fix_failed

## Summary

The Gradle excerpt shows all 12 generated `Pekko_3Test` native tests failing at Pekko `ActorSystem` startup with the same exception:

```text
com.typesafe.config.ConfigException$Missing: system properties: No configuration setting found for key 'pekko'
```

This is metadata-related, not an unsupported native-image behavior or a test bug. The tests exercise normal `sttp.capabilities.pekko.PekkoStreams` stream construction, byte limiting, materialization, and failure propagation; they do not depend on runtime bytecode generation, class redefinition, Java agent attachment, instrumentation, substitutions, or Byte Buddy-backed mocking.

No generated tests were removed.

## Root cause classification

Every failing test has the same root cause: Pekko tries to build an `ActorSystem`, and `ActorSystem$Settings.amendSlf4jConfig` reads the `pekko` configuration namespace from Typesafe Config. In the failing native image, the Pekko configuration resources were not available, so Typesafe Config only reported `system properties` as the source and could not find the required `pekko` key.

The Codex metadata-fix log confirms this was a reachability/resource-metadata path. After the initial `ConfigException$Missing` failure, Codex iterated through the Pekko startup metadata needed by the actor system, including Pekko reference configuration resources and config-driven reflective/runtime class lookups for Pekko serializers, the stream serializer, binding target classes such as `scala.Int`, `scala.Long`, and `scala.Boolean`, and Pekko `ByteString` binding classes.

The final pinned run recorded in the Codex log passed all 12 tests, so the provided Gradle failure excerpt appears to be an earlier metadata gap rather than a remaining unsupported native-image limitation. There is no remaining generated test in this suite whose failure should be handled by deletion.

## Why the remaining generated support should be preserved

The generated tests provide meaningful coverage for `com.softwaremill.sttp.shared:pekko_3:1.5.1` by exercising the public `PekkoStreams` capability and `limitBytes` behavior on real Pekko `Source`, `Flow`, `Sink`, `ByteString`, materialization, and stream-failure paths. Preserving them keeps coverage for the native-image metadata that Pekko needs at normal actor-system and stream startup, especially resource loading and config-driven serializer/binding initialization.

Because the observed failures are metadata-related and the Codex log shows the support can run successfully after metadata completion, deleting these tests would remove valid native-image coverage instead of avoiding an unsupported platform feature.

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
