### PR TITLE
[GenAI] Mark io.projectreactor.netty:reactor-netty as not for Native Image

### DIFF
--- a/metadata/io.projectreactor.netty/reactor-netty/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published reactor-netty 1.1.1 JAR contains only META-INF/MANIFEST.MF and no JVM class files, so there is no artifact-owned library code for native-image metadata.",
+    "replacement": "Use the class-bearing Reactor Netty module artifacts declared by this aggregate, such as io.projectreactor.netty:reactor-netty-core:1.1.1 and io.projectreactor.netty:reactor-netty-http:1.1.1."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #1405

This PR records `io.projectreactor.netty:reactor-netty` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published reactor-netty 1.1.1 JAR contains only META-INF/MANIFEST.MF and no JVM class files, so there is no artifact-owned library code for native-image metadata.

Replacement guidance:
- Use the class-bearing Reactor Netty module artifacts declared by this aggregate, such as io.projectreactor.netty:reactor-netty-core:1.1.1 and io.projectreactor.netty:reactor-netty-http:1.1.1.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1c55bcf510a4ce9e84492d4d2350315d9eef14f2`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
