### PR TITLE
[GenAI] Add support for org.eclipse.collections:eclipse-collections:11.1.0 using gpt-5.5 (chunked dynamic-access)

### DIFF
--- a/metadata/org.eclipse.collections/eclipse-collections/11.1.0/reachability-metadata.json
+++ b/metadata/org.eclipse.collections/eclipse-collections/11.1.0/reachability-metadata.json
@@ -2,6 +2,36 @@
   "reflection": [
     {
       "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
         "typeReached": "org.eclipse.collections.impl.list.fixed.ArrayAdapter"
       },
       "type": "java.lang.Object"
@@ -22,8 +52,129 @@
       "condition": {
         "typeReached": "org.eclipse.collections.impl.list.fixed.ArrayAdapter"
       },
-      "type": "sun.security.x509.X509CertInfo",
-      "allPublicConstructors": true
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.internal.ReflectionHelper"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.bimap.mutable.AbstractMutableBiMap$EntrySet"
+      },
+      "type": "java.util.Map$Entry[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.list.fixed.ArrayAdapter"
+      },
+      "type": "org.eclipse.collections.impl.list.fixed.ArrayAdapter",
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
+      },
+      "type": "org.eclipse.collections.impl.list.fixed.FixedSizeListFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
+      },
+      "type": "org.eclipse.collections.impl.list.immutable.ImmutableListFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.internal.ReflectionHelper"
+      },
+      "type": "org.eclipse.collections.impl.list.mutable.FastList",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
+      },
+      "type": "org.eclipse.collections.impl.list.mutable.MultiReaderMutableListFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
+      },
+      "type": "org.eclipse.collections.impl.list.mutable.MutableListFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
+      },
+      "type": "org.eclipse.collections.impl.map.fixed.FixedSizeMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
+      },
+      "type": "org.eclipse.collections.impl.map.immutable.ImmutableMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.bag.mutable.HashBag"
+      },
+      "type": "org.eclipse.collections.impl.map.immutable.primitive.ImmutableObjectIntMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe"
+      },
+      "type": "org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
+      },
+      "type": "org.eclipse.collections.impl.map.mutable.MutableMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.bag.mutable.HashBag"
+      },
+      "type": "org.eclipse.collections.impl.map.mutable.primitive.MutableObjectIntMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.bag.sorted.mutable.TreeBag"
+      },
+      "type": "org.eclipse.collections.impl.map.sorted.immutable.ImmutableSortedMapFactoryImpl"
+    },
+    {
+      "condition": {
+        "typeReached": "org.eclipse.collections.impl.bag.sorted.mutable.TreeBag"
+      },
+      "type": "org.eclipse.collections.impl.map.sorted.mutable.MutableSortedMapFactoryImpl"
     },
     {
       "condition": {
@@ -209,129 +360,8 @@
       "condition": {
         "typeReached": "org.eclipse.collections.impl.list.fixed.ArrayAdapter"
       },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.internal.ReflectionHelper"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.bimap.mutable.AbstractMutableBiMap$EntrySet"
-      },
-      "type": "java.util.Map$Entry[]"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.list.fixed.ArrayAdapter"
-      },
-      "type": "org.eclipse.collections.impl.list.fixed.ArrayAdapter",
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
-      },
-      "type": "org.eclipse.collections.impl.list.fixed.FixedSizeListFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
-      },
-      "type": "org.eclipse.collections.impl.list.immutable.ImmutableListFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.internal.ReflectionHelper"
-      },
-      "type": "org.eclipse.collections.impl.list.mutable.FastList",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "int"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
-      },
-      "type": "org.eclipse.collections.impl.list.mutable.MultiReaderMutableListFactory"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.utility.LazyIterate"
-      },
-      "type": "org.eclipse.collections.impl.list.mutable.MutableListFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
-      },
-      "type": "org.eclipse.collections.impl.map.fixed.FixedSizeMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
-      },
-      "type": "org.eclipse.collections.impl.map.immutable.ImmutableMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.bag.mutable.HashBag"
-      },
-      "type": "org.eclipse.collections.impl.map.immutable.primitive.ImmutableObjectIntMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe"
-      },
-      "type": "org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.map.mutable.UnifiedMap"
-      },
-      "type": "org.eclipse.collections.impl.map.mutable.MutableMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.bag.mutable.HashBag"
-      },
-      "type": "org.eclipse.collections.impl.map.mutable.primitive.MutableObjectIntMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.bag.sorted.mutable.TreeBag"
-      },
-      "type": "org.eclipse.collections.impl.map.sorted.immutable.ImmutableSortedMapFactoryImpl"
-    },
-    {
-      "condition": {
-        "typeReached": "org.eclipse.collections.impl.bag.sorted.mutable.TreeBag"
-      },
-      "type": "org.eclipse.collections.impl.map.sorted.mutable.MutableSortedMapFactoryImpl"
+      "type": "sun.security.x509.X509CertInfo",
+      "allPublicConstructors": true
     }
   ],
   "serialization": [

--- a/metadata/org.eclipse.collections/eclipse-collections/index.json
+++ b/metadata/org.eclipse.collections/eclipse-collections/index.json
@@ -3,8 +3,8 @@
     "latest" : true,
     "metadata-version" : "11.1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/collections/eclipse-collections/$version$/eclipse-collections-$version$-sources.jar",
-    "repository-url" : "https://github.com/eclipse/eclipse-collections",
-    "test-code-url" : "https://github.com/eclipse/eclipse-collections/tree/$version$/unit-tests/src/test/java",
+    "repository-url" : "https://github.com/eclipse-collections/eclipse-collections",
+    "test-code-url" : "https://github.com/eclipse-collections/eclipse-collections/tree/$version$/unit-tests/src/test/java",
     "documentation-url" : "https://repo1.maven.org/maven2/org/eclipse/collections/eclipse-collections/$version$/eclipse-collections-$version$-javadoc.jar",
     "description" : "Eclipse Collections is a Java collections framework that provides rich mutable, immutable, lazy, parallel, and primitive collection types alongside JDK-compatible List, Set, and Map implementations. The eclipse-collections artifact supplies the concrete implementations and factories used with the eclipse-collections-api interfaces at runtime.",
     "tested-versions" : [

--- a/stats/org.eclipse.collections/eclipse-collections/11.1.0/execution-metrics.json
+++ b/stats/org.eclipse.collections/eclipse-collections/11.1.0/execution-metrics.json
@@ -88,5 +88,96 @@
       "test_file": "tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/UnifiedMapInnerKeySetTest.java",
       "metadata_file": "metadata/org.eclipse.collections/eclipse-collections/11.1.0/reachability-metadata.json"
     }
+  },
+  "add_new_library_support:2026-06-29": {
+    "timestamp": "2026-06-29T11:02:29.222366Z",
+    "library": "org.eclipse.collections:eclipse-collections:11.1.0",
+    "starting_commit": "7ecb53628d84f3ba1d76326212d58e822d2990e9",
+    "ending_commit": "b58d22454a3843394b1d96a7a9e51c59a2082d92",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "oca/gpt-5.5",
+    "status": "chunk_ready",
+    "stats": {
+      "version": "11.1.0",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.730769,
+            "coveredCalls": 38,
+            "totalCalls": 52
+          }
+        },
+        "coverageRatio": 0.730769,
+        "coveredCalls": 38,
+        "totalCalls": 52
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 8304,
+          "missed": 924874,
+          "ratio": 0.008899,
+          "total": 933178
+        },
+        "line": {
+          "covered": 1841,
+          "missed": 193406,
+          "ratio": 0.009429,
+          "total": 195247
+        },
+        "method": {
+          "covered": 665,
+          "missed": 76331,
+          "ratio": 0.008637,
+          "total": 76996
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 4699,
+      "issue_label": "library-new-request",
+      "library": "org.eclipse.collections:eclipse-collections:11.1.0",
+      "summary": "Eclipse Collections is a pure Java collections library; the resolved org.eclipse.collections:eclipse-collections:11.1.0 artifact transitively brings eclipse-collections-api:11.1.0, and meaningful tests can exercise factories, mutable/immutable collections, primitive collections, adapters, utilities, and maps without external services or additional dependencies.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "The artifact contains META-INF/services providers for API factories, so tests should exercise factory-based usage as well as direct implementation classes, but this does not require extra setup.",
+        "Some internals use sun.misc.Unsafe and ArrayList reflection fallbacks; normal public-behavior tests run without special JVM flags, but tests that specifically assert JDK-private field access may need local Gradle/native verification."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4699 Support for org.eclipse.collections:eclipse-collections:11.1.0; label=library-new-request; body_chars=119"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "21 existing test file path(s) included"
+        }
+      ],
+      "model": "oca/gpt-5.5",
+      "input_tokens_used": 69806,
+      "output_tokens_used": 3736,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.eclipse.collections:eclipse-collections:11.1.0/library-preparation-preflight/pi-generation-2026-06-29T10-09-14-135912Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 395948,
+      "cached_input_tokens_used": 2369024,
+      "output_tokens_used": 20298,
+      "iterations": 15,
+      "cost_usd": 1.7934,
+      "generated_loc": 808,
+      "tested_library_loc": 1841,
+      "metadata_entries": 55,
+      "code_coverage_percent": 0.94
+    },
+    "artifacts": {
+      "test_file": "tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/UnifiedMapInnerKeySetTest.java",
+      "metadata_file": "metadata/org.eclipse.collections/eclipse-collections/11.1.0/reachability-metadata.json"
+    }
   }
 }

