### PR TITLE
Fork a per-class exploration anchor for dynamic-access attempts

### DIFF
--- a/forge/ai_workflows/agents/agent.py
+++ b/forge/ai_workflows/agents/agent.py
@@ -32,6 +32,18 @@ class Agent(ABC):
 
     _registry: dict[str, type["Agent"]] = {}
 
+    # Fork token accounting. A fork child inherits this agent's counters, spends
+    # its own tokens, and is then discarded. On the child's ``with``-block exit
+    # it folds its delta into the parent's accumulators below, so a discarded
+    # child's usage still surfaces in run metrics. Token-tracking agents add
+    # these accumulators into their token properties. Class-level defaults let
+    # this work without every backend initializing them in ``__init__``.
+    _forked_tokens_sent: int = 0
+    _forked_tokens_received: int = 0
+    _forked_tokens_cached: int = 0
+    _fork_parent: "Agent | None" = None
+    _fork_baseline: "tuple[int, int, int] | None" = None
+
     @classmethod
     def register(cls, agent_key: str):
         """Class decorator that registers an agent implementation under the given key."""
@@ -67,6 +79,58 @@ class Agent(ABC):
     def cached_input_tokens_used(self) -> int | None:
         """Return cumulative cached input tokens when the backend reports them."""
         return None
