### PR TITLE
[GenAI] Mark io.kotest:kotest-runner-junit5-jvm as not for Native Image

### DIFF
--- a/metadata/io.kotest/kotest-runner-junit5-jvm/index.json
+++ b/metadata/io.kotest/kotest-runner-junit5-jvm/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published kotest-runner-junit5-jvm 6.1.11 JAR contains only META-INF/MANIFEST.MF and META-INF/services/org.junit.platform.engine.TestEngine and no JVM class files; implementation classes are supplied by io.kotest:kotest-runner-junit-platform-jvm:6.1.11.",
+    "replacement": "io.kotest:kotest-runner-junit-platform-jvm:6.1.11"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #5317

This PR records `io.kotest:kotest-runner-junit5-jvm` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published kotest-runner-junit5-jvm 6.1.11 JAR contains only META-INF/MANIFEST.MF and META-INF/services/org.junit.platform.engine.TestEngine and no JVM class files; implementation classes are supplied by io.kotest:kotest-runner-junit-platform-jvm:6.1.11.

Replacement guidance:
- io.kotest:kotest-runner-junit-platform-jvm:6.1.11

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `cdfca02cc7bd44548516677c0ee008613fbf3558`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
