### PR TITLE
Ungate scheduled release from test-all-metadata sweep

### DIFF
--- a/.github/workflows/create-scheduled-release.yml
+++ b/.github/workflows/create-scheduled-release.yml
@@ -1,6 +1,6 @@
 # Scheduled release (weekly Monday): packages changed metadata after spotlessCheck.
-# §CI-create-scheduled-release; gated on §CI-test-all-metadata.
-# Produces the native-build-tools artifact (§FS-repository-functional-spec.4).
+# §CI-create-scheduled-release; NOT gated on §CI-test-all-metadata (sweep failures
+# must not stall releases). Produces the nbt artifact (§FS-repository-functional-spec.4).
 name: "Create scheduled release"
 
 on:
@@ -10,60 +10,11 @@ on:
 
 permissions:
   contents: write
-  actions: read
 
 jobs:
-  check-last-test-all:
-    name: "📋 Check last test-all metadata run"
-    if: github.repository == 'oracle/graalvm-reachability-metadata'
-    runs-on: "ubuntu-22.04"
-    timeout-minutes: 5
-    outputs:
-      can-release: ${{ steps.check.outputs.can-release }}
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: "🔎 Check latest completed test-all metadata run"
-        id: check
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "can-release=true" >> "$GITHUB_OUTPUT"
-            echo "Manual release dispatch bypasses the test-all metadata gate."
-            exit 0
-          fi
-
-          LAST_RUN_JSON="$(
-            gh run list \
-              --repo "${{ github.repository }}" \
-              --workflow "test-all-metadata.yml" \
-              --branch "master" \
-              --status "completed" \
-              --limit 1 \
-              --json databaseId,conclusion,url
-          )"
-
-          if [[ "$(printf '%s' "$LAST_RUN_JSON" | jq 'length')" -eq 0 ]]; then
-            echo "can-release=false" >> "$GITHUB_OUTPUT"
-            echo "No completed test-all metadata workflow run was found."
-            exit 0
-          fi
-
-          CONCLUSION="$(printf '%s' "$LAST_RUN_JSON" | jq -r '.[0].conclusion')"
-          RUN_URL="$(printf '%s' "$LAST_RUN_JSON" | jq -r '.[0].url')"
-          echo "Latest completed test-all metadata run: $RUN_URL ($CONCLUSION)"
-
-          if [[ "$CONCLUSION" == "success" ]]; then
-            echo "can-release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can-release=false" >> "$GITHUB_OUTPUT"
-          fi
-
   get-changed-metadata:
     name: "📋 Get a list of changed metadata"
-    needs: check-last-test-all
-    if: github.repository == 'oracle/graalvm-reachability-metadata' && needs.check-last-test-all.outputs.can-release == 'true'
+    if: github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: "ubuntu-22.04"
     timeout-minutes: 5
     outputs:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -117,9 +117,9 @@ Every Sunday (`0 2 * * 0`) and on manual dispatch. Uses
 the full `test` lane, pulls only allowed images, then disables Docker networking.
 Failed batches are isolated down to concrete library versions, publish result
 and failure-log artifacts, and fail in the matrix so the Actions UI points at
-the failing batch. The aggregate job remains release-blocking when failures are
-found (§FS-repository-functional-spec.5.3) and gates the scheduled release
-(§CI-create-scheduled-release).
+the failing batch. The aggregate job publishes a failure report when failures are
+found (§FS-repository-functional-spec.5.3); it surfaces sweep regressions but does
+not gate the scheduled release (§CI-create-scheduled-release).
 
 ### CI-verify-new-library-version-compatibility: Verify new library version compatibility
 
@@ -148,9 +148,10 @@ to the `stats/coverage` branch. The published branch keeps only `COVERAGE.md`,
 ### CI-create-scheduled-release: Create scheduled release
 
 Every Monday (`0 3 * * 1`) and on manual dispatch. Packages metadata only if it
