### PR TITLE
Auto-close triage issues for not-for-native-image artifacts

### DIFF
--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -175,7 +175,7 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
-      - name: "Check if library/version is already supported by the repository"
+      - name: "Check whether the request is already covered by the repository"
         if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' }}
         id: support
         env:
@@ -188,10 +188,15 @@ jobs:
           STATUS=$?
           set -e
           echo "$OUTPUT"
-          if grep -qF "is supported" <<<"$OUTPUT"; then
+          if grep -q '^STATUS=supported$' <<<"$OUTPUT"; then
             echo "supported=true" >> "$GITHUB_OUTPUT"
           else
             echo "supported=false" >> "$GITHUB_OUTPUT"
+          fi
+          if grep -q '^STATUS=not-for-native-image$' <<<"$OUTPUT"; then
+            echo "not_for_native_image=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "not_for_native_image=false" >> "$GITHUB_OUTPUT"
           fi
           echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
 
@@ -215,8 +220,29 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
+      - name: "Close issue - artifact is already marked not-for-native-image"
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.support.outputs.not_for_native_image == 'true' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          COORDS: ${{ steps.extract.outputs.coords }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const coords = process.env.COORDS || "";
+            const body = [
+              `Automated triage: The requested artifact (${coords}) is already recorded by the GraalVM Reachability Metadata repository as \`not-for-native-image\`.`,
+              "",
+              "Closing this issue because the repository already tracks that this artifact is intentionally not a native-image metadata target.",
+              "If you believe this classification is wrong, please reopen the issue with additional details.",
+              "Note: Reopening will not re-run automation; maintainers will review manually."
+            ].join("\n");
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
+
       - name: "Mark issue eligible for dependency graph expansion"
-        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' }}
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' && steps.support.outputs.not_for_native_image != 'true' }}
         id: expand
         run: |
           set -Eeuo pipefail

--- a/check-library-support.sh
+++ b/check-library-support.sh
@@ -4,7 +4,8 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-# User-facing support lookup: check tested versions in the published index.
+# User-facing support lookup: check the published index for either exact
+# tested-version support or an artifact-level `not-for-native-image` decision.
 # §FS-repository-functional-spec.8.1.
 # Index semantics come from §FS-repository-functional-spec.4.7.
 
@@ -31,8 +32,27 @@ REMOTE_INDEX_URL="$REMOTE_BASE_URL/$GROUP/$ARTIFACT/index.json"
 INDEX_CONTENT=$(curl -fsSL "$REMOTE_INDEX_URL" 2>/dev/null || true)
 
 if [[ -z "$INDEX_CONTENT" ]]; then
+    echo "STATUS=unsupported"
     echo "Library $GAV is NOT supported by the GraalVM Reachability Metadata repository."
     exit 1
+fi
+
+if grep -q '"not-for-native-image"[[:space:]]*:[[:space:]]*true' <<< "$INDEX_CONTENT"; then
+    REASON=$(
+        sed -n 's/.*"reason"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' <<< "$INDEX_CONTENT" | head -n 1
+    )
+    REPLACEMENT=$(
+        sed -n 's/.*"replacement"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' <<< "$INDEX_CONTENT" | head -n 1
+    )
+    echo "STATUS=not-for-native-image"
+    echo "Library $GAV is marked as NOT_FOR_NATIVE_IMAGE by the GraalVM Reachability Metadata repository."
+    if [[ -n "$REASON" ]]; then
+        echo "Reason: $REASON"
+    fi
+    if [[ -n "$REPLACEMENT" ]]; then
+        echo "Replacement: $REPLACEMENT"
+    fi
+    exit 0
 fi
 
 FOUND=$(
@@ -44,7 +64,10 @@ FOUND=$(
 )
 
 if [ "$FOUND" = "yes" ]; then
+    echo "STATUS=supported"
     echo "Library $GAV is supported by the GraalVM Reachability Metadata repository."
 else
+    echo "STATUS=unsupported"
     echo "Library $GAV is NOT supported by the GraalVM Reachability Metadata repository."
+    exit 1
 fi

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -178,7 +178,10 @@ eligible. For automated native-build-tools issues with no labels and the standar
 `Support for groupId:artifactId:version` title, the workflow adds
 `library-new-request` and `priority` first. Once eligible it extracts and
 validates the Maven coordinates, closes invalid/duplicate/already-supported
-requests, and — via `open-dependency-issues-and-link-blockers.js`
+requests, and also closes requests whose `groupId:artifactId` already has an
+`index.json` recorded as `not-for-native-image` even when that index carries no
+per-version `tested-versions`. It then — via
+`open-dependency-issues-and-link-blockers.js`
 (§CI-shared-scripts) — generates a deps.dev dependency graph and opens or reuses
 `library-new-request` issues for unsupported transitive dependencies, linking
 them as blockers. The label vocabulary it applies is defined in

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -305,7 +305,9 @@ every dependency in your build and passes it to `native-image` (§4.7). Concrete
   `curl -sSL …/check-library-support.sh | bash -s "<group>:<artifact>:<version>"`,
   or browse the [libraries-and-frameworks page](https://www.graalvm.org/native-image/libraries-and-frameworks/),
   which is derived from `metadata/library-and-framework-list.json` (§METADATA-suite).
-  The script checks the published `index.json` tested-version contract (§4.7).
+  The script checks the published `index.json` contract (§4.7): it reports exact
+  tested-version support when present, and it also reports when the artifact is
+  already recorded as `not-for-native-image`.
 - **Request a missing library.** File a
   [`01_support_new_library`](../.github/ISSUE_TEMPLATE/01_support_new_library.yml)
   issue, or `02_update_existing_library` to extend an existing entry.


### PR DESCRIPTION
## Summary

This change teaches issue triage to auto-close `library-new-request` issues when the requested artifact is already recorded in the repository as `not-for-native-image`.

## Why this change exists

The repository already distinguishes two different kinds of coverage in `metadata/<groupId>/<artifactId>/index.json`:

1. versioned support entries with `tested-versions`
2. artifact-level `not-for-native-image` entries that intentionally record that the artifact is not a native-image metadata target

Before this change, the triage workflow only understood the first case. Its support check treated an artifact as covered only when the requested version appeared in `tested-versions`.

That behavior is correct for normal supported metadata, but it is incomplete for `not-for-native-image` artifacts because those index files intentionally do not contain `tested-versions`. The repository already has a decision on record for those artifacts, but triage could not see it.

The result was a bad workflow:

- a ticket would be opened for an artifact already recorded as `not-for-native-image`
- the support check would report it as unsupported
- triage would leave the issue open
- dependency expansion could continue even though the repository had already classified the artifact

Issue `#7677` is the concrete example that exposed this gap. `org.springframework.boot:spring-boot-starter-actuator` already has an index entry marked `not-for-native-image`, but the issue was not auto-closed because the old check only looked for `tested-versions`.

## What changed

### 1. Support lookup now returns explicit coverage states

`check-library-support.sh` now distinguishes three outcomes:

- `STATUS=supported`
- `STATUS=not-for-native-image`
- `STATUS=unsupported`

This is important because `not-for-native-image` is not the same thing as “the exact requested version is supported”. It is a separate artifact-level decision and should be surfaced as such.

### 2. Triage closes issues for existing `not-for-native-image` artifacts

The triage workflow now:

- keeps the existing close path for exact supported versions
- adds a separate close path when the artifact already has a `not-for-native-image` index entry
- posts a dedicated close comment that explains the artifact is already recorded as intentionally not being a native-image metadata target
- stops before dependency expansion in that case

### 3. Docs now describe the intended behavior

The CI and functional-spec docs now reflect that:

- the support check is based on the published `index.json` contract rather than only `tested-versions`
- issue triage should auto-close requests when the artifact is already classified as `not-for-native-image`

## Why the match is on group and artifact only

For normal support entries, the lookup must stay version-specific because `tested-versions` defines an exact version contract.

For `not-for-native-image` entries, the repository records an artifact-level policy decision:

- the index entry is intentionally versionless
- the decision applies to the artifact coordinate family
- requiring an exact version match would make the triage logic blind to the repository entry and keep creating redundant work

So the implementation keeps the distinction explicit:

- exact version match for normal supported metadata
- `groupId:artifactId` match for `not-for-native-image`

## Verification

Verified locally with the updated support-check script:

- `org.springframework.boot:spring-boot-starter-actuator:4.0.6` -> `STATUS=not-for-native-image`
- `org.springframework.boot:spring-boot-jdbc:4.0.6` -> `STATUS=supported`
- `definitely.fake:artifact:1.0.0` -> `STATUS=unsupported`
- `.github/workflows/triage-new-issues.yml` parses successfully as YAML

Closes #8912
