### PR TITLE
Default Pi provider to openai-codex

### DIFF
--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -14,6 +14,9 @@ from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.pi_logs import build_pi_log_path
 
 
+DEFAULT_PI_PROVIDER = "openai-codex"
+
+
 @Agent.register("pi")
 class PiAgent(Agent):
     """Agent adapter that drives Pi through its RPC mode."""
@@ -32,7 +35,7 @@ class PiAgent(Agent):
             **_,
     ):
         self._model_name = model_name
-        self._provider = provider
+        self._provider = provider or DEFAULT_PI_PROVIDER
         self._pi_command = pi_command
         self._session_dir = session_dir
         self._working_dir = os.path.abspath(working_dir)


### PR DESCRIPTION
## What this does

Fixes: #8978

Strategies without an explicit `provider` let Pi resolve the bare model name against its full catalog (§forge/AR-agent-api). Newly introduced model names also exist in Pi's builtin catalog under other providers, `gpt-5.6-terra` also matches `azure-openai-responses`, so resolution was nondeterministic and runs intermittently failed with `No API key found for azure-openai-responses`.

`PiAgent` now falls back to `openai-codex` when the strategy gives no provider, so `--provider` is always passed and resolution is deterministic. Strategies with an explicit `provider` (e.g. `openrouter`) are unaffected.