### PR TITLE
[GenAI] Add support for org.apache.pekko:pekko-parsing_2.13:1.3.0 using gpt-5.5

### DIFF
--- a/metadata/org.apache.pekko/pekko-parsing_2.13/1.3.0/reachability-metadata.json
+++ b/metadata/org.apache.pekko/pekko-parsing_2.13/1.3.0/reachability-metadata.json
@@ -1,0 +1,43 @@
+{
+  "reflection" : [
+    {
+      "type" : "org.apache.pekko.http.ccompat.pre213",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.http.ccompat.since213",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "type" : "org.apache.pekko.http.ccompat.pre213macro"
+    },
+    {
+      "type" : "org.apache.pekko.http.ccompat.pre213macro$"
+    },
+    {
+      "type" : "org.apache.pekko.http.ccompat.since213macro"
+    },
+    {
+      "type" : "org.apache.pekko.http.ccompat.since213macro$"
+    },
+    {
+      "type" : "org.apache.pekko.macros.LogHelper"
+    },
+    {
+      "type" : "org.apache.pekko.macros.LogHelperMacro"
+    },
+    {
+      "type" : "org.apache.pekko.macros.LogHelperMacro$"
+    }
+  ]
+}

--- a/metadata/org.apache.pekko/pekko-parsing_2.13/index.json
+++ b/metadata/org.apache.pekko/pekko-parsing_2.13/index.json
@@ -1,0 +1,22 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.3.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-parsing_2.13/$version$/pekko-parsing_2.13-$version$-sources.jar",
+    "repository-url" : "https://github.com/apache/pekko-http",
+    "test-code-url" : "https://github.com/apache/pekko-http/tree/v$version$/http-core/src/test/scala/org/apache/pekko/http/impl/engine/parsing",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/apache/pekko/pekko-parsing_2.13/$version$/pekko-parsing_2.13-$version$-javadoc.jar",
+    "description" : "Apache Pekko Parsing is a Scala-specific internal support module for Pekko HTTP that provides compile-time logging guards and cross-Scala-version compatibility annotations used by the HTTP parsing implementation. It is published as a JVM JAR for each Scala binary version, including Scala 2.13, so downstream Pekko HTTP modules can share those internal helpers without duplicating them.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "1.3.0"
+    ],
+    "allowed-packages" : [
+      "org.apache.pekko.http.ccompat",
+      "org.apache.pekko.macros"
+    ]
+  }
+]