-changed and the latest completed test-all-metadata workflow passed
-(§CI-test-all-metadata); runs `spotlessCheck` before packaging
-(§FS-repository-functional-spec.5.3). Manual dispatches bypass the test-all gate.
+changed; runs `spotlessCheck` before packaging
+(§FS-repository-functional-spec.5.3). It is deliberately not gated on the periodic
+`test-all-metadata` sweep (§CI-test-all-metadata) so bleeding-edge sweep failures
+cannot stall the release cadence.
 The workflow considers only semantic version tags when choosing the previous
 numbered release tag, so floating snapshot tags such as `SNAPSHOT` are ignored.
 It then creates the next `<major>.<minor>.<patch>` release. The packaged ZIP is

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -72,7 +72,7 @@ CI must pass before any merge, and is the authoritative gate — local runs are 
 
 ### 4.4 Releases
 
-Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed and the latest completed test-all metadata workflow passed (§CI-create-scheduled-release). Manual release dispatches bypass this test-all gate. Numbered releases consider only semantic version tags when computing the previous version tag, so floating snapshot tags such as `SNAPSHOT` cannot affect the permanent release cadence.
+Every Monday the `create-scheduled-release` workflow packages metadata into the next numbered release if it has changed (§CI-create-scheduled-release). The release is deliberately not gated on the periodic `test-all-metadata` sweep: merged metadata is already gated per-PR (§5.3), and the sweep exercises bleeding-edge JDK and native-image configurations whose failures must not stall the release cadence. Numbered releases consider only semantic version tags when computing the previous version tag, so floating snapshot tags such as `SNAPSHOT` cannot affect the permanent release cadence.
 
 The `create-snapshot-release` workflow refreshes a floating `SNAPSHOT` GitHub Release on the `SNAPSHOT` tag after `master` pushes when metadata changed since the previous `SNAPSHOT` tag, or since the latest numbered release when bootstrapping (§CI-create-snapshot-release). It packages the repository with version `SNAPSHOT`, replaces the previous snapshot release/tag, and provides a continuously updated snapshot-style metadata bundle between numbered releases without taking GitHub's Latest marker from the newest numbered release. The packaged artifacts are what the GraalVM Gradle/Maven plugins consume.
 
@@ -242,7 +242,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 - **Spring AOT scope.** The Spring AOT smoke matrix runs only when `metadata/` changes affect a Spring AOT project.
 - **Compatibility budget.** `verify-new-library-version-compatibility` caps each scheduled run at a fixed library budget and at most 30 newer versions per library, expanding across the configured GraalVM JDK/OS combinations, and creates one aggregated GitHub issue per failed `(library, version)` pair.
 - **Docker tag sync.** Dependabot updates to `allowed-docker-images` trigger `sync-docker-tags.yml`, which back-commits the synchronized tags into the Dependabot PR.
-- **Full sweep.** `test-all-metadata` runs only on a weekly Sunday schedule or manual dispatch in the main repository, uses 85 batches, isolates failed batches down to concrete library versions, publishes result and failure-log artifacts, fails affected matrix batches, and is release-blocking when failures are found.
+- **Full sweep.** `test-all-metadata` runs only on a weekly Sunday schedule or manual dispatch in the main repository, uses 85 batches, isolates failed batches down to concrete library versions, publishes result and failure-log artifacts, and fails affected matrix batches. It surfaces sweep regressions but does not gate the scheduled release (§4.4).
 
 ### 5.4 Native-image modes
 


### PR DESCRIPTION
Closes #8893

## What

The weekly scheduled metadata release was gated on the `test-all-metadata` sweep passing: a `check-last-test-all` job blocked the release whenever the most recent sweep had failed. Because the sweep runs across the entire metadata suite, a single unrelated library failure would suppress the release even when the changed metadata was fine.

This PR removes that gate. The scheduled release now fires whenever metadata has changed, independent of the `test-all-metadata` sweep result.

## Changes

- `.github/workflows/create-scheduled-release.yml` — removed the `check-last-test-all` gate job and the now-unused `actions: read` permission.
- `docs/functional-spec.md` (§4.4, §5.3) and `docs/ci.md` (§CI-create-scheduled-release, §CI-test-all-metadata) — updated to match the new behavior.

## Verification

- `grund check` clean on all edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
