### PR TITLE
Persist Docker declarations through generation and repair missing allow-list pins at finalization

### DIFF
--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -545,8 +545,12 @@ def main(argv=None):
         # Re-apply deterministic docker setup now that the scaffolded test dir exists: this
         # writes `required-docker-images.txt` and re-pins the allow-list Dockerfiles. Stage the
         # shared pins explicitly so the library-scoped scaffold commit (the reset checkpoint)
-        # preserves them instead of dropping them on the next `git reset --hard`.
-        apply_library_preparation_setup(library_preparation_preflight, reachability_repo_path)
+        # preserves them instead of dropping them on the next `git reset --hard`. Restricted to
+        # docker so dependency edits stay advisory, matching the model context already rendered
+        # pre-scaffold (which lists them as pending work).
+        apply_library_preparation_setup(
+            library_preparation_preflight, reachability_repo_path, only_kinds={"docker_image"}
+        )
         docker_setup_targets = [
             os.path.join(reachability_repo_path, item["target"])
             for item in (library_preparation_preflight or {}).get("applied_setup") or []

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -52,6 +52,7 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.dynamic_access_exhaust_report import resolve_workflow_exhaust_report
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
+    apply_library_preparation_setup,
     prepare_library_preparation_preflight,
 )
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
@@ -541,8 +542,18 @@ def main(argv=None):
     directory_path = module_dir
     index_json_path = os.path.join(reachability_repo_path, "metadata", package, artifact, "index.json")
     if not resume_existing_tree:
+        # Re-apply deterministic docker setup now that the scaffolded test dir exists: this
+        # writes `required-docker-images.txt` and re-pins the allow-list Dockerfiles. Stage the
+        # shared pins explicitly so the library-scoped scaffold commit (the reset checkpoint)
+        # preserves them instead of dropping them on the next `git reset --hard`.
+        apply_library_preparation_setup(library_preparation_preflight, reachability_repo_path)
+        docker_setup_targets = [
+            os.path.join(reachability_repo_path, item["target"])
+            for item in (library_preparation_preflight or {}).get("applied_setup") or []
+            if isinstance(item, dict) and item.get("kind") == "docker_image" and item.get("target")
+        ]
         # Add generated files to git and commit; record commit hash (do not use it)
-        subprocess.run(["git", "add", directory_path, index_json_path], check=False)
+        subprocess.run(["git", "add", directory_path, index_json_path, *docker_setup_targets], check=False)
         subprocess.run(["git", "commit", "-m", f"Scaffold {library}"], check=False, capture_output=True, text=True)
     checkpoint_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     log_stage("scaffold", f"Checkpoint at {checkpoint_commit_hash}")

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -369,6 +369,10 @@ def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
         '  - {"kind": "dependency", "coordinate": "group:artifact:version", '
         '"scope": "testImplementation", "reason": "..."}\n'
         '  - {"kind": "docker_image", "image": "name:tag", "slug": "short-slug", "reason": "..."}\n'
+        "If a test needs a Docker image that is already pinned under "
+        "`tests/tck-build-logic/src/main/resources/allowed-docker-images/`, reuse the exact "
+        "tag from that `Dockerfile-<slug>` instead of introducing a new one, since the "
+        "allow-list permits a single shared tag per image.\n"
         "Put environment variables, system properties, and other test-code setup in "
         "`agent_guidance`. Do not restate deterministic entries as guidance.\n\n"
         "Return a single JSON object with this shape:\n"
