### PR TITLE
[GenAI] Mark io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom as not for Native Image

### DIFF
--- a/metadata/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom/index.json
+++ b/metadata/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The artifact is published as a POM/Gradle platform BOM with no JVM class files for native-image to analyze."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8516

This PR records `io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The artifact is published as a POM/Gradle platform BOM with no JVM class files for native-image to analyze.

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `f565a62192ed9007ddc1227319b5eb6867dab853`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
