### PR TITLE
[GenAI] Add support for com.github.ghik:silencer-lib_2.13.12:1.7.14 using gpt-5.5

### DIFF
--- a/metadata/com.github.ghik/silencer-lib_2.13.12/1.7.14/reachability-metadata.json
+++ b/metadata/com.github.ghik/silencer-lib_2.13.12/1.7.14/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "com.github.ghik.silencer.silent"
+      },
+      "type": "scala.tools.nsc.Reporting$WarningCategory$",
+      "allDeclaredFields": true
+    }
+  ]
+}

--- a/metadata/com.github.ghik/silencer-lib_2.13.12/index.json
+++ b/metadata/com.github.ghik/silencer-lib_2.13.12/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.7.14",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/com/github/ghik/silencer-lib_2.13.12/$version$/silencer-lib_2.13.12-$version$-sources.jar",
+    "repository-url" : "https://github.com/ghik/silencer",
+    "test-code-url" : "https://github.com/ghik/silencer/tree/v$version$/silencer-lib/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/com/github/ghik/silencer-lib_2.13.12/$version$/silencer-lib_2.13.12-$version$-javadoc.jar",
+    "description" : "This artifact provides the Scala annotation API used by the Silencer compiler plugin to suppress selected compiler warnings in Scala source code. It lets Scala projects mark definitions, statements, or expressions with @silent while the companion compiler plugin performs the warning filtering at compile time.",
+    "language" : {
+      "name" : "scala",
+      "version" : "2"
+    },
+    "tested-versions" : [
+      "1.7.14"
+    ],
+    "allowed-packages" : [
+      "com.github.ghik.silencer"
+    ]
+  }
+]

