### PR TITLE
[GenAI] Add support for com.typesafe.play:play-streams_2.13:2.9.10 using gpt-5.5

### DIFF
--- a/metadata/com.typesafe.play/play-streams_2.13/2.9.10/reachability-metadata.json
+++ b/metadata/com.typesafe.play/play-streams_2.13/2.9.10/reachability-metadata.json
@@ -1,0 +1,411 @@
+{
+  "reflection" : [
+    {
+      "type" : "akka.event.DefaultLoggingFilter",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "akka.event.EventStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.Logging$DefaultLogger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LightArrayRevolverScheduler",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config",
+            "akka.event.LoggingAdapter",
+            "java.util.concurrent.ThreadFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "akka.actor.ActorSystem$Settings",
+            "akka.event.EventStream",
+            "akka.actor.DynamicAccess"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.routing.ConsistentHashingPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.routing.RoundRobinPool",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.Props$EmptyActor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedDequeBasedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.BoundedDequeBasedMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.MultipleConsumerSemantics"
+    },
+    {
+      "type" : "akka.dispatch.ControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.BoundedControlAwareMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.event.LoggerMessageQueueSemantics"
+    },
+    {
+      "type" : "akka.dispatch.UnboundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedDequeBasedMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.UnboundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.dispatch.BoundedControlAwareMailbox",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.LoggerMailboxType",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ActorSystem$Settings",
+            "com.typesafe.config.Config"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider$Guardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.SupervisorStrategy"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.LocalActorRefProvider$SystemGuardian",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.SupervisorStrategy",
+            "akka.actor.ActorRef"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.actor.DefaultSupervisorStrategy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.DeadLetterListener",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.event.EventStreamUnsubscriber",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.event.EventStream",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.SerializationExtension$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "type" : "akka.stream.SystemMaterializer$",
+      "fields" : [
+        {
+          "name" : "MODULE$"
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.ByteArraySerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.LongSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.IntSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.StringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.ByteStringSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.BooleanSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.JavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.serialization.DisabledJavaSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.stream.serialization.StreamRefSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "akka.actor.ExtendedActorSystem"
+          ]
+        }
+      ]
+    },
+    {
+      "type" : "akka.stream.SinkRef"
+    },
+    {
+      "type" : "akka.stream.SourceRef"
+    },
+    {
+      "type" : "akka.stream.impl.streamref.StreamRefsProtocol"
+    },
+    {
+      "type" : "akka.util.ByteString$ByteString1C"
+    },
+    {
+      "type" : "akka.util.ByteString$ByteString1"
+    },
+    {
+      "type" : "akka.util.ByteString$ByteStrings"
+    },
+    {
+      "type" : "scala.Long"
+    },
+    {
+      "type" : "scala.Int"
+    },
+    {
+      "type" : "scala.Boolean"
+    },
+    {
+      "type" : "akka.io.InetAddressDnsProvider",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "glob" : "reference.conf"
+    },
+    {
+      "glob" : "version.conf"
+    }
+  ]
+}

--- a/metadata/com.typesafe.play/play-streams_2.13/index.json
+++ b/metadata/com.typesafe.play/play-streams_2.13/index.json
@@ -1,0 +1,22 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.9.10",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/typesafe/play/play-streams_2.13/$version$/play-streams_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/playframework/playframework",
+    "test-code-url" : "https://github.com/playframework/playframework/tree/$version$/core/play-streams/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/typesafe/play/play-streams_2.13/$version$/play-streams_2.13-$version$-javadoc.jar",
+    "description" : "Play Streams provides Play Framework's stream integration layer for Scala and Java APIs backed by Akka Streams and Reactive Streams. It includes utilities such as accumulators, actor-backed flows, stream execution helpers, and gzip flows used by Play applications.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "2.9.10"
+    ],
+    "allowed-packages" : [
+      "play.api.libs.streams",
+      "play.libs.streams"
+    ]
+  }
+]

