### PR TITLE
[GenAI] Add support for org.scalatest:scalatest-propspec_3:3.2.19 using gpt-5.5

### DIFF
--- a/metadata/org.scalatest/scalatest-propspec_3/3.2.19/reachability-metadata.json
+++ b/metadata/org.scalatest/scalatest-propspec_3/3.2.19/reachability-metadata.json
@@ -1,0 +1,221 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Assertions"
+      },
+      "type": "org.scalatest.Assertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.SuperEngine"
+      },
+      "type": "org.scalatest.SuperEngine",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.Position"
+      },
+      "type": "org.scalactic.source.Position$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Resources$"
+      },
+      "type": "org.scalactic.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.SimpleBool"
+      },
+      "type": "org.scalactic.SimpleBool",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.BinaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$6"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.LengthSizeMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$9"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.NotBool",
+      "fields": [
+        {
+          "name": "0bitmap$4"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.SimpleMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$5"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.Bool$"
+      },
+      "type": "org.scalactic.UnaryMacroBool",
+      "fields": [
+        {
+          "name": "0bitmap$7"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "type": "org.scalatest.Resources$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalactic.source.ObjectMeta$$anon$1"
+      },
+      "type": "org.scalactic.source.ObjectMeta$$anon$1",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.NonImplicitAssertions$"
+      },
+      "type": "org.scalatest.NonImplicitAssertions$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.events.Event"
+      },
+      "type": "org.scalatest.events.Event",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.exceptions.StackDepthException"
+      },
+      "type": "org.scalatest.exceptions.StackDepthException",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.package$"
+      },
+      "type": "org.scalatest.package$",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.time.Span"
+      },
+      "type": "org.scalatest.time.Span",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.propspec.AnyPropSpec"
+      },
+      "type": "org.scalatest.propspec.AnyPropSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.scalatest.propspec.FixtureAnyPropSpec"
+      },
+      "type": "org.scalatest.propspec.FixtureAnyPropSpec",
+      "fields": [
+        {
+          "name": "0bitmap$1"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.scalatest.Resources$"
+      },
+      "bundle": "org.scalatest.ScalaTestBundle"
+    }
+  ]
+}

--- a/metadata/org.scalatest/scalatest-propspec_3/index.json
+++ b/metadata/org.scalatest/scalatest-propspec_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.2.19",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-propspec_3/$version$/scalatest-propspec_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/scalatest/scalatest",
+    "test-code-url" : "https://github.com/scalatest/scalatest/tree/release-$version$/jvm/propspec-test/src/test/scala/org/scalatest/propspec",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/scalatest/scalatest-propspec_3/$version$/scalatest-propspec_3-$version$-javadoc.jar",
+    "description" : "ScalaTest PropSpec provides the property-specification testing style for ScalaTest, letting Scala developers organize tests as named properties with optional fixtures. This Scala 3 JVM artifact supplies the org.scalatest.propspec APIs for property-style suites that integrate with ScalaTest assertions, tagging, and reporting.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "3.2.19"
+    ],
+    "allowed-packages" : [
+      "org.scalatest.propspec"
+    ]
+  }
+]

--- a/metadata/org.scalatest/scalatest-propspec_3/index.json
+++ b/metadata/org.scalatest/scalatest-propspec_3/index.json
@@ -15,7 +15,13 @@
       "3.2.19"
     ],
     "allowed-packages" : [
-      "org.scalatest.propspec"
+      "org.scalatest.propspec",
+      "org.scalactic",
+      "org.scalactic.source",
+      "org.scalatest",
+      "org.scalatest.events",
+      "org.scalatest.exceptions",
+      "org.scalatest.time"
     ]
   }
 ]

