### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-webflux as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-webflux/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-webflux/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR for org.springframework.boot:spring-boot-starter-webflux:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.",
+    "replacement": "Use class-bearing dependencies such as org.springframework:spring-webflux:5.3.31, org.springframework:spring-web:5.3.31, io.projectreactor.netty:reactor-netty-http:1.0.39, and org.springframework.boot:spring-boot-autoconfigure:2.7.18."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3635

This PR records `org.springframework.boot:spring-boot-starter-webflux` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR for org.springframework.boot:spring-boot-starter-webflux:2.7.18 contains only META-INF files and no JVM class files; it is a dependency starter whose runtime classes are supplied by its dependencies.

Replacement guidance:
- Use class-bearing dependencies such as org.springframework:spring-webflux:5.3.31, org.springframework:spring-web:5.3.31, io.projectreactor.netty:reactor-netty-http:1.0.39, and org.springframework.boot:spring-boot-autoconfigure:2.7.18.

### Metadata Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `38b4d09e8b1a76b057525d488e99cfc510a0046c`

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 0
