### PR TITLE
[GenAI] Add support for io.undertow:undertow-servlet:2.3.18.Final using gpt-5.5

### DIFF
--- a/metadata/io.undertow/undertow-servlet/2.3.18.Final/reachability-metadata.json
+++ b/metadata/io.undertow/undertow-servlet/2.3.18.Final/reachability-metadata.json
@@ -1,0 +1,2304 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "boolean[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "byte[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "char[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.AESCipher$General",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.ARCFOURCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.DESCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.DESedeCipher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.DHParameters",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.GarbageCollectorMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.GcInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.HotSpotDiagnosticMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.ThreadMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.UnixOperatingSystemMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.VMOption"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandArgumentInfo",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "boolean",
+            "boolean",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandArgumentInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandInfo",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.DiagnosticCommandInfo[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.GarbageCollectorExtImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.HotSpotDiagnostic"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.HotSpotThreadImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.OperatingSystemImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "com.sun.management.internal.VirtualThreadSchedulerImpls$VirtualThreadSchedulerImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "double[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "float[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImplLogger_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImplLogger_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.server.ConnectorStatisticsImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.server.DefaultByteBufferPool"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.server.DefaultByteBufferPool$DefaultPooledBuffer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.ServletPathMatches"
+      },
+      "type": "io.undertow.server.handlers.cache.LRUCache$CacheEntry"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.server.protocol.http.HttpRequestParser$$generated",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.xnio.OptionMap"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.HttpServletRequestImpl"
+      },
+      "type": "io.undertow.server.session.InMemorySessionManager$SessionImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.ManagedFilter"
+      },
+      "type": "io.undertow.servlet.core.ManagedFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.ManagedServlet"
+      },
+      "type": "io.undertow.servlet.core.ManagedServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.handlers.DefaultServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.handlers.DefaultServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.ServletInputStreamImpl"
+      },
+      "type": "io.undertow.servlet.spec.ServletInputStreamImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.ServletOutputStreamImpl"
+      },
+      "type": "io.undertow.servlet.spec.ServletOutputStreamImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.ServletPrintWriterDelegate"
+      },
+      "type": "io.undertow.servlet.spec.ServletPrintWriterDelegate",
+      "unsafeAllocated": true
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.ServletPathMatches"
+      },
+      "type": "io.undertow.util.FastConcurrentDirectDeque",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.ServletContextImpl"
+      },
+      "type": "io.undertow.util.FastConcurrentDirectDeque",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.FastConcurrentDirectDeque",
+      "fields": [
+        {
+          "name": "head"
+        },
+        {
+          "name": "tail"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.FastConcurrentDirectDeque$Node",
+      "fields": [
+        {
+          "name": "item"
+        },
+        {
+          "name": "next"
+        },
+        {
+          "name": "prev"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.Headers",
+      "fields": [
+        {
+          "name": "ACCEPT"
+        },
+        {
+          "name": "ACCEPT_CHARSET"
+        },
+        {
+          "name": "ACCEPT_ENCODING"
+        },
+        {
+          "name": "ACCEPT_LANGUAGE"
+        },
+        {
+          "name": "ACCEPT_RANGES"
+        },
+        {
+          "name": "AGE"
+        },
+        {
+          "name": "ALGORITHM"
+        },
+        {
+          "name": "ALLOW"
+        },
+        {
+          "name": "AUTHENTICATION_INFO"
+        },
+        {
+          "name": "AUTHORIZATION"
+        },
+        {
+          "name": "AUTH_PARAM"
+        },
+        {
+          "name": "BASIC"
+        },
+        {
+          "name": "CACHE_CONTROL"
+        },
+        {
+          "name": "CHUNKED"
+        },
+        {
+          "name": "CLOSE"
+        },
+        {
+          "name": "CNONCE"
+        },
+        {
+          "name": "COMPRESS"
+        },
+        {
+          "name": "CONNECTION"
+        },
+        {
+          "name": "CONTENT_DISPOSITION"
+        },
+        {
+          "name": "CONTENT_ENCODING"
+        },
+        {
+          "name": "CONTENT_LANGUAGE"
+        },
+        {
+          "name": "CONTENT_LENGTH"
+        },
+        {
+          "name": "CONTENT_LOCATION"
+        },
+        {
+          "name": "CONTENT_MD5"
+        },
+        {
+          "name": "CONTENT_RANGE"
+        },
+        {
+          "name": "CONTENT_SECURITY_POLICY"
+        },
+        {
+          "name": "CONTENT_TRANSFER_ENCODING"
+        },
+        {
+          "name": "CONTENT_TYPE"
+        },
+        {
+          "name": "COOKIE"
+        },
+        {
+          "name": "COOKIE2"
+        },
+        {
+          "name": "DATE"
+        },
+        {
+          "name": "DEFLATE"
+        },
+        {
+          "name": "DIGEST"
+        },
+        {
+          "name": "DOMAIN"
+        },
+        {
+          "name": "ETAG"
+        },
+        {
+          "name": "EXPECT"
+        },
+        {
+          "name": "EXPIRES"
+        },
+        {
+          "name": "FORWARDED"
+        },
+        {
+          "name": "FROM"
+        },
+        {
+          "name": "GZIP"
+        },
+        {
+          "name": "HOST"
+        },
+        {
+          "name": "IDENTITY"
+        },
+        {
+          "name": "IF_MATCH"
+        },
+        {
+          "name": "IF_MODIFIED_SINCE"
+        },
+        {
+          "name": "IF_NONE_MATCH"
+        },
+        {
+          "name": "IF_RANGE"
+        },
+        {
+          "name": "IF_UNMODIFIED_SINCE"
+        },
+        {
+          "name": "KEEP_ALIVE"
+        },
+        {
+          "name": "LAST_MODIFIED"
+        },
+        {
+          "name": "LOCATION"
+        },
+        {
+          "name": "MAX_FORWARDS"
+        },
+        {
+          "name": "NEGOTIATE"
+        },
+        {
+          "name": "NEXT_NONCE"
+        },
+        {
+          "name": "NONCE"
+        },
+        {
+          "name": "NONCE_COUNT"
+        },
+        {
+          "name": "OPAQUE"
+        },
+        {
+          "name": "ORIGIN"
+        },
+        {
+          "name": "PRAGMA"
+        },
+        {
+          "name": "PROXY_AUTHENTICATE"
+        },
+        {
+          "name": "PROXY_AUTHORIZATION"
+        },
+        {
+          "name": "QOP"
+        },
+        {
+          "name": "RANGE"
+        },
+        {
+          "name": "REALM"
+        },
+        {
+          "name": "REFERER"
+        },
+        {
+          "name": "REFERRER_POLICY"
+        },
+        {
+          "name": "REFRESH"
+        },
+        {
+          "name": "RESPONSE"
+        },
+        {
+          "name": "RESPONSE_AUTH"
+        },
+        {
+          "name": "RETRY_AFTER"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_ACCEPT"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_EXTENSIONS"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_KEY"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_KEY1"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_KEY2"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_LOCATION"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_ORIGIN"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_PROTOCOL"
+        },
+        {
+          "name": "SEC_WEB_SOCKET_VERSION"
+        },
+        {
+          "name": "SERVER"
+        },
+        {
+          "name": "SERVLET_ENGINE"
+        },
+        {
+          "name": "SET_COOKIE"
+        },
+        {
+          "name": "SET_COOKIE2"
+        },
+        {
+          "name": "SSL_CIPHER"
+        },
+        {
+          "name": "SSL_CIPHER_USEKEYSIZE"
+        },
+        {
+          "name": "SSL_CLIENT_CERT"
+        },
+        {
+          "name": "SSL_SESSION_ID"
+        },
+        {
+          "name": "STALE"
+        },
+        {
+          "name": "STATUS"
+        },
+        {
+          "name": "STRICT_TRANSPORT_SECURITY"
+        },
+        {
+          "name": "TE"
+        },
+        {
+          "name": "TRAILER"
+        },
+        {
+          "name": "TRANSFER_ENCODING"
+        },
+        {
+          "name": "UPGRADE"
+        },
+        {
+          "name": "URI"
+        },
+        {
+          "name": "USERNAME"
+        },
+        {
+          "name": "USER_AGENT"
+        },
+        {
+          "name": "VARY"
+        },
+        {
+          "name": "VIA"
+        },
+        {
+          "name": "WARNING"
+        },
+        {
+          "name": "WWW_AUTHENTICATE"
+        },
+        {
+          "name": "X_COMPRESS"
+        },
+        {
+          "name": "X_CONTENT_TYPE_OPTIONS"
+        },
+        {
+          "name": "X_DISABLE_PUSH"
+        },
+        {
+          "name": "X_FORWARDED_FOR"
+        },
+        {
+          "name": "X_FORWARDED_HOST"
+        },
+        {
+          "name": "X_FORWARDED_PORT"
+        },
+        {
+          "name": "X_FORWARDED_PROTO"
+        },
+        {
+          "name": "X_FORWARDED_SERVER"
+        },
+        {
+          "name": "X_FRAME_OPTIONS"
+        },
+        {
+          "name": "X_GZIP"
+        },
+        {
+          "name": "X_XSS_PROTECTION"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.HttpString"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.Methods",
+      "fields": [
+        {
+          "name": "ACL"
+        },
+        {
+          "name": "BASELINE_CONTROL"
+        },
+        {
+          "name": "CHECKIN"
+        },
+        {
+          "name": "CHECKOUT"
+        },
+        {
+          "name": "CONNECT"
+        },
+        {
+          "name": "COPY"
+        },
+        {
+          "name": "DELETE"
+        },
+        {
+          "name": "GET"
+        },
+        {
+          "name": "HEAD"
+        },
+        {
+          "name": "LABEL"
+        },
+        {
+          "name": "LOCK"
+        },
+        {
+          "name": "MERGE"
+        },
+        {
+          "name": "MKACTIVITY"
+        },
+        {
+          "name": "MKCOL"
+        },
+        {
+          "name": "MKWORKSPACE"
+        },
+        {
+          "name": "MOVE"
+        },
+        {
+          "name": "OPTIONS"
+        },
+        {
+          "name": "PATCH"
+        },
+        {
+          "name": "POST"
+        },
+        {
+          "name": "PROPFIND"
+        },
+        {
+          "name": "PROPPATCH"
+        },
+        {
+          "name": "PUT"
+        },
+        {
+          "name": "REPORT"
+        },
+        {
+          "name": "SEARCH"
+        },
+        {
+          "name": "TRACE"
+        },
+        {
+          "name": "UNCHECKOUT"
+        },
+        {
+          "name": "UNLOCK"
+        },
+        {
+          "name": "UPDATE"
+        },
+        {
+          "name": "VERSION_CONTROL"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.util.Protocols",
+      "fields": [
+        {
+          "name": "HTTP_0_9"
+        },
+        {
+          "name": "HTTP_1_0"
+        },
+        {
+          "name": "HTTP_1_1"
+        },
+        {
+          "name": "HTTP_2_0"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.api.ListenerInfo"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$ApplicationListener"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.ManagedListener"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$ApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$AsyncServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$AsyncServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$DynamicServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.util.DefaultClassIntrospector"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$DynamicServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.api.ServletContainerInitializerInfo"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$DynamicServletInitializer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$DynamicServletInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$ErrorServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$FailingServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$FailingServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$FrontControllerServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$FrontControllerServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.api.FilterInfo"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$MarkerFilter"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.ManagedFilter"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$MarkerFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$SessionServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$SessionServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$TargetServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$UploadServlet",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "io.undertow.servlet.core.DeploymentManagerImpl$UploadServlet"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Boolean",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Byte",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Character",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Deprecated"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Double",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Float",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Integer",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Long",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Short",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.StackTraceElement"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Thread",
+      "fields": [
+        {
+          "name": "contextClassLoader"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.Void",
+      "fields": [
+        {
+          "name": "TYPE"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.BufferPoolMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.ClassLoadingMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.CompilationMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.LockInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.MemoryMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.MemoryManagerMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.MemoryPoolMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.MemoryUsage"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.MonitorInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.PlatformLoggingMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.RuntimeMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.lang.management.ThreadInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.math.BigDecimal"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.math.BigInteger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.security.KeyStoreSpi"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.util.Arrays",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "asList",
+          "parameterTypes": [
+            "java.lang.Object[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "java.util.Date"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.MBeanOperationInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.MBeanServerBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.ObjectName"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.ObjectName[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.StandardEmitterMBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.openmbean.CompositeData"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.openmbean.CompositeData[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.openmbean.OpenMBeanOperationInfoSupport"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "javax.management.openmbean.TabularData"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.VirtualThreadSchedulerMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.ConfigurationInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.EventTypeInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.FlightRecorderMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.FlightRecorderMXBeanImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.RecordingInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "jdk.management.jfr.SettingDescriptorInfo"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "long[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.apache.log4j.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.EnhancedQueueExecutor",
+      "fields": [
+        {
+          "name": "activeCount"
+        },
+        {
+          "name": "peakQueueSize"
+        },
+        {
+          "name": "peakThreadCount"
+        },
+        {
+          "name": "queueSize"
+        },
+        {
+          "name": "terminationWaiters"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.EnhancedQueueExecutor$QNode",
+      "fields": [
+        {
+          "name": "next"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.EnhancedQueueExecutorBase1",
+      "fields": [
+        {
+          "name": "tail"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.EnhancedQueueExecutorBase3",
+      "fields": [
+        {
+          "name": "head"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.EnhancedQueueExecutorBase5",
+      "fields": [
+        {
+          "name": "threadStatus"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.jboss.threads.Messages_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.XnioWorker"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio._private.Messages_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio._private.Messages_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.management.XnioProviderMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.management.XnioServerMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.management.XnioWorkerMXBean"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.Log_$logger",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.Log_$logger_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioTcpServer"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioTcpServer$1"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioXnio$3"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioXnioProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioXnioProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioXnioWorker"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.NioXnioWorker$NioWorkerMetrics"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "org.xnio.nio.WorkerThread"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "short[]"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.ClassLoadingImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.CompilationImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.ManagementFactoryHelper$1"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.ManagementFactoryHelper$PlatformLoggingImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.MemoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.MemoryManagerImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.MemoryPoolImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.RuntimeImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.AsyncContextImpl"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "invokeCleaner",
+          "parameterTypes": [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.spec.ServletPrintWriterDelegate"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.nio.ch.EPollSelectorProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.nio.ch.PollSelectorProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.DSA$SHA224withDSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.DSA$SHA256withDSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.api.DeploymentInfo"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.SHA2$SHA224",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.SHA2$SHA256",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.SHA5$SHA384",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.SHA5$SHA512",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.provider.X509Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.rsa.PSSParameters",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.rsa.RSAPSSSignature",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.rsa.RSASignature$SHA224withRSA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.BasicConstraintsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.CRLDistributionPointsExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.CertificatePoliciesExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.KeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.NetscapeCertTypeExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.PrivateKeyUsageExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "type": "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.DefaultServlet"
+      },
+      "type": "sun.text.resources.cldr.FormatData_en_US"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.DefaultServlet"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.DefaultServlet"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.DefaultServlet"
+      },
+      "type": "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "META-INF/services/io.undertow.servlet.ServletExtension"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "META-INF/services/org.xnio.XnioProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "io/undertow/version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "glob": "jakarta/servlet/LocalStrings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "glob": "jakarta/servlet/LocalStrings_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "glob": "jakarta/servlet/http/LocalStrings.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.handlers.security.SSLInformationAssociationHandler"
+      },
+      "glob": "jakarta/servlet/http/LocalStrings_en.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "org/jboss/threads/Version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "org/xnio/Version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "glob": "org/xnio/nio/Version.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "io.undertow.servlet.core.DeploymentManagerImpl"
+      },
+      "module": "jdk.jfr",
+      "glob": "jdk/jfr/internal/query/view.ini"
+    },
+    {
+      "bundle": "jakarta.servlet.LocalStrings"
+    },
+    {
+      "bundle": "jakarta.servlet.http.LocalStrings"
+    }
+  ]
+}

--- a/metadata/io.undertow/undertow-servlet/index.json
+++ b/metadata/io.undertow/undertow-servlet/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "2.3.18.Final",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/io/undertow/undertow-servlet/$version$/undertow-servlet-$version$-sources.jar",
+    "repository-url" : "https://github.com/undertow-io/undertow",
+    "test-code-url" : "https://repo.maven.apache.org/maven2/io/undertow/undertow-servlet/$version$/undertow-servlet-$version$-tests.jar",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/io/undertow/undertow-servlet/$version$/undertow-servlet-$version$-javadoc.jar",
+    "description" : "Undertow Servlet provides Undertow's Jakarta Servlet container integration on top of its non-blocking Java web server. It lets JVM applications embed or run servlet deployments using Undertow handlers, Jakarta Servlet APIs, and Undertow core HTTP services.",
+    "tested-versions" : [
+      "2.3.18.Final"
+    ],
+    "allowed-packages" : [
+      "io.undertow.servlet"
+    ]
+  }
+]

--- a/stats/io.undertow/undertow-servlet/2.3.18.Final/execution-metrics.json
+++ b/stats/io.undertow/undertow-servlet/2.3.18.Final/execution-metrics.json
@@ -1,0 +1,93 @@
+{
+  "add_new_library_support:2026-06-28": {
+    "timestamp": "2026-06-28T01:14:25.327103Z",
+    "library": "io.undertow:undertow-servlet:2.3.18.Final",
+    "starting_commit": "65191710c50fa014717bc6cb814ee573fcb051f5",
+    "ending_commit": "d4e55830b58de82afc986a312f9d0e4bf289bd24",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "2.3.18.Final",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.4375,
+            "coveredCalls": 7,
+            "totalCalls": 16
+          }
+        },
+        "coverageRatio": 0.4375,
+        "coveredCalls": 7,
+        "totalCalls": 16
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 11872,
+          "missed": 30274,
+          "ratio": 0.281687,
+          "total": 42146
+        },
+        "line": {
+          "covered": 2966,
+          "missed": 7324,
+          "ratio": 0.288241,
+          "total": 10290
+        },
+        "method": {
+          "covered": 690,
+          "missed": 1557,
+          "ratio": 0.307076,
+          "total": 2247
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 4507,
+      "issue_label": "library-new-request",
+      "library": "io.undertow:undertow-servlet:2.3.18.Final",
+      "summary": "No extra setup is needed: undertow-servlet brings Undertow core, Jakarta Servlet/Annotation APIs, and XNIO runtime dependencies transitively, and normal meaningful usage is an embedded Undertow servlet deployment reachable over localhost.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Generated tests should avoid being scaffold-only; meaningful coverage should deploy at least one servlet via DeploymentInfo/DeploymentManager and exercise it through an embedded localhost Undertow server.",
+        "Local Gradle and Native Image verification remain authoritative for any Undertow/XNIO service-loading or networking metadata issues."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4507 Support for io.undertow:undertow-servlet:2.3.18.Final; label=library-new-request; body_chars=110"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 20676,
+      "output_tokens_used": 2689,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.undertow:undertow-servlet:2.3.18.Final/library-preparation-preflight/pi-generation-2026-06-28T00-49-21-416238Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 200035,
+      "cached_input_tokens_used": 1555968,
+      "output_tokens_used": 19844,
+      "iterations": 6,
+      "cost_usd": 1.3733,
+      "generated_loc": 382,
+      "tested_library_loc": 2966,
+      "metadata_entries": 460,
+      "code_coverage_percent": 28.82
+    },
+    "artifacts": {
+      "test_file": "tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java",
+      "metadata_file": "metadata/io.undertow/undertow-servlet/2.3.18.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.undertow/undertow-servlet/2.3.18.Final/stats.json
+++ b/stats/io.undertow/undertow-servlet/2.3.18.Final/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "2.3.18.Final",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.4375,
+          "coveredCalls" : 7,
+          "totalCalls" : 16
+        }
+      },
+      "coverageRatio" : 0.4375,
+      "coveredCalls" : 7,
+      "totalCalls" : 16
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 11872,
+        "missed" : 30274,
+        "ratio" : 0.281687,
+        "total" : 42146
+      },
+      "line" : {
+        "covered" : 2966,
+        "missed" : 7324,
+        "ratio" : 0.288241,
+        "total" : 10290
+      },
+      "method" : {
+        "covered" : 690,
+        "missed" : 1557,
+        "ratio" : 0.307076,
+        "total" : 2247
+      }
+    }
+  } ]
+}

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/.gitignore
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.undertow:undertow-servlet:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/build.gradle
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "io.undertow:undertow-servlet:$libraryVersion"
+    testImplementation "org.wildfly.common:wildfly-common:1.7.0.Final"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/gradle.properties
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.undertow:undertow-servlet:2.3.18.Final
+library.version = 2.3.18.Final
+metadata.dir = io.undertow/undertow-servlet/2.3.18.Final/

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/settings.gradle
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.undertow.undertow-servlet_tests'

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_undertow.undertow_servlet;
+
+import org.junit.jupiter.api.Test;
+
+class Undertow_servletTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
@@ -6,11 +6,334 @@
  */
 package io_undertow.undertow_servlet;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class Undertow_servletTest {
+import io.undertow.Undertow;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletContainerInitializerInfo;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Part;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class Undertow_servletTest {
+    private static final String LOOPBACK_HOST = "127.0.0.1";
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(10);
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void embeddedDeploymentRunsListenersFiltersForwardingAndSessions() throws Exception {
+        DeploymentInfo deploymentInfo = baseDeployment("pipeline")
+                .addInitParameter("application.name", "undertow-servlet-test")
+                .addServlets(
+                        Servlets.servlet("front", FrontControllerServlet.class).addMapping("/front"),
+                        Servlets.servlet("target", TargetServlet.class).addMapping("/target"),
+                        Servlets.servlet("session", SessionServlet.class).addMapping("/session"))
+                .addFilter(Servlets.filter("marker", MarkerFilter.class).addInitParam("marker", "filter-init"))
+                .addFilterUrlMapping("marker", "/*", DispatcherType.REQUEST)
+                .addListener(Servlets.listener(ApplicationListener.class));
+
+        try (RunningServer server = startServer(deploymentInfo);
+                HttpClient client = newHttpClient()) {
+            HttpResponse<String> forwarded = get(client, server.resolve("/front?name=GraalVM"));
+            assertThat(forwarded.statusCode()).isEqualTo(200);
+            assertThat(forwarded.headers().firstValue("X-Marker")).contains("filter-init");
+            assertThat(forwarded.body()).contains(
+                    "name=GraalVM",
+                    "filter=filter-init",
+                    "listener=started",
+                    "application=undertow-servlet-test");
+
+            HttpResponse<String> firstSessionRequest = get(client, server.resolve("/session"));
+            String sessionCookie = firstSessionRequest.headers().allValues("Set-Cookie").stream()
+                    .filter(cookie -> cookie.startsWith("JSESSIONID="))
+                    .map(cookie -> cookie.substring(0, cookie.indexOf(';')))
+                    .findFirst()
+                    .orElseThrow();
+            HttpResponse<String> secondSessionRequest = getWithCookie(
+                    client, server.resolve("/session"), sessionCookie);
+            assertThat(firstSessionRequest.body()).contains("visits=1");
+            assertThat(secondSessionRequest.body()).contains("visits=2");
+        }
+    }
+
+    @Test
+    void servletContainerInitializerRegistersServletAndErrorPageHandlesException() throws Exception {
+        DeploymentInfo deploymentInfo = baseDeployment("initializer")
+                .addServletContainerInitializer(new ServletContainerInitializerInfo(
+                        DynamicServletInitializer.class, Set.of()))
+                .addServlets(
+                        Servlets.servlet("failing", FailingServlet.class).addMapping("/boom"),
+                        Servlets.servlet("error", ErrorServlet.class).addMapping("/error"))
+                .addErrorPage(Servlets.errorPage("/error", IllegalStateException.class));
+
+        try (RunningServer server = startServer(deploymentInfo);
+                HttpClient client = newHttpClient()) {
+            HttpResponse<String> dynamicResponse = get(client, server.resolve("/dynamic"));
+            assertThat(dynamicResponse.statusCode()).isEqualTo(200);
+            assertThat(dynamicResponse.body()).contains("dynamic=true", "init=from-initializer");
+
+            HttpResponse<String> errorResponse = get(client, server.resolve("/boom"));
+            assertThat(errorResponse.statusCode()).isEqualTo(500);
+            assertThat(errorResponse.body()).contains(
+                    "status=500",
+                    "exception=java.lang.IllegalStateException",
+                    "message=intentional failure");
+        }
+    }
+
+    @Test
+    void multipartServletParsesFormFieldsAndUploadedFile(@TempDir Path tempDir) throws Exception {
+        DeploymentInfo deploymentInfo = baseDeployment("multipart")
+                .setTempDir(tempDir)
+                .addServlet(Servlets.servlet("upload", UploadServlet.class)
+                        .addMapping("/upload")
+                        .setMultipartConfig(Servlets.multipartConfig(
+                                tempDir.toString(), 1024 * 1024, 1024 * 1024, 0)));
+
+        String boundary = "----undertowServletBoundary";
+        String body = "--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"description\"\r\n\r\n"
+                + "native-image friendly upload\r\n"
+                + "--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"\r\n"
+                + "Content-Type: text/plain\r\n\r\n"
+                + "hello from multipart\r\n"
+                + "--" + boundary + "--\r\n";
+
+        try (RunningServer server = startServer(deploymentInfo);
+                HttpClient client = newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder(server.resolve("/upload"))
+                    .timeout(HTTP_TIMEOUT)
+                    .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+                    .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains(
+                    "parts=2",
+                    "description=native-image friendly upload",
+                    "filename=hello.txt",
+                    "content=hello from multipart");
+        }
+    }
+
+    private static DeploymentInfo baseDeployment(String name) {
+        return Servlets.deployment()
+                .setClassLoader(Undertow_servletTest.class.getClassLoader())
+                .setContextPath("/" + name)
+                .setDeploymentName(name + ".war")
+                .setDefaultEncoding(StandardCharsets.UTF_8.name());
+    }
+
+    private static RunningServer startServer(DeploymentInfo deploymentInfo) throws ServletException {
+        ServletContainer container = Servlets.newContainer();
+        DeploymentManager manager = container.addDeployment(deploymentInfo);
+        manager.deploy();
+        Undertow server = Undertow.builder()
+                .addHttpListener(0, LOOPBACK_HOST)
+                .setHandler(manager.start())
+                .build();
+        server.start();
+        return new RunningServer(container, deploymentInfo, manager, server);
+    }
+
+    private static HttpClient newHttpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(HTTP_TIMEOUT)
+                .build();
+    }
+
+    private static HttpResponse<String> get(HttpClient client, URI uri) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(HTTP_TIMEOUT)
+                .GET()
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> getWithCookie(HttpClient client, URI uri, String cookie)
+            throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(HTTP_TIMEOUT)
+                .header("Cookie", cookie)
+                .GET()
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static final class RunningServer implements AutoCloseable {
+        private final ServletContainer container;
+        private final DeploymentInfo deploymentInfo;
+        private final DeploymentManager manager;
+        private final Undertow server;
+        private final URI baseUri;
+
+        private RunningServer(
+                ServletContainer container,
+                DeploymentInfo deploymentInfo,
+                DeploymentManager manager,
+                Undertow server) {
+            this.container = container;
+            this.deploymentInfo = deploymentInfo;
+            this.manager = manager;
+            this.server = server;
+            InetSocketAddress address = (InetSocketAddress) server.getListenerInfo().get(0).getAddress();
+            this.baseUri = URI.create("http://" + LOOPBACK_HOST + ":" + address.getPort());
+        }
+
+        private URI resolve(String pathAndQuery) {
+            return baseUri.resolve(baseUri.getPath() + pathAndQuery);
+        }
+
+        @Override
+        public void close() throws ServletException {
+            server.stop();
+            if (manager.getState() == DeploymentManager.State.STARTED) {
+                manager.stop();
+            }
+            if (manager.getState() == DeploymentManager.State.DEPLOYED) {
+                manager.undeploy();
+            }
+            container.removeDeployment(deploymentInfo);
+        }
+    }
+
+    public static final class ApplicationListener implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent event) {
+            event.getServletContext().setAttribute("listener.state", "started");
+        }
+    }
+
+    public static final class MarkerFilter implements Filter {
+        private String marker;
+
+        @Override
+        public void init(FilterConfig filterConfig) {
+            marker = filterConfig.getInitParameter("marker");
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            request.setAttribute("filter.marker", marker);
+            ((HttpServletResponse) response).setHeader("X-Marker", marker);
+            chain.doFilter(request, response);
+        }
+    }
+
+    public static final class FrontControllerServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException {
+            request.setAttribute("forwarded.name", request.getParameter("name"));
+            request.getRequestDispatcher("/target").forward(request, response);
+        }
+    }
+
+    public static final class TargetServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            response.setContentType("text/plain;charset=UTF-8");
+            ServletContext context = request.getServletContext();
+            response.getWriter().println("name=" + request.getAttribute("forwarded.name"));
+            response.getWriter().println("filter=" + request.getAttribute("filter.marker"));
+            response.getWriter().println("listener=" + context.getAttribute("listener.state"));
+            response.getWriter().println("application=" + context.getInitParameter("application.name"));
+        }
+    }
+
+    public static final class SessionServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            HttpSession session = request.getSession(true);
+            Integer visits = (Integer) session.getAttribute("visits");
+            int nextVisit = visits == null ? 1 : visits + 1;
+            session.setAttribute("visits", nextVisit);
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().println("visits=" + nextVisit);
+        }
+    }
+
+    public static final class DynamicServletInitializer implements ServletContainerInitializer {
+        @Override
+        public void onStartup(Set<Class<?>> classes, ServletContext context) {
+            ServletRegistration.Dynamic registration = context.addServlet("dynamic", DynamicServlet.class);
+            registration.setInitParameter("createdBy", "from-initializer");
+            registration.addMapping("/dynamic");
+        }
+    }
+
+    public static final class DynamicServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().println("dynamic=true");
+            response.getWriter().println("init=" + getServletConfig().getInitParameter("createdBy"));
+        }
+    }
+
+    public static final class FailingServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+            throw new IllegalStateException("intentional failure");
+        }
+    }
+
+    public static final class ErrorServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            Throwable exception = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().println("status=" + request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE));
+            response.getWriter().println("exception=" + exception.getClass().getName());
+            response.getWriter().println("message=" + exception.getMessage());
+        }
+    }
+
+    public static final class UploadServlet extends HttpServlet {
+        @Override
+        protected void doPost(HttpServletRequest request, HttpServletResponse response)
+                throws IOException, ServletException {
+            Collection<Part> parts = request.getParts();
+            Part file = request.getPart("file");
+            String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().println("parts=" + parts.size());
+            response.getWriter().println("description=" + request.getParameter("description"));
+            response.getWriter().println("filename=" + file.getSubmittedFileName());
+            response.getWriter().println("content=" + content);
+        }
     }
 }

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
@@ -9,11 +9,14 @@ package io_undertow.undertow_servlet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.undertow.Undertow;
+import io.undertow.server.handlers.resource.PathResourceManager;
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.MimeMapping;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletContainerInitializerInfo;
+import io.undertow.servlet.handlers.DefaultServlet;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -40,6 +43,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
@@ -164,6 +168,34 @@ public class Undertow_servletTest {
                     "asyncSupported=true",
                     "message=complete",
                     "complete=true");
