### PR TITLE
Ignore gosu Go-stdlib false positives in docker scan

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,19 @@
+# grype configuration for the docker-image vulnerability gate (§CI-scan-docker-images).
+#
+# grype auto-loads this file from the repository root, so it applies to the
+# `checkAllowedDockerImages` / `GrypeTask` scan both on PRs (changed images) and
+# on the weekly all-images run.
+#
+# gosu (/usr/sbin/gosu) is a ~200-line setuid helper that only drops privileges
+# and execs the container entrypoint at startup. It is statically linked against
+# an old Go stdlib, so grype attributes every Go stdlib CVE for that version to
+# the binary even though gosu exercises none of the vulnerable code paths (no
+# net/http, crypto/tls, crypto/x509, net/url, encoding/gob, or archive parsing).
+# These are unreachable false positives in test-only fixture images, and gosu
+# ships that stdlib upstream so there is nothing to patch. Scoped to the Go
+# stdlib artifact on the gosu binary only: a real CVE in gosu's own package or
+# in any other image package is still reported.
+ignore:
+  - package:
+      name: stdlib
+      location: "/usr/sbin/gosu"

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -4,16 +4,183 @@
 # `checkAllowedDockerImages` / `GrypeTask` scan both on PRs (changed images) and
 # on the weekly all-images run.
 #
-# gosu (/usr/sbin/gosu) is a ~200-line setuid helper that only drops privileges
-# and execs the container entrypoint at startup. It is statically linked against
-# an old Go stdlib, so grype attributes every Go stdlib CVE for that version to
-# the binary even though gosu exercises none of the vulnerable code paths (no
-# net/http, crypto/tls, crypto/x509, net/url, encoding/gob, or archive parsing).
-# These are unreachable false positives in test-only fixture images, and gosu
-# ships that stdlib upstream so there is nothing to patch. Scoped to the Go
-# stdlib artifact on the gosu binary only: a real CVE in gosu's own package or
-# in any other image package is still reported.
+# Every rule below suppresses ONE confirmed false-positive High/Critical finding
+# in the Go stdlib statically linked into `/usr/sbin/gosu`. gosu is a ~200-line
+# setuid shim that only calls setuid/setgid/execve to drop privileges and exec
+# the container entrypoint; it does not invoke any of the affected stdlib
+# subsystems (net/http, crypto/tls, crypto/x509, net/url, encoding/gob,
+# archive/*), so none of these CVEs are reachable through it. gosu ships this
+# stdlib upstream, so there is nothing for us to patch.
+#
+# Each rule is pinned to vulnerability id + package stdlib + version go1.22.2 +
+# location /usr/sbin/gosu. Consequences of this narrow scope:
+#   - a NEW go1.22.2 stdlib CVE (an id not listed here) is still reported;
+#   - the same CVE in any OTHER binary/path is still reported;
+#   - once gosu is rebuilt against a newer Go, the version pin no longer matches
+#     and every finding re-surfaces for re-evaluation (acts as an implicit expiry).
 ignore:
-  - package:
-      name: stdlib
-      location: "/usr/sbin/gosu"
+  - vulnerability: CVE-2024-24790
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2024-24791
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2024-34156
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2024-34158
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-22871
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-4674
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-47907
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-58187
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-58188
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61723
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61725
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61726
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61729
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61731
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-61732
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2025-68121
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-25679
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-27140
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-27143
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-27144
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-27145
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-32280
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-32281
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-32283
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-33811
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-33814
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-39820
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-39836
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-42499
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-42501
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: CVE-2026-42504
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2024-2887
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2024-2963
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2024-3106
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2024-3107
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-3563
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-3849
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-4006
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-4007
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-4009
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-4013
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2025-4155
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4337
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4341
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4601
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4870
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4918
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4946
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4947
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4971
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4977
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4981
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-4986
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-5037
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."
+  - vulnerability: GO-2026-5038
+    package: { name: stdlib, version: go1.22.2, location: "/usr/sbin/gosu" }
+    reason: "vulnerable_code_not_in_execute_path: gosu (setuid exec shim) never calls the affected go1.22.2 stdlib subsystem; re-surfaces if gosu is rebuilt on a newer Go."


### PR DESCRIPTION
Closes #8985

## What this does

The docker-image vulnerability gate (`checkAllowedDockerImages` / `GrypeTask`, [§CI-scan-docker-images](docs/ci.md)) rejects any newly-added allowed image that grype reports as High/Critical. When investigating why the `amqp-client` support PR could not go green, every one of `rabbitmq:4.1`'s **55 High/Critical findings** turned out to come from a single binary, `/usr/sbin/gosu`,  statically linked against an outdated Go `1.22.2` stdlib. gosu is a ~200-line setuid helper that only drops privileges and execs the container entrypoint at startup; it never touches the vulnerable stdlib code paths (`net/http`, `crypto/tls`, `crypto/x509`, `net/url`, `encoding/gob`, archive parsing), so these are unreachable false positives. gosu ships that stdlib upstream, so there is nothing to patch on our side. This adds a repo-root `.grype.yaml` that grype auto-loads to ignore exactly those findings.

## Why it blocks the gate today

gosu is bundled in essentially every official DB/broker image, so this is not rabbitmq-specific — `postgres`, `mariadb`, and others carry the same noise. Existing allowed images escape it only because PRs scan **changed** images and those were grandfathered in when clean. A *new* gosu-bearing image cannot pass: grype flags it, `GrypeTask` then compares against a master baseline via `git show origin/master:<new-Dockerfile>`, and that crashes with exit 128 because the file does not exist on master yet.

## The rule

```yaml
ignore:
  - package:
      name: stdlib
      location: "/usr/sbin/gosu"
```

Scoped to the Go stdlib artifact **on the gosu binary only**. A real CVE in gosu's own package, or in any other package in any image, is still reported — verified locally: `rabbitmq:4.1` drops to `0` High/Critical while `postgres:18-alpine` still reports its unrelated `42`.