### PR TITLE
[GenAI] Add support for org.jboss.modules:jboss-modules:2.1.6.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json
+++ b/metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json
@@ -1,0 +1,28 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.modules.ModuleLoader"
+      },
+      "type" : "org.jboss.modules.DelegatingModuleLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.modules.ModuleLoader"
+      },
+      "type" : "org.jboss.modules.LocalModuleLoader"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.modules.Module"
+      },
+      "type" : "java.lang.ClassLoader",
+      "methods" : [
+        {
+          "name" : "registerAsParallelCapable",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/org.jboss.modules/jboss-modules/index.json
+++ b/metadata/org.jboss.modules/jboss-modules/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.1.6.Final",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/jboss/modules/jboss-modules/$version$/jboss-modules-$version$-sources.jar",
+    "repository-url" : "https://github.com/jboss-modules/jboss-modules",
+    "test-code-url" : "https://repo1.maven.org/maven2/org/jboss/modules/jboss-modules/$version$/jboss-modules-$version$-source-release.zip",
+    "documentation-url" : "https://repo1.maven.org/maven2/org/jboss/modules/jboss-modules/$version$/jboss-modules-$version$-javadoc.jar",
+    "description" : "JBoss Modules is a standalone Java module and class loading system that lets applications run with explicit, isolated module dependencies instead of one flat class path. It provides a fast, concurrent delegating class loader and extensible module resolution so existing Java libraries and applications can be executed in a modular environment.",
+    "tested-versions" : [
+      "2.1.6.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.modules"
+    ]
+  }
+]