--- a/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/execution-metrics.json
+++ b/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/execution-metrics.json
@@ -1,0 +1,113 @@
+{
+  "add_new_library_support:2026-06-28": {
+    "timestamp": "2026-06-28T04:08:02.383699Z",
+    "library": "org.apache.pekko:pekko-parsing_2.13:1.3.0",
+    "starting_commit": "e93b8bd9c333d3806706ddc0a781b265e94ef961",
+    "ending_commit": "ed4789892fb927de9e21df19a4ae44a9cc451f98",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.3.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 21,
+          "missed": 652,
+          "ratio": 0.031204,
+          "total": 673
+        },
+        "line": {
+          "covered": 5,
+          "missed": 28,
+          "ratio": 0.151515,
+          "total": 33
+        },
+        "method": {
+          "covered": 5,
+          "missed": 28,
+          "ratio": 0.151515,
+          "total": 33
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 5447,
+      "issue_label": "library-new-request",
+      "library": "org.apache.pekko:pekko-parsing_2.13:1.3.0",
+      "summary": "The artifact is a small Scala 2.13 internal macro/annotation support jar. Its POM marks `pekko-actor_2.13` and `scala-reflect` as `provided`, but the shipped public bytecode references `org.apache.pekko.event.LoggingAdapter` and `scala.reflect.macros.blackbox.Context`, so meaningful class loading/reflection coverage needs those libraries on the test classpath.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.pekko:pekko-actor_2.13:1.1.5",
+          "scope": "testImplementation",
+          "reason": "`LogHelper` exposes `org.apache.pekko.event.LoggingAdapter`; this dependency is declared as provided by `pekko-parsing_2.13` and is not pulled transitively for tests."
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.scala-lang:scala-reflect:2.13.17",
+          "scope": "testImplementation",
+          "reason": "The macro classes expose `scala.reflect.macros.blackbox.Context` and related reflection APIs; this dependency is declared as provided and is required to reflect or load those macro members."
+        }
+      ],
+      "agent_guidance": "No Docker image, environment variable, or system property appears necessary. Tests should treat this as an internal Scala macro-support artifact: exercise annotation construction, safe class loading/reflection of the macro module classes, and `LogHelper` default methods with a minimal `LoggingAdapter` test double rather than requiring an external service.",
+      "risks": [
+        "Actual Scala macro expansion is compile-time behavior and may be hard to exercise from the normal Java generated test scaffold.",
+        "Most classes are internal APIs, so meaningful coverage may be limited to reflective/runtime smoke coverage unless the generator creates Scala-aware tests."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.apache.pekko:pekko-actor_2.13:1.1.5",
+          "result": "applied",
+          "target": "tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle"
+        },
+        {
+          "kind": "dependency",
+          "coordinate": "org.scala-lang:scala-reflect:2.13.17",
+          "result": "applied",
+          "target": "tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5447 Support for org.apache.pekko:pekko-parsing_2.13:1.3.0; label=library-new-request; body_chars=110"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 21252,
+      "output_tokens_used": 3375,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.pekko:pekko-parsing_2.13:1.3.0/library-preparation-preflight/pi-generation-2026-06-28T03-29-09-430004Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 372306,
+      "cached_input_tokens_used": 4214272,
+      "output_tokens_used": 54165,
+      "iterations": 11,
+      "cost_usd": 3.732,
+      "generated_loc": 143,
+      "tested_library_loc": 5,
+      "metadata_entries": 11,
+      "code_coverage_percent": 15.15
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala",
+      "metadata_file": "metadata/org.apache.pekko/pekko-parsing_2.13/1.3.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/stats.json
+++ b/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.3.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 21,
+        "missed" : 652,
+        "ratio" : 0.031204,
+        "total" : 673
+      },
+      "line" : {
+        "covered" : 5,
+        "missed" : 28,
+        "ratio" : 0.151515,
+        "total" : 33
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 28,
+        "ratio" : 0.151515,
+        "total" : 33
+      }
+    }
+  } ]
+}

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/.gitignore
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
+
+dependencies {
+    testImplementation "org.apache.pekko:pekko-parsing_2.13:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
+    testImplementation "org.apache.pekko:pekko-actor_2.13:1.1.5"
+    testImplementation "org.scala-lang:scala-reflect:2.13.17"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/build.gradle
@@ -4,6 +4,8 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.gradle.api.tasks.scala.ScalaCompile
+
 plugins {
     id "org.graalvm.internal.tck"
     id "scala"
@@ -12,6 +14,11 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
 String scala2Version = tck.scala2Version.get()
+
+tasks.withType(ScalaCompile).configureEach {
+    scalaCompileOptions.additionalParameters =
+            (scalaCompileOptions.additionalParameters ?: []) + ['-Ymacro-annotations']
+}
 
 dependencies {
     testImplementation "org.apache.pekko:pekko-parsing_2.13:$libraryVersion"

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/gradle.properties
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.apache.pekko:pekko-parsing_2.13:1.3.0
+library.version = 1.3.0
+metadata.dir = org.apache.pekko/pekko-parsing_2.13/1.3.0/

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/settings.gradle
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.apache.pekko.pekko-parsing_2.13_tests'

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_pekko.pekko_parsing_2_13
+
+import org.junit.jupiter.api.Test
+
+class Pekko_parsing_2_13Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
@@ -6,6 +6,7 @@
  */
 package org_apache_pekko.pekko_parsing_2_13
 
+import org.apache.pekko.http.ccompat.{pre213, since213}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -111,6 +112,13 @@ class Pekko_parsing_2_13Test {
       .containsExactly("LogHelper", "LogHelperMacro")
   }
 
+  @Test
+  def crossVersionMacroAnnotationsSelectScala213ImplementationAtCompileTime(): Unit = {
+    assertThat(CrossVersionParsingRules.separatorName).isEqualTo("pipe")
+    assertThat(CrossVersionParsingRules.normalizedSegments("alpha | beta || gamma").asJava)
+      .containsExactly("alpha", "beta", "gamma")
+  }
+
   private def renderTokenFor(annotation: StaticAnnotation, token: String): String =
     annotation.getClass.getName match {
       case "org.apache.pekko.http.ccompat.pre213" => s"pre213:$token"
@@ -136,11 +144,29 @@ class Pekko_parsing_2_13Test {
     tokens(value, "\\|")
 
   private def tokens(value: String, separator: String): java.util.List[String] =
+    splitAndTrim(value, separator).asJava
+
+  private def splitAndTrim(value: String, separator: String): List[String] =
     value
       .split(separator)
       .iterator
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
-      .asJava
+
+  private object CrossVersionParsingRules {
+    @pre213
+    def separatorName: String = "comma"
+
+    @since213
+    def separatorName: String = "pipe"
+
+    @pre213
+    def normalizedSegments(value: String): List[String] =
+      splitAndTrim(value, ",")
+
+    @since213
+    def normalizedSegments(value: String): List[String] =
+      splitAndTrim(value, "\\|")
+  }
 }

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
@@ -63,6 +63,19 @@ class Pekko_parsing_2_13Test {
   }
 
   @Test
+  def annotationInstancesCanBeUsedToDispatchCrossVersionBehaviorAtRuntime(): Unit = {
+    val annotations: List[(StaticAnnotation, String)] = List(
+      newStaticAnnotation("org.apache.pekko.http.ccompat.pre213") -> "legacy",
+      newStaticAnnotation("org.apache.pekko.http.ccompat.since213") -> "current")
+
+    val renderedTokens: List[String] = annotations.map { case (annotation, token) =>
+      renderTokenFor(annotation, token)
+    }
+
+    assertThat(renderedTokens.asJava).containsExactly("pre213:legacy", "since213:current")
+  }
+
+  @Test
   def annotationTypesCanBeUsedToSelectCrossVersionImplementationsAtRuntime(): Unit = {
     val pre213Class: Class[_ <: StaticAnnotation] = loadStaticAnnotation("org.apache.pekko.http.ccompat.pre213")
     val since213Class: Class[_ <: StaticAnnotation] = loadStaticAnnotation("org.apache.pekko.http.ccompat.since213")
@@ -97,6 +110,15 @@ class Pekko_parsing_2_13Test {
     assertThat(groupedNames("org.apache.pekko.macros").asJava)
       .containsExactly("LogHelper", "LogHelperMacro")
   }
+
+  private def renderTokenFor(annotation: StaticAnnotation, token: String): String =
+    annotation.getClass.getName match {
+      case "org.apache.pekko.http.ccompat.pre213" => s"pre213:$token"
+      case "org.apache.pekko.http.ccompat.since213" => s"since213:$token"
+    }
+
+  private def newStaticAnnotation(name: String): StaticAnnotation =
+    loadStaticAnnotation(name).getDeclaredConstructor().newInstance()
 
   private def loadClass(name: String): Class[_] =
     Class.forName(name, true, Thread.currentThread().getContextClassLoader)

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/src/test/scala/org_apache_pekko/pekko_parsing_2_13/Pekko_parsing_2_13Test.scala
@@ -6,11 +6,119 @@
  */
 package org_apache_pekko.pekko_parsing_2_13
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+
+import scala.annotation.StaticAnnotation
+import scala.jdk.CollectionConverters._
 
 class Pekko_parsing_2_13Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def annotationClassesAreAvailableAsStaticAnnotations(): Unit = {
+    val annotationClasses: List[Class[_ <: StaticAnnotation]] = List(
+      loadStaticAnnotation("org.apache.pekko.http.ccompat.pre213"),
+      loadStaticAnnotation("org.apache.pekko.http.ccompat.since213"))
+
+    assertThat(annotationClasses.map(_.getName).asJava)
+      .containsExactly(
+        "org.apache.pekko.http.ccompat.pre213",
+        "org.apache.pekko.http.ccompat.since213")
+    annotationClasses.foreach { annotationClass =>
+      assertThat(classOf[StaticAnnotation].isAssignableFrom(annotationClass)).isTrue
+      assertThat(annotationClass.getDeclaredConstructor()).isNotNull
+    }
   }
+
+  @Test
+  def compatibilityMacroClassesLoadWithScalaReflectOnTheClasspath(): Unit = {
+    val macroClasses: List[Class[_]] = List(
+      loadClass("org.apache.pekko.http.ccompat.pre213macro"),
+      loadClass("org.apache.pekko.http.ccompat.pre213macro$"),
+      loadClass("org.apache.pekko.http.ccompat.since213macro"),
+      loadClass("org.apache.pekko.http.ccompat.since213macro$"))
+
+    assertThat(macroClasses.map(_.getName).asJava)
+      .containsExactly(
+        "org.apache.pekko.http.ccompat.pre213macro",
+        "org.apache.pekko.http.ccompat.pre213macro$",
+        "org.apache.pekko.http.ccompat.since213macro",
+        "org.apache.pekko.http.ccompat.since213macro$")
+    assertThat(macroClasses.forall(_.getClassLoader != null)).isTrue
+  }
+
+  @Test
+  def logHelperMacroSupportClassesLoadWithProvidedPekkoActorAndScalaReflectDependencies(): Unit = {
+    val logHelperClass: Class[_] = loadClass("org.apache.pekko.macros.LogHelper")
+    val logHelperMacroClass: Class[_] = loadClass("org.apache.pekko.macros.LogHelperMacro")
+    val logHelperMacroModuleClass: Class[_] = loadClass("org.apache.pekko.macros.LogHelperMacro$")
+    val loggingAdapterClass: Class[_] = loadClass("org.apache.pekko.event.LoggingAdapter")
+    val scalaMacroContextClass: Class[_] = loadClass("scala.reflect.macros.blackbox.Context")
+
+    assertThat(logHelperClass.isInterface).isTrue
+    assertThat(logHelperMacroClass.isInterface).isTrue
+    assertThat(logHelperMacroClass.isAssignableFrom(logHelperClass)).isTrue
+    assertThat(logHelperMacroModuleClass.getName).endsWith("LogHelperMacro$")
+    assertThat(loggingAdapterClass.getName).isEqualTo("org.apache.pekko.event.LoggingAdapter")
+    assertThat(scalaMacroContextClass.getName).isEqualTo("scala.reflect.macros.blackbox.Context")
+  }
+
+  @Test
+  def annotationTypesCanBeUsedToSelectCrossVersionImplementationsAtRuntime(): Unit = {
+    val pre213Class: Class[_ <: StaticAnnotation] = loadStaticAnnotation("org.apache.pekko.http.ccompat.pre213")
+    val since213Class: Class[_ <: StaticAnnotation] = loadStaticAnnotation("org.apache.pekko.http.ccompat.since213")
+    val selectors: Map[Class[_ <: StaticAnnotation], String => java.util.List[String]] = Map(
+      pre213Class -> commaSeparatedTokens,
+      since213Class -> pipeSeparatedTokens)
+
+    assertThat(selectors(pre213Class).apply("alpha, beta,,gamma"))
+      .containsExactly("alpha", "beta", "gamma")
+    assertThat(selectors(since213Class).apply("delta| epsilon || zeta"))
+      .containsExactly("delta", "epsilon", "zeta")
+  }
+
+  @Test
+  def loadedMacroSupportClassesCanBeGroupedByTheirPekkoPackage(): Unit = {
+    val classes: List[Class[_]] = List(
+      loadClass("org.apache.pekko.http.ccompat.pre213"),
+      loadClass("org.apache.pekko.http.ccompat.since213"),
+      loadClass("org.apache.pekko.http.ccompat.pre213macro"),
+      loadClass("org.apache.pekko.http.ccompat.since213macro"),
+      loadClass("org.apache.pekko.macros.LogHelper"),
+      loadClass("org.apache.pekko.macros.LogHelperMacro"))
+
+    val groupedNames: Map[String, List[String]] = classes
+      .groupBy(_.getPackage.getName)
+      .view
+      .mapValues(_.map(_.getSimpleName).sorted)
+      .toMap
+
+    assertThat(groupedNames("org.apache.pekko.http.ccompat").asJava)
+      .containsExactly("pre213", "pre213macro", "since213", "since213macro")
+    assertThat(groupedNames("org.apache.pekko.macros").asJava)
+      .containsExactly("LogHelper", "LogHelperMacro")
+  }
+
+  private def loadClass(name: String): Class[_] =
+    Class.forName(name, true, Thread.currentThread().getContextClassLoader)
+
+  private def loadStaticAnnotation(name: String): Class[_ <: StaticAnnotation] = {
+    val loadedClass: Class[_] = loadClass(name)
+    assertThat(classOf[StaticAnnotation].isAssignableFrom(loadedClass)).isTrue
+    loadedClass.asSubclass(classOf[StaticAnnotation])
+  }
+
+  private def commaSeparatedTokens(value: String): java.util.List[String] =
+    tokens(value, ",")
+
+  private def pipeSeparatedTokens(value: String): java.util.List[String] =
+    tokens(value, "\\|")
+
+  private def tokens(value: String, separator: String): java.util.List[String] =
+    value
+      .split(separator)
+      .iterator
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toList
+      .asJava
 }

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/user-code-filter.json
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/user-code-filter.json
@@ -1,13 +1,16 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.apache.pekko.http.ccompat.**"
+      "includeClasses" : "org.apache.pekko.http.ccompat.**"
     },
     {
-      "includeClasses": "org.apache.pekko.macros.**"
+      "includeClasses" : "org.apache.pekko.macros.**"
+    },
+    {
+      "includeClasses" : "org_apache_pekko.pekko_parsing_2_13.**"
     }
   ]
 }

--- a/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/user-code-filter.json
+++ b/tests/src/org.apache.pekko/pekko-parsing_2.13/1.3.0/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.apache.pekko.http.ccompat.**"
+    },
+    {
+      "includeClasses": "org.apache.pekko.macros.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #5447

This PR introduces tests and metadata for org.apache.pekko:pekko-parsing_2.13:1.3.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 372306
- Cached input tokens: 4214272
- Output tokens: 54165
- Metadata entries: 11
- Iterations: 11
- Library coverage percentage: 15.15
- Generated lines of code: 143
- Tested library lines of code: 5

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `495672c318b0fc9e4429f334c582286782220a41`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 21/673 (3.12%)
- Line: 5/33 (15.15%)
- Method: 5/33 (15.15%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
