### PR TITLE
[GenAI] Mark org.seleniumhq.selenium:selenium-java as not for Native Image

### DIFF
--- a/metadata/org.seleniumhq.selenium/selenium-java/index.json
+++ b/metadata/org.seleniumhq.selenium/selenium-java/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published selenium-java 3.141.59 JAR contains only META-INF/MANIFEST.MF and no JVM class files; runtime classes are supplied by its class-bearing module dependencies.",
+    "replacement": "Use the class-bearing Selenium modules declared by this aggregate, such as org.seleniumhq.selenium:selenium-api:3.141.59, org.seleniumhq.selenium:selenium-remote-driver:3.141.59, browser driver modules, and org.seleniumhq.selenium:selenium-support:3.141.59 as needed."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #3606

This PR records `org.seleniumhq.selenium:selenium-java` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published selenium-java 3.141.59 JAR contains only META-INF/MANIFEST.MF and no JVM class files; runtime classes are supplied by its class-bearing module dependencies.

Replacement guidance:
- Use the class-bearing Selenium modules declared by this aggregate, such as org.seleniumhq.selenium:selenium-api:3.141.59, org.seleniumhq.selenium:selenium-remote-driver:3.141.59, browser driver modules, and org.seleniumhq.selenium:selenium-support:3.141.59 as needed.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `136f67809649aa706d4dcfe46ba8c166275211ca`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
