### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-graphql as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-graphql/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-graphql/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8974

This PR records `org.springframework.boot:spring-boot-starter-graphql` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `5f4f894f12e2b715a74a82d32f503d67a71867ec`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
- Human intervention: required because repository-level files changed during verification.
- Repository-level fix paths:
  - `forge/ai_workflows/agents/agent.py`
  - `forge/ai_workflows/agents/codex_agent.py`
  - `forge/ai_workflows/agents/pi_agent.py`
  - `forge/ai_workflows/core/dynamic_access_iterative_strategy.py`
  - `forge/docs/workflows/dynamic-access.md`
  - `forge/prompt_templates/dynamic_access/dynamic-access-explore.md`
  - `forge/prompt_templates/dynamic_access/dynamic-access-iteration.md`
  - `forge/strategies/predefined_strategies.json`
  - `forge/tests/test_dynamic_access_iterative_strategy.py`
  - `forge/utility_scripts/metrics_writer.py`
