### PR TITLE
Fix input-token cost billed as zero

### DIFF
--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -17,6 +17,8 @@ from ai_workflows.drivers.java_fail_workflow import JAVAC_CONFIG, resolve_fix_me
 from utility_scripts.library_stats import load_library_stats_entry, resolve_stats_file_path
 from utility_scripts.metrics_writer import (
     append_execution_metrics,
+    calc_model_session_cost,
+    collect_token_usage_metrics,
     count_metadata_entries,
     count_test_only_metadata_entries,
     create_run_metrics_output_json,
@@ -89,6 +91,44 @@ class DummyAgent:
     total_tokens_sent = 1
     total_tokens_received = 2
     cached_input_tokens_used = 0
+
+
+class TokenCostTests(unittest.TestCase):
+    """Full-rate input and cached input are separate, non-overlapping counters;
+    the input cost must not be zeroed out when cached reads exceed full-rate input.
+    """
+
+    # gpt-5.6-terra rates: input $2.50/1M, cached $0.25/1M, output $15.00/1M.
+    INPUT_TOKENS = 212_117
+    CACHED_INPUT_TOKENS = 1_833_984
+    OUTPUT_TOKENS = 23_679
+    EXPECTED_INPUT_COST = 0.5303
+    EXPECTED_CACHED_COST = 0.4585
+    EXPECTED_OUTPUT_COST = 0.3552
+    EXPECTED_TOTAL_COST = 1.3440
+
+    def test_calc_model_session_cost_bills_input_when_cached_exceeds_input(self) -> None:
+        cost = calc_model_session_cost(
+            "gpt-5.6-terra",
+            self.INPUT_TOKENS,
+            self.CACHED_INPUT_TOKENS,
+            self.OUTPUT_TOKENS,
+        )
+
+        self.assertEqual(cost, self.EXPECTED_TOTAL_COST)
+
+    def test_collect_token_usage_metrics_bills_input_when_cached_exceeds_input(self) -> None:
+        agent = DummyAgent()
+        agent.total_tokens_sent = self.INPUT_TOKENS
+        agent.cached_input_tokens_used = self.CACHED_INPUT_TOKENS
+        agent.total_tokens_received = self.OUTPUT_TOKENS
+
+        metrics = collect_token_usage_metrics(agent, "gpt-5.6-terra")
+
+        self.assertEqual(metrics["input_cost_usd"], self.EXPECTED_INPUT_COST)
+        self.assertEqual(metrics["cached_input_cost_usd"], self.EXPECTED_CACHED_COST)
+        self.assertEqual(metrics["output_cost_usd"], self.EXPECTED_OUTPUT_COST)
+        self.assertEqual(metrics["cost_usd"], self.EXPECTED_TOTAL_COST)
 
 
 class MetricsPathTests(unittest.TestCase):

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -225,10 +225,12 @@ def collect_token_usage_metrics(agent, model_name: str | None) -> dict[str, int 
         DEFAULT_CACHED_INPUT_RATE_PER_1M,
     )
 
+    # `total_tokens_sent` counts full-rate input; cached reads are a separate
+    # counter billed at the cached rate. They do not overlap, so the two costs
+    # simply add up.
     billable_input_tokens = input_tokens_used
     cached_input_cost_usd = 0.0
     if cached_input_tokens_used is not None:
-        billable_input_tokens = max(input_tokens_used - cached_input_tokens_used, 0)
         cached_input_cost_usd = calc_input_cost(
             cached_input_tokens_used,
             cached_input_rate or DEFAULT_CACHED_INPUT_RATE_PER_1M,

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -84,10 +84,10 @@ def calc_model_session_cost(
 ) -> float:
     """Return the total USD cost for a session's token usage using per-model rates.
 
-    Cached input tokens are billed at the cached rate and the remaining
-    (uncached) input tokens at the standard input rate. Unknown models fall back
-    to the default rates. Token counts are normalized per million by
-    `calc_token_cost`.
+    `input_tokens` counts full-rate input; `cached_input_tokens` counts cache
+    reads billed at the cached rate. The two counters do not overlap, so their
+    costs simply add up. Unknown models fall back to the default rates. Token
+    counts are normalized per million by `calc_token_cost`.
     """
     cached_input_tokens = cached_input_tokens or 0
     input_rate = _get_model_rate(model_name, INPUT_TOKEN_RATE_PER_1M_BY_MODEL, DEFAULT_INPUT_RATE_PER_1M)
@@ -95,9 +95,8 @@ def calc_model_session_cost(
         model_name, CACHED_INPUT_TOKEN_RATE_PER_1M_BY_MODEL, DEFAULT_CACHED_INPUT_RATE_PER_1M
     )
     output_rate = _get_model_rate(model_name, OUTPUT_TOKEN_RATE_PER_1M_BY_MODEL, DEFAULT_OUTPUT_RATE_PER_1M)
-    billable_input_tokens = max(input_tokens - cached_input_tokens, 0)
     total = (
-        calc_input_cost(billable_input_tokens, input_rate)
+        calc_input_cost(input_tokens, input_rate)
         + calc_input_cost(cached_input_tokens, cached_input_rate)
         + calc_output_cost(output_tokens, output_rate)
     )


### PR DESCRIPTION
## Bug

There is a bug in the token-cost accounting: the full-rate input charge is dropped, so run costs are under-reported.

The biller computes full-rate input tokens as `total_tokens_sent - cached_input_tokens`, assuming cached reads are folded into the input total. In fact `total_tokens_sent` (full-rate input) and `cached_input_tokens` (cache reads) are **separate, non-overlapping** counters. With any real cache reuse `cached_input_tokens > total_tokens_sent`, so the subtraction clamps billable input to `0` and the full-rate input cost silently becomes `$0`.

Concretely, a run reporting 212,117 input / 1,833,984 cached / 23,679 output on `gpt-5.6-terra`:

| Component | Tokens | Rate/1M | Reported | Correct |
|---|---|---|---|---|
| Full-rate input | 212,117 | $2.50 | **$0.0000** | $0.5303 |
| Cached input | 1,833,984 | $0.25 | $0.4585 | $0.4585 |
| Output | 23,679 | $15.00 | $0.3552 | $0.3552 |
| **Total** | | | **$0.8137** | **$1.3440** |
