### PR TITLE
Stop writing singular test file metrics

### DIFF
--- a/forge/DEVELOPING.md
+++ b/forge/DEVELOPING.md
@@ -294,7 +294,6 @@ that persistent layer was configured without printing the instruction text.
       library_version="1.2.3",
       agent=None,  # Agent implementation exposing token counters
       global_iterations=3,
-      tests_root="/abs/path/to/tests/root",
       strategy_name="basic_iterative",
       status="success",
   )

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -700,7 +700,6 @@ def main(argv=None):
             agent=agent,
             model_name=model_name,
             global_iterations=global_iterations,
-            tests_root=test_source_layout.source_root,
             strategy_name=strategy_name,
             status=workflow_status,
             starting_commit=checkpoint_commit_hash,

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -973,7 +973,6 @@ def main(argv=None) -> int:
             agent=agent,
             model_name=model_name,
             global_iterations=iterations,
-            tests_root=test_source_layout.source_root,
             strategy_name=strategy_name,
             status=workflow_status,
             starting_commit=checkpoint_commit,

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -625,7 +625,6 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
             agent=agent,
             model_name=model_name,
             global_iterations=iterations,
-            tests_root=test_source_layout.source_root,
             strategy_name=strategy_name,
             status=workflow_status,
             starting_commit=commit_checkpoint,

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -222,6 +222,9 @@ transiently in the Forge metrics directory as `.pending_metrics.json` and
 consumed by the PR step; they are not a durable output. Benchmark-mode runs
 instead record durable, schema-validated metrics under
 `benchmarks/benchmark_results/` (§BENCH-forge-generation-benchmarking.4).
+Run metrics may identify the generated metadata artifact, but must not record a
+single test-file artifact: the version-controlled test tree and pull-request
+diff are the authoritative set of test files for the run.
 When a failed run is preserved for continuation, `.pending_metrics.json` carries
 the accumulated token, cached-token, cost, and iteration counters for the
 preserved work. Any later resumed run for the same library must add its current

--- a/forge/schemas/benchmark_run_metrics_schema.json
+++ b/forge/schemas/benchmark_run_metrics_schema.json
@@ -183,13 +183,13 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "test_file",
         "metadata_file"
       ],
       "properties": {
         "test_file": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Deprecated; accepted for historical benchmark records."
         },
         "metadata_file": {
           "type": "string",
@@ -428,7 +428,6 @@
               "metadata_entries": 975
             },
             "artifacts": {
-              "test_file": "tests/src/com.hazelcast/hazelcast/5.5.0/src/test/java/com_hazelcast/hazelcast/HazelcastTest.java",
               "metadata_file": "metadata/com.hazelcast/hazelcast/5.5.0/reachability-metadata.json"
             }
           }

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -21,7 +21,7 @@ from utility_scripts.metrics_writer import (
     count_test_only_metadata_entries,
     create_run_metrics_output_json,
     execution_metrics_path,
-    resolve_artifact_paths,
+    resolve_metadata_artifact_path,
 )
 from utility_scripts.native_image_config_policy import (
     find_legacy_test_native_image_config_files_for_coordinate,
@@ -63,7 +63,6 @@ def _minimal_run_metrics(library: str = "org.example:demo:1.0.0") -> dict:
             "metadata_entries": 5,
         },
         "artifacts": {
-            "test_file": "tests/src/org.example/demo/1.0.0/src/test/java/DemoTest.java",
             "metadata_file": "metadata/org.example/demo/1.0.0/reachability-metadata.json",
         },
     }
@@ -122,23 +121,11 @@ class MetricsPathTests(unittest.TestCase):
 
             self.assertEqual(count_metadata_entries(temp_dir, "org.example", "demo", "1.0.1"), 2)
 