@@ -654,12 +658,19 @@ def _apply_docker_image_setup(reachability_repo_path: str, entry: dict[str, str]
 def apply_library_preparation_setup(
         preflight: dict[str, Any] | None,
         reachability_repo_path: str,
+        only_kinds: set[str] | None = None,
 ) -> dict[str, Any] | None:
     """Apply deterministic preflight setup once and idempotently, recording results.
 
     Driver-owned step (§ORCH-forge-orchestration-spec.1.1): typed `dependency` and
     `docker_image` entries are applied as source edits; unappliable entries are
     left for the advisory guidance fallback. Mutates and returns the record.
+
+    `only_kinds` restricts which entry kinds are (re)applied on this pass; entries of
+    other kinds keep their prior `applied_setup` result untouched. The post-scaffold
+    reapply passes `{"docker_image"}` so it re-pins allow-list Dockerfiles without
+    re-touching dependencies the model's already-rendered context still lists as
+    pending work.
     """
     if not isinstance(preflight, dict):
         return preflight
@@ -667,9 +678,18 @@ def apply_library_preparation_setup(
         preflight.setdefault("applied_setup", [])
         return preflight
     library_coordinate = str(preflight.get("library") or "")
+    previous: dict[tuple[Any, Any], dict[str, str]] = {}
+    for item in preflight.get("applied_setup") or []:
+        if isinstance(item, dict):
+            previous[(item.get("kind"), item.get("coordinate") or item.get("slug"))] = item
     applied: list[dict[str, str]] = []
     for entry in preflight.get("deterministic_setup") or []:
         kind = entry.get("kind") if isinstance(entry, dict) else None
+        key = (kind, entry.get("coordinate") or entry.get("slug")) if isinstance(entry, dict) else (kind, None)
+        if only_kinds is not None and kind not in only_kinds:
+            if key in previous:
+                applied.append(previous[key])
+            continue
         try:
             if kind == "dependency":
                 applied.append(_apply_dependency_setup(reachability_repo_path, library_coordinate, entry))

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -602,7 +602,32 @@ def _apply_dependency_setup(
     return {**result, "result": "applied", "target": os.path.relpath(build_gradle, reachability_repo_path)}
 
 
-def _apply_docker_image_setup(reachability_repo_path: str, entry: dict[str, str]) -> dict[str, str]:
+def _ensure_required_docker_image(reachability_repo_path: str, library_coordinate: str, image: str) -> None:
+    """Declare `image` in the library's `required-docker-images.txt` once its test dir exists.
+
+    For a new library the test dir is created by `scaffold`, so at preflight time this is a
+    no-op and the driver re-applies the setup after scaffold.
+    """
+    parts = library_coordinate.split(":")
+    if len(parts) != 3:
+        return
+    group, artifact, version = parts
+    test_dir = os.path.join(reachability_repo_path, "tests", "src", group, artifact, version)
+    if not os.path.isdir(test_dir):
+        return
+    required_path = os.path.join(test_dir, "required-docker-images.txt")
+    lines: list[str] = []
+    if os.path.isfile(required_path):
+        with open(required_path, "r", encoding="utf-8") as required_file:
+            lines = [line.strip() for line in required_file if line.strip()]
+    if image in lines:
+        return
+    lines.append(image)
+    with open(required_path, "w", encoding="utf-8") as required_file:
+        required_file.write("\n".join(lines) + "\n")
+
+
+def _apply_docker_image_setup(reachability_repo_path: str, entry: dict[str, str], library_coordinate: str) -> dict[str, str]:
     """Idempotently add a Dockerfile pin to the allowed-docker-images directory."""
     image = entry["image"]
     slug = entry["slug"]
@@ -610,6 +635,7 @@ def _apply_docker_image_setup(reachability_repo_path: str, entry: dict[str, str]
     images_dir = os.path.join(reachability_repo_path, ALLOWED_DOCKER_IMAGES_RELDIR)
     if not os.path.isdir(images_dir):
         return {**result, "result": "skipped", "reason": "allowed_images_dir_absent"}
+    _ensure_required_docker_image(reachability_repo_path, library_coordinate, image)
     target = os.path.join(images_dir, f"Dockerfile-{slug}")
     relative_target = os.path.relpath(target, reachability_repo_path)
     desired = f"FROM {image}\n"
@@ -648,7 +674,7 @@ def apply_library_preparation_setup(
             if kind == "dependency":
                 applied.append(_apply_dependency_setup(reachability_repo_path, library_coordinate, entry))
             elif kind == "docker_image":
-                applied.append(_apply_docker_image_setup(reachability_repo_path, entry))
+                applied.append(_apply_docker_image_setup(reachability_repo_path, entry, library_coordinate))
         except Exception as exc:
             applied.append({"kind": str(kind), "result": "skipped", "reason": f"{type(exc).__name__}: {exc}"})
     preflight["applied_setup"] = applied

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -775,7 +775,17 @@ def _run_test_matrix_entries(
             result,
         )
         if failed is not None:
-            return failed
+            # A declared image may be missing from the allow-list (e.g. a preflight pin dropped
+            # by the library-scoped scaffold commit). Pin it deterministically and retry once.
+            if _repair_missing_allowed_images(repo_path, coordinates):
+                failed = _run_recorded_command(
+                    repo_path,
+                    "pull-allowed-docker-images",
+                    ["./gradlew", "pullAllowedDockerImages", f"-Pcoordinates={coordinates}"],
+                    result,
+                )
+            if failed is not None:
+                return failed
         pulled_coordinates.add(coordinates)
 
     for entry in entries:
@@ -921,6 +931,48 @@ def _resolve_coordinate_test_version(repo_path: str, coordinates: str) -> str | 
 def _is_required_docker_image_line(line: str) -> bool:
     stripped = line.strip()
     return bool(stripped and not stripped.startswith("#"))
+
+
+def _docker_image_slug(image: str) -> str:
+    """Derive the allow-list slug: repository path without tag, `/` -> `_`."""
+    if ":" in image.rsplit("/", 1)[-1]:
+        image = image.rsplit(":", 1)[0]
+    return image.replace("/", "_")
+
+
+def _repair_missing_allowed_images(repo_path: str, coordinates: str) -> list[str]:
+    """Pin allow-list Dockerfiles for images declared in `required-docker-images.txt` but not
+    yet allow-listed, then commit them. Returns the repaired images (empty when nothing to do).
+    """
+    required_path = _required_docker_images_path(repo_path, coordinates)
+    if required_path is None or not os.path.isfile(required_path):
+        return []
+    with open(required_path, "r", encoding="utf-8") as required_file:
+        required = [line.strip() for line in required_file if _is_required_docker_image_line(line)]
+    images_dir = os.path.join(repo_path, "tests", "tck-build-logic", "src", "main", "resources", "allowed-docker-images")
+    if not os.path.isdir(images_dir):
+        return []
+    allowed: set[str] = set()
+    for name in os.listdir(images_dir):
+        path = os.path.join(images_dir, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path, "r", encoding="utf-8") as image_file:
+            allowed.update(line[len("FROM"):].strip() for line in image_file if line.startswith("FROM"))
+    repaired: list[str] = []
+    for image in required:
+        if image in allowed:
+            continue
+        target = os.path.join(images_dir, f"Dockerfile-{_docker_image_slug(image)}")
+        if os.path.isfile(target):
+            continue
+        with open(target, "w", encoding="utf-8") as image_file:
+            image_file.write(f"FROM {image}\n")
+        repaired.append(image)
+    if repaired:
+        subprocess.run(["git", "add", images_dir], cwd=repo_path, check=False)
+        subprocess.run(["git", "commit", "-m", "Pin required Docker images to allow-list"], cwd=repo_path, check=False)
+    return repaired
 
 
 def _spring_aot_env(entry: dict) -> dict[str, str]:


### PR DESCRIPTION
Closes #8890

## What this does

New-library PRs with Docker-backed tests kept landing in `human-intervention` because their Docker declaration files went missing even though preflight had already computed the right images. Two mechanisms were at play: the allow-list pin preflight writes to the shared `allowed-docker-images/` tree was dropped by the library-scoped scaffold commit and the iteration `git reset --hard` (e.g. #8860's `rabbitmq:4.1`), and `required-docker-images.txt` was never written by preflight at all because a new library's test dir does not exist until `scaffold` runs, so it silently became advisory work the agent skipped (e.g. #8789's `valkey/valkey:7.2.6`). The data is fully determined — preflight knows the images and the test source states them — so this is fixed deterministically rather than left for a human.

## The three changes

- **Preflight also writes `required-docker-images.txt`.** `_apply_docker_image_setup` now declares the image in `tests/src/<g>/<a>/<v>/required-docker-images.txt` alongside the allow-list `Dockerfile-<slug>`, so a `docker_image` setup produces both declarations (`§forge/ORCH-forge-orchestration-spec.1.1`). Before the test dir exists it stays a no-op, matching the advisory-fallback contract.
- **Pins are committed after branch creation.** The new-library driver re-applies the deterministic setup once the scaffolded test dir exists, then stages the shared `Dockerfile-<slug>` targets into the `Scaffold <library>` commit. Because that commit is the reset checkpoint, `git reset --hard` during iteration preserves them instead of wiping them.
- **Finalization repairs a still-missing pin.** The `pullAllowedDockerImages` gate is preserved; on failure it now pins any image declared in `required-docker-images.txt` but absent from the allow-list (slug derived, `FROM <image>`), commits it, and retries the pull once before falling through (`§forge/FS-local-ci-equivalent-verification`). The image string comes from the declaration file, so no source parsing is involved.

## What each case needs

| Case | Fixed by |
|------|----------|
| #8860 — declared, allow-list pin dropped | commit-after-branch; finalization repair as backstop |
| #8789 — preflight knew the image, no `required-docker-images.txt` | preflight write + committed pin |
| Agent-declared image, pin still missing at finalization | deterministic repair on the pull gate |

Both declarations land in both places, so `pullAllowedDockerImages` pre-pulls the image and the network-disabled test gate (`§FS-repository-functional-spec.5.2`) runs clean. The only residual case — a test that uses an image and declares nothing — is left to the agent instruction and the runtime-observation backstop, unchanged here.