--- a/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/execution-metrics.json
+++ b/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/execution-metrics.json
@@ -1,0 +1,101 @@
+{
+  "add_new_library_support:2026-06-28": {
+    "timestamp": "2026-06-28T06:59:01.563147Z",
+    "library": "com.github.ghik:silencer-lib_2.13.12:1.7.14",
+    "starting_commit": "8b47d45804ab9ee6960db20f8bab55e428026289",
+    "ending_commit": "adea9552b9c4e780c5074cb745fe537d750f1614",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "1.7.14",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 6
+        },
+        "line": {
+          "covered": 2,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 2
+        },
+        "method": {
+          "covered": 2,
+          "missed": 0,
+          "ratio": 1.0,
+          "total": 2
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 5026,
+      "issue_label": "library-new-request",
+      "library": "com.github.ghik:silencer-lib_2.13.12:1.7.14",
+      "summary": "silencer-lib is only the Scala annotation jar; normal documented use pairs it with the matching silencer compiler plugin to make warning suppression behavior reachable.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "com.github.ghik:silencer-plugin_2.13.12:1.7.14",
+          "scope": "testImplementation",
+          "reason": "The artifact under test contains only com.github.ghik.silencer.silent; the documented setup requires the matching compiler plugin to exercise actual annotation-based warning suppression."
+        }
+      ],
+      "agent_guidance": "Tests should treat this as compile-time Scala functionality. Meaningful coverage should compile temporary Scala 2.13.12 source that imports com.github.ghik.silencer.silent, applies @silent to code that would otherwise warn, enables warning flags such as -deprecation or -Xlint, and asserts the expected compiler outcome. Use temporary files/directories only; no Docker image, service, environment variable, or system property appears required.",
+      "risks": [
+        "The requested jar is tiny and contains only an annotation class, so direct runtime/native coverage may be limited.",
+        "Wiring a scalac plugin from a Java/JUnit test can be awkward; local Gradle and native-image verification remain authoritative."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "com.github.ghik:silencer-plugin_2.13.12:1.7.14",
+          "result": "applied",
+          "target": "tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/build.gradle"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#5026 Support for com.github.ghik:silencer-lib_2.13.12:1.7.14; label=library-new-request; body_chars=112"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 47797,
+      "output_tokens_used": 2475,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.github.ghik:silencer-lib_2.13.12:1.7.14/library-preparation-preflight/pi-generation-2026-06-28T06-22-35-884903Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 135127,
+      "cached_input_tokens_used": 1383424,
+      "output_tokens_used": 17085,
+      "iterations": 3,
+      "cost_usd": 1.2042,
+      "generated_loc": 409,
+      "tested_library_loc": 2,
+      "metadata_entries": 2,
+      "code_coverage_percent": 100.0
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala",
+      "metadata_file": "metadata/com.github.ghik/silencer-lib_2.13.12/1.7.14/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/stats.json
+++ b/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.7.14",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 6,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 6
+      },
+      "line" : {
+        "covered" : 2,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 2
+      },
+      "method" : {
+        "covered" : 2,
+        "missed" : 0,
+        "ratio" : 1.0,
+        "total" : 2
+      }
+    }
+  } ]
+}

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/.gitignore
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala2Version = tck.scala2Version.get()
+
+dependencies {
+    testImplementation "com.github.ghik:silencer-lib_2.13.12:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala-library:$scala2Version"
+    testImplementation "org.scala-lang:scala-compiler:$scala2Version"
+    testImplementation "com.github.ghik:silencer-plugin_2.13.12:1.7.14"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/build.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/build.gradle
@@ -4,6 +4,9 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
+import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+import java.io.OutputStream
+
 plugins {
     id "org.graalvm.internal.tck"
     id "scala"
@@ -12,6 +15,12 @@ plugins {
 String libraryVersion = tck.testedLibraryVersion.get()
 int testJvmVersion = tck.testJvmVersion.get()
 String scala2Version = tck.scala2Version.get()
+String javaHome = System.getenv('JAVA_HOME') ?: System.getenv('GRAALVM_HOME')
+Provider<Directory> generatedTestRuntimePropertiesDir = layout.buildDirectory.dir("generated/test-runtime-properties")
+List<String> nativeRuntimeArgs = [
+        "-Djava.home=${javaHome}",
+        "-Djava.class.path=${-> sourceSets.test.runtimeClasspath.asPath}"
+]
 
 dependencies {
     testImplementation "com.github.ghik:silencer-lib_2.13.12:$libraryVersion"
@@ -21,13 +30,41 @@ dependencies {
     testImplementation "com.github.ghik:silencer-plugin_2.13.12:1.7.14"
 }
 
+tasks.register("generateNativeRuntimeProperties") {
+    outputs.dir(generatedTestRuntimePropertiesDir)
+    doLast {
+        File outputDir = generatedTestRuntimePropertiesDir.get().asFile
+        outputDir.mkdirs()
+
+        Properties properties = new Properties()
+        properties.setProperty("java.home", javaHome ?: "")
+        properties.setProperty("java.class.path", sourceSets.test.runtimeClasspath.asPath)
+
+        File outputFile = new File(outputDir, "native-runtime.properties")
+        outputFile.withOutputStream { OutputStream outputStream ->
+            properties.store(outputStream, "Generated runtime properties for silencer native tests")
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(testJvmVersion)
     }
 }
 
+processTestResources {
+    dependsOn(tasks.named("generateNativeRuntimeProperties"))
+    from(generatedTestRuntimePropertiesDir)
+}
+
 graalvmNative {
+    binaries {
+        test {
+            buildArgs("-H:+AllowJRTFileSystem")
+            runtimeArgs.addAll(nativeRuntimeArgs)
+        }
+    }
     agent {
         defaultMode = "conditional"
         modes {
@@ -36,4 +73,8 @@ graalvmNative {
             }
         }
     }
+}
+
+tasks.named("nativeTest", NativeRunTask) {
+    runtimeArgs.addAll(nativeRuntimeArgs)
 }

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/gradle.properties
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.github.ghik:silencer-lib_2.13.12:1.7.14
+library.version = 1.7.14
+metadata.dir = com.github.ghik/silencer-lib_2.13.12/1.7.14/

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/settings.gradle
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.github.ghik.silencer-lib_2.13.12_tests'

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_github_ghik.silencer_lib_2_13_12
+
+import org.junit.jupiter.api.Test
+
+class Silencer_lib_2_13_12Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Comparator
+import java.util.Properties
 import scala.annotation.Annotation
 import scala.jdk.CollectionConverters._
 import scala.tools.nsc.Global
@@ -29,6 +30,8 @@ import scala.tools.nsc.plugins.Plugin
 import scala.tools.nsc.reporters.StoreReporter
 
 class Silencer_lib_2_13_12Test {
+  restoreMissingRuntimeProperties()
+
   @Test
   def constructorsCreateIndependentScalaAnnotationInstances(): Unit = {
     val withoutPattern: silent = new silent()
@@ -262,6 +265,44 @@ class Silencer_lib_2_13_12Test {
       throw new IllegalArgumentException(s"Could not configure scalac options: ${unprocessed.mkString(" ")}")
     }
     settings
+  }
+
+  private def restoreMissingRuntimeProperties(): Unit = {
+    val embeddedRuntimeProperties: Properties = loadEmbeddedRuntimeProperties()
+
+    if (System.getProperty("java.home", "").isBlank) {
+      val javaHome: String = firstNonBlank(
+        embeddedRuntimeProperties.getProperty("java.home", ""),
+        System.getenv("JAVA_HOME"),
+        System.getenv("GRAALVM_HOME")
+      )
+      if (javaHome.nonEmpty) {
+        System.setProperty("java.home", javaHome)
+      }
+    }
+
+    if (System.getProperty("java.class.path", "").isBlank) {
+      val classPath: String = embeddedRuntimeProperties.getProperty("java.class.path", "")
+      if (classPath.nonEmpty) {
+        System.setProperty("java.class.path", classPath)
+      }
+    }
+  }
+
+  private def loadEmbeddedRuntimeProperties(): Properties = {
+    val properties = new Properties()
+    Option(getClass.getResourceAsStream("/native-runtime.properties")).foreach { inputStream =>
+      try {
+        properties.load(inputStream)
+      } finally {
+        inputStream.close()
+      }
+    }
+    properties
+  }
+
+  private def firstNonBlank(candidates: String*): String = {
+    candidates.find(candidate => candidate != null && !candidate.isBlank).getOrElse("")
   }
 
   private def runtimeClasspath: String = {

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
@@ -210,6 +210,17 @@ class Silencer_lib_2_13_12Test {
     assertEquals(("metadata", 8), first.zip(length).value)
   }
 
+  @Test
+  def annotationsOnImplicitDefinitionsKeepImplicitResolutionAndExtensionMethods(): Unit = {
+    import SilencerImplicitFixture._
+
+    assertEquals("int:7", render(7))
+    assertEquals("string:metadata", render("metadata"))
+    assertEquals("some(int:3)", render(Option(3)))
+    assertEquals("none", render(Option.empty[Int]))
+    assertEquals("int:12", 12.rendered)
+  }
+
   private def compileWithSilencer(fileName: String, source: String): CompilationResult = {
     val tempDirectory: Path = Files.createTempDirectory("silencer-compiler-test-")
     try {
@@ -362,5 +373,55 @@ final class SilencerGenericBox[@silent("class type parameter annotation") A](val
 object SilencerGenericBox {
   def apply[@silent("factory type parameter annotation") A](value: A): SilencerGenericBox[A] = {
     new SilencerGenericBox(value)
+  }
+}
+
+@silent("implicit type class annotation")
+trait SilencerFormatter[A] {
+  def render(value: A): String
+}
+
+object SilencerImplicitFixture {
+  @silent("implicit integer formatter annotation")
+  implicit val intFormatter: SilencerFormatter[Int] = new SilencerFormatter[Int] {
+    override def render(value: Int): String = {
+      s"int:$value"
+    }
+  }
+
+  @silent("implicit string formatter annotation")
+  implicit val stringFormatter: SilencerFormatter[String] = new SilencerFormatter[String] {
+    override def render(value: String): String = {
+      s"string:$value"
+    }
+  }
+
+  @silent("implicit option formatter annotation")
+  implicit def optionFormatter[A](implicit formatter: SilencerFormatter[A]): SilencerFormatter[Option[A]] = {
+    new SilencerFormatter[Option[A]] {
+      override def render(value: Option[A]): String = {
+        value match {
+          case Some(innerValue) => s"some(${formatter.render(innerValue)})"
+          case None => "none"
+        }
+      }
+    }
+  }
+
+  @silent("implicit-parameter method annotation")
+  def render[A](value: A)(
+      implicit @silent("implicit formatter parameter annotation") formatter: SilencerFormatter[A]
+  ): String = {
+    formatter.render(value)
+  }
+
+  @silent("implicit extension class annotation")
+  implicit final class RenderOps[A](
+      @silent("extension receiver annotation") private val value: A
+  ) extends AnyVal {
+    @silent("extension method annotation")
+    def rendered(implicit formatter: SilencerFormatter[A]): String = {
+      render(value)
+    }
   }
 }

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
@@ -6,11 +6,332 @@
  */
 package com_github_ghik.silencer_lib_2_13_12
 
+import com.github.ghik.silencer.SilencerPlugin
+import com.github.ghik.silencer.silent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import scala.annotation.Annotation
+import scala.jdk.CollectionConverters._
+import scala.tools.nsc.Global
+import scala.tools.nsc.Settings
+import scala.tools.nsc.plugins.Plugin
+import scala.tools.nsc.reporters.StoreReporter
 
 class Silencer_lib_2_13_12Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def constructorsCreateIndependentScalaAnnotationInstances(): Unit = {
+    val withoutPattern: silent = new silent()
+    val emptyPattern: silent = new silent("")
+    val warningPattern: silent = new silent("(?s).*local val unusedValue.*never used.*")
+    val alternationPattern: silent = new silent(".*(deprecated|feature|unchecked).*warning.*")
+
+    assertTrue(withoutPattern.isInstanceOf[Annotation])
+    assertTrue(emptyPattern.isInstanceOf[Annotation])
+    assertTrue(warningPattern.isInstanceOf[Annotation])
+    assertTrue(alternationPattern.isInstanceOf[Annotation])
+    assertSame(warningPattern, warningPattern)
+    assertNotSame(withoutPattern, emptyPattern)
+    assertNotSame(warningPattern, alternationPattern)
+  }
+
+  @Test
+  def silentAnnotationSuppressesFatalUnusedLocalCompilerWarning(): Unit = {
+    val result: CompilationResult = compileWithSilencer(
+      "SilencedUnusedWarning.scala",
+      """
+        |package example
+        |
+        |import com.github.ghik.silencer.silent
+        |
+        |object SilencedUnusedWarning {
+        |  @silent("(?s).*unusedSilencedLocal.*never used.*")
+        |  def answer(): Int = {
+        |    val unusedSilencedLocal: String = "compiled only when the warning is silenced"
+        |    42
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    assertTrue(result.success, result.renderedMessages)
+    assertFalse(result.hasMessageContaining("unusedSilencedLocal"), result.renderedMessages)
+  }
+
+  @Test
+  def compilerStillReportsUnsilencedUnusedLocalWarningsAsErrors(): Unit = {
+    val result: CompilationResult = compileWithSilencer(
+      "UnsilencedUnusedWarning.scala",
+      """
+        |package example
+        |
+        |object UnsilencedUnusedWarning {
+        |  def answer(): Int = {
+        |    val unsilencedLocal: String = "this local value should remain a fatal warning"
+        |    42
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    assertFalse(result.success, result.renderedMessages)
+    assertTrue(result.hasMessageContaining("unsilencedLocal"), result.renderedMessages)
+  }
+
+  @Test
+  def silentAnnotationSuppressesDeprecationWarningMatchedByMessagePattern(): Unit = {
+    val result: CompilationResult = compileWithSilencer(
+      "SilencedDeprecationWarning.scala",
+      """
+        |package example
+        |
+        |import com.github.ghik.silencer.silent
+        |
+        |object DeprecatedApi {
+        |  @deprecated("use replacement", "1.0")
+        |  def oldValue: Int = 7
+        |
+        |  def replacement: Int = 8
+        |}
+        |
+        |object SilencedDeprecationWarning {
+        |  @silent("(?s).*oldValue.*deprecated.*")
+        |  def value(): Int = DeprecatedApi.oldValue + DeprecatedApi.replacement
+        |}
+        |""".stripMargin
+    )
+
+    assertTrue(result.success, result.renderedMessages)
+    assertFalse(result.hasMessageContaining("oldValue"), result.renderedMessages)
+  }
+
+  @Test
+  def messagePatternOnlySuppressesMatchingCompilerWarnings(): Unit = {
+    val result: CompilationResult = compileWithSilencer(
+      "PartiallySilencedWarnings.scala",
+      """
+        |package example
+        |
+        |import com.github.ghik.silencer.silent
+        |
+        |object PartiallyDeprecatedApi {
+        |  @deprecated("use replacement", "1.0")
+        |  def oldValue: Int = 7
+        |}
+        |
+        |object PartiallySilencedWarnings {
+        |  @silent("(?s).*oldValue.*deprecated.*")
+        |  def value(): Int = {
+        |    val stillUnsilencedLocal: String = "not matched by the deprecation-only silencer"
+        |    PartiallyDeprecatedApi.oldValue
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    assertFalse(result.success, result.renderedMessages)
+    assertTrue(result.hasMessageContaining("stillUnsilencedLocal"), result.renderedMessages)
+  }
+
+  @Test
+  def annotatedDefinitionsKeepNormalScalaRuntimeSemantics(): Unit = {
+    val fixture: SilencerAnnotatedFixture = new SilencerAnnotatedFixture(" Native Image ")
+
+    assertEquals("Hello, Native Image!", fixture.greeting("!"))
+    assertEquals("native image", fixture.normalizedName)
+    assertEquals(42, fixture.transform(41)(_ + 1))
+    assertEquals("NATIVE IMAGE", SilencerAnnotatedFixture.normalize("native image"))
+
+    fixture.suffix = "?"
+    assertEquals("Hello, Native Image?", fixture.greeting(fixture.suffix))
+  }
+
+  @Test
+  def localExpressionTypeAliasAndGenericAnnotationsDoNotChangeEvaluation(): Unit = {
+    @silent("local collection used to verify expression evaluation")
+    val baseValues: Vector[Int] = Vector(2, 4, 8)
+
+    val folded: Int = ({
+      @silent("local accumulator seed")
+      val seed: Int = 1
+      baseValues.foldLeft(seed)(_ + _)
+    }: @silent("block expression annotation"))
+    val rendered: String = (baseValues.map(_ / 2).mkString("-"): @silent("method call expression annotation"))
+
+    val aliases: SilencerTypeAliasFixture = new SilencerTypeAliasFixture()
+    val label: aliases.Label = "metadata"
+    val groupedValues: aliases.Grouped[Int] = Map("odd" -> Vector(1, 3), "even" -> Vector(2, 4))
+
+    val first: SilencerGenericBox[String] = SilencerGenericBox("metadata")
+    val length: SilencerGenericBox[Int] = first.map(_.length)
+
+    assertEquals(15, folded)
+    assertEquals("1-2-4", rendered)
+    assertEquals("metadata:10", aliases.describe(label, groupedValues))
+    assertEquals(("metadata", 8), first.zip(length).value)
+  }
+
+  private def compileWithSilencer(fileName: String, source: String): CompilationResult = {
+    val tempDirectory: Path = Files.createTempDirectory("silencer-compiler-test-")
+    try {
+      val sourceFile: Path = tempDirectory.resolve(fileName)
+      val classesDirectory: Path = Files.createDirectories(tempDirectory.resolve("classes"))
+      Files.write(sourceFile, source.getBytes(StandardCharsets.UTF_8))
+
+      val reporter: StoreReporter = new StoreReporter()
+      val settings: Settings = compilerSettings(classesDirectory)
+      val global: Global = new Global(settings, reporter) {
+        override protected def loadRoughPluginsList(): List[Plugin] = {
+          List(new SilencerPlugin(this))
+        }
+      }
+      val run: global.Run = new global.Run()
+      run.compile(List(sourceFile.toString))
+
+      CompilationResult(!reporter.hasErrors, reporter.infos.toList.map(_.msg))
+    } finally {
+      deleteRecursively(tempDirectory)
+    }
+  }
+
+  private def compilerSettings(classesDirectory: Path): Settings = {
+    val settings: Settings = new Settings(message => throw new IllegalArgumentException(message))
+    settings.usejavacp.value = true
+    settings.outputDirs.setSingleOutput(classesDirectory.toString)
+    settings.classpath.value = runtimeClasspath
+
+    val arguments: List[String] = List(
+      "-encoding",
+      StandardCharsets.UTF_8.name(),
+      "-deprecation",
+      "-Wunused:locals",
+      "-Werror"
+    )
+    val (processed, unprocessed): (Boolean, List[String]) = settings.processArguments(arguments, processAll = true)
+    if (!processed || unprocessed.nonEmpty) {
+      throw new IllegalArgumentException(s"Could not configure scalac options: ${unprocessed.mkString(" ")}")
+    }
+    settings
+  }
+
+  private def runtimeClasspath: String = {
+    val propertyEntries: List[String] = System.getProperty("java.class.path", "")
+      .split(File.pathSeparator)
+      .filter(_.nonEmpty)
+      .toList
+    val loaderEntries: List[String] = classLoaderHierarchy(Thread.currentThread().getContextClassLoader).flatMap {
+      case loader: URLClassLoader => loader.getURLs.toList.collect {
+          case url if url.getProtocol == "file" => Path.of(url.toURI).toString
+        }
+      case _ => Nil
+    }
+
+    (propertyEntries ++ loaderEntries).distinct.mkString(File.pathSeparator)
+  }
+
+  private def classLoaderHierarchy(classLoader: ClassLoader): List[ClassLoader] = {
+    if (classLoader == null) {
+      Nil
+    } else {
+      classLoader :: classLoaderHierarchy(classLoader.getParent)
+    }
+  }
+
+  private def deleteRecursively(path: Path): Unit = {
+    if (Files.exists(path)) {
+      val paths = Files.walk(path)
+      try {
+        paths.sorted(Comparator.reverseOrder[Path]()).iterator().asScala.foreach { current: Path =>
+          Files.deleteIfExists(current)
+        }
+      } finally {
+        paths.close()
+      }
+    }
+  }
+}
+
+final case class CompilationResult(success: Boolean, messages: List[String]) {
+  def hasMessageContaining(text: String): Boolean = {
+    messages.exists(_.contains(text))
+  }
+
+  def renderedMessages: String = {
+    if (messages.isEmpty) {
+      "No compiler diagnostics were reported."
+    } else {
+      messages.mkString(System.lineSeparator())
+    }
+  }
+}
+
+@silent("class-level silencer annotation")
+final class SilencerAnnotatedFixture(@silent("constructor parameter annotation") val name: String) {
+  @silent("field annotation")
+  private val prefix: String = "Hello"
+
+  @silent("mutable field annotation")
+  var suffix: String = "!"
+
+  @silent("lazy value annotation")
+  lazy val normalizedName: String = name.trim.toLowerCase(java.util.Locale.ROOT)
+
+  @silent("method annotation")
+  def greeting(@silent("method parameter annotation") punctuation: String): String = {
+    s"$prefix, ${name.trim}$punctuation"
+  }
+
+  @silent("curried higher-order method annotation")
+  def transform(value: Int)(operation: Int => Int): Int = {
+    operation(value)
+  }
+}
+
+@silent("companion object annotation")
+object SilencerAnnotatedFixture {
+  @silent("companion method annotation")
+  def normalize(value: String): String = {
+    value.toUpperCase(java.util.Locale.ROOT)
+  }
+}
+
+final class SilencerTypeAliasFixture {
+  @silent("simple type alias annotation")
+  type Label = String
+
+  @silent("nested generic type alias annotation")
+  type Grouped[A] = Map[String, Vector[A]]
+
+  def describe(label: Label, groupedValues: Grouped[Int]): String = {
+    val total: Int = groupedValues.values.flatten.sum
+    s"$label:$total"
+  }
+}
+
+final class SilencerGenericBox[@silent("class type parameter annotation") A](val value: A) {
+  @silent("method with annotated result type parameter")
+  def map[@silent("map result type parameter annotation") B](transform: A => B): SilencerGenericBox[B] = {
+    SilencerGenericBox(transform(value))
+  }
+
+  @silent("method with annotated peer type parameter")
+  def zip[@silent("zip peer type parameter annotation") B](other: SilencerGenericBox[B]): SilencerGenericBox[(A, B)] = {
+    SilencerGenericBox((value, other.value))
+  }
+}
+
+object SilencerGenericBox {
+  def apply[@silent("factory type parameter annotation") A](value: A): SilencerGenericBox[A] = {
+    new SilencerGenericBox(value)
   }
 }

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/src/test/scala/com_github_ghik/silencer_lib_2_13_12/Silencer_lib_2_13_12Test.scala
@@ -89,6 +89,35 @@ class Silencer_lib_2_13_12Test {
   }
 
   @Test
+  def noArgumentSilentAnnotationSuppressesEveryWarningInAnnotatedScope(): Unit = {
+    val result: CompilationResult = compileWithSilencer(
+      "BroadlySilencedWarnings.scala",
+      """
+        |package example
+        |
+        |import com.github.ghik.silencer.silent
+        |
+        |object BroadlyDeprecatedApi {
+        |  @deprecated("use replacement", "1.0")
+        |  def oldValue: Int = 7
+        |}
+        |
+        |object BroadlySilencedWarnings {
+        |  @silent
+        |  def value(): Int = {
+        |    val unusedBroadlySilencedLocal: String = "covered by the no-argument silencer"
+        |    BroadlyDeprecatedApi.oldValue
+        |  }
+        |}
+        |""".stripMargin
+    )
+
+    assertTrue(result.success, result.renderedMessages)
+    assertFalse(result.hasMessageContaining("unusedBroadlySilencedLocal"), result.renderedMessages)
+    assertFalse(result.hasMessageContaining("oldValue"), result.renderedMessages)
+  }
+
+  @Test
   def silentAnnotationSuppressesDeprecationWarningMatchedByMessagePattern(): Unit = {
     val result: CompilationResult = compileWithSilencer(
       "SilencedDeprecationWarning.scala",

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/user-code-filter.json
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.github.ghik.silencer.**"
+    }
+  ]
+}

--- a/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/user-code-filter.json
+++ b/tests/src/com.github.ghik/silencer-lib_2.13.12/1.7.14/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.github.ghik.silencer.**"
+      "includeClasses" : "com.github.ghik.silencer.**"
+    },
+    {
+      "includeClasses" : "com_github_ghik.silencer_lib_2_13_12.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #5026

This PR introduces tests and metadata for com.github.ghik:silencer-lib_2.13.12:1.7.14, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 135127
- Cached input tokens: 1383424
- Output tokens: 17085
- Metadata entries: 2
- Iterations: 3
- Library coverage percentage: 100.0
- Generated lines of code: 409
- Tested library lines of code: 2

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `495672c318b0fc9e4429f334c582286782220a41`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 6/6 (100.00%)
- Line: 2/2 (100.00%)
- Method: 2/2 (100.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
