### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-quartz as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-quartz/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-quartz/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-quartz:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.",
+    "replacement": "Use the class-bearing org.springframework.boot:spring-boot-quartz:4.1.0 artifact for Quartz auto-configuration."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8722

This PR records `org.springframework.boot:spring-boot-starter-quartz` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-quartz:4.1.0 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by dependencies.

Replacement guidance:
- Use the class-bearing org.springframework.boot:spring-boot-quartz:4.1.0 artifact for Quartz auto-configuration.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fed8abd7b7c260a454a60bd37b32ba6803cf9d6f`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
