### PR TITLE
[GenAI] Add support for com.mailjet:mailjet-client:6.0.1 using gpt-5.5

### DIFF
--- a/metadata/com.mailjet/mailjet-client/6.0.1/reachability-metadata.json
+++ b/metadata/com.mailjet/mailjet-client/6.0.1/reachability-metadata.json
@@ -1,0 +1,305 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.Attachment",
+      "fields" : [
+        {
+          "name" : "base64Content"
+        },
+        {
+          "name" : "contentID"
+        },
+        {
+          "name" : "contentType"
+        },
+        {
+          "name" : "filename"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.SendContact",
+      "fields" : [
+        {
+          "name" : "Email"
+        },
+        {
+          "name" : "Name"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.SendEmailsRequest",
+      "fields" : [
+        {
+          "name" : "advanceErrorHandling"
+        },
+        {
+          "name" : "messages"
+        },
+        {
+          "name" : "sandboxMode"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.TrackClicks",
+      "fields" : [
+        {
+          "name" : "ACCOUNT_DEFAULT"
+        },
+        {
+          "name" : "DISABLED"
+        },
+        {
+          "name" : "ENABLED"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.TrackOpens",
+      "fields" : [
+        {
+          "name" : "ACCOUNT_DEFAULT"
+        },
+        {
+          "name" : "DISABLED"
+        },
+        {
+          "name" : "ENABLED"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.TransactionalEmail",
+      "fields" : [
+        {
+          "name" : "attachments"
+        },
+        {
+          "name" : "bcc"
+        },
+        {
+          "name" : "cc"
+        },
+        {
+          "name" : "customCampaign"
+        },
+        {
+          "name" : "customID"
+        },
+        {
+          "name" : "deduplicateCampaign"
+        },
+        {
+          "name" : "eventPayload"
+        },
+        {
+          "name" : "from"
+        },
+        {
+          "name" : "headers"
+        },
+        {
+          "name" : "htmlPart"
+        },
+        {
+          "name" : "inlinedAttachments"
+        },
+        {
+          "name" : "priority"
+        },
+        {
+          "name" : "replyTo"
+        },
+        {
+          "name" : "sender"
+        },
+        {
+          "name" : "subject"
+        },
+        {
+          "name" : "templateErrorDelivery"
+        },
+        {
+          "name" : "templateErrorReporting"
+        },
+        {
+          "name" : "templateID"
+        },
+        {
+          "name" : "templateLanguage"
+        },
+        {
+          "name" : "textPart"
+        },
+        {
+          "name" : "to"
+        },
+        {
+          "name" : "trackClicks"
+        },
+        {
+          "name" : "trackOpens"
+        },
+        {
+          "name" : "urlTags"
+        },
+        {
+          "name" : "variables"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.EmailResult",
+      "fields" : [
+        {
+          "name" : "email"
+        },
+        {
+          "name" : "messageHref"
+        },
+        {
+          "name" : "messageID"
+        },
+        {
+          "name" : "messageUUID"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.MessageResult",
+      "fields" : [
+        {
+          "name" : "customID"
+        },
+        {
+          "name" : "status"
+        },
+        {
+          "name" : "to"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.MessageResult[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.SendEmailError"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.SendEmailError[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.SendEmailsResponse",
+      "fields" : [
+        {
+          "name" : "messages"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "com.mailjet.client.transactional.response.SentMessageStatus",
+      "fields" : [
+        {
+          "name" : "ERROR"
+        },
+        {
+          "name" : "SUCCESS"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "java.sql.Date"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com.mailjet.client.transactional.SendEmailsRequest"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "bundle" : "sun.util.logging.resources.logging"
+    }
+  ]
+}

--- a/metadata/com.mailjet/mailjet-client/index.json
+++ b/metadata/com.mailjet/mailjet-client/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.0.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/mailjet/mailjet-client/$version$/mailjet-client-$version$-sources.jar",
+    "repository-url" : "https://github.com/mailjet/mailjet-apiv3-java",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://javadoc.io/doc/com.mailjet/mailjet-client/$version$",
+    "description" : "Mailjet Client is the official Java wrapper for the Mailjet API. It lets JVM applications authenticate with Mailjet and make API requests for email, SMS, and related resources.",
+    "tested-versions" : [
+      "6.0.1"
+    ],
+    "allowed-packages" : [
+      "com.mailjet.client"
+    ]
+  }
+]

--- a/stats/com.mailjet/mailjet-client/6.0.1/execution-metrics.json
+++ b/stats/com.mailjet/mailjet-client/6.0.1/execution-metrics.json
@@ -1,0 +1,84 @@
+{
+  "add_new_library_support:2026-07-06": {
+    "timestamp": "2026-07-06T00:55:31.776229Z",
+    "library": "com.mailjet:mailjet-client:6.0.1",
+    "starting_commit": "b420d410e9c28203b3a68bfc661edb42c70686cf",
+    "ending_commit": "e5f119b462624c7a13b679bbe2cd8c831c36bf6f",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1236,
+          "missed": 4134,
+          "ratio": 0.230168,
+          "total": 5370
+        },
+        "line": {
+          "covered": 291,
+          "missed": 1543,
+          "ratio": 0.15867,
+          "total": 1834
+        },
+        "method": {
+          "covered": 60,
+          "missed": 227,
+          "ratio": 0.209059,
+          "total": 287
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 8955,
+      "issue_label": "library-new-request",
+      "library": "com.mailjet:mailjet-client:6.0.1",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#8955 Support for com.mailjet:mailjet-client:6.0.1; label=library-new-request; body_chars=52"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
+      "model": "gpt-5.5",
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.mailjet:mailjet-client:6.0.1/library-preparation-preflight/pi-generation-2026-07-06T00-20-42-858182Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 225765,
+      "cached_input_tokens_used": 2269696,
+      "output_tokens_used": 16894,
+      "iterations": 4,
+      "cost_usd": 2.7704,
+      "generated_loc": 398,
+      "tested_library_loc": 291,
+      "metadata_entries": 73,
+      "test_only_metadata_entries": 69,
+      "code_coverage_percent": 15.87
+    },
+    "artifacts": {
+      "test_file": "tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java",
+      "metadata_file": "metadata/com.mailjet/mailjet-client/6.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.mailjet/mailjet-client/6.0.1/stats.json
+++ b/stats/com.mailjet/mailjet-client/6.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1236,
+        "missed" : 4134,
+        "ratio" : 0.230168,
+        "total" : 5370
+      },
+      "line" : {
+        "covered" : 291,
+        "missed" : 1543,
+        "ratio" : 0.15867,
+        "total" : 1834
+      },
+      "method" : {
+        "covered" : 60,
+        "missed" : 227,
+        "ratio" : 0.209059,
+        "total" : 287
+      }
+    }
+  } ]
+}

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/.gitignore
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/build.gradle
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.mailjet:mailjet-client:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/gradle.properties
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.mailjet:mailjet-client:6.0.1
+library.version = 6.0.1
+metadata.dir = com.mailjet/mailjet-client/6.0.1/

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/settings.gradle
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.mailjet.mailjet-client_tests'

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
@@ -6,11 +6,346 @@
  */
 package com_mailjet.mailjet_client;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mailjet.client.ClientOptions;
+import com.mailjet.client.MailjetClient;
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.MailjetResponse;
+import com.mailjet.client.Resource;
+import com.mailjet.client.enums.ApiAuthenticationType;
+import com.mailjet.client.enums.ApiVersion;
+import com.mailjet.client.resource.Contact;
+import com.mailjet.client.transactional.Attachment;
+import com.mailjet.client.transactional.SendContact;
+import com.mailjet.client.transactional.SendEmailsRequest;
+import com.mailjet.client.transactional.TrackClicks;
+import com.mailjet.client.transactional.TrackOpens;
+import com.mailjet.client.transactional.TransactionalEmail;
+import com.mailjet.client.transactional.response.EmailResult;
+import com.mailjet.client.transactional.response.MessageResult;
+import com.mailjet.client.transactional.response.SendEmailError;
+import com.mailjet.client.transactional.response.SendEmailsResponse;
+import com.mailjet.client.transactional.response.SentMessageStatus;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
-class Mailjet_clientTest {
+public class Mailjet_clientTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void requestBuildsUrlsQueriesAndJsonBodies() throws Exception {
+        MailjetRequest contactRequest = new MailjetRequest(Contact.resource, "user+tag@example.com")
+                .filter(Contact.LIMIT, 25)
+                .filter(Contact.COUNTONLY, "false")
+                .property(Contact.EMAIL, "user+tag@example.com")
+                .append("Tags", "native")
+                .append("Tags", "mailjet");
+
+        String url = contactRequest.buildUrl("https://api.test.local/base");
+        assertThat(url).startsWith("https://api.test.local/base/v3/REST/contact/user%2Btag%40example.com?");
+        assertThat(url).contains("Limit=25", "CountOnly=false");
+        assertThat(contactRequest.queryString()).contains("Limit=25", "CountOnly=false");
+        assertThat(contactRequest.getApiVersion()).isEqualTo(ApiVersion.V3);
+        assertThat(contactRequest.getAuthenticationType()).isEqualTo(ApiAuthenticationType.Basic);
+        assertThat(contactRequest.getResource()).isEqualTo("contact");
+
+        JSONObject body = contactRequest.getBodyJSON();
+        assertThat(body.getString(Contact.EMAIL)).isEqualTo("user+tag@example.com");
+        assertThat(body.getJSONArray("Tags").toList()).containsExactly("native", "mailjet");
+        assertThat(new JSONObject(contactRequest.getBody()).getJSONArray("Tags").length()).isEqualTo(2);
+
+        HashMap<String, Object> mapBody = new HashMap<>();
+        mapBody.put("Name", "Map Body");
+        assertThat(new MailjetRequest(Contact.resource).setBody(mapBody).getBodyJSON().getString("Name"))
+                .isEqualTo("Map Body");
+    }
+
+    @Test
+    void clientSendsAuthenticatedGetAndParsesMailjetResponse() throws Exception {
+        try (TestServer server = TestServer.respondingWith(200, """
+                {
+                  "Count": 1,
+                  "Total": 1,
+                  "Greeting": "hello",
+                  "Data": [ { "Email": "reader@example.com", "ID": 42 } ]
+                }
+                """);
+                TestHttpClient httpClient = TestHttpClient.create()) {
+            MailjetClient client = new MailjetClient(ClientOptions.builder()
+                    .baseUrl(server.baseUrl())
+                    .apiKey("key")
+                    .apiSecretKey("secret")
+                    .okHttpClient(httpClient.client())
+                    .build());
+            MailjetRequest request = new MailjetRequest(Contact.resource)
+                    .filter(Contact.LIMIT, 1)
+                    .filter(Contact.OFFSET, 2);
+
+            MailjetResponse response = client.get(request);
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.method()).isEqualTo("GET");
+            assertThat(recorded.path()).isEqualTo("/v3/REST/contact");
+            assertThat(recorded.query()).contains("Limit=1", "Offset=2");
+            assertThat(recorded.headers().getFirst("Accept")).isEqualTo("application/json");
+            assertThat(recorded.headers().getFirst("User-Agent")).startsWith("mailjet-apiv3-java/");
+            String expectedAuthorization = "Basic " + Base64.getEncoder()
+                    .encodeToString("key:secret".getBytes(StandardCharsets.UTF_8));
+            assertThat(recorded.headers().getFirst("Authorization")).isEqualTo(expectedAuthorization);
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getCount()).isEqualTo(1);
+            assertThat(response.getTotal()).isEqualTo(1);
+            assertThat(response.getString("Greeting")).isEqualTo("hello");
+            assertThat(response.getData().getJSONObject(0).getString("Email")).isEqualTo("reader@example.com");
+        }
+    }
+
+    @Test
+    void transactionalEmailRequestPostsSerializedMessageAndConvertsResponse() throws Exception {
+        try (TestServer server = TestServer.respondingWith(201, """
+                {
+                  "Messages": [ {
+                    "Status": "success",
+                    "CustomID": "custom-123",
+                    "To": [ {
+                      "Email": "recipient@example.com",
+                      "MessageUUID": "uuid-1",
+                      "MessageID": 12345,
+                      "MessageHref": "https://api.mailjet.test/message/12345"
+                    } ]
+                  } ]
+                }
+                """);
+                TestHttpClient httpClient = TestHttpClient.create()) {
+            MailjetClient client = new MailjetClient(ClientOptions.builder()
+                    .baseUrl(server.baseUrl())
+                    .apiKey("mailjet-key")
+                    .apiSecretKey("mailjet-secret")
+                    .okHttpClient(httpClient.client())
+                    .build());
+            Attachment attachment = Attachment.fromInputStream(
+                    new ByteArrayInputStream("report".getBytes(StandardCharsets.UTF_8)),
+                    "report.txt",
+                    "text/plain");
+            TransactionalEmail email = TransactionalEmail.builder()
+                    .from(new SendContact("sender@example.com", "Sender"))
+                    .to(new SendContact("recipient@example.com", "Recipient"))
+                    .cc(new SendContact("copy@example.com"))
+                    .subject("Integration test")
+                    .textPart("Plain body")
+                    .htmlPart("<strong>HTML body</strong>")
+                    .attachment(attachment)
+                    .trackOpens(TrackOpens.ENABLED)
+                    .trackClicks(TrackClicks.DISABLED)
+                    .customID("custom-123")
+                    .variable("invoice", 7)
+                    .header("X-Test", "mailjet")
+                    .build();
+            SendEmailsRequest request = SendEmailsRequest.builder()
+                    .message(email)
+                    .sandboxMode(true)
+                    .advanceErrorHandling(true)
+                    .build();
+
+            SendEmailsResponse response = request.sendWith(client);
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.method()).isEqualTo("POST");
+            assertThat(recorded.path()).isEqualTo("/v3.1/send");
+            JSONObject posted = new JSONObject(recorded.body());
+            assertThat(posted.getBoolean("SandboxMode")).isTrue();
+            assertThat(posted.getBoolean("AdvanceErrorHandling")).isTrue();
+            JSONArray messages = posted.getJSONArray("Messages");
+            JSONObject message = messages.getJSONObject(0);
+            assertThat(message.getString("Subject")).isEqualTo("Integration test");
+            assertThat(message.getString("TrackOpens")).isEqualTo("enabled");
+            assertThat(message.getString("TrackClicks")).isEqualTo("disabled");
+            assertThat(message.getJSONObject("From").getString("Email")).isEqualTo("sender@example.com");
+            assertThat(message.getJSONArray("To").getJSONObject(0).getString("Name")).isEqualTo("Recipient");
+            assertThat(message.getJSONArray("Attachments").getJSONObject(0).getString("Base64Content"))
+                    .isEqualTo(Base64.getEncoder().encodeToString("report".getBytes(StandardCharsets.UTF_8)));
+            assertThat(message.getJSONObject("Variables").getInt("invoice")).isEqualTo(7);
+            assertThat(message.getJSONObject("Headers").getString("X-Test")).isEqualTo("mailjet");
+            assertThat(response.getMessages()).hasSize(1);
+            assertThat(response.getMessages()[0].getStatus()).isEqualTo(SentMessageStatus.SUCCESS);
+            assertThat(response.getMessages()[0].getCustomID()).isEqualTo("custom-123");
+            assertThat(response.getMessages()[0].getTo().get(0).getMessageID()).isEqualTo(12345);
+        }
+    }
+
+    @Test
+    void publicResponseAndAttachmentModelsExposeBeanState() {
+        Attachment attachment = Attachment.builder()
+                .filename("inline.txt")
+                .contentType("text/plain")
+                .base64Content("aW5saW5l")
+                .contentID("cid-1")
+                .build();
+        attachment.setFilename("renamed.txt");
+        attachment.setContentType("text/custom");
+        attachment.setBase64Content("cmVuYW1lZA==");
+        attachment.setContentID("cid-2");
+
+        EmailResult emailResult = new EmailResult();
+        emailResult.setEmail("delivered@example.com");
+        emailResult.setMessageUUID("uuid-2");
+        emailResult.setMessageID(6789L);
+        emailResult.setMessageHref("https://api.mailjet.test/message/6789");
+        SendEmailError error = new SendEmailError();
+        error.setErrorIdentifier("id-1");
+        error.setErrorCode("mj-001");
+        error.setStatusCode(400);
+        error.setErrorMessage("Invalid recipient");
+        error.setErrorRelatedTo(new String[] {"To[0].Email"});
+        MessageResult messageResult = new MessageResult();
+        messageResult.setStatus(SentMessageStatus.ERROR);
+        messageResult.setCustomID("custom-error");
+        messageResult.setTo(List.of(emailResult));
+        messageResult.setErrors(new SendEmailError[] {error});
+        SendEmailsResponse response = new SendEmailsResponse();
+        response.setMessages(new MessageResult[] {messageResult});
+
+        assertThat(attachment.getFilename()).isEqualTo("renamed.txt");
+        assertThat(attachment.getContentType()).isEqualTo("text/custom");
+        assertThat(attachment.getBase64Content()).isEqualTo("cmVuYW1lZA==");
+        assertThat(attachment.getContentID()).isEqualTo("cid-2");
+        assertThat(response.getMessages()[0].getStatus()).isEqualTo(SentMessageStatus.ERROR);
+        assertThat(response.getMessages()[0].getTo()).containsExactly(emailResult);
+        assertThat(response.getMessages()[0].getErrors()[0].getErrorRelatedTo()).containsExactly("To[0].Email");
+        assertThat(error.getStatusCode()).isEqualTo(400);
+        assertThat(emailResult.getMessageUUID()).isEqualTo("uuid-2");
+    }
+
+    @Test
+    void customBearerResourceCanBeDeletedWithoutNamespace() throws Exception {
+        Resource bearerResource = new Resource(
+                "sms-send",
+                "",
+                ApiVersion.V4,
+                ApiAuthenticationType.Bearer,
+                true);
+        try (TestServer server = TestServer.respondingWith(204, "");
+                TestHttpClient httpClient = TestHttpClient.create()) {
+            MailjetClient client = new MailjetClient(ClientOptions.builder()
+                    .baseUrl(server.baseUrl())
+                    .bearerAccessToken("token-123")
+                    .okHttpClient(httpClient.client())
+                    .build());
+
+            MailjetResponse response = client.delete(new MailjetRequest(bearerResource, 99L));
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.method()).isEqualTo("DELETE");
+            assertThat(recorded.path()).isEqualTo("/v4/sms-send/99");
+            assertThat(recorded.headers().getFirst("Authorization")).isEqualTo("Bearer token-123");
+            assertThat(response.getStatus()).isEqualTo(204);
+            assertThat(response.getInt("status")).isEqualTo(204);
+        }
+    }
+
+    private static final class TestHttpClient implements AutoCloseable {
+        private final OkHttpClient client;
+
+        private TestHttpClient(OkHttpClient client) {
+            this.client = client;
+        }
+
+        static TestHttpClient create() {
+            OkHttpClient client = new OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .callTimeout(10, TimeUnit.SECONDS)
+                    .build();
+            return new TestHttpClient(client);
+        }
+
+        OkHttpClient client() {
+            return client;
+        }
+
+        @Override
+        public void close() {
+            client.dispatcher().executorService().shutdown();
+            client.connectionPool().evictAll();
+        }
+    }
+
+    private record RecordedRequest(String method, String path, String query, Headers headers, String body) {
+    }
+
+    private static final class TestServer implements AutoCloseable {
+        private final HttpServer server;
+        private final ExecutorService executor;
+        private final LinkedBlockingQueue<RecordedRequest> requests;
+
+        private TestServer(HttpServer server, ExecutorService executor, LinkedBlockingQueue<RecordedRequest> requests) {
+            this.server = server;
+            this.executor = executor;
+            this.requests = requests;
+        }
+
+        static TestServer respondingWith(int status, String body) throws IOException {
+            LinkedBlockingQueue<RecordedRequest> requests = new LinkedBlockingQueue<>();
+            HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+            server.createContext("/", exchange -> handle(exchange, status, body, requests));
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            server.setExecutor(executor);
+            server.start();
+            return new TestServer(server, executor, requests);
+        }
+
+        String baseUrl() {
+            return "http://" + server.getAddress().getHostString() + ":" + server.getAddress().getPort();
+        }
+
+        RecordedRequest takeRequest() throws InterruptedException {
+            RecordedRequest request = requests.poll(10, TimeUnit.SECONDS);
+            assertThat(request).isNotNull();
+            return request;
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+            executor.shutdownNow();
+        }
+
+        private static void handle(
+                HttpExchange exchange,
+                int status,
+                String body,
+                LinkedBlockingQueue<RecordedRequest> requests) throws IOException {
+            String requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            requests.add(new RecordedRequest(
+                    exchange.getRequestMethod(),
+                    exchange.getRequestURI().getPath(),
+                    exchange.getRequestURI().getRawQuery(),
+                    exchange.getRequestHeaders(),
+                    requestBody));
+            byte[] responseBody = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(status, responseBody.length);
+            try (OutputStream stream = exchange.getResponseBody()) {
+                stream.write(responseBody);
+            }
+        }
     }
 }

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_mailjet.mailjet_client;
+
+import org.junit.jupiter.api.Test;
+
+class Mailjet_clientTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
@@ -17,6 +17,7 @@ import com.mailjet.client.enums.ApiAuthenticationType;
 import com.mailjet.client.enums.ApiVersion;
 import com.mailjet.client.resource.Contact;
 import com.mailjet.client.resource.Contactslist;
+import com.mailjet.client.resource.Csvimport;
 import com.mailjet.client.transactional.Attachment;
 import com.mailjet.client.transactional.SendContact;
 import com.mailjet.client.transactional.SendEmailsRequest;
@@ -37,6 +38,8 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -221,6 +224,53 @@ public class Mailjet_clientTest {
             assertThat(new JSONObject(recorded.body()).getString(Contactslist.NAME)).isEqualTo("Updated list");
             assertThat(response.getStatus()).isEqualTo(200);
             assertThat(response.getData().getJSONObject(0).getString(Contactslist.NAME)).isEqualTo("Updated list");
+        }
+    }
+
+    @Test
+    void csvDataPostReadsFileDataAndSendsEncodedPlainTextBody() throws Exception {
+        Path csvFile = Files.createTempFile("mailjet-contacts", ".csv");
+        try {
+            String csvData = "email,name\nreader@example.com,Reader\n";
+            Files.writeString(csvFile, csvData, StandardCharsets.UTF_8);
+            Resource csvDataResource = new Resource(
+                    "csvimport",
+                    "csvdata",
+                    ApiVersion.V3,
+                    ApiAuthenticationType.Basic);
+            try (TestServer server = TestServer.respondingWith(201, """
+                    {
+                      "Count": 1,
+                      "Total": 1,
+                      "Data": [ { "ID": 77, "Status": "Upload" } ]
+                    }
+                    """);
+                    TestHttpClient httpClient = TestHttpClient.create()) {
+                MailjetClient client = new MailjetClient(ClientOptions.builder()
+                        .baseUrl(server.baseUrl())
+                        .apiKey("key")
+                        .apiSecretKey("secret")
+                        .okHttpClient(httpClient.client())
+                        .build());
+                MailjetRequest request = new MailjetRequest(csvDataResource, 77L)
+                        .filter(Csvimport.ERRTRESHOLD, 5)
+                        .setData(csvFile.toString());
+
+                MailjetResponse response = client.post(request);
+
+                RecordedRequest recorded = server.takeRequest();
+                assertThat(recorded.method()).isEqualTo("POST");
+                assertThat(recorded.path()).isEqualTo("/v3/DATA/csvimport/77/csvdata/text:plain");
+                assertThat(recorded.query()).contains("ErrTreshold=5");
+                assertThat(recorded.headers().getFirst("Content-Type")).startsWith("text/plain");
+                assertThat(recorded.body())
+                        .isEqualTo(Base64.getEncoder().encodeToString(csvData.getBytes(StandardCharsets.UTF_8)));
+                assertThat(request.getContentType()).isEqualTo("text/plain");
+                assertThat(response.getStatus()).isEqualTo(201);
+                assertThat(response.getData().getJSONObject(0).getString(Csvimport.STATUS)).isEqualTo("Upload");
+            }
+        } finally {
+            Files.deleteIfExists(csvFile);
         }
     }
 

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/java/com_mailjet/mailjet_client/Mailjet_clientTest.java
@@ -16,6 +16,7 @@ import com.mailjet.client.Resource;
 import com.mailjet.client.enums.ApiAuthenticationType;
 import com.mailjet.client.enums.ApiVersion;
 import com.mailjet.client.resource.Contact;
+import com.mailjet.client.resource.Contactslist;
 import com.mailjet.client.transactional.Attachment;
 import com.mailjet.client.transactional.SendContact;
 import com.mailjet.client.transactional.SendEmailsRequest;
@@ -39,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -187,6 +189,38 @@ public class Mailjet_clientTest {
             assertThat(response.getMessages()[0].getStatus()).isEqualTo(SentMessageStatus.SUCCESS);
             assertThat(response.getMessages()[0].getCustomID()).isEqualTo("custom-123");
             assertThat(response.getMessages()[0].getTo().get(0).getMessageID()).isEqualTo(12345);
+        }
+    }
+
+    @Test
+    void asyncPutSendsJsonBodyAndCompletesWithParsedResponse() throws Exception {
+        try (TestServer server = TestServer.respondingWith(200, """
+                {
+                  "Count": 1,
+                  "Total": 1,
+                  "Data": [ { "ID": 123, "Name": "Updated list" } ]
+                }
+                """);
+                TestHttpClient httpClient = TestHttpClient.create()) {
+            MailjetClient client = new MailjetClient(ClientOptions.builder()
+                    .baseUrl(server.baseUrl())
+                    .apiKey("key")
+                    .apiSecretKey("secret")
+                    .okHttpClient(httpClient.client())
+                    .build());
+            MailjetRequest request = new MailjetRequest(Contactslist.resource, 123L)
+                    .property(Contactslist.NAME, "Updated list");
+
+            CompletableFuture<MailjetResponse> future = client.putAsync(request);
+            MailjetResponse response = future.get(10, TimeUnit.SECONDS);
+
+            RecordedRequest recorded = server.takeRequest();
+            assertThat(recorded.method()).isEqualTo("PUT");
+            assertThat(recorded.path()).isEqualTo("/v3/REST/contactslist/123");
+            assertThat(recorded.headers().getFirst("Content-Type")).startsWith("application/json");
+            assertThat(new JSONObject(recorded.body()).getString(Contactslist.NAME)).isEqualTo("Updated list");
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getData().getJSONObject(0).getString(Contactslist.NAME)).isEqualTo("Updated list");
         }
     }
 

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,439 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.AESCipher$General",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.ARCFOURCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.DESCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.DESedeCipher",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "java.security.AlgorithmParametersSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "java.security.KeyStoreSpi"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "okhttp3.internal.connection.RealConnectionPool"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestHttpClient"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.provider.X509Factory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestHttpClient"
+      },
+      "type" : "sun.security.ssl.SSLContextImpl$TLSContext",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestHttpClient"
+      },
+      "type" : "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.AuthorityInfoAccessExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.AuthorityKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.BasicConstraintsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.CRLDistributionPointsExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.CertificatePoliciesExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.ExtendedKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.KeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.NetscapeCertTypeExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.PrivateKeyUsageExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "type" : "sun.security.x509.SubjectKeyIdentifierExtension",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.Boolean",
+            "java.lang.Object"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.text.resources.FormatData"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.text.resources.FormatData_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.text.resources.FormatData_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.text.resources.JavaTimeSupplementary"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "type" : "sun.util.resources.cldr.TimeZoneNames_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "glob" : "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest"
+      },
+      "module" : "java.base",
+      "glob" : "jdk/internal/icu/impl/data/icudt76b/nfkc.nrm"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com_mailjet.mailjet_client.Mailjet_clientTest$TestServer"
+      },
+      "module" : "java.logging",
+      "glob" : "sun/util/logging/resources/logging_en_US.properties"
+    }
+  ]
+}

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/user-code-filter.json
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.mailjet.client.**"
+      "includeClasses" : "com.mailjet.client.**"
+    },
+    {
+      "includeClasses" : "com_mailjet.mailjet_client.**"
     }
   ]
 }

