### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-reactor-netty as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-reactor-netty/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-reactor-netty/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-reactor-netty:2.7.18 contains only META-INF manifest, license, and notice files and no JVM class files.",
+    "replacement": "io.projectreactor.netty:reactor-netty-http:1.0.39"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3808

This PR records `org.springframework.boot:spring-boot-starter-reactor-netty` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-reactor-netty:2.7.18 contains only META-INF manifest, license, and notice files and no JVM class files.

Replacement guidance:
- io.projectreactor.netty:reactor-netty-http:1.0.39

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `136f67809649aa706d4dcfe46ba8c166275211ca`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