--- a/stats/org.eclipse.collections/eclipse-collections/11.1.0/stats.json
+++ b/stats/org.eclipse.collections/eclipse-collections/11.1.0/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.442308,
-          "coveredCalls" : 23,
+          "coverageRatio" : 0.730769,
+          "coveredCalls" : 38,
           "totalCalls" : 52
         }
       },
-      "coverageRatio" : 0.442308,
-      "coveredCalls" : 23,
+      "coverageRatio" : 0.730769,
+      "coveredCalls" : 38,
       "totalCalls" : 52
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 3982,
-        "missed" : 929196,
-        "ratio" : 0.004267,
+        "covered" : 8304,
+        "missed" : 924874,
+        "ratio" : 0.008899,
         "total" : 933178
       },
       "line" : {
-        "covered" : 959,
-        "missed" : 194288,
-        "ratio" : 0.004912,
+        "covered" : 1841,
+        "missed" : 193406,
+        "ratio" : 0.009429,
         "total" : 195247
       },
       "method" : {
-        "covered" : 351,
-        "missed" : 76645,
-        "ratio" : 0.004559,
+        "covered" : 665,
+        "missed" : 76331,
+        "ratio" : 0.008637,
         "total" : 76996
       }
     }

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -19,7 +19,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -25,7 +25,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -23,7 +23,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -20,7 +20,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -22,7 +22,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -24,7 +24,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -17,7 +17,8 @@
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$ValuesCollection",
     "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -21,7 +21,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -29,7 +29,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMapWithHashingStrategy$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMapWithHashingStrategy$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectFloatHashMap$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -37,7 +37,7 @@
   "exhaustedClasses": [],
   "failedClasses": [],
   "issueNumber": 4699,