-    def test_resolve_artifact_paths_uses_metadata_version_for_tested_version(self) -> None:
+    def test_resolve_metadata_artifact_path_uses_metadata_version_for_tested_version(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo", "1.0.0")
             metadata_index_dir = os.path.dirname(metadata_dir)
-            tests_root = os.path.join(
-                temp_dir,
-                "tests",
-                "src",
-                "org.example",
-                "demo",
-                "1.0.0",
-                "src",
-                "test",
-                "java",
-            )
             os.makedirs(metadata_dir)
-            os.makedirs(tests_root)
             with open(os.path.join(metadata_index_dir, "index.json"), "w", encoding="utf-8") as file:
                 json.dump(
                     [
@@ -151,15 +138,11 @@ class MetricsPathTests(unittest.TestCase):
                 )
             with open(os.path.join(metadata_dir, "reachability-metadata.json"), "w", encoding="utf-8") as file:
                 json.dump({"reflection": [{"type": "org.example.Demo"}]}, file)
-            with open(os.path.join(tests_root, "DemoTest.java"), "w", encoding="utf-8") as file:
-                file.write("class DemoTest {}\n")
-
-            _test_file, metadata_file = resolve_artifact_paths(
+            metadata_file = resolve_metadata_artifact_path(
                 temp_dir,
                 "org.example",
                 "demo",
                 "1.0.1",
-                tests_root,
             )
 
             self.assertEqual(
@@ -567,11 +550,11 @@ class MetricsPathTests(unittest.TestCase):
                 agent=DummyAgent(),
                 model_name="gpt-5.4",
                 global_iterations=1,
-                tests_root=tests_root,
                 strategy_name="basic_iterative_pi_gpt-5.4",
                 status="success",
             )
 
+            self.assertNotIn("test_file", run_metrics["artifacts"])
             self.assertEqual(run_metrics["metrics"]["metadata_entries"], 1)
             self.assertEqual(run_metrics["metrics"]["test_only_metadata_entries"], 1)
 

--- a/forge/tests/test_schema_validator.py
+++ b/forge/tests/test_schema_validator.py
@@ -12,7 +12,7 @@ from utility_scripts.schema_validator import validate_run_metrics
 
 
 class RunMetricsSchemaTests(unittest.TestCase):
-    def test_run_metrics_schema_accepts_chunk_ready_status(self) -> None:
+    def test_run_metrics_schema_accepts_current_and_historical_artifacts(self) -> None:
         run_metrics = [
             {
                 "timestamp": "2026-05-02T00:00:00Z",
@@ -29,7 +29,6 @@ class RunMetricsSchemaTests(unittest.TestCase):
                     "metadata_entries": 0,
                 },
                 "artifacts": {
-                    "test_file": "tests/src/org.example/lib/1.0.0/src/test/java/org/example/LibTest.java",
                     "metadata_file": "metadata/org.example/lib/1.0.0/reflect-config.json",
                 },
             },
@@ -37,6 +36,14 @@ class RunMetricsSchemaTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             metrics_path = os.path.join(tmpdir, "results.json")
+            with open(metrics_path, "w", encoding="utf-8") as metrics_file:
+                json.dump(run_metrics, metrics_file)
+
+            validate_run_metrics(metrics_path)
+
+            run_metrics[0]["artifacts"]["test_file"] = (
+                "tests/src/org.example/lib/1.0.0/src/test/java/org/example/LibTest.java"
+            )
             with open(metrics_path, "w", encoding="utf-8") as metrics_file:
                 json.dump(run_metrics, metrics_file)
 

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -435,7 +435,6 @@ def build_run_metrics_dict(
         lines_covered: int,
         coverage_percent: float,
         total_entries: int,
-        test_file: str,
         metadata_file: str,
         test_only_metadata_entries: int = 0,
         generated_loc: int | None = None,
@@ -502,25 +501,14 @@ def build_run_metrics_dict(
         run_metrics["library_preparation_preflight"] = library_preparation_preflight
     run_metrics["metrics"] = metrics
     run_metrics["artifacts"] = {
-        "test_file": test_file,
         "metadata_file": metadata_file,
     }
 
     return run_metrics
 
 
-def resolve_artifact_paths(repo_path, package, artifact, library_version, tests_root):
-    """Resolve test file and metadata file paths for a library version."""
-    test_file_path = None
-    for dirpath, _, filenames in os.walk(tests_root):
-        for fname in filenames:
-            if _is_test_source_file(fname):
-                test_file_path = os.path.relpath(os.path.join(dirpath, fname), repo_path)
-                break
-        if test_file_path:
-            break
-
-    # Determine metadata_file path (either reachability-metadata.json or the metadata dir)
+def resolve_metadata_artifact_path(repo_path: str, package: str, artifact: str, library_version: str) -> str:
+    """Resolve the metadata artifact path for a library version."""
     metadata_version = resolve_metadata_version(repo_path, package, artifact, library_version)
     reach_json = os.path.join(repo_path, "metadata", package, artifact, metadata_version, "reachability-metadata.json")
     if os.path.isfile(reach_json):
@@ -531,7 +519,7 @@ def resolve_artifact_paths(repo_path, package, artifact, library_version, tests_
             repo_path,
         )
 
-    return str(test_file_path), str(metadata_file_path)
+    return str(metadata_file_path)
 
 
 def _is_test_source_file(file_name: str) -> bool:
@@ -570,7 +558,6 @@ def create_run_metrics_output_json(
         agent,
         model_name,
         global_iterations,
-        tests_root,
         strategy_name,
         status,
         starting_commit: str | None = None,
@@ -591,7 +578,7 @@ def create_run_metrics_output_json(
         global_iterations,
         starting_commit=starting_commit,
     )
-    test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, library_version, tests_root)
+    metadata_file = resolve_metadata_artifact_path(repo_path, package, artifact, library_version)
     agent_name = resolve_agent(strategy_name)
     stats = load_library_stats_snapshot(repo_path, package, artifact, library_version)
 
@@ -615,7 +602,6 @@ def create_run_metrics_output_json(
         coverage_percent=metrics.get("coverage_percent", 0.0),
         total_entries=metrics.get("total_entries", 0),
         test_only_metadata_entries=metrics.get("test_only_metadata_entries", 0),
-        test_file=test_file,
         metadata_file=metadata_file,
         stats=stats,
         post_generation_intervention=post_generation_intervention,
@@ -632,7 +618,6 @@ def create_javac_fix_run_metrics_output_json(
         agent,
         model_name,
         global_iterations,
-        tests_root,
         strategy_name,
         status,
         starting_commit: str | None = None,
@@ -651,7 +636,7 @@ def create_javac_fix_run_metrics_output_json(
         global_iterations,
         starting_commit=starting_commit,
     )
-    test_file, metadata_file = resolve_artifact_paths(repo_path, package, artifact, new_library_version, tests_root)
+    metadata_file = resolve_metadata_artifact_path(repo_path, package, artifact, new_library_version)
 
     previous_coverage_percent, _ = collect_version_coverage_metrics(
         repo_path=repo_path,
@@ -684,7 +669,6 @@ def create_javac_fix_run_metrics_output_json(
         coverage_percent=metrics.get("coverage_percent", 0.0),
         total_entries=metrics.get("total_entries", 0),
         test_only_metadata_entries=metrics.get("test_only_metadata_entries", 0),
-        test_file=test_file,
         metadata_file=metadata_file,
         previous_library=f"{package}:{artifact}:{previous_library_version}",
         previous_library_metadata_entries=previous_entries,
@@ -736,7 +720,6 @@ def create_failure_run_metrics_output(
         lines_covered=0,
         coverage_percent=0.0,
         total_entries=0,
-        test_file="None",
         metadata_file="None",
         library_preparation_preflight=library_preparation_preflight,
     )

--- a/stats/schemas/run-metrics-output-schema-v1.0.1.json
+++ b/stats/schemas/run-metrics-output-schema-v1.0.1.json
@@ -547,14 +547,13 @@
           "description": "Paths to generated output artifacts.",
           "additionalProperties": false,
           "required": [
-            "test_file",
             "metadata_file"
           ],
           "properties": {
             "test_file": {
               "type": "string",
               "minLength": 1,
-              "description": "Path to the generated test file."
+              "description": "Deprecated path to one generated test file; accepted for historical records."
             },
             "metadata_file": {
               "type": "string",


### PR DESCRIPTION
### Summary

- stop writing the singular `artifacts.test_file` field in new Forge execution metrics
- remove the obsolete test-source scan and its workflow plumbing
- keep the deprecated schema property optional so historical records remain valid
- document the version-controlled test tree and PR diff as the authoritative test-file set

Fixes #8949