--- a/tests/src/com.mailjet/mailjet-client/6.0.1/user-code-filter.json
+++ b/tests/src/com.mailjet/mailjet-client/6.0.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.mailjet.client.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #8955

This PR introduces tests and metadata for com.mailjet:mailjet-client:6.0.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 225765
- Cached input tokens: 2269696
- Output tokens: 16894
- Metadata entries: 73
- Test-only metadata entries: 69
- Iterations: 4
- Library coverage percentage: 15.87
- Generated lines of code: 398
- Tested library lines of code: 291

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `5f4f894f12e2b715a74a82d32f503d67a71867ec`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1236/5370 (23.02%)
- Line: 291/1834 (15.87%)
- Method: 60/287 (20.91%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `forge/ai_workflows/agents/agent.py`
  - `forge/ai_workflows/agents/codex_agent.py`
  - `forge/ai_workflows/agents/pi_agent.py`
  - `forge/ai_workflows/core/dynamic_access_iterative_strategy.py`
  - `forge/docs/workflows/dynamic-access.md`
  - `forge/prompt_templates/dynamic_access/dynamic-access-explore.md`
  - `forge/prompt_templates/dynamic_access/dynamic-access-iteration.md`
  - `forge/strategies/predefined_strategies.json`
  - `forge/tests/test_dynamic_access_iterative_strategy.py`
  - `forge/utility_scripts/metrics_writer.py`