-  "latestChunkCommit": "fa210b9fc7a790d632939a0a9dd67032008c631a",
-  "latestChunkPullRequest": 8776,
+  "latestChunkCommit": "0a1b22142cfd64ad5eb5b099c64798d82fb606a2",
+  "latestChunkPullRequest": 8871,
   "skippedClasses": []
 }

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -26,7 +26,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -16,7 +16,8 @@
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$EntrySet",
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$ValuesCollection",
-    "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -28,7 +28,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMapWithHashingStrategy$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -27,7 +27,8 @@
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy$KeySet",
     "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap$KeySet",
-    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy$KeySet"
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy$KeySet",
+    "org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap$KeySet"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -15,7 +15,8 @@
     "org.eclipse.collections.impl.map.mutable.ConcurrentHashMapUnsafe$1",
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$EntrySet",
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$KeySet",
-    "org.eclipse.collections.impl.map.mutable.UnifiedMap$ValuesCollection"
+    "org.eclipse.collections.impl.map.mutable.UnifiedMap$ValuesCollection",
+    "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/dynamic-access-exhaust-report.json
@@ -18,7 +18,8 @@
     "org.eclipse.collections.impl.map.mutable.UnifiedMap$ValuesCollection",
     "org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap",
     "org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap",
-    "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap"
+    "org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap",
+    "org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap"
   ],
   "coordinate": "org.eclipse.collections:eclipse-collections:11.1.0",
   "currentChunkClassCount": 15,

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ByteObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ByteObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ByteObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        ByteObjectHashMap<String> map = ByteObjectHashMap.newWithKeysValues(
+                (byte) 2,
+                "two",
+                (byte) 3,
+                "three",
+                (byte) 4,
+                "four");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("two", "three", "four");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/CharObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/CharObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.CharObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CharObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        CharObjectHashMap<String> map = CharObjectHashMap.newWithKeysValues(
+                'a',
+                "alpha",
+                'b',
+                "bravo",
+                'c',
+                "charlie");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("alpha", "bravo", "charlie");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/DoubleObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/DoubleObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.DoubleObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DoubleObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        DoubleObjectHashMap<String> map = DoubleObjectHashMap.newWithKeysValues(
+                2.0d,
+                "two",
+                3.0d,
+                "three",
+                4.0d,
+                "four");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("two", "three", "four");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/FloatObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/FloatObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.FloatObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FloatObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        FloatObjectHashMap<String> map = FloatObjectHashMap.newWithKeysValues(
+                2.0f,
+                "two",
+                3.0f,
+                "three",
+                4.0f,
+                "four");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("two", "three", "four");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/IntObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/IntObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        IntObjectHashMap<String> map = IntObjectHashMap.newWithKeysValues(
+                2,
+                "two",
+                3,
+                "three",
+                4,
+                "four");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("two", "three", "four");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/LongObjectHashMapTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/LongObjectHashMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LongObjectHashMapTest {
+
+    @Test
+    void toArrayAllocatesTypedArrayWhenProvidedArrayIsTooSmall() {
+        LongObjectHashMap<String> map = LongObjectHashMap.newWithKeysValues(
+                2L,
+                "two",
+                3L,
+                "three",
+                4L,
+                "four");
+
+        CharSequence[] values = map.toArray(new CharSequence[0]);
+
+        assertThat(values.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(values).containsExactlyInAnyOrder("two", "three", "four");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectBooleanHashMapInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectBooleanHashMapInnerKeySetTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectBooleanHashMapInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectBooleanHashMap<String> map = ObjectBooleanHashMap.newWithKeysValues(
+                "alpha",
+                true,
+                "beta",
+                false,
+                "gamma",
+                true);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectBooleanHashMapWithHashingStrategyInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectBooleanHashMapWithHashingStrategyInnerKeySetTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectBooleanHashMapWithHashingStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectBooleanHashMapWithHashingStrategyInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectBooleanHashMapWithHashingStrategy<String> map = ObjectBooleanHashMapWithHashingStrategy.newWithKeysValues(
+                HashingStrategies.defaultStrategy(),
+                "alpha",
+                true,
+                "beta",
+                false,
+                "gamma",
+                true);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectByteHashMapInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectByteHashMapInnerKeySetTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectByteHashMapInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectByteHashMap<String> map = ObjectByteHashMap.newWithKeysValues(
+                "alpha",
+                (byte) 1,
+                "beta",
+                (byte) 2,
+                "gamma",
+                (byte) 3);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectByteHashMapWithHashingStrategyInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectByteHashMapWithHashingStrategyInnerKeySetTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectByteHashMapWithHashingStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectByteHashMapWithHashingStrategyInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectByteHashMapWithHashingStrategy<String> map = ObjectByteHashMapWithHashingStrategy.newWithKeysValues(
+                HashingStrategies.defaultStrategy(),
+                "alpha",
+                (byte) 1,
+                "beta",
+                (byte) 2,
+                "gamma",
+                (byte) 3);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectCharHashMapInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectCharHashMapInnerKeySetTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectCharHashMapInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectCharHashMap<String> map = ObjectCharHashMap.newWithKeysValues(
+                "alpha",
+                'a',
+                "beta",
+                'b',
+                "gamma",
+                'g');
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectCharHashMapWithHashingStrategyInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectCharHashMapWithHashingStrategyInnerKeySetTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectCharHashMapWithHashingStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectCharHashMapWithHashingStrategyInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectCharHashMapWithHashingStrategy<String> map = ObjectCharHashMapWithHashingStrategy.newWithKeysValues(
+                HashingStrategies.defaultStrategy(),
+                "alpha",
+                'a',
+                "beta",
+                'b',
+                "gamma",
+                'g');
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectDoubleHashMapInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectDoubleHashMapInnerKeySetTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectDoubleHashMapInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectDoubleHashMap<String> map = ObjectDoubleHashMap.newWithKeysValues(
+                "alpha",
+                1.0d,
+                "beta",
+                2.0d,
+                "gamma",
+                3.0d);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectDoubleHashMapWithHashingStrategyInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectDoubleHashMapWithHashingStrategyInnerKeySetTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.block.factory.HashingStrategies;
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectDoubleHashMapWithHashingStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectDoubleHashMapWithHashingStrategyInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectDoubleHashMapWithHashingStrategy<String> map = ObjectDoubleHashMapWithHashingStrategy.newWithKeysValues(
+                HashingStrategies.defaultStrategy(),
+                "alpha",
+                1.0d,
+                "beta",
+                2.0d,
+                "gamma",
+                3.0d);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}

--- a/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectFloatHashMapInnerKeySetTest.java
+++ b/tests/src/org.eclipse.collections/eclipse-collections/11.1.0/src/test/java/org_eclipse_collections/eclipse_collections/ObjectFloatHashMapInnerKeySetTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_eclipse_collections.eclipse_collections;
+
+import java.util.Set;
+
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectFloatHashMap;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ObjectFloatHashMapInnerKeySetTest {
+
+    @Test
+    void createsTypedKeyArrayWhenTargetArrayIsTooSmall() {
+        ObjectFloatHashMap<String> map = ObjectFloatHashMap.newWithKeysValues(
+                "alpha",
+                1.0f,
+                "beta",
+                2.0f,
+                "gamma",
+                3.0f);
+        Set<String> keys = map.keySet();
+
+        CharSequence[] result = keys.toArray(new CharSequence[0]);
+
+        assertThat(result.getClass()).isEqualTo(CharSequence[].class);
+        assertThat(result).containsExactlyInAnyOrder("alpha", "beta", "gamma");
+    }
+}


### PR DESCRIPTION

## What does this PR do?

Refs: #4699

This PR introduces tests and metadata for org.eclipse.collections:eclipse-collections:11.1.0, enabling support for this library.

Summary:
- Chunked dynamic-access: yes
- Chunk class threshold: 15
- Current chunk class count: 15
- Processed dynamic-access classes: completed=30, skipped=0, exhausted=0, failed=0
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 395948
- Cached input tokens: 2369024
- Output tokens: 20298
- Metadata entries: 55
- Iterations: 15
- Library coverage percentage: 0.94
- Generated lines of code: 808
- Tested library lines of code: 1841

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `1f32e951871ade67ee02726a5f64b4704ee0d6e6`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 38/52 covered calls (73.08%)
- Reflection: 38/52 covered calls (73.08%)

Library coverage:
- Instruction: 8304/933178 (0.89%)
- Line: 1841/195247 (0.94%)
- Method: 665/76996 (0.86%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