+
+    def add_forked_usage(
+            self,
+            tokens_sent: int,
+            tokens_received: int,
+            cached_input_tokens: int = 0,
+    ) -> None:
+        """Accumulate token usage handed back by a discarded fork child.
+
+        Token-tracking agents surface these accumulators through their token
+        properties; keeping them on the base means the bookkeeping works for any
+        backend without extra per-agent code.
+        """
+        self._forked_tokens_sent += max(int(tokens_sent), 0)
+        self._forked_tokens_received += max(int(tokens_received), 0)
+        self._forked_tokens_cached += max(int(cached_input_tokens), 0)
+
+    def _begin_fork_child(self, parent: "Agent") -> None:
+        """Stamp a freshly forked child with its parent and pre-turn baseline.
+
+        Call this after the child inherits the parent's counters but before its
+        first turn is counted, so the child's delta (``total - baseline``) covers
+        every turn it runs, including the initial generation prompt.
+        """
+        self._fork_parent = parent
+        self._fork_baseline = self._usage_tuple()
+
+    def _usage_tuple(self) -> tuple[int, int, int]:
+        """Current (sent, received, cached) totals, tolerant of ``None`` cached."""
+        return (
+            int(self.total_tokens_sent or 0),
+            int(self.total_tokens_received or 0),
+            int(self.cached_input_tokens_used or 0),
+        )
+
+    def __enter__(self) -> "Agent":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        # Block exit is the fork child's "kill" point: fold its delta into the
+        # parent so the discarded child's tokens survive in run metrics.
+        if self._fork_parent is not None:
+            sent, received, cached = self._usage_tuple()
+            base_sent, base_received, base_cached = self._fork_baseline or (0, 0, 0)
+            self._fork_parent.add_forked_usage(
+                sent - base_sent,
+                received - base_received,
+                cached - base_cached,
+            )
+            self._fork_parent = None
+            self._fork_baseline = None
+        return False
 
     def _create_session_log_path(
             self,

--- a/forge/ai_workflows/agents/codex_agent.py
+++ b/forge/ai_workflows/agents/codex_agent.py
@@ -128,15 +128,15 @@ class CodexAgent(Agent):
 
     @property
     def total_tokens_sent(self) -> int:
-        return self._total_tokens_sent
+        return self._total_tokens_sent + self._forked_tokens_sent
 
     @property
     def total_tokens_received(self) -> int:
-        return self._total_tokens_received
+        return self._total_tokens_received + self._forked_tokens_received
 
     @property
     def cached_input_tokens_used(self) -> int:
-        return self._cached_input_tokens_used
+        return self._cached_input_tokens_used + self._forked_tokens_cached
 
     @property
     def thread_id(self) -> str | None:
@@ -302,6 +302,7 @@ class CodexAgent(Agent):
         child._total_tokens_sent = self._total_tokens_sent
         child._cached_input_tokens_used = self._cached_input_tokens_used
         child._total_tokens_received = self._total_tokens_received
+        child._begin_fork_child(self)
         child.send_prompt(prompt)
         return child
 
@@ -315,6 +316,7 @@ class CodexAgent(Agent):
         child._total_tokens_sent = self._total_tokens_sent
         child._cached_input_tokens_used = self._cached_input_tokens_used
         child._total_tokens_received = self._total_tokens_received
+        child._begin_fork_child(self)
         child.send_prompt(prompt)
         return child
 

--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -60,15 +60,15 @@ class PiAgent(Agent):
 
     @property
     def total_tokens_sent(self) -> int:
-        return self._total_tokens_sent
+        return self._total_tokens_sent + self._forked_tokens_sent
 
     @property
     def total_tokens_received(self) -> int:
-        return self._total_tokens_received
+        return self._total_tokens_received + self._forked_tokens_received
 
     @property
     def cached_input_tokens_used(self) -> int:
-        return self._cached_input_tokens_used
+        return self._cached_input_tokens_used + self._forked_tokens_cached
 
     def graphify(self, source_dirs: list[str]) -> str:
         """Send /skill:graphify to the Pi session to build a merged knowledge graph context."""
@@ -134,6 +134,7 @@ class PiAgent(Agent):
         child._prev_input = self._prev_input
         child._prev_output = self._prev_output
         child._prev_cache = self._prev_cache
+        child._begin_fork_child(self)
         child._apply_fork_token_delta(result.session_stats)
         child._print_session_log_once("Pi", child._session_log_path)
         child._write_turn_log(child._session_path, prompt, result)

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -17,6 +17,7 @@ from utility_scripts.dynamic_access_report import (
     DynamicAccessCoverageReport,
     compute_class_delta,
     format_call_sites,
+    format_full_report,
     load_dynamic_access_coverage_report,
 )
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
@@ -34,6 +35,7 @@ from utility_scripts.strategy_loader import load_strategy_by_name
 FALLBACK_STRATEGY_NAME = "basic_iterative_pi_gpt-5.5"
 DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
 DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE = 5
+DEFAULT_DYNAMIC_ACCESS_EXPLORE_PROMPT = "prompt_templates/dynamic_access/dynamic-access-explore.md"
 
 
 @WorkflowStrategy.register("dynamic_access_iterative")
@@ -55,6 +57,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
 
     def __init__(self, strategy_obj: dict, **context):
         super().__init__(strategy_obj, **context)
+        # The per-class exploration anchor prompt is optional in the bundle: when
+        # a strategy does not declare it, fall back to the packaged default so
+        # existing configs keep working without listing the new prompt key.
+        self.prompts.setdefault("dynamic-access-explore", DEFAULT_DYNAMIC_ACCESS_EXPLORE_PROMPT)
         self.library = self.context["library"]
         self.reachability_repo_path = self.context["reachability_repo_path"]
         self.keep_tests_without_dynamic_access = bool(self.context.get("keep_tests_without_dynamic_access", False))
@@ -360,6 +366,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             class_failed = False
             class_committed = False
             gate_failed = False
+            # Build one exploration anchor per class, then fork it for each
+            # attempt: the shared exploration is reused, but each attempt starts
+            # from the same lean, pre-generation state instead of accumulating
+            # the previous attempts' turns (§WF-dynamic-access-iterative-strategy).
+            agent.clear_context()
+            self._explore_class(agent, class_name, active_class, current_report)
             while class_attempts < self.max_class_iterations:
                 self._print_dynamic_access_detail(
                     "attempt {attempt}/{max_attempts}".format(
@@ -375,53 +387,55 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     dynamic_access_progress=self._format_progress(delta, class_attempts),
                     uncovered_dynamic_access_calls=format_call_sites(active_class.uncovered_call_sites),
                 )
-                self._print_dynamic_access_detail("agent: running dynamic-access prompt", indent_level=2)
-                agent.send_prompt(dynamic_prompt)
-                self._print_dynamic_access_detail("agent: complete", indent_level=2)
-                prompt_iterations += 1
-                save_phase_update(
-                    self.continuation_marker_path,
-                    lambda marker: marker.record_iteration(PHASE_EXPLORE, prompt_iterations),
-                )
-                class_attempts += 1
-
+                self._print_dynamic_access_detail("agent: forking exploration anchor for generation", indent_level=2)
                 reached_native_test = False
                 last_test_output = ""
                 last_failed_task = None
-                for test_iteration in range(self.max_class_test_iterations):
-                    self._print_dynamic_access_detail(
-                        "test {current}/{maximum}: running ./gradlew test -Pcoordinates={library}".format(
-                            current=test_iteration + 1,
-                            maximum=self.max_class_test_iterations,
-                            library=self.library,
-                        ),
-                        indent_level=2,
-                    )
-                    test_output = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
-                    failed_task = self._get_first_failed_task(test_output)
-                    last_test_output = test_output
-                    last_failed_task = failed_task
-                    self._print_dynamic_access_detail(
-                        "test: complete (failed task: {failed_task})".format(
-                            failed_task=failed_task or "none",
-                        ),
-                        indent_level=2,
-                    )
-                    if failed_task in {"nativeTest", None}:
-                        reached_native_test = True
-                        break
-                    self._print_dynamic_access_detail(
-                        "agent: test failed before nativeTest; sending failure output back to agent",
-                        indent_level=2,
-                    )
-                    agent.send_prompt(
-                        "When `./gradlew test -Pcoordinates={library}` is ran this is the error:\n{error_output}".format(
-                            library=self.library,
-                            error_output=test_output,
-                        )
-                    )
+                # Fork the anchor for this attempt. The child folds its own token
+                # usage into the anchor when the `with` block exits, so no per-site
+                # accounting is needed here (see Agent.fork / Agent.__exit__).
+                with agent.fork(dynamic_prompt) as attempt_agent:
                     self._print_dynamic_access_detail("agent: complete", indent_level=2)
                     prompt_iterations += 1
+                    save_phase_update(
+                        self.continuation_marker_path,
+                        lambda marker: marker.record_iteration(PHASE_EXPLORE, prompt_iterations),
+                    )
+                    class_attempts += 1
+
+                    for test_iteration in range(self.max_class_test_iterations):
+                        self._print_dynamic_access_detail(
+                            "test {current}/{maximum}: running ./gradlew test -Pcoordinates={library}".format(
+                                current=test_iteration + 1,
+                                maximum=self.max_class_test_iterations,
+                                library=self.library,
+                            ),
+                            indent_level=2,
+                        )
+                        test_output = attempt_agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
+                        failed_task = self._get_first_failed_task(test_output)
+                        last_test_output = test_output
+                        last_failed_task = failed_task
+                        self._print_dynamic_access_detail(
+                            "test: complete (failed task: {failed_task})".format(
+                                failed_task=failed_task or "none",
+                            ),
+                            indent_level=2,
+                        )
+                        if failed_task in {"nativeTest", None}:
+                            reached_native_test = True
+                            break
+                        self._print_dynamic_access_detail(
+                            "agent: test failed before nativeTest; sending failure output back to agent",
+                            indent_level=2,
+                        )
+                        failure_message = (
+                            f"When `./gradlew test -Pcoordinates={self.library}` is ran "
+                            f"this is the error:\n{test_output}"
+                        )
+                        attempt_agent.send_prompt(failure_message)
+                        self._print_dynamic_access_detail("agent: complete", indent_level=2)
+                        prompt_iterations += 1
 
                 if not reached_native_test:
                     # Tests failed for this class, roll back to before this class
@@ -550,8 +564,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     )
                 active_class = updated_class
 
-            # Clear context between classes to keep the agent window focused.
-            agent.clear_context()
+            # The exploration anchor is rebuilt from scratch for the next class
+            # (clear + explore at the top of the loop), so no clear is needed here.
             if gate_failed:
                 self._print_failure_analysis(
                     "native_test_verification_gate_failed",
@@ -665,6 +679,25 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     len(terminal_classes_this_part),
                 )
                 return True, prompt_iterations
+
+    def _explore_class(self, agent, class_name: str, active_class, current_report) -> None:
+        """Prime a per-class exploration anchor that later attempts fork from.
+
+        This is the read-only exploration turn of
+        §WF-dynamic-access-iterative-strategy: the agent studies the active class
+        and the complete report and plans coverage, but writes nothing. Each
+        attempt then forks this anchor so the exploration is reused without
+        carrying prior attempts' turns forward.
+        """
+        explore_prompt = self._render_prompt(
+            "dynamic-access-explore",
+            active_class_name=class_name,
+            active_class_source_file=active_class.resolved_source_file or active_class.source_file or "N/A",
+            dynamic_access_report=format_full_report(current_report),
+        )
+        self._print_dynamic_access_detail("agent: exploring class (no test generation)", indent_level=2)
+        agent.send_prompt(explore_prompt)
+        self._print_dynamic_access_detail("agent: exploration complete", indent_level=2)
 
     def _mark_continuation_explore_completed(
             self,

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -39,6 +39,18 @@ classes. Each selected class receives bounded prompt attempts, bounded test
 repair attempts, coverage-delta checks, per-class checkpointing, and native-test
 verification after each configured batch of coverage-gain commits.
 
+Within a class, the engine first primes a per-class exploration anchor: a single
+read-only turn (the `dynamic-access-explore` prompt) that studies the active
+class and the complete report and plans coverage without writing any files. Each
+attempt then **forks** that anchor and sends only a slim generation prompt (the
+`dynamic-access-iteration` prompt) carrying the latest report delta, so the
+shared exploration is reused once instead of re-accumulating across attempts.
+Because a fork branches the conversation but not the working tree, the slim
+prompt instructs the fork to read the tests already on disk and extend them
+additively so it does not clobber coverage authored by a sibling attempt it has
+no memory of. Token usage from each discarded fork child is folded back into the
+anchor so run metrics stay accurate.
+
 The iterative engine may return `RUN_STATUS_CHUNK_READY` when chunked issue
 orchestration gave it a class limit and the current chunk passed all local
 verification gates. Otherwise it returns success only when the dynamic-access
@@ -209,8 +221,10 @@ State held for one strategy `run(...)` invocation, independent of chunking:
   again within the run.
 - `class_checkpoint` — git SHA captured before each class attempt; used to roll
   back a failed class iteration without losing previously committed classes.
-- `prompt_iterations` — total agent prompts sent (returned to the caller as
-  `global_iterations`).
+- `prompt_iterations` — count of generation and test-repair prompts sent
+  (returned to the caller as `global_iterations`). The read-only per-class
+  exploration turn is not counted; its token cost is still captured in the
+  agent's token totals.
 - `successful_classes` — count of classes that contributed at least one newly
   covered call site and whose test changes were committed.
 

--- a/forge/prompt_templates/dynamic_access/dynamic-access-explore.md
+++ b/forge/prompt_templates/dynamic_access/dynamic-access-explore.md
@@ -1,0 +1,33 @@
+Role: You are an expert JVM test engineer specializing in high-coverage integration testing for external libraries.
+
+Task:
+Explore — do not write tests yet. This is a read-only planning turn for the active dynamic-access class in `{library}`. Subsequent turns will fork this session to generate the tests, so build a durable understanding here that those turns can rely on.
+
+Source Context:
+{source_context_overview}
+
+{resolved_edit_scope_context}
+
+Issue-Requested Metadata:
+{issue_requested_metadata_context}
+
+Library Preparation Preflight:
+{library_preparation_preflight_context}
+
+Active class (focus your exploration here):
+- Class: {active_class_name}
+- Source file: {active_class_source_file}
+
+Complete dynamic-access report for this library:
+{dynamic_access_report}
+
+What to produce:
+- Read the active class source and any collaborators needed to reach its uncovered dynamic-access call sites.
+- Identify the public API entry points that drive execution to each uncovered call site of the active class.
+- Note the setup, fixtures, and inputs a test would need, and any call sites reachable only through broken or version-specific paths that should be left alone.
+- Summarize a concrete coverage plan for the active class that a follow-up test-writing turn can execute.
+
+Rules:
+- Do NOT create, edit, or delete any files during this turn. Exploration only.
+- Focus on the active class; use the rest of the report only as context for shared setup or collaborators.
+- Prefer coverage through the library's normal public API. Do not plan to satisfy coverage by asserting a known broken, regressed, or version-specific failure path.

--- a/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
+++ b/forge/prompt_templates/dynamic_access/dynamic-access-iteration.md
@@ -1,22 +1,13 @@
 Role: You are an expert JVM test engineer specializing in high-coverage integration testing for external libraries.
 
 Task:
-Improve test coverage for the active dynamic-access class in `{library}`.
-
-Source Context:
-{source_context_overview}
-
-{resolved_edit_scope_context}
-
-Issue-Requested Metadata:
-{issue_requested_metadata_context}
-
-Library Preparation Preflight:
-{library_preparation_preflight_context}
+Using the exploration you already did for the active class in `{library}`, write or refine tests so execution reaches its remaining uncovered dynamic-access call sites.
 
 Active class:
 - Class: {active_class_name}
 - Source file: {active_class_source_file}
+
+{resolved_edit_scope_context}
 
 Progress since the previous dynamic-access report:
 {dynamic_access_progress}
@@ -24,10 +15,14 @@ Progress since the previous dynamic-access report:
 Remaining uncovered dynamic-access call sites for this class:
 {uncovered_dynamic_access_calls}
 
+Reconcile with what is already on disk (important):
+- Other attempts may already have written passing tests for this class that are not part of this conversation's history. Before editing, read the current test sources for this class under the resolved target test source root and treat whatever is there as the source of truth.
+- If tests already exist, extend them: add new test methods only. Do not delete, rewrite, or restructure existing tests — that would silently drop coverage already achieved.
+- Only add what is needed to cover the remaining uncovered call sites listed above.
+
 Rules:
-- Add or refine tests so execution reaches the remaining uncovered call sites for the active class.
 - Focus on the active class only.
 - Create or update tests only under the resolved target test source root listed above. Do not edit cloned baseline test directories or other versioned test directories.
-- Reporter issue context identifies what is missing; infer the requested metadata from that context and ensure any added or modified reachability metadata uses appropriate conditions, preferably `typeReached`. A condition is valid only if that type is reached before the dynamic access occurs; do not use a later or merely related class as the condition.
+- Ensure any added or modified reachability metadata uses appropriate conditions, preferably `typeReached`. A condition is valid only if that type is reached before the dynamic access occurs; do not use a later or merely related class as the condition.
 - Cover supported behavior through the library's normal public API. Do not satisfy coverage by asserting a known broken, regressed, or version-specific failure path for the current artifact.
-- If the remaining call site is reachable only through behavior that is known to be broken in this library version, choose another supported path or leave the call site uncovered.
+- If a remaining call site is reachable only through behavior that is known to be broken in this library version, choose another supported path or leave the call site uncovered.

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -195,6 +195,15 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             def send_prompt(self, prompt: str) -> None:
                 pass
 
+            def fork(self, prompt: str) -> "FakeAgent":
+                return self
+
+            def __enter__(self) -> "FakeAgent":
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
+
             def run_test_command(self, command: str) -> str:
                 return "BUILD SUCCESSFUL"
 
@@ -239,6 +248,15 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             def send_prompt(self, prompt: str) -> None:
                 pass
 
+            def fork(self, prompt: str) -> "FakeAgent":
+                return self
+
+            def __enter__(self) -> "FakeAgent":
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
+
             def run_test_command(self, command: str) -> str:
                 return "BUILD SUCCESSFUL"
 
@@ -282,6 +300,15 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         class FakeAgent:
             def send_prompt(self, prompt: str) -> None:
                 pass
+
+            def fork(self, prompt: str) -> "FakeAgent":
+                return self
+
+            def __enter__(self) -> "FakeAgent":
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
 
             def run_test_command(self, command: str) -> str:
                 return "BUILD SUCCESSFUL"
@@ -337,6 +364,15 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         class FakeAgent:
             def send_prompt(self, prompt: str) -> None:
                 pass
+
+            def fork(self, prompt: str) -> "FakeAgent":
+                return self
+
+            def __enter__(self) -> "FakeAgent":
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
 
             def run_test_command(self, command: str) -> str:
                 return "BUILD SUCCESSFUL"


### PR DESCRIPTION
Closes #8936

## What this does

The `dynamic_access_iterative` strategy used to run every attempt for a class on
one shared agent session, so each attempt re-sent the full static context and
carried the previous attempts' turns forward — the class exploration was paid
for again as the conversation grew. This reworks the per-class loop so each
class is **explored once** into an anchor session, and every attempt **forks**
that anchor with only a slim prompt carrying the latest report delta
(§WF-dynamic-access-iterative-strategy in
[forge/docs/workflows/dynamic-access.md](forge/docs/workflows/dynamic-access.md)).

## How the design was chosen

The shape came out of working through the trade-offs of forking — a
conversation-branch primitive already implemented on both agents but so far
unused:

- **A fork branches the conversation, not the working tree.** All forks share
  one checkout, so per-attempt forks can't run in parallel, and even
  sequentially a fork's memory drifts from disk: once one attempt commits a
  passing test, the next fork (branched from the pre-generation anchor) has no
  memory of it. Rather than re-anchoring after every commit — which would defeat
  the reuse — the slim prompt tells the fork to **read the on-disk tests first
  and extend them additively, never rewrite**, so it can't clobber coverage it
  didn't author.
- **Complete fork, not compacted** — keeps the full exploration reasoning
  available to every attempt. The trade-off is a larger cached prefix per fork,
  and the token win is only realized if the provider serves that shared prefix
  from cache across forked threads; for a class resolved in a single attempt the
  extra explore turn is net cost.

## Fork token accounting

A fork child inherits the anchor's counters, spends its own tokens, and is then
discarded — so without help its tokens vanish from run metrics (which read
totals off the single agent object). The fold is built into the fork lifecycle
rather than bolted onto each call site:

- The fork child is a **context manager**. On block exit it folds its delta —
  `child_total − baseline`, where `baseline` is captured at fork time *before*
  the first turn — into the parent's fork-usage accumulator. Subtracting the
  baseline is what prevents double-counting the inherited history.
- Each agent's token properties report **own + forked** usage, so the anchor's
  own-thread counter stays clean.
- Call sites just do `with agent.fork(prompt) as child:` — adding a fork
  anywhere else needs no bespoke accounting.

## What changed

| Area | Change |
| --- | --- |
| `dynamic-access-explore.md` (new) | Read-only anchor turn: study the active class and the complete report, plan coverage, write nothing. |
| `dynamic-access-iteration.md` | Rewritten into the slim per-attempt prompt: latest report delta + "read on-disk tests, extend additively". |
| `dynamic_access_iterative_strategy.py` | Per class: `clear_context` → explore anchor → `with agent.fork(...)` per attempt; the inner test-repair loop runs on the fork. |
| `agent.py` | Fork-usage accumulators, `add_forked_usage`, fork-child baseline stamping, and the context-manager fold in `__exit__`. |
| `codex_agent.py` / `pi_agent.py` | Token properties report own + forked; `fork`/`compact_fork` stamp the child's baseline. |

Existing strategy bundles need no config change: the explore prompt is
auto-defaulted in the strategy (`prompts.setdefault`) and stays overridable.