### PR TITLE
Abort mid-rebase before preserving failed work branch

### DIFF
--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -181,7 +181,12 @@ durable execution-metrics entry because that would lose local-only PR fields.
 Continuation does not change the human-intervention contract
 (§FS-human-intervention-policy). A logical failure still preserves the work
 branch and labels the issue `human-intervention`, so a maintainer always retains
-the existing safety signal and diagnostics. The marker rides that same preserved
+the existing safety signal and diagnostics. This holds even when the failure
+halts the worktree mid-rebase — for example a publication `git rebase` that stops
+on an `index.json` conflict from a sibling same-artifact PR that landed while the
+run was in flight: preservation first aborts any in-progress rebase so the
+generated tree still commits to the preserved branch instead of the branch being
+silently dropped. The marker rides that same preserved
 branch, giving a later automated run — or the maintainer — a precise place to
 continue. A repeated failure in the same resumed phase only removes
 `resumable`; it leaves the earlier `human-intervention` signal and comment in

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4368,6 +4368,24 @@ def baseline_stats_relpaths_for_preservation(repo_path: str) -> list[str]:
     return sorted(relpaths)
 
 
+def git_rebase_in_progress(repo_path: str, git_env: dict[str, str]) -> bool:
+    """Return whether a rebase is currently halted in the given worktree."""
+    # `git rev-parse --git-path` resolves the sequencer directories against the
+    # worktree-specific gitdir, so this stays correct inside linked worktrees.
+    for sequencer_dir in ("rebase-merge", "rebase-apply"):
+        resolved = subprocess.run(
+            ["git", "rev-parse", "--git-path", sequencer_dir],
+            cwd=repo_path,
+            env=git_env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if resolved and os.path.isdir(os.path.join(repo_path, resolved)):
+            return True
+    return False
+
+
 def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservationResult:
     """Commit and push the failed run worktree so it survives workspace cleanup."""
     branch_name = build_failure_preservation_branch_name(claimed_issue)
@@ -4379,8 +4397,12 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     # A publication `git rebase` that halts on an index.json conflict leaves the
     # worktree mid-rebase with unmerged entries, and `git switch -C` then refuses
     # ("resolve your current index first"). Clear the sequencer state first so the
-    # generated work is still preserved for later resume. §FS-forge-run-continuation
-    subprocess.run(["git", "rebase", "--abort"], cwd=repo_path, env=git_env, check=False)
+    # generated work is still preserved for later resume. Gate the abort on an
+    # actual rebase so the common clean-worktree path does not log a spurious
+    # "fatal: No rebase in progress?" from git. §FS-forge-run-continuation
+    if git_rebase_in_progress(repo_path, git_env):
+        log_stage("preserve-failed-work", f"Aborting in-progress rebase before preserving issue #{issue_number}.")
+        subprocess.run(["git", "rebase", "--abort"], cwd=repo_path, env=git_env, check=False)
     subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, env=git_env, check=True)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
     marker_path = continuation_marker_path(repo_path)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4376,6 +4376,11 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     issue_number = claimed_issue.issue["number"]
 
     log_stage("preserve-failed-work", f"Preserving failed work for issue #{issue_number} on branch {branch_name}")
+    # A publication `git rebase` that halts on an index.json conflict leaves the
+    # worktree mid-rebase with unmerged entries, and `git switch -C` then refuses
+    # ("resolve your current index first"). Clear the sequencer state first so the
+    # generated work is still preserved for later resume. §FS-forge-run-continuation
+    subprocess.run(["git", "rebase", "--abort"], cwd=repo_path, env=git_env, check=False)
     subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, env=git_env, check=True)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
     marker_path = continuation_marker_path(repo_path)


### PR DESCRIPTION
Closes #8889

## What this does

When a Forge run fails during the publication `git rebase` — e.g. an `index.json` conflict from a sibling same-artifact PR that landed while the run was in flight — the worktree is left **halted mid-rebase** with unmerged index entries. The failure is correctly classified as logical, so `preserve_failed_work_branch` runs, but its first step `git switch -C` refuses on a conflicted index (*"resolve your current index first"*). The exception is swallowed, so the failed-work branch is silently dropped: no preserved branch, no continuation marker, no `resumable` label, and no branch link in the human-intervention comment — defeating continuation for exactly this failure class. Observed on #8770 and #8718.

This makes `preserve_failed_work_branch` defensively clear the rebase sequencer state before switching branches.

## The fix

A single `git rebase --abort` with `check=False` before `git switch -C` at `forge/forge_metadata.py`:

```python
subprocess.run(["git", "rebase", "--abort"], cwd=repo_path, env=git_env, check=False)
subprocess.run(["git", "switch", "-C", branch_name], ...)
```

`check=False` makes it a no-op when no rebase is in progress, so the clean-worktree path is unchanged. After the abort, the preserved branch holds the generated work with `publication` still pending, so a later resume (or the `fix-index-file-inconsistencies` skill) re-runs publication and resolves the `index.json` merge.

The spec is updated in §FS-forge-run-continuation ([forge/docs/continuation.md](forge/docs/continuation.md)) to record that preservation aborts an in-progress rebase so the work branch survives even when the failure halts the worktree mid-rebase.