+        }
+    }
+
+    @Test
+    void defaultServletServesWelcomeFilesAndConfiguredMimeMappings(@TempDir Path webRoot) throws Exception {
+        Files.writeString(webRoot.resolve("index.txt"), "welcome from resource manager", StandardCharsets.UTF_8);
+        Path assets = Files.createDirectories(webRoot.resolve("assets"));
+        Files.writeString(assets.resolve("info.example"), "custom mime resource", StandardCharsets.UTF_8);
+
+        DeploymentInfo deploymentInfo = baseDeployment("static")
+                .setResourceManager(new PathResourceManager(webRoot, 1024))
+                .addWelcomePage("index.txt")
+                .addMimeMapping(new MimeMapping("example", "application/x-undertow-test"))
+                .addServlet(Servlets.servlet("default", DefaultServlet.class)
+                        .addInitParam(DefaultServlet.DEFAULT_ALLOWED, "true")
+                        .addMapping("/"));
+
+        try (RunningServer server = startServer(deploymentInfo);
+                HttpClient client = newHttpClient()) {
+            HttpResponse<String> welcomeResponse = get(client, server.resolve("/"));
+            assertThat(welcomeResponse.statusCode()).isEqualTo(200);
+            assertThat(welcomeResponse.body()).contains("welcome from resource manager");
+
+            HttpResponse<String> resourceResponse = get(client, server.resolve("/assets/info.example"));
+            assertThat(resourceResponse.statusCode()).isEqualTo(200);
+            assertThat(resourceResponse.headers().firstValue("Content-Type"))
+                    .contains("application/x-undertow-test");
+            assertThat(resourceResponse.body()).contains("custom mime resource");
         }
     }
 

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/src/test/java/io_undertow/undertow_servlet/Undertow_servletTest.java
@@ -14,6 +14,7 @@ import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletContainerInitializerInfo;
+import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -145,6 +146,24 @@ public class Undertow_servletTest {
                     "description=native-image friendly upload",
                     "filename=hello.txt",
                     "content=hello from multipart");