--- a/stats/org.scalatest/scalatest-propspec_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-propspec_3/3.2.19/execution-metrics.json
@@ -1,0 +1,86 @@
+{
+  "add_new_library_support:2026-06-28": {
+    "timestamp": "2026-06-28T22:23:39.355040Z",
+    "library": "org.scalatest:scalatest-propspec_3:3.2.19",
+    "starting_commit": "aba027487f5e7cd0b0dd41fbe174073ab04c3116",
+    "ending_commit": "dd50198ce777920837e39ca5d93a575bc1f77c83",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "3.2.19",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 730,
+          "missed": 744,
+          "ratio": 0.495251,
+          "total": 1474
+        },
+        "line": {
+          "covered": 80,
+          "missed": 30,
+          "ratio": 0.727273,
+          "total": 110
+        },
+        "method": {
+          "covered": 86,
+          "missed": 62,
+          "ratio": 0.581081,
+          "total": 148
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 2276,
+      "issue_label": "library-new-request",
+      "library": "org.scalatest:scalatest-propspec_3:3.2.19",
+      "summary": "No extra setup is concretely required: the artifact resolves to ScalaTest PropSpec plus transitive ScalaTest core and Scala 3 runtime dependencies, and existing Scala 3 scaffolding can compile and exercise PropSpec suites without Docker images or environment/system properties.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "ScalaTest documentation examples often mix PropSpec with matcher syntax from separate matcher modules; that dependency is optional for meaningful PropSpec coverage because tests can use ScalaTest assertions and suite execution APIs directly."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#2276 Support for org.scalatest:scalatest-propspec_3:3.2.19; label=library-new-request; body_chars=110"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 67923,
+      "output_tokens_used": 3288,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.scalatest:scalatest-propspec_3:3.2.19/library-preparation-preflight/pi-generation-2026-06-28T21-45-04-531911Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 227468,
+      "cached_input_tokens_used": 1888256,
+      "output_tokens_used": 21605,
+      "iterations": 6,
+      "cost_usd": 1.5923,
+      "generated_loc": 353,
+      "tested_library_loc": 80,
+      "metadata_entries": 39,
+      "code_coverage_percent": 72.73
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala",
+      "metadata_file": "metadata/org.scalatest/scalatest-propspec_3/3.2.19/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.scalatest/scalatest-propspec_3/3.2.19/stats.json
+++ b/stats/org.scalatest/scalatest-propspec_3/3.2.19/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.2.19",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 730,
+        "missed" : 744,
+        "ratio" : 0.495251,
+        "total" : 1474
+      },
+      "line" : {
+        "covered" : 80,
+        "missed" : 30,
+        "ratio" : 0.727273,
+        "total" : 110
+      },
+      "method" : {
+        "covered" : 86,
+        "missed" : 62,
+        "ratio" : 0.581081,
+        "total" : 148
+      }
+    }
+  } ]
+}

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/.gitignore
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/build.gradle
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
+
+dependencies {
+    testImplementation "org.scalatest:scalatest-propspec_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/gradle.properties
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.scalatest:scalatest-propspec_3:3.2.19
+library.version = 3.2.19
+metadata.dir = org.scalatest/scalatest-propspec_3/3.2.19/

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/settings.gradle
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.scalatest.scalatest-propspec_3_tests'

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_scalatest.scalatest_propspec_3
+
+import org.junit.jupiter.api.Test
+
+class Scalatest_propspec_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
@@ -23,6 +23,7 @@ import org.scalatest.Outcome
 import org.scalatest.Reporter
 import org.scalatest.Suite
 import org.scalatest.Tag
+import org.scalatest.TestData
 import org.scalatest.events.AlertProvided
 import org.scalatest.events.Event
 import org.scalatest.events.InfoProvided
@@ -148,6 +149,18 @@ class Scalatest_propspec_3Test:
     assert(suite.testNames.toVector == Vector("registered property", "ignored registered property"))
     assert(succeededEvents(result.events).map(_.testName) == Vector("registered property"))
     assert(ignoredEvents(result.events).map(_.testName) == Vector("ignored registered property"))
+
+  @Test
+  def anyPropSpecExposesPropertyMetadataThroughTestDataFor(): Unit =
+    val suite: TestDataPropSpec = new TestDataPropSpec
+    val configMap: ConfigMap = ConfigMap("sample" -> 7)
+    val testData: TestData = suite.testDataFor("tagged data property", configMap)
+
+    assert(testData.name == "tagged data property")
+    assert(testData.configMap == configMap)
+    assert(testData.scopes.isEmpty)
+    assert(testData.text == "tagged data property")
+    assert(testData.tags == Set(FastTag.name, DatabaseTag.name))
 
   @Test
   def fixtureAnyPropSpecProvidesFixturesNoArgPropertiesAndConfigMaps(): Unit =
@@ -301,6 +314,9 @@ class Scalatest_propspec_3Test:
     registerIgnoredTest("ignored registered property") {
       executionLog = executionLog :+ "ignored"
     }
+
+  private final class TestDataPropSpec extends AnyPropSpec:
+    property("tagged data property", FastTag, DatabaseTag) {}
 
   private final class FixtureBackedPropSpec extends FixtureAnyPropSpec:
     type FixtureParam = String

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
@@ -6,11 +6,386 @@
  */
 package org_scalatest.scalatest_propspec_3
 
-import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
-class Scalatest_propspec_3Test {
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.scalatest.Args
+import org.scalatest.ConfigMap
+import org.scalatest.Filter
+import org.scalatest.Outcome
+import org.scalatest.Reporter
+import org.scalatest.Suite
+import org.scalatest.Tag
+import org.scalatest.events.AlertProvided
+import org.scalatest.events.Event
+import org.scalatest.events.InfoProvided
+import org.scalatest.events.MarkupProvided
+import org.scalatest.events.NoteProvided
+import org.scalatest.events.TestCanceled
+import org.scalatest.events.TestFailed
+import org.scalatest.events.TestIgnored
+import org.scalatest.events.TestPending
+import org.scalatest.events.TestStarting
+import org.scalatest.events.TestSucceeded
+import org.scalatest.exceptions.DuplicateTestNameException
+import org.scalatest.exceptions.TestRegistrationClosedException
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.propspec.FixtureAnyPropSpec
+
+class Scalatest_propspec_3Test:
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
-  }
-}
+  def anyPropSpecRegistersAndRunsPropertiesInDeclarationOrder(): Unit =
+    val suite: OrderedPropSpec = new OrderedPropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.testNames.toVector == Vector("first property", "second property"))
+    assert(suite.executionLog == Vector("first", "second"))
+    assert(startingEvents(result.events).map(_.testName) == Vector("first property", "second property"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("first property", "second property"))
+
+  @Test
+  def anyPropSpecRunsASingleNamedPropertyWithoutExecutingTheOthers(): Unit =
+    val suite: OrderedPropSpec = new OrderedPropSpec
+    val result: RunResult = runSuite(suite, testName = Some("second property"))
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("second"))
+    assert(startingEvents(result.events).map(_.testName) == Vector("second property"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("second property"))
+
+  @Test
+  def anyPropSpecReportsSucceededIgnoredPendingFailedAndInfoEvents(): Unit =
+    val suite: OutcomePropSpec = new OutcomePropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(!result.succeeded)
+    assert(succeededEvents(result.events).map(_.testName) == Vector("successful property with info"))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector("ignored property"))
+    assert(pendingEvents(result.events).map(_.testName) == Vector("pending property"))
+    assert(failedEvents(result.events).map(_.testName) == Vector("failing property"))
+    assert(suite.executionLog == Vector("succeeded", "pending", "failed"))
+
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val messages: Vector[String] = success.recordedEvents.collect {
+      case event: InfoProvided => event.message
+    }.toVector
+    assert(messages == Vector("property diagnostics"))
+
+  @Test
+  def anyPropSpecReportsCanceledPropertiesAndContinuesTheSuite(): Unit =
+    val suite: CancelingPropSpec = new CancelingPropSpec
+    val result: RunResult = runSuite(suite)
+    val canceled: Vector[TestCanceled] = canceledEvents(result.events)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("before", "cancel", "after"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("property before cancellation", "property after cancellation"))
+    assert(canceled.map(_.testName) == Vector("canceled property"))
+    assert(canceled.head.message.contains("input generator unavailable"))
+    assert(failedEvents(result.events).isEmpty)
+
+  @Test
+  def anyPropSpecReportsNotificationsAndRecordedMarkup(): Unit =
+    val suite: DocumentationPropSpec = new DocumentationPropSpec
+    val result: RunResult = runSuite(suite)
+    val success: TestSucceeded = succeededEvents(result.events).head
+    val markup: Vector[String] = success.recordedEvents.collect {
+      case event: MarkupProvided => event.text
+    }.toVector
+
+    assert(result.succeeded)
+    assert(noteEvents(result.events).map(_.message) == Vector("note for the property runner"))
+    assert(alertEvents(result.events).map(_.message) == Vector("alert for the property runner"))
+    assert(markup == Vector("### property evidence"))
+
+  @Test
+  def anyPropSpecExposesTagsForCountingAndFiltering(): Unit =
+    val suite: TaggedPropSpec = new TaggedPropSpec
+    val includeFastOnly: Filter = Filter(tagsToInclude = Some(Set(FastTag.name)), tagsToExclude = Set.empty)
+    val excludeDatabase: Filter = Filter(tagsToExclude = Set(DatabaseTag.name))
+
+    assert(suite.tags("fast property") == Set(FastTag.name))
+    assert(suite.tags("database property") == Set(DatabaseTag.name))
+    assert(suite.expectedTestCount(includeFastOnly) == 1)
+    assert(suite.expectedTestCount(excludeDatabase) == 1)
+
+    val result: RunResult = runSuite(suite, filter = includeFastOnly)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("fast"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("fast property"))
+
+  @Test
+  def anyPropSpecRegistersSharedPropertiesThroughPropertiesFor(): Unit =
+    val suite: SharedPropertyPropSpec = new SharedPropertyPropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.testNames.toVector == Vector(
+      "non-empty stack created with one element reports non-empty",
+      "non-empty stack created with one element exposes the top element"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(
+      "non-empty stack created with one element reports non-empty",
+      "non-empty stack created with one element exposes the top element"
+    ))
+
+  @Test
+  def anyPropSpecSupportsRegisterTestAndRegisterIgnoredTestAliases(): Unit =
+    val suite: RegisteredAliasPropSpec = new RegisteredAliasPropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.executionLog == Vector("registered"))
+    assert(suite.testNames.toVector == Vector("registered property", "ignored registered property"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("registered property"))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector("ignored registered property"))
+
+  @Test
+  def fixtureAnyPropSpecProvidesFixturesNoArgPropertiesAndConfigMaps(): Unit =
+    val suite: FixtureBackedPropSpec = new FixtureBackedPropSpec
+    val result: RunResult = runSuite(suite, configMap = ConfigMap("seed" -> "configured value"))
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "create:uses fixture argument",
+      "property:configured value",
+      "cleanup:configured value",
+      "property:no-arg"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector(
+      "uses fixture argument",
+      "uses no-arg fixture wrapper"
+    ))
+
+  @Test
+  def anyPropSpecAppliesNoArgFixturesAroundEachProperty(): Unit =
+    val suite: NoArgFixturePropSpec = new NoArgFixturePropSpec
+    val result: RunResult = runSuite(suite, configMap = ConfigMap("mode" -> "fixture value"))
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "before:first wrapped property:fixture value",
+      "body:first",
+      "after:first wrapped property",
+      "before:second wrapped property:fixture value",
+      "body:second",
+      "after:second wrapped property"
+    ))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("first wrapped property", "second wrapped property"))
+
+  @Test
+  def anyPropSpecRejectsDuplicatePropertyNames(): Unit =
+    assertThrows(classOf[DuplicateTestNameException], () => new DuplicateNamePropSpec)
+    ()
+
+  @Test
+  def anyPropSpecClosesRegistrationAfterRunStarts(): Unit =
+    val suite: LateRegistrationPropSpec = new LateRegistrationPropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assertThrows(classOf[TestRegistrationClosedException], () => suite.registerAdditionalProperty())
+    ()
+
+  private final class OrderedPropSpec extends AnyPropSpec:
+    var executionLog: Vector[String] = Vector.empty
+
+    property("first property") {
+      executionLog = executionLog :+ "first"
+    }
+
+    property("second property") {
+      executionLog = executionLog :+ "second"
+    }
+
+  private final class OutcomePropSpec extends AnyPropSpec:
+    var executionLog: Vector[String] = Vector.empty
+
+    property("successful property with info") {
+      executionLog = executionLog :+ "succeeded"
+      info("property diagnostics")
+    }
+
+    ignore("ignored property") {
+      executionLog = executionLog :+ "ignored"
+    }
+
+    property("pending property") {
+      executionLog = executionLog :+ "pending"
+      pending
+    }
+
+    property("failing property") {
+      executionLog = executionLog :+ "failed"
+      throw new IllegalStateException("intentional property failure")
+    }
+
+  private final class CancelingPropSpec extends AnyPropSpec:
+    var executionLog: Vector[String] = Vector.empty
+
+    property("property before cancellation") {
+      executionLog = executionLog :+ "before"
+    }
+
+    property("canceled property") {
+      executionLog = executionLog :+ "cancel"
+      cancel("input generator unavailable")
+    }
+
+    property("property after cancellation") {
+      executionLog = executionLog :+ "after"
+    }
+
+  private final class DocumentationPropSpec extends AnyPropSpec:
+    property("emits notifications and markup") {
+      note("note for the property runner")
+      alert("alert for the property runner")
+      markup("### property evidence")
+    }
+
+  private final class TaggedPropSpec extends AnyPropSpec:
+    var executionLog: Vector[String] = Vector.empty
+
+    property("fast property", FastTag) {
+      executionLog = executionLog :+ "fast"
+    }
+
+    property("database property", DatabaseTag) {
+      executionLog = executionLog :+ "database"
+    }
+
+  private final class SharedPropertyPropSpec extends AnyPropSpec:
+    propertiesFor(nonEmptyStack("non-empty stack created with one element", List(1)))
+
+    private def nonEmptyStack(description: String, stack: List[Int]): Unit =
+      property(s"$description reports non-empty") {
+        assert(stack.nonEmpty)
+      }
+
+      property(s"$description exposes the top element") {
+        assert(stack.head == 1)
+      }
+
+  private final class RegisteredAliasPropSpec extends AnyPropSpec:
+    var executionLog: Vector[String] = Vector.empty
+
+    registerTest("registered property") {
+      executionLog = executionLog :+ "registered"
+      assert(2 + 2 == 4)
+    }
+
+    registerIgnoredTest("ignored registered property") {
+      executionLog = executionLog :+ "ignored"
+    }
+
+  private final class FixtureBackedPropSpec extends FixtureAnyPropSpec:
+    type FixtureParam = String
+
+    var events: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: OneArgTest): Outcome =
+      events = events :+ s"create:${test.name}"
+      val fixture: String = test.configMap("seed").asInstanceOf[String]
+      try test(fixture)
+      finally events = events :+ s"cleanup:$fixture"
+
+    property("uses fixture argument") { (fixture: String) =>
+      events = events :+ s"property:$fixture"
+      assert(fixture == "configured value")
+    }
+
+    property("uses no-arg fixture wrapper") { () =>
+      events = events :+ "property:no-arg"
+    }
+
+  private final class NoArgFixturePropSpec extends AnyPropSpec:
+    var events: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: NoArgTest): Outcome =
+      events = events :+ s"before:${test.name}:${test.configMap("mode")}"
+      try test()
+      finally events = events :+ s"after:${test.name}"
+
+    property("first wrapped property") {
+      events = events :+ "body:first"
+    }
+
+    property("second wrapped property") {
+      events = events :+ "body:second"
+    }
+
+  private final class DuplicateNamePropSpec extends AnyPropSpec:
+    property("duplicate property") {}
+    property("duplicate property") {}
+
+  private final class LateRegistrationPropSpec extends AnyPropSpec:
+    property("registered before run") {}
+
+    def registerAdditionalProperty(): Unit =
+      property("registered after run") {}
+
+  private def runSuite(
+      suite: Suite,
+      filter: Filter = Filter.default,
+      testName: Option[String] = None,
+      configMap: ConfigMap = ConfigMap()): RunResult =
+    val reporter: RecordingReporter = new RecordingReporter
+    val completion: AtomicReference[Try[Boolean]] = new AtomicReference[Try[Boolean]]()
+    val completed: CountDownLatch = new CountDownLatch(1)
+    val runArgs: Args = Args(reporter = reporter, filter = filter, configMap = configMap)
+    val status = suite.run(testName, runArgs)
+    status.whenCompleted { (result: Try[Boolean]) =>
+      completion.set(result)
+      completed.countDown()
+    }
+
+    assert(completed.await(30, TimeUnit.SECONDS), s"ScalaTest suite ${suite.suiteName} did not complete")
+    RunResult(completion.get().get, reporter.events)
+
+  private def startingEvents(events: Vector[Event]): Vector[TestStarting] =
+    events.collect { case event: TestStarting => event }
+
+  private def succeededEvents(events: Vector[Event]): Vector[TestSucceeded] =
+    events.collect { case event: TestSucceeded => event }
+
+  private def pendingEvents(events: Vector[Event]): Vector[TestPending] =
+    events.collect { case event: TestPending => event }
+
+  private def canceledEvents(events: Vector[Event]): Vector[TestCanceled] =
+    events.collect { case event: TestCanceled => event }
+
+  private def noteEvents(events: Vector[Event]): Vector[NoteProvided] =
+    events.collect { case event: NoteProvided => event }
+
+  private def alertEvents(events: Vector[Event]): Vector[AlertProvided] =
+    events.collect { case event: AlertProvided => event }
+
+  private def ignoredEvents(events: Vector[Event]): Vector[TestIgnored] =
+    events.collect { case event: TestIgnored => event }
+
+  private def failedEvents(events: Vector[Event]): Vector[TestFailed] =
+    events.collect { case event: TestFailed => event }
+
+  private final class RecordingReporter extends Reporter:
+    private val recordedEvents: CopyOnWriteArrayList[Event] = new CopyOnWriteArrayList[Event]()
+
+    override def apply(event: Event): Unit =
+      recordedEvents.add(event)
+      ()
+
+    def events: Vector[Event] = recordedEvents.asScala.toVector
+
+  private final case class RunResult(succeeded: Boolean, events: Vector[Event])
+
+  private object FastTag extends Tag("org.scalatest.propspec.generated.Fast")
+
+  private object DatabaseTag extends Tag("org.scalatest.propspec.generated.Database")

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/src/test/scala/org_scalatest/scalatest_propspec_3/Scalatest_propspec_3Test.scala
@@ -167,6 +167,21 @@ class Scalatest_propspec_3Test:
     ))
 
   @Test
