### PR TITLE
[GenAI] Add support for dev.profunktor:redis4cats-effects_3:1.7.2 using gpt-5.6-terra

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -2958,8 +2958,12 @@ def build_review_prompt(pr_number: int) -> str:
         "the wrong metadata bucket or duplicated across buckets, use the `fix-index-file-inconsistencies` skill. "
         "In that exception path, you may check out the PR branch, fix only the required `index.json` files, commit "
         "the repair, and push it to this PR branch before submitting the GitHub review. "
-        "If you find blocking issues, submit a review that requests changes with a concise summary. "
-        "If there are no blocking issues, submit an approval review summarizing the check and stating that you found no blocking issues."
+        "Only request changes for a concrete violation of an enumerated review rule in the applicable review skill for this PR's label. "
+        "Do not block on self-formed test-quality, test-scope, or 'end-user behavior' judgments that are not backed by a specific enumerated rule; "
+        "in particular, do not require a test to exercise a chosen public API entry point when it already exercises the library's types, "
+        "including relocated or shaded types that ship in the library JAR. "
+        "If you find such a rule-backed blocking issue, submit a review that requests changes with a concise summary that cites the specific rule. "
+        "If there are no rule-backed blocking issues, submit an approval review summarizing the check and stating that you found no blocking issues."
     )
 
 

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -798,6 +798,63 @@
     "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
   },
   {
+    "name": "dynamic_access_main_sources_pi_gpt-5.6-sol",
+    "description": "Same configuration as dynamic_access_main_sources_pi_gpt-5.5, but uses gpt-5.6-sol instead.",
+    "agent": "pi",
+    "workflow": "dynamic_access_iterative",
+    "model": "gpt-5.6-sol",
+    "prompts": {
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 3,
+      "max-class-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": [],
+    "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
+  },
+  {
+    "name": "dynamic_access_main_sources_pi_gpt-5.6-luna",
+    "description": "Same configuration as dynamic_access_main_sources_pi_gpt-5.5, but uses gpt-5.6-luna instead.",
+    "agent": "pi",
+    "workflow": "dynamic_access_iterative",
+    "model": "gpt-5.6-luna",
+    "prompts": {
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 3,
+      "max-class-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": [],
+    "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
+  },
+  {
+    "name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "description": "Same configuration as dynamic_access_main_sources_pi_gpt-5.5, but uses gpt-5.6-terra instead.",
+    "agent": "pi",
+    "workflow": "dynamic_access_iterative",
+    "model": "gpt-5.6-terra",
+    "prompts": {
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+    },
+    "parameters": {
+      "max-iterations": 3,
+      "max-class-test-iterations": 3,
+      "source-context-types": [
+        "main"
+      ]
+    },
+    "mcps": [],
+    "persistent-instructions": "prompt_templates/persistent/dynamic_access_rules.md"
+  },
+  {
     "name": "dynamic_access_documentation_sources_codex_gpt-5.5",
     "description": "Dynamic-access-guided Codex workflow using downloaded documentation artifacts as read-only context. Uses gpt-5.5.",
     "agent": "codex",

--- a/metadata/dev.profunktor/redis4cats-effects_3/1.7.2/reachability-metadata.json
+++ b/metadata/dev.profunktor/redis4cats-effects_3/1.7.2/reachability-metadata.json
@@ -1,0 +1,559 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.ConnectionBuilder$PlainChannelInitializer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.RedisAsyncCommandsImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.RedisChannelHandler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.BaseRedis"
+      },
+      "type" : "io.lettuce.core.ScoredValue[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.BaseRedisCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisAclCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisFunctionCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisGeoCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisHLLCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisHashCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisJsonCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisKeyCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisListCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisScriptingCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisServerCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisSetCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisSortedSetCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisStreamCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisStringCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.api.sync.RedisTransactionalCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.cluster.api.sync.RedisClusterCommands"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.event.connection.JfrConnectEvent",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.lettuce.core.event.connection.ConnectEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.event.connection.JfrConnectionCreatedEvent",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.lettuce.core.event.connection.ConnectionCreatedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.lettuce.core.metrics.DefaultCommandLatencyCollector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.protocol.DefaultEndpoint"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.lettuce.core.protocol.SharedLock"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.micrometer.context.ContextRegistry"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.buffer.AbstractByteBufAllocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.AbstractChannelHandlerContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.ChannelOutboundBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.DefaultChannelConfig"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$HeadContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.DefaultChannelPipeline$TailContext"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.epoll.Epoll"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.kqueue.KQueue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.channel.socket.nio.NioSocketChannel",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.incubator.channel.uring.IOUring"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.resolver.dns$DnsAddressResolverGroup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.resolver.dns.DnsAddressResolverGroup"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.util.DefaultAttributeMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "io.netty.util.DefaultAttributeMap$DefaultAttribute"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.HashedWheelTimer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.ResourceLeakDetector$DefaultResourceLeak"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.concurrent.DefaultPromise"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.concurrent.SingleThreadEventExecutor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+      "fields" : [
+        {
+          "name" : "producerLimit"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+      "fields" : [
+        {
+          "name" : "consumerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+      "fields" : [
+        {
+          "name" : "producerIndex"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.BaseRedis"
+      },
+      "type" : "java.lang.Object[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "java.lang.ProcessHandle",
+      "methods" : [
+        {
+          "name" : "current",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "pid",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.BaseRedis"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.nio.Bits"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.nio.ByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "java.nio.DirectByteBuffer"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "jdk.internal.misc.Unsafe",
+      "methods" : [
+        {
+          "name" : "getUnsafe",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "jdk.jfr.Event"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "org.HdrHistogram$Histogram"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "org.HdrHistogram.Histogram"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "org.LatencyUtils$PauseDetector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "org.LatencyUtils.PauseDetector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "reactor.core.publisher.LambdaMonoSubscriber"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "reactor.core.publisher.MonoCallable$MonoCallableSubscription"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "reactor.core.publisher.SinkManyBestEffort"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "reactor.core.publisher.SinksSpecs$AbstractSerializedSink"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "reactor.core.scheduler.DelegateServiceScheduler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "invokeCleaner",
+          "parameterTypes" : [
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.connection.RedisClient$"
+      },
+      "type" : "sun.misc.VM"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : "sun.nio.ch.SelectorImpl",
+      "fields" : [
+        {
+          "name" : "publicSelectedKeys"
+        },
+        {
+          "name" : "selectedKeys"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "type" : {
+        "proxy" : [
+          "io.lettuce.core.api.sync.RedisCommands",
+          "io.lettuce.core.cluster.api.sync.RedisClusterCommands"
+        ]
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "dev.profunktor.redis4cats.Redis$"
+      },
+      "module" : "jdk.jfr",
+      "glob" : "jdk/jfr/internal/types/metadata.bin"
+    }
+  ]
+}

--- a/metadata/dev.profunktor/redis4cats-effects_3/index.json
+++ b/metadata/dev.profunktor/redis4cats-effects_3/index.json
@@ -1,0 +1,21 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.7.2",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/dev/profunktor/redis4cats-effects_3/$version$/redis4cats-effects_3-$version$-sources.jar",
+    "repository-url" : "https://github.com/profunktor/redis4cats",
+    "test-code-url" : "https://github.com/profunktor/redis4cats/tree/v$version$/modules/tests/src",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/dev/profunktor/redis4cats-effects_3/$version$/redis4cats-effects_3-$version$-javadoc.jar",
+    "description" : "redis4cats-effects provides the Cats Effect-based Redis API for redis4cats, a Scala Redis client built on Lettuce. It lets Scala applications manage Redis connections and run effectful key-value, server, transaction, and related Redis commands through Cats Effect resource and type class abstractions.",
+    "language" : {
+      "name" : "scala",
+      "version" : "3"
+    },
+    "tested-versions" : [
+      "1.7.2"
+    ],
+    "allowed-packages" : [
+      "dev.profunktor.redis4cats"
+    ]
+  }
+]

--- a/stats/dev.profunktor/redis4cats-effects_3/1.7.2/execution-metrics.json
+++ b/stats/dev.profunktor/redis4cats-effects_3/1.7.2/execution-metrics.json
@@ -1,0 +1,109 @@
+{
+  "add_new_library_support:2026-07-02": {
+    "timestamp": "2026-07-02T15:38:29.965460Z",
+    "library": "dev.profunktor:redis4cats-effects_3:1.7.2",
+    "starting_commit": "9a1470768ba269acf8c7db7e6cc1e21dbb641b75",
+    "ending_commit": "cd60410d74ebf073fd2fe50462296f112de3c35c",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "1.7.2",
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 626,
+          "missed": 14894,
+          "ratio": 0.040335,
+          "total": 15520
+        },
+        "line": {
+          "covered": 57,
+          "missed": 687,
+          "ratio": 0.076613,
+          "total": 744
+        },
+        "method": {
+          "covered": 67,
+          "missed": 1831,
+          "ratio": 0.0353,
+          "total": 1898
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 4885,
+      "issue_label": "library-new-request",
+      "library": "dev.profunktor:redis4cats-effects_3:1.7.2",
+      "summary": "The effects API requires Cats Effect’s concrete IO runtime and meaningful command coverage requires a Redis-compatible server.",
+      "deterministic_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.typelevel:cats-effect_3:3.5.7",
+          "scope": "testImplementation",
+          "reason": "The artifact exposes Cats Effect kernel abstractions but its own POM declares cats-effect_3 only for tests; normal Redis[IO] usage requires IO."
+        },
+        {
+          "kind": "docker_image",
+          "image": "valkey/valkey:7.2.6",
+          "slug": "valkey_valkey",
+          "reason": "The upstream v1.7.2 docker-compose integration environment uses this single-node Redis-compatible server on port 6379; it is not currently allow-listed."
+        }
+      ],
+      "agent_guidance": "Exercise Redis[IO].utf8 against a loopback server with resource-safe acquisition/release and assert real set/get plus representative command operations. Wait for readiness and clean up the launched container; avoid cluster and replica coverage unless separately needed.",
+      "risks": [
+        "The new Docker image must be allow-listed and declared in required-docker-images.txt.",
+        "Port 6379 collisions or server readiness races can make tests flaky."
+      ],
+      "applied_setup": [
+        {
+          "kind": "dependency",
+          "coordinate": "org.typelevel:cats-effect_3:3.5.7",
+          "result": "applied",
+          "target": "tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/build.gradle"
+        },
+        {
+          "kind": "docker_image",
+          "image": "valkey/valkey:7.2.6",
+          "slug": "valkey_valkey",
+          "result": "already_present",
+          "target": "tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey"
+        }
+      ],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#4885 Support for dev.profunktor:redis4cats-effects_3:1.7.2; label=library-new-request; body_chars=110"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.6-terra",
+      "input_tokens_used": 75196,
+      "output_tokens_used": 3039,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/dev.profunktor:redis4cats-effects_3:1.7.2/library-preparation-preflight/pi-generation-2026-07-02T15-01-32-685306Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 179385,
+      "cached_input_tokens_used": 2738688,
+      "output_tokens_used": 16900,
+      "iterations": 9,
+      "cost_usd": 0.9382,
+      "generated_loc": 150,
+      "tested_library_loc": 57,
+      "metadata_entries": 93,
+      "test_only_metadata_entries": 108,
+      "code_coverage_percent": 7.66
+    },
+    "artifacts": {
+      "test_file": "tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala",
+      "metadata_file": "metadata/dev.profunktor/redis4cats-effects_3/1.7.2/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/dev.profunktor/redis4cats-effects_3/1.7.2/stats.json
+++ b/stats/dev.profunktor/redis4cats-effects_3/1.7.2/stats.json
@@ -1,0 +1,26 @@
+{
+  "versions" : [ {
+    "version" : "1.7.2",
+    "dynamicAccess" : "N/A",
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 626,
+        "missed" : 14894,
+        "ratio" : 0.040335,
+        "total" : 15520
+      },
+      "line" : {
+        "covered" : 57,
+        "missed" : 687,
+        "ratio" : 0.076613,
+        "total" : 744
+      },
+      "method" : {
+        "covered" : 67,
+        "missed" : 1831,
+        "ratio" : 0.0353,
+        "total" : 1898
+      }
+    }
+  } ]
+}

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/.gitignore
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
     testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
     testImplementation "org.typelevel:cats-effect_3:3.5.7"
+    testImplementation "org.typelevel:cats-core_3:2.12.0"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.17.0"
 }
 
 java {

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/build.gradle
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/build.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+    id "scala"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+int testJvmVersion = tck.testJvmVersion.get()
+String scala3Version = tck.scala3Version.get()
+
+dependencies {
+    testImplementation "dev.profunktor:redis4cats-effects_3:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation "org.scala-lang:scala3-library_3:$scala3Version"
+    testImplementation "org.scala-lang:scala3-compiler_3:$scala3Version"
+    testImplementation "org.typelevel:cats-effect_3:3.5.7"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(testJvmVersion)
+    }
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/gradle.properties
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = dev.profunktor:redis4cats-effects_3:1.7.2
+library.version = 1.7.2
+metadata.dir = dev.profunktor/redis4cats-effects_3/1.7.2/

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/required-docker-images.txt
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/required-docker-images.txt
@@ -1,0 +1,1 @@
+valkey/valkey:7.2.6

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/required-docker-images.txt
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/required-docker-images.txt
@@ -1,1 +1,1 @@
-valkey/valkey:7.2.6
+bitnami/valkey@sha256:1d36cd0d9929e59f6dcf698189152f5ee09339242cfbe18aed01a38b0a5d981f

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/settings.gradle
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'dev.profunktor.redis4cats-effects_3_tests'

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,640 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "boolean[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "byte[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.std.Console$",
+      "fields" : [
+        {
+          "name" : "0bitmap$1"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.Head"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.Tail"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.ComputePoolSampler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.ComputePoolSamplerMBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.LiveFiberSnapshotTrigger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.LiveFiberSnapshotTriggerMBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.LocalQueueSampler"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "cats.effect.unsafe.metrics.LocalQueueSamplerMBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "char[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.GarbageCollectorMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.GcInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.HotSpotDiagnosticMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.ThreadMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.UnixOperatingSystemMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.VMOption"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.DiagnosticCommandArgumentInfo",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "boolean",
+            "boolean",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.DiagnosticCommandArgumentInfo[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.DiagnosticCommandInfo",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String",
+            "java.lang.String",
+            "java.lang.String",
+            "boolean",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.DiagnosticCommandInfo[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.GarbageCollectorExtImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.HotSpotDiagnostic"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.HotSpotThreadImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.OperatingSystemImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "com.sun.management.internal.VirtualThreadSchedulerImpls$VirtualThreadSchedulerImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "double[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "float[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "int[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Boolean",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Byte",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Character",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.ClassValue"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Deprecated"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Double",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Float",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Integer",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Long",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Short",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.StackTraceElement"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.String"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.Void",
+      "fields" : [
+        {
+          "name" : "TYPE"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.invoke.VarHandle",
+      "methods" : [
+        {
+          "name" : "releaseFence",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.BufferPoolMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.ClassLoadingMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.CompilationMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.LockInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.MemoryMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.MemoryManagerMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.MemoryPoolMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.MemoryUsage"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.MonitorInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.PlatformLoggingMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.RuntimeMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.lang.management.ThreadInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.math.BigDecimal"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.math.BigInteger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.util.Arrays",
+      "jniAccessible" : true,
+      "methods" : [
+        {
+          "name" : "asList",
+          "parameterTypes" : [
+            "java.lang.Object[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "java.util.Date"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.MBeanOperationInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.MBeanServerBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.ObjectName"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.StandardEmitterMBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.openmbean.CompositeData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.openmbean.CompositeData[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.openmbean.OpenMBeanOperationInfoSupport"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "javax.management.openmbean.TabularData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.VirtualThreadSchedulerMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.ConfigurationInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.EventTypeInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.FlightRecorderMXBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.FlightRecorderMXBeanImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.RecordingInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "jdk.management.jfr.SettingDescriptorInfo"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "long[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "short[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.ClassLoadingImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.CompilationImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.ManagementFactoryHelper$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.ManagementFactoryHelper$PlatformLoggingImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.MemoryImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.MemoryManagerImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.MemoryPoolImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.management.RuntimeImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "dev_profunktor.redis4cats_effects_3.Redis4cats_effects_3Test"
+      },
+      "module" : "jdk.jfr",
+      "glob" : "jdk/jfr/internal/query/view.ini"
+    }
+  ]
+}

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package dev_profunktor.redis4cats_effects_3
+
+import org.junit.jupiter.api.Test
+
+class Redis4cats_effects_3Test {
+  @Test
+  def test(): Unit = {
+    println("This is just a placeholder, implement your test")
+  }
+}

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
@@ -6,11 +6,85 @@
  */
 package dev_profunktor.redis4cats_effects_3
 
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import dev.profunktor.redis4cats.Redis
+import dev.profunktor.redis4cats.effect.Log.NoOp.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 
 class Redis4cats_effects_3Test {
   @Test
-  def test(): Unit = {
-    println("This is just a placeholder, implement your test")
+  def utf8ClientExecutesStringHashSetListAndCounterCommands(): Unit = {
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    try {
+      val port: Int = runDocker(
+        "inspect",
+        "--format",
+        "{{(index (index .NetworkSettings.Ports \"6379/tcp\") 0).HostPort}}",
+        containerId
+      ).toInt
+      awaitReady(port)
+
+      val result: (Option[String], Map[String, String], Set[String], List[String], Long) =
+        Redis[IO].utf8(s"redis://127.0.0.1:$port?timeout=10s").use { redis =>
+          for {
+            _ <- redis.set("greeting", "hello")
+            greeting <- redis.get("greeting")
+            _ <- redis.hSet("profile", Map("name" -> "Redis4cats", "language" -> "Scala"))
+            profile <- redis.hGetAll("profile")
+            _ <- redis.sAdd("roles", "reader", "writer")
+            roles <- redis.sMembers("roles")
+            _ <- redis.rPush("events", "created", "updated")
+            events <- redis.lRange("events", 0, -1)
+            _ <- redis.set("counter", "4")
+            counter <- redis.incrBy("counter", 3)
+          } yield (greeting, profile, roles, events, counter)
+        }.unsafeRunSync()
+
+      assertEquals(Some("hello"), result._1)
+      assertEquals(Map("name" -> "Redis4cats", "language" -> "Scala"), result._2)
+      assertEquals(Set("reader", "writer"), result._3)
+      assertEquals(List("created", "updated"), result._4)
+      assertEquals(7L, result._5)
+    } finally {
+      runDocker("rm", "-f", containerId)
+    }
+  }
+
+  private def awaitReady(port: Int): Unit = {
+    val deadlineNanos: Long = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+    var ready: Boolean = false
+    while (!ready && System.nanoTime() < deadlineNanos) {
+      val socket: Socket = new Socket()
+      try {
+        socket.connect(new InetSocketAddress("127.0.0.1", port), 10000)
+        ready = true
+      } catch {
+        case _: java.net.ConnectException => Thread.sleep(100)
+      } finally {
+        socket.close()
+      }
+    }
+    assertEquals(true, ready, "Valkey did not become ready within 30 seconds")
+  }
+
+  private def runDocker(arguments: String*): String = {
+    val process: Process = new ProcessBuilder(("docker" +: arguments)*).redirectErrorStream(true).start()
+    val finished: Boolean = process.waitFor(30, TimeUnit.SECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      process.waitFor(10, TimeUnit.SECONDS)
+    }
+    val output: String = new String(process.getInputStream.readAllBytes(), StandardCharsets.UTF_8).trim
+    assertEquals(true, finished, s"Docker command timed out: docker ${arguments.mkString(" ")}")
+    assertEquals(0, process.exitValue(), s"Docker command failed: docker ${arguments.mkString(" ")}\n$output")
+    output
   }
 }

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
@@ -13,6 +13,7 @@ import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.effect.Log.NoOp.*
 import dev.profunktor.redis4cats.effects.Score
 import dev.profunktor.redis4cats.effects.ScoreWithValue
+import dev.profunktor.redis4cats.effects.ScriptOutputType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -92,6 +93,39 @@ class Redis4cats_effects_3Test {
       assertEquals(List("Ada", "Linus", "Grace"), result._2)
       assertEquals(Some(2L), result._3)
       assertEquals(Some(22.0), result._4)
+    } finally {
+      runDocker("rm", "-f", containerId)
+    }
+  }
+
+  @Test
+  def utf8ClientLoadsAndExecutesCachedLuaScripts(): Unit = {
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    try {
+      val port: Int = runDocker(
+        "inspect",
+        "--format",
+        "{{(index (index .NetworkSettings.Ports \"6379/tcp\") 0).HostPort}}",
+        containerId
+      ).toInt
+      awaitReady(port)
+
+      val result: (List[Boolean], String) =
+        Redis[IO].utf8(s"redis://127.0.0.1:$port?timeout=10s").use { redis =>
+          for {
+            digest <- redis.scriptLoad("return ARGV[1]")
+            exists <- redis.scriptExists(digest)
+            value <- redis.evalSha(
+              digest,
+              ScriptOutputType.Value[String],
+              List.empty[String],
+              List("cached result")
+            )
+          } yield (exists, value)
+        }.unsafeRunSync()
+
+      assertEquals(List(true), result._1)
+      assertEquals("cached result", result._2)
     } finally {
       runDocker("rm", "-f", containerId)
     }

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
@@ -11,6 +11,8 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import dev.profunktor.redis4cats.Redis
 import dev.profunktor.redis4cats.effect.Log.NoOp.*
+import dev.profunktor.redis4cats.effects.Score
+import dev.profunktor.redis4cats.effects.ScoreWithValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -53,6 +55,43 @@ class Redis4cats_effects_3Test {
       assertEquals(Set("reader", "writer"), result._3)
       assertEquals(List("created", "updated"), result._4)
       assertEquals(7L, result._5)
+    } finally {
+      runDocker("rm", "-f", containerId)
+    }
+  }
+
+  @Test
+  def utf8ClientStoresAndRanksSortedSetMembers(): Unit = {
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    try {
+      val port: Int = runDocker(
+        "inspect",
+        "--format",
+        "{{(index (index .NetworkSettings.Ports \"6379/tcp\") 0).HostPort}}",
+        containerId
+      ).toInt
+      awaitReady(port)
+
+      val result: (Long, List[String], Option[Long], Option[Double]) =
+        Redis[IO].utf8(s"redis://127.0.0.1:$port?timeout=10s").use { redis =>
+          for {
+            added <- redis.zAdd(
+              "leaderboard",
+              None,
+              ScoreWithValue(Score(15.0), "Ada"),
+              ScoreWithValue(Score(30.0), "Grace"),
+              ScoreWithValue(Score(22.0), "Linus")
+            )
+            rankedMembers <- redis.zRange("leaderboard", 0, -1)
+            graceRank <- redis.zRank("leaderboard", "Grace")
+            linusScore <- redis.zScore("leaderboard", "Linus")
+          } yield (added, rankedMembers, graceRank, linusScore)
+        }.unsafeRunSync()
+
+      assertEquals(3L, result._1)
+      assertEquals(List("Ada", "Linus", "Grace"), result._2)
+      assertEquals(Some(2L), result._3)
+      assertEquals(Some(22.0), result._4)
     } finally {
       runDocker("rm", "-f", containerId)
     }

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/src/test/scala/dev_profunktor/redis4cats_effects_3/Redis4cats_effects_3Test.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 class Redis4cats_effects_3Test {
   @Test
   def utf8ClientExecutesStringHashSetListAndCounterCommands(): Unit = {
-    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "bitnami/valkey@sha256:1d36cd0d9929e59f6dcf698189152f5ee09339242cfbe18aed01a38b0a5d981f")
     try {
       val port: Int = runDocker(
         "inspect",
@@ -63,7 +63,7 @@ class Redis4cats_effects_3Test {
 
   @Test
   def utf8ClientStoresAndRanksSortedSetMembers(): Unit = {
-    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "bitnami/valkey@sha256:1d36cd0d9929e59f6dcf698189152f5ee09339242cfbe18aed01a38b0a5d981f")
     try {
       val port: Int = runDocker(
         "inspect",
@@ -100,7 +100,7 @@ class Redis4cats_effects_3Test {
 
   @Test
   def utf8ClientLoadsAndExecutesCachedLuaScripts(): Unit = {
-    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "valkey/valkey:7.2.6")
+    val containerId: String = runDocker("run", "--rm", "-d", "-p", "127.0.0.1::6379", "bitnami/valkey@sha256:1d36cd0d9929e59f6dcf698189152f5ee09339242cfbe18aed01a38b0a5d981f")
     try {
       val port: Int = runDocker(
         "inspect",

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/user-code-filter.json
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "dev.profunktor.redis4cats.**"
+      "includeClasses" : "dev.profunktor.redis4cats.**"
+    },
+    {
+      "includeClasses" : "dev_profunktor.redis4cats_effects_3.**"
     }
   ]
 }

--- a/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/user-code-filter.json
+++ b/tests/src/dev.profunktor/redis4cats-effects_3/1.7.2/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "dev.profunktor.redis4cats.**"
+    }
+  ]
+}

--- a/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey
+++ b/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey
@@ -1,0 +1,1 @@
+FROM valkey/valkey:7.2.6

--- a/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey
+++ b/tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey
@@ -1,1 +1,1 @@
-FROM valkey/valkey:7.2.6
+FROM bitnami/valkey@sha256:1d36cd0d9929e59f6dcf698189152f5ee09339242cfbe18aed01a38b0a5d981f


### PR DESCRIPTION

## What does this PR do?

Fixes: #4885

This PR introduces tests and metadata for dev.profunktor:redis4cats-effects_3:1.7.2, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 179385
- Cached input tokens: 2738688
- Output tokens: 16900
- Metadata entries: 93
- Test-only metadata entries: 108
- Iterations: 9
- Library coverage percentage: 7.66
- Generated lines of code: 150
- Tested library lines of code: 57

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `cb9a8a742bb476df1ce83c0f2a71d1bd53a7002d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Library coverage:
- Instruction: 626/15520 (4.03%)
- Line: 57/744 (7.66%)
- Method: 67/1898 (3.53%)

### Local CI Verification

- Status: `success`
- Commands run: 6
- Fixup attempts: 1
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `forge/forge_metadata.py`
  - `forge/strategies/predefined_strategies.json`
  - `tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-valkey_valkey`