+        }
+    }
+
+    @Test
+    void asyncServletCompletesResponseOnContainerWorkerThread() throws Exception {
+        DeploymentInfo deploymentInfo = baseDeployment("async")
+                .addServlet(Servlets.servlet("async", AsyncServlet.class)
+                        .addMapping("/async")
+                        .setAsyncSupported(true));
+
+        try (RunningServer server = startServer(deploymentInfo);
+                HttpClient client = newHttpClient()) {
+            HttpResponse<String> response = get(client, server.resolve("/async?message=complete"));
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains(
+                    "asyncSupported=true",
+                    "message=complete",
+                    "complete=true");
         }
     }
 
@@ -334,6 +353,42 @@ public class Undertow_servletTest {
             response.getWriter().println("description=" + request.getParameter("description"));
             response.getWriter().println("filename=" + file.getSubmittedFileName());
             response.getWriter().println("content=" + content);
+        }
+    }
+
+    public static final class AsyncServlet extends HttpServlet {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+            response.setContentType("text/plain;charset=UTF-8");
+            AsyncContext asyncContext = request.startAsync();
+            asyncContext.setTimeout(HTTP_TIMEOUT.toMillis());
+            asyncContext.start(new AsyncResponseTask(
+                    asyncContext, request.isAsyncSupported(), request.getParameter("message")));
+        }
+    }
+
+    public static final class AsyncResponseTask implements Runnable {
+        private final AsyncContext asyncContext;
+        private final boolean asyncSupported;
+        private final String message;
+
+        private AsyncResponseTask(AsyncContext asyncContext, boolean asyncSupported, String message) {
+            this.asyncContext = asyncContext;
+            this.asyncSupported = asyncSupported;
+            this.message = message;
+        }
+
+        @Override
+        public void run() {
+            try {
+                HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
+                response.getWriter().println("asyncSupported=" + asyncSupported);
+                response.getWriter().println("message=" + message);
+                response.getWriter().println("complete=true");
+                asyncContext.complete();
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to write asynchronous response", e);
+            }
         }
     }
 }

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/user-code-filter.json
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.undertow.servlet.**"
+    }
+  ]
+}

--- a/tests/src/io.undertow/undertow-servlet/2.3.18.Final/user-code-filter.json
+++ b/tests/src/io.undertow/undertow-servlet/2.3.18.Final/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.undertow.servlet.**"
+      "includeClasses" : "io.undertow.servlet.**"
+    },
+    {
+      "includeClasses" : "io_undertow.undertow_servlet.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #4507

This PR introduces tests and metadata for io.undertow:undertow-servlet:2.3.18.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 200035
- Cached input tokens: 1555968
- Output tokens: 19844
- Metadata entries: 460
- Iterations: 6
- Library coverage percentage: 28.82
- Generated lines of code: 382
- Tested library lines of code: 2966

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `e2b1defba40d00bf056223ec50b2cf41dcd21c2b`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 7/16 covered calls (43.75%)
- Reflection: 7/16 covered calls (43.75%)

Library coverage:
- Instruction: 11872/42146 (28.17%)
- Line: 2966/10290 (28.82%)
- Method: 690/2247 (30.71%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