--- a/stats/com.typesafe.play/play-streams_2.13/2.9.10/execution-metrics.json
+++ b/stats/com.typesafe.play/play-streams_2.13/2.9.10/execution-metrics.json
@@ -1,0 +1,88 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T17:42:20.168905Z",
+    "library": "com.typesafe.play:play-streams_2.13:2.9.10",
+    "starting_commit": "64bdcff83773790b141ef9c55d272d4f2885ef77",
+    "ending_commit": "54e405b3639a4fedcce7e862843c0caa445a8bbc",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.9.10",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 949,
+          "missed": 2146,
+          "ratio": 0.306624,
+          "total": 3095
+        },
+        "line": {
+          "covered": 144,
+          "missed": 217,
+          "ratio": 0.398892,
+          "total": 361
+        },
+        "method": {
+          "covered": 100,
+          "missed": 281,
+          "ratio": 0.262467,
+          "total": 381
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 5467,
+      "issue_label": "library-new-request",
+      "library": "com.typesafe.play:play-streams_2.13:2.9.10",
+      "summary": "No extra Maven dependency or Docker image is needed, but meaningful tests need an Akka Streams fixture because play-streams is a thin Play wrapper over Akka Streams.",
+      "deterministic_setup": [],
+      "agent_guidance": "Create an akka.actor.ActorSystem in test setup, derive a Materializer with Materializer.matFromSystem(system), and terminate the ActorSystem in teardown. Use Akka javadsl Source/Sink/Flow to exercise play.libs.streams.Accumulator methods such as fromSink, map, through, run, and recover. No environment variables or system properties were found to be required.",
+      "risks": [
+        "Tests that create an ActorSystem but do not terminate it may hang or leak threads.",
+        "The Scala API surface is present, but Java tests can reach meaningful coverage through play.libs.streams.Accumulator without adding Scala test libraries.",
+        "Akka may emit JDK Unsafe deprecation warnings on newer JDKs; these do not indicate missing setup."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5467 Support for com.typesafe.play:play-streams_2.13:2.9.10; label=library-new-request; body_chars=111"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 25690,
+      "output_tokens_used": 4170,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.typesafe.play:play-streams_2.13:2.9.10/library-preparation-preflight/pi-generation-2026-06-27T17-15-50-279232Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 176141,
+      "cached_input_tokens_used": 1193472,
+      "output_tokens_used": 16778,
+      "iterations": 5,
+      "cost_usd": 1.1,
+      "generated_loc": 222,
+      "tested_library_loc": 144,
+      "metadata_entries": 83,
+      "code_coverage_percent": 39.89
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala",
+      "metadata_file": "metadata/com.typesafe.play/play-streams_2.13/2.9.10/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.typesafe.play/play-streams_2.13/2.9.10/stats.json
+++ b/stats/com.typesafe.play/play-streams_2.13/2.9.10/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "2.9.10",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 949,
+        "missed" : 2146,
+        "ratio" : 0.306624,
+        "total" : 3095
+      },
+      "line" : {
+        "covered" : 144,
+        "missed" : 217,
+        "ratio" : 0.398892,
+        "total" : 361
+      },
+      "method" : {
+        "covered" : 100,
+        "missed" : 281,
+        "ratio" : 0.262467,
+        "total" : 381
+      }
+    }
+  } ]
+}

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/.gitignore
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/build.gradle
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
+
+dependencies {
+    testImplementation "com.typesafe.play:play-streams_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/gradle.properties
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.typesafe.play:play-streams_2.13:2.9.10
+library.version = 2.9.10
+metadata.dir = com.typesafe.play/play-streams_2.13/2.9.10/

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/settings.gradle
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.typesafe.play.play-streams_2.13_tests'

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
@@ -6,6 +6,8 @@
  */
 package com_typesafe_play.play_streams_2_13
 
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 import java.util.Arrays
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -14,6 +16,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import java.util.{List => JList}
 import java.util.function.{Function => JFunction}
+import java.util.zip.GZIPInputStream
 
 import akka.actor.ActorSystem
 import akka.japi.function.{Function => AkkaFunction}
@@ -22,10 +25,13 @@ import akka.stream.Materializer
 import akka.stream.javadsl.Flow
 import akka.stream.javadsl.Sink
 import akka.stream.javadsl.Source
+import akka.stream.scaladsl.{Source => ScalaSource}
+import akka.util.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import play.api.libs.streams.GzipFlow
 import play.libs.streams.Accumulator
 
 import scala.concurrent.Await
@@ -160,6 +166,25 @@ class Play_streams_2_13Test {
   }
 
   @Test
+  def compressesChunkedByteStringsWithScalaGzipFlow(): Unit = {
+    val plainText: String = "Play streams compresses chunked data"
+    val inputChunks: List[ByteString] = List(
+      ByteString("Play streams ", StandardCharsets.UTF_8.name()),
+      ByteString("compresses ", StandardCharsets.UTF_8.name()),
+      ByteString("chunked data", StandardCharsets.UTF_8.name())
+    )
+
+    val compressedBytes: ByteString = Await.result(
+      ScalaSource(inputChunks).via(GzipFlow.gzip()).runFold(ByteString.empty)(_ ++ _)(materializer),
+      10.seconds
+    )
+    val decompressedText: String = gunzip(compressedBytes.toArray)
+
+    assertThat(compressedBytes.length).isGreaterThan(0)
+    assertThat(decompressedText).isEqualTo(plainText)
+  }
+
+  @Test
   def convertsBetweenJavaAndScalaAccumulatorApis(): Unit = {
     val javaAccumulator: Accumulator[Integer, Integer] = Accumulator.fromSink(integerSumSink)
     val scalaAccumulator: play.api.libs.streams.Accumulator[Integer, Integer] = javaAccumulator.asScala()
@@ -187,6 +212,15 @@ object Play_streams_2_13Test {
   }
 
   private def completed[A](value: A): CompletionStage[A] = CompletableFuture.completedFuture(value)
+
+  private def gunzip(bytes: Array[Byte]): String = {
+    val gzipInputStream: GZIPInputStream = new GZIPInputStream(new ByteArrayInputStream(bytes))
+    try {
+      new String(gzipInputStream.readAllBytes(), StandardCharsets.UTF_8)
+    } finally {
+      gzipInputStream.close()
+    }
+  }
 
   private def awaitStage[A](stage: CompletionStage[A]): A = {
     stage.toCompletableFuture.get(10, TimeUnit.SECONDS)

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_typesafe_play.play_streams_2_13
+
+import org.junit.jupiter.api.Test
+
+class Play_streams_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
@@ -25,17 +25,19 @@ import akka.stream.Materializer
 import akka.stream.javadsl.Flow
 import akka.stream.javadsl.Sink
 import akka.stream.javadsl.Source
-import akka.stream.scaladsl.{Source => ScalaSource}
+import akka.stream.scaladsl.{Flow => ScalaFlow, Sink => ScalaSink, Source => ScalaSource}
 import akka.util.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import play.api.libs.streams.AkkaStreams
 import play.api.libs.streams.GzipFlow
 import play.libs.streams.Accumulator
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 
 class Play_streams_2_13Test {
   import Play_streams_2_13Test._
@@ -163,6 +165,31 @@ class Play_streams_2_13Test {
     assertThat(doneResult).isEqualTo("precomputed")
     assertThat(futureDoneResult).isEqualTo("future-value")
     assertThat(flattenedResult).isEqualTo(Integer.valueOf(9))
+  }
+
+  @Test
+  def routesSelectedElementsAroundScalaStreamProcessing(): Unit = {
+    val processingFlow: ScalaFlow[String, String, _] = ScalaFlow[String].map(value => s"processed:$value")
+    val bypassingFlow: ScalaFlow[String, String, _] = AkkaStreams
+      .bypassWith[String, String, String] { value: String =>
+        if (value.startsWith("cached:")) Right(s"bypassed:${value.stripPrefix("cached:")}")
+        else Left(value)
+      }
+      .apply(processingFlow)
+
+    val results: Seq[String] = Await.result(
+      ScalaSource(List("cached:alpha", "beta", "cached:gamma", "delta"))
+        .via(bypassingFlow)
+        .runWith(ScalaSink.seq[String])(materializer),
+      10.seconds
+    )
+
+    assertThat(results.asJava).containsExactlyInAnyOrder(
+      "bypassed:alpha",
+      "processed:beta",
+      "bypassed:gamma",
+      "processed:delta"
+    )
   }
 
   @Test

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/src/test/scala/com_typesafe_play/play_streams_2_13/Play_streams_2_13Test.scala
@@ -6,11 +6,189 @@
  */
 package com_typesafe_play.play_streams_2_13
 
+import java.util.Arrays
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import java.util.{List => JList}
+import java.util.function.{Function => JFunction}
+
+import akka.actor.ActorSystem
+import akka.japi.function.{Function => AkkaFunction}
+import akka.japi.function.{Function2 => AkkaFunction2}
+import akka.stream.Materializer
+import akka.stream.javadsl.Flow
+import akka.stream.javadsl.Sink
+import akka.stream.javadsl.Source
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import play.libs.streams.Accumulator
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 
 class Play_streams_2_13Test {
+  import Play_streams_2_13Test._
+
+  private var system: ActorSystem = _
+  private var materializer: Materializer = _
+
+  @BeforeEach
+  def createActorSystem(): Unit = {
+    system = ActorSystem.create("play-streams-accumulator-test")
+    materializer = Materializer.matFromSystem(system)
+  }
+
+  @AfterEach
+  def terminateActorSystem(): Unit = {
+    if (system != null) {
+      Await.result(system.terminate(), 10.seconds)
+      system = null
+      materializer = null
+    }
+  }
+
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def composesSinkAccumulatorWithFlowAndResultMappings(): Unit = {
+    val sumAccumulator: Accumulator[Integer, Integer] = Accumulator.fromSink(integerSumSink)
+    val parseNumbers: Flow[String, Integer, _] = Flow.of(classOf[String]).map(
+      new AkkaFunction[String, Integer] {
+        override def apply(value: String): Integer = Integer.valueOf(value)
+      }
+    )
+    val parsedAccumulator: Accumulator[String, Integer] = sumAccumulator.through(parseNumbers)
+    val labelledAccumulator: Accumulator[String, String] = parsedAccumulator.map(
+      new JFunction[Integer, String] {
+        override def apply(sum: Integer): String = s"sum=${sum.intValue() * 2}"
+      },
+      DirectExecutor
+    )
+    val asynchronousAccumulator: Accumulator[String, String] = labelledAccumulator.mapFuture(
+      new JFunction[String, CompletionStage[String]] {
+        override def apply(label: String): CompletionStage[String] = completed(label.toUpperCase)
+      },
+      DirectExecutor
+    )
+
+    val result: String = awaitStage(
+      asynchronousAccumulator.run(Source.from(Arrays.asList("1", "2", "3")), materializer)
+    )
+
+    assertThat(result).isEqualTo("SUM=12")
+  }
+
+  @Test
+  def recoversFailedStreamsWithImmediateAndAsynchronousFallbacks(): Unit = {
+    val sumAccumulator: Accumulator[Integer, Integer] = Accumulator.fromSink(integerSumSink)
+    val recoveredAccumulator: Accumulator[Integer, Integer] = sumAccumulator.recover(
+      new JFunction[Throwable, Integer] {
+        override def apply(error: Throwable): Integer = Integer.valueOf(17)
+      },
+      DirectExecutor
+    )
+    val recoveredWithAccumulator: Accumulator[Integer, Integer] = sumAccumulator.recoverWith(
+      new JFunction[Throwable, CompletionStage[Integer]] {
+        override def apply(error: Throwable): CompletionStage[Integer] = completed(Integer.valueOf(23))
+      },
+      DirectExecutor
+    )
+
+    val recoveredResult: Integer = awaitStage(
+      recoveredAccumulator.run(Source.failed[Integer](new IllegalStateException("failed-source")), materializer)
+    )
+    val recoveredWithResult: Integer = awaitStage(
+      recoveredWithAccumulator.run(Source.failed[Integer](new IllegalArgumentException("failed-source")), materializer)
+    )
+
+    assertThat(recoveredResult).isEqualTo(Integer.valueOf(17))
+    assertThat(recoveredWithResult).isEqualTo(Integer.valueOf(23))
+  }
+
+  @Test
+  def exposesAccumulatedElementsAsSourceAndSinkRepresentations(): Unit = {
+    val sourceAccumulator: Accumulator[String, Source[String, _]] = Accumulator.source[String]()
+    val capturedSource: Source[String, _] = awaitStage(
+      sourceAccumulator.run(Source.from(Arrays.asList("alpha", "beta", "gamma")), materializer)
+    )
+    val capturedElements: JList[String] = awaitStage(capturedSource.runWith(Sink.seq[String], materializer))
+
+    val sinkAccumulator: Accumulator[String, JList[String]] = Accumulator.fromSink(Sink.seq[String])
+    val sinkResult: JList[String] = awaitStage(
+      Source.from(Arrays.asList("left", "right")).runWith(sinkAccumulator.toSink(), materializer)
+    )
+
+    assertThat(capturedElements).containsExactly("alpha", "beta", "gamma")
+    assertThat(sinkResult).containsExactly("left", "right")
+  }
+
+  @Test
+  def completesStrictDoneAndFlattenedAccumulators(): Unit = {
+    val strictAccumulator: Accumulator[String, String] = Accumulator.strict(
+      new JFunction[Optional[String], CompletionStage[String]] {
+        override def apply(element: Optional[String]): CompletionStage[String] = {
+          completed(element.orElse("empty").toUpperCase)
+        }
+      },
+      Sink.fold[String, String]("", new AkkaFunction2[String, String, String] {
+        override def apply(total: String, element: String): String = total + element
+      })
+    )
+    val doneAccumulator: Accumulator[String, String] = Accumulator.done[String, String]("precomputed")
+    val futureDoneAccumulator: Accumulator[String, String] = Accumulator.done[String, String](completed("future-value"))
+    val flattenedAccumulator: Accumulator[Integer, Integer] = Accumulator.flatten(
+      completed(Accumulator.fromSink[Integer, Integer](integerSumSink)),
+      materializer
+    )
+
+    val strictResult: String = awaitStage(strictAccumulator.run("play", materializer))
+    val doneResult: String = awaitStage(
+      doneAccumulator.run(Source.from(Arrays.asList("ignored", "elements")), materializer)
+    )
+    val futureDoneResult: String = awaitStage(futureDoneAccumulator.run(materializer))
+    val flattenedResult: Integer = awaitStage(
+      flattenedAccumulator.run(Source.from(Arrays.asList(Integer.valueOf(4), Integer.valueOf(5))), materializer)
+    )
+
+    assertThat(strictResult).isEqualTo("PLAY")
+    assertThat(doneResult).isEqualTo("precomputed")
+    assertThat(futureDoneResult).isEqualTo("future-value")
+    assertThat(flattenedResult).isEqualTo(Integer.valueOf(9))
+  }
+
+  @Test
+  def convertsBetweenJavaAndScalaAccumulatorApis(): Unit = {
+    val javaAccumulator: Accumulator[Integer, Integer] = Accumulator.fromSink(integerSumSink)
+    val scalaAccumulator: play.api.libs.streams.Accumulator[Integer, Integer] = javaAccumulator.asScala()
+    val roundTrippedAccumulator: Accumulator[Integer, Integer] = scalaAccumulator.asJava
+
+    val result: Integer = awaitStage(
+      roundTrippedAccumulator.run(Source.from(Arrays.asList(Integer.valueOf(7), Integer.valueOf(8))), materializer)
+    )
+
+    assertThat(result).isEqualTo(Integer.valueOf(15))
+  }
+}
+
+object Play_streams_2_13Test {
+  private object DirectExecutor extends Executor {
+    override def execute(command: Runnable): Unit = command.run()
+  }
+
+  private def integerSumSink: Sink[Integer, CompletionStage[Integer]] = {
+    Sink.fold[Integer, Integer](Integer.valueOf(0), new AkkaFunction2[Integer, Integer, Integer] {
+      override def apply(total: Integer, element: Integer): Integer = {
+        Integer.valueOf(total.intValue() + element.intValue())
+      }
+    })
+  }
+
+  private def completed[A](value: A): CompletionStage[A] = CompletableFuture.completedFuture(value)
+
+  private def awaitStage[A](stage: CompletionStage[A]): A = {
+    stage.toCompletableFuture.get(10, TimeUnit.SECONDS)
   }
 }

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/user-code-filter.json
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "play.api.libs.streams.**"
+    },
+    {
+      "includeClasses": "play.libs.streams.**"
+    }
+  ]
+}

--- a/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/user-code-filter.json
+++ b/tests/src/com.typesafe.play/play-streams_2.13/2.9.10/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "play.api.libs.streams.**"
+      "includeClasses" : "play.api.libs.streams.**"
     },
     {
-      "includeClasses": "play.libs.streams.**"
+      "includeClasses" : "play.libs.streams.**"
+    },
+    {
+      "includeClasses" : "com_typesafe_play.play_streams_2_13.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5467

This PR introduces tests and metadata for com.typesafe.play:play-streams_2.13:2.9.10, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 176141
- Cached input tokens: 1193472
- Output tokens: 16778
- Metadata entries: 83
- Iterations: 5
- Library coverage percentage: 39.89
- Generated lines of code: 222
- Tested library lines of code: 144

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `fed8abd7b7c260a454a60bd37b32ba6803cf9d6f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 949/3095 (30.66%)
- Line: 144/361 (39.89%)
- Method: 100/381 (26.25%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