+  def fixtureAnyPropSpecIgnoresFixtureBackedPropertiesWithoutCreatingFixtures(): Unit =
+    val suite: IgnoredFixturePropSpec = new IgnoredFixturePropSpec
+    val result: RunResult = runSuite(suite)
+
+    assert(result.succeeded)
+    assert(suite.events == Vector(
+      "create:active fixture property",
+      "property:active fixture",
+      "cleanup:active fixture"
+    ))
+    assert(suite.testNames.toVector == Vector("ignored fixture property", "active fixture property"))
+    assert(ignoredEvents(result.events).map(_.testName) == Vector("ignored fixture property"))
+    assert(succeededEvents(result.events).map(_.testName) == Vector("active fixture property"))
+
+  @Test
   def anyPropSpecAppliesNoArgFixturesAroundEachProperty(): Unit =
     val suite: NoArgFixturePropSpec = new NoArgFixturePropSpec
     val result: RunResult = runSuite(suite, configMap = ConfigMap("mode" -> "fixture value"))
@@ -305,6 +320,26 @@ class Scalatest_propspec_3Test:
 
     property("uses no-arg fixture wrapper") { () =>
       events = events :+ "property:no-arg"
+    }
+
+  private final class IgnoredFixturePropSpec extends FixtureAnyPropSpec:
+    type FixtureParam = String
+
+    var events: Vector[String] = Vector.empty
+
+    override protected def withFixture(test: OneArgTest): Outcome =
+      events = events :+ s"create:${test.name}"
+      val fixture: String = test.name.stripSuffix(" property")
+      try test(fixture)
+      finally events = events :+ s"cleanup:$fixture"
+
+    ignore("ignored fixture property") { (fixture: String) =>
+      events = events :+ s"ignored:$fixture"
+    }
+
+    property("active fixture property") { (fixture: String) =>
+      events = events :+ s"property:$fixture"
+      assert(fixture == "active fixture")
     }
 
   private final class NoArgFixturePropSpec extends AnyPropSpec:

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.scalatest.propspec.**"
+    }
+  ]
+}

--- a/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/user-code-filter.json
+++ b/tests/src/org.scalatest/scalatest-propspec_3/3.2.19/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.scalatest.propspec.**"
+      "includeClasses" : "org.scalatest.propspec.**"
+    },
+    {
+      "includeClasses" : "org_scalatest.scalatest_propspec_3.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #2276

This PR introduces tests and metadata for org.scalatest:scalatest-propspec_3:3.2.19, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 227468
- Cached input tokens: 1888256
- Output tokens: 21605
- Metadata entries: 39
- Iterations: 6
- Library coverage percentage: 72.73
- Generated lines of code: 353
- Tested library lines of code: 80

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `f831682a0bbad3502b4de33fc0dc8bb584685126`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 730/1474 (49.53%)
- Line: 80/110 (72.73%)
- Method: 86/148 (58.11%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