--- a/stats/org.jboss.modules/jboss-modules/2.1.6.Final/execution-metrics.json
+++ b/stats/org.jboss.modules/jboss-modules/2.1.6.Final/execution-metrics.json
@@ -1,0 +1,98 @@
+{
+  "add_new_library_support:2026-06-27": {
+    "timestamp": "2026-06-27T20:46:42.594757Z",
+    "library": "org.jboss.modules:jboss-modules:2.1.6.Final",
+    "starting_commit": "c969bd2cbd5b5a06931749fc6fc917ec354d0d8e",
+    "ending_commit": "f747d48725bc32c2a273c179b8303bd01289396e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.1.6.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.021739,
+            "coveredCalls": 1,
+            "totalCalls": 46
+          },
+          "resources": {
+            "coverageRatio": 0.0,
+            "coveredCalls": 0,
+            "totalCalls": 11
+          }
+        },
+        "coverageRatio": 0.017544,
+        "coveredCalls": 1,
+        "totalCalls": 57
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8830,
+          "missed": 29964,
+          "ratio": 0.227613,
+          "total": 38794
+        },
+        "line": {
+          "covered": 2127,
+          "missed": 6854,
+          "ratio": 0.236833,
+          "total": 8981
+        },
+        "method": {
+          "covered": 437,
+          "missed": 1137,
+          "ratio": 0.277637,
+          "total": 1574
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 3283,
+      "issue_label": "library-new-request",
+      "library": "org.jboss.modules:jboss-modules:2.1.6.Final",
+      "summary": "JBoss Modules has no extra runtime Maven dependencies or external services, but meaningful coverage normally requires a filesystem/JAR module repository with module descriptors rather than only the default scaffold.",
+      "deterministic_setup": [],
+      "agent_guidance": "Create a temporary module repository in the generated tests, with a module path layout containing `module.xml` and a simple resource-root directory or JAR. Prefer constructing `LocalModuleLoader` or `LocalModuleFinder` with `new File[] { repoRoot }` to avoid global state. If testing the default loader or `Main`, set and restore the `module.path` system property to the temporary repository. Avoid `module.xml` `<artifact>` entries unless the test also deliberately configures a local/remote Maven repository; plain `resource-root` paths are sufficient and deterministic.",
+      "risks": [
+        "Native Image support for arbitrary runtime class loading is limited, so tests that expect JBoss Modules to define brand-new external classes may fail even when JVM tests pass.",
+        "Using global properties such as `module.path` can leak between tests unless restored in cleanup."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#3283 Support for org.jboss.modules:jboss-modules:2.1.6.Final; label=library-new-request; body_chars=112"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 82064,
+      "output_tokens_used": 5110,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jboss.modules:jboss-modules:2.1.6.Final/library-preparation-preflight/pi-generation-2026-06-27T20-16-05-030953Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 248331,
+      "cached_input_tokens_used": 2243072,
+      "output_tokens_used": 17960,
+      "iterations": 7,
+      "cost_usd": 1.6603,
+      "generated_loc": 241,
+      "tested_library_loc": 2127,
+      "metadata_entries": 4,
+      "code_coverage_percent": 23.68
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java",
+      "metadata_file": "metadata/org.jboss.modules/jboss-modules/2.1.6.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.modules/jboss-modules/2.1.6.Final/stats.json
+++ b/stats/org.jboss.modules/jboss-modules/2.1.6.Final/stats.json
@@ -1,0 +1,42 @@
+{
+  "versions" : [ {
+    "version" : "2.1.6.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.021739,
+          "coveredCalls" : 1,
+          "totalCalls" : 46
+        },
+        "resources" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 11
+        }
+      },
+      "coverageRatio" : 0.017544,
+      "coveredCalls" : 1,
+      "totalCalls" : 57
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 8830,
+        "missed" : 29964,
+        "ratio" : 0.227613,
+        "total" : 38794
+      },
+      "line" : {
+        "covered" : 2127,
+        "missed" : 6854,
+        "ratio" : 0.236833,
+        "total" : 8981
+      },
+      "method" : {
+        "covered" : 437,
+        "missed" : 1137,
+        "ratio" : 0.277637,
+        "total" : 1574
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/.gitignore
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.modules:jboss-modules:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 }
 
 graalvmNative {
+    binaries {
+        test {
+            buildArgs.add('--initialize-at-build-time=org.jboss.modules.ModuleLoggerFinder,org.jboss.modules.ModuleLoggerFinder$1,org.jboss.modules.ModuleLoggerFinder$2,org.jboss.modules.ModuleLoggerFinder$DelegatingSystemLogger,org.jboss.modules.ModuleLoggerFinder$JulSystemLogger,org.jboss.modules.ModuleLoggerFinder$QueueingSystemLogger,org.jboss.modules.ModuleLoggerFinder$SystemLogRecord')
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 graalvmNative {
     binaries {
         test {
+            buildArgs.add('--enable-url-protocols=jar')
             buildArgs.add('--initialize-at-build-time=org.jboss.modules.ModuleLoggerFinder,org.jboss.modules.ModuleLoggerFinder$1,org.jboss.modules.ModuleLoggerFinder$2,org.jboss.modules.ModuleLoggerFinder$DelegatingSystemLogger,org.jboss.modules.ModuleLoggerFinder$JulSystemLogger,org.jboss.modules.ModuleLoggerFinder$QueueingSystemLogger,org.jboss.modules.ModuleLoggerFinder$SystemLogRecord')
         }
     }

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/gradle.properties
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.modules:jboss-modules:2.1.6.Final
+library.version = 2.1.6.Final
+metadata.dir = org.jboss.modules/jboss-modules/2.1.6.Final/

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/settings.gradle
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.modules.jboss-modules_tests'

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_modules.jboss_modules;
+
+import org.junit.jupiter.api.Test;
+
+class Jboss_modulesTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -9,26 +9,37 @@ package org_jboss_modules.jboss_modules;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import org.jboss.modules.LocalModuleLoader;
 import org.jboss.modules.Module;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import sun.misc.Unsafe;
+
 public class Jboss_modulesTest {
     @TempDir
     Path repositoryRoot;
+
+    @BeforeEach
+    void seedParallelLoaders() throws ReflectiveOperationException {
+        // Native image substitutes ClassLoader$ParallelLoaders without seeding ClassLoader.class.
+        addParallelLoaderType(ClassLoader.class);
+    }
 
     @Test
     void loadsModuleWithDirectoryResourceRootAndProperties() throws Exception {
@@ -46,7 +57,7 @@ public class Jboss_modulesTest {
                 </properties>
                 """);
 
-        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] {repositoryRoot.toFile() })) {
             Module module = loader.loadModule("example.resources");
 
             assertThat(module.getName()).isEqualTo("example.resources");
@@ -71,7 +82,7 @@ public class Jboss_modulesTest {
                 </resources>
                 """);
 
-        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] {repositoryRoot.toFile() })) {
             Module module = loader.loadModule("example.jarroot");
 
             URL exportedResource = module.getExportedResource("config/settings.properties");
@@ -105,7 +116,7 @@ public class Jboss_modulesTest {
                 </resources>
                 """);
 
-        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] {repositoryRoot.toFile() })) {
             Module module = loader.loadModule("example.filtered");
 
             assertThat(readText(module.getExportedResource("public/visible.txt"))).isEqualTo("visible resource");
@@ -140,7 +151,7 @@ public class Jboss_modulesTest {
                 </dependencies>
                 """);
 
-        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] {repositoryRoot.toFile() })) {
             Module application = loader.loadModule("example.application");
 
             assertThat(readText(application.getClassLoader().getResource("application/name.txt")))
@@ -166,7 +177,7 @@ public class Jboss_modulesTest {
         Path aliasDirectory = createModuleDirectory("example.alias.name");
         writeModuleAliasXml(aliasDirectory, "example.alias.name", "example.alias.target");
 
-        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] {repositoryRoot.toFile() })) {
             Module target = loader.loadModule("example.alias.target");
             Module alias = loader.loadModule("example.alias.name");
 
@@ -238,5 +249,28 @@ public class Jboss_modulesTest {
         try (InputStream input = resource.openStream()) {
             return new String(input.readAllBytes(), UTF_8);
         }
+    }
+
+    private static void addParallelLoaderType(Class<? extends ClassLoader> classLoaderType)
+            throws ReflectiveOperationException {
+        Class<?> parallelLoadersClass = Class.forName("java.lang.ClassLoader$ParallelLoaders");
+        Field loaderTypesField = parallelLoadersClass.getDeclaredField("loaderTypes");
+        Set<Class<? extends ClassLoader>> loaderTypes = getStaticFieldValue(loaderTypesField);
+        loaderTypes.add(classLoaderType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<Class<? extends ClassLoader>> getStaticFieldValue(Field field)
+            throws ReflectiveOperationException {
+        Unsafe unsafe = getUnsafe();
+        Object base = unsafe.staticFieldBase(field);
+        long offset = unsafe.staticFieldOffset(field);
+        return (Set<Class<? extends ClassLoader>>) unsafe.getObject(base, offset);
+    }
+
+    private static Unsafe getUnsafe() throws ReflectiveOperationException {
+        Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        return (Unsafe) unsafeField.get(null);
     }
 }

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -87,6 +87,35 @@ public class Jboss_modulesTest {
     }
 
     @Test
+    void appliesResourceRootFiltersFromModuleDescriptor() throws Exception {
+        Path moduleDirectory = createModuleDirectory("example.filtered");
+        Path resources = moduleDirectory.resolve("resources");
+        Files.createDirectories(resources.resolve("public"));
+        Files.createDirectories(resources.resolve("private"));
+        Files.writeString(resources.resolve("public/visible.txt"), "visible resource", UTF_8);
+        Files.writeString(resources.resolve("private/secret.txt"), "hidden resource", UTF_8);
+        writeModuleXml(moduleDirectory, "example.filtered", """
+                <resources>
+                    <resource-root path="resources">
+                        <filter>
+                            <include path="public"/>
+                            <exclude path="**"/>
+                        </filter>
+                    </resource-root>
+                </resources>
+                """);
+
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+            Module module = loader.loadModule("example.filtered");
+
+            assertThat(readText(module.getExportedResource("public/visible.txt"))).isEqualTo("visible resource");
+            assertThat(readText(module.getClassLoader().getResource("public/visible.txt"))).isEqualTo("visible resource");
+            assertThat(module.getExportedResource("private/secret.txt")).isNull();
+            assertThat(module.getClassLoader().getResource("private/secret.txt")).isNull();
+        }
+    }
+
+    @Test
     void resolvesResourcesFromModuleDependency() throws Exception {
         Path apiDirectory = createModuleDirectory("example.api");
         Path apiResources = apiDirectory.resolve("api-resources");

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -123,6 +123,31 @@ public class Jboss_modulesTest {
     }
 
     @Test
+    void resolvesModuleAliasToTargetModule() throws Exception {
+        Path targetDirectory = createModuleDirectory("example.alias.target");
+        Path resources = targetDirectory.resolve("resources");
+        Files.createDirectories(resources.resolve("alias"));
+        Files.writeString(resources.resolve("alias/value.txt"), "from target module", UTF_8);
+        writeModuleXml(targetDirectory, "example.alias.target", """
+                <resources>
+                    <resource-root path="resources"/>
+                </resources>
+                """);
+
+        Path aliasDirectory = createModuleDirectory("example.alias.name");
+        writeModuleAliasXml(aliasDirectory, "example.alias.name", "example.alias.target");
+
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+            Module target = loader.loadModule("example.alias.target");
+            Module alias = loader.loadModule("example.alias.name");
+
+            assertThat(alias).isSameAs(target);
+            assertThat(alias.getName()).isEqualTo("example.alias.target");
+            assertThat(readText(alias.getExportedResource("alias/value.txt"))).isEqualTo("from target module");
+        }
+    }
+
+    @Test
     void defaultLocalModuleLoaderUsesModulePathSystemProperty() throws Exception {
         Path moduleDirectory = createModuleDirectory("example.defaultloader");
         Path resources = moduleDirectory.resolve("resources");
@@ -160,6 +185,13 @@ public class Jboss_modulesTest {
                 <module xmlns="urn:jboss:module:1.9" name="%s">
                 %s</module>
                 """.formatted(moduleName, body);
+        Files.writeString(moduleDirectory.resolve("module.xml"), moduleXml, UTF_8);
+    }
+
+    private static void writeModuleAliasXml(Path moduleDirectory, String aliasName, String targetName) throws IOException {
+        String moduleXml = """
+                <module-alias xmlns="urn:jboss:module:1.9" name="%s" target-name="%s"/>
+                """.formatted(aliasName, targetName);
         Files.writeString(moduleDirectory.resolve("module.xml"), moduleXml, UTF_8);
     }
 

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/src/test/java/org_jboss_modules/jboss_modules/Jboss_modulesTest.java
@@ -6,11 +6,176 @@
  */
 package org_jboss_modules.jboss_modules;
 
-import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
-class Jboss_modulesTest {
+import org.jboss.modules.LocalModuleLoader;
+import org.jboss.modules.Module;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jboss_modulesTest {
+    @TempDir
+    Path repositoryRoot;
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void loadsModuleWithDirectoryResourceRootAndProperties() throws Exception {
+        Path moduleDirectory = createModuleDirectory("example.resources");
+        Path contentDirectory = moduleDirectory.resolve("content");
+        Files.createDirectories(contentDirectory.resolve("messages"));
+        Files.writeString(contentDirectory.resolve("messages/greeting.txt"), "hello from a directory root", UTF_8);
+        writeModuleXml(moduleDirectory, "example.resources", """
+                <resources>
+                    <resource-root path="content"/>
+                </resources>
+                <properties>
+                    <property name="module.kind" value="directory"/>
+                    <property name="module.owner" value="integration-test"/>
+                </properties>
+                """);
+
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+            Module module = loader.loadModule("example.resources");
+
+            assertThat(module.getName()).isEqualTo("example.resources");
+            assertThat(module.getProperty("module.kind")).isEqualTo("directory");
+            assertThat(module.getProperty("missing.property", "fallback")).isEqualTo("fallback");
+            assertThat(module.getPropertyNames()).contains("module.owner", "module.kind");
+            assertThat(readText(module.getExportedResource("messages/greeting.txt")))
+                    .isEqualTo("hello from a directory root");
+            assertThat(readText(module.getClassLoader().getResource("messages/greeting.txt")))
+                    .isEqualTo("hello from a directory root");
+        }
+    }
+
+    @Test
+    void loadsResourcesFromJarResourceRoot() throws Exception {
+        Path moduleDirectory = createModuleDirectory("example.jarroot");
+        Path jarPath = moduleDirectory.resolve("support.jar");
+        writeJar(jarPath, "config/settings.properties", "feature.enabled=true\n");
+        writeModuleXml(moduleDirectory, "example.jarroot", """
+                <resources>
+                    <resource-root path="support.jar"/>
+                </resources>
+                """);
+
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+            Module module = loader.loadModule("example.jarroot");
+
+            URL exportedResource = module.getExportedResource("config/settings.properties");
+            assertThat(exportedResource).isNotNull();
+            assertThat(exportedResource.toString()).contains("support.jar");
+            assertThat(readText(exportedResource)).isEqualTo("feature.enabled=true\n");
+
+            Enumeration<URL> resources = module.getExportedResources("config/settings.properties");
+            List<URL> urls = Collections.list(resources);
+            assertThat(urls).hasSize(1);
+            assertThat(readText(urls.get(0))).isEqualTo("feature.enabled=true\n");
+        }
+    }
+
+    @Test
+    void resolvesResourcesFromModuleDependency() throws Exception {
+        Path apiDirectory = createModuleDirectory("example.api");
+        Path apiResources = apiDirectory.resolve("api-resources");
+        Files.createDirectories(apiResources.resolve("api"));
+        Files.writeString(apiResources.resolve("api/contract.txt"), "stable-api", UTF_8);
+        writeModuleXml(apiDirectory, "example.api", """
+                <resources>
+                    <resource-root path="api-resources"/>
+                </resources>
+                """);
+
+        Path applicationDirectory = createModuleDirectory("example.application");
+        Path applicationResources = applicationDirectory.resolve("application-resources");
+        Files.createDirectories(applicationResources.resolve("application"));
+        Files.writeString(applicationResources.resolve("application/name.txt"), "consumer", UTF_8);
+        writeModuleXml(applicationDirectory, "example.application", """
+                <resources>
+                    <resource-root path="application-resources"/>
+                </resources>
+                <dependencies>
+                    <module name="example.api" export="true"/>
+                </dependencies>
+                """);
+
+        try (LocalModuleLoader loader = new LocalModuleLoader(new File[] { repositoryRoot.toFile() })) {
+            Module application = loader.loadModule("example.application");
+
+            assertThat(readText(application.getClassLoader().getResource("application/name.txt")))
+                    .isEqualTo("consumer");
+            assertThat(readText(application.getClassLoader().getResource("api/contract.txt")))
+                    .isEqualTo("stable-api");
+            assertThat(readText(application.getExportedResource("api/contract.txt"))).isEqualTo("stable-api");
+        }
+    }
+
+    @Test
+    void defaultLocalModuleLoaderUsesModulePathSystemProperty() throws Exception {
+        Path moduleDirectory = createModuleDirectory("example.defaultloader");
+        Path resources = moduleDirectory.resolve("resources");
+        Files.createDirectories(resources.resolve("defaultloader"));
+        Files.writeString(resources.resolve("defaultloader/value.txt"), "from module.path", UTF_8);
+        writeModuleXml(moduleDirectory, "example.defaultloader", """
+                <resources>
+                    <resource-root path="resources"/>
+                </resources>
+                """);
+
+        String previousModulePath = System.getProperty("module.path");
+        System.setProperty("module.path", repositoryRoot.toString());
+        try (LocalModuleLoader loader = new LocalModuleLoader()) {
+            Module module = loader.loadModule("example.defaultloader");
+
+            assertThat(readText(module.getExportedResource("defaultloader/value.txt"))).isEqualTo("from module.path");
+        } finally {
+            if (previousModulePath == null) {
+                System.clearProperty("module.path");
+            } else {
+                System.setProperty("module.path", previousModulePath);
+            }
+        }
+    }
+
+    private Path createModuleDirectory(String moduleName) throws IOException {
+        Path directory = repositoryRoot.resolve(moduleName.replace('.', File.separatorChar)).resolve("main");
+        Files.createDirectories(directory);
+        return directory;
+    }
+
+    private static void writeModuleXml(Path moduleDirectory, String moduleName, String body) throws IOException {
+        String moduleXml = """
+                <module xmlns="urn:jboss:module:1.9" name="%s">
+                %s</module>
+                """.formatted(moduleName, body);
+        Files.writeString(moduleDirectory.resolve("module.xml"), moduleXml, UTF_8);
+    }
+
+    private static void writeJar(Path jarPath, String entryName, String content) throws IOException {
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            JarEntry entry = new JarEntry(entryName);
+            output.putNextEntry(entry);
+            output.write(content.getBytes(UTF_8));
+            output.closeEntry();
+        }
+    }
+
+    private static String readText(URL resource) throws IOException {
+        assertThat(resource).isNotNull();
+        try (InputStream input = resource.openStream()) {
+            return new String(input.readAllBytes(), UTF_8);
+        }
     }
 }

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.modules.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
+++ b/tests/src/org.jboss.modules/jboss-modules/2.1.6.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.modules.**"
+      "includeClasses" : "org.jboss.modules.**"
+    },
+    {
+      "includeClasses" : "org_jboss_modules.jboss_modules.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3283

This PR introduces tests and metadata for org.jboss.modules:jboss-modules:2.1.6.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 248331
- Cached input tokens: 2243072
- Output tokens: 17960
- Metadata entries: 4
- Iterations: 7
- Library coverage percentage: 23.68
- Generated lines of code: 241
- Tested library lines of code: 2127

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cdfca02cc7bd44548516677c0ee008613fbf3558`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 1/57 covered calls (1.75%)
- Reflection: 1/46 covered calls (2.17%)
- Resources: 0/11 covered calls (0.00%)

Library coverage:
- Instruction: 8830/38794 (22.76%)
- Line: 2127/8981 (23.68%)
- Method: 437/1574 (27.76%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
