### PR TITLE
Match line-less dynamic access via agent configuration origins

### DIFF
--- a/docs/tck.md
+++ b/docs/tck.md
@@ -129,8 +129,13 @@ carries a source line and JaCoCo covered that line. Some jars are compiled
 without a `LineNumberTable`, so every dynamic-access frame is line-less
 (`Unknown Source`) and line-based matching can never succeed. In that case only
 — the report has call sites but none carries a line number — the harness
-collects a `native-image-agent` trace from a JVM `test` run and falls back to
-matching a call site by the tracked-API method name plus the caller class: a
-call site is covered when a trace event for the same JDK entry-point method name
-fired from exactly that caller class. Line-based matching stays the primary path
-and is unchanged for jars that carry line information.
+collects `native-image-agent` configuration origins from a JVM `test` run and
+falls back to matching the complete origin path against the statically reported
+call sites. The harness streams the agent's compressed origin tree and marks a
+line-less call site covered when the same path contains both its exact tracked
+API and its caller class and method, with the caller preceding the API. It keeps
+only the current origin-tree branch and the matched call-site identities in
+memory. If multiple reported callers precede the API, the nearest one wins; a
+nested tracked API ends the caller search so delegated JDK calls do not cover a
+different API with the same method name. Line-based matching stays the primary
+path and is unchanged for jars that carry line information.

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -123,3 +123,14 @@ These emit the GitHub Actions matrices the workflows consume, all driven by
 | `generateDynamicAccessCoverageReport`, `analyzeExternalLibraryDynamicAccess` | Dynamic-access coverage reporting (§FS-repository-functional-spec.4.5). |
 | `generateLibraryStats`, `listTopCoordinatesByMetric`, `generateTopCoordinatesByMetricMatrix`, `generateReadmeBadgeSummary`, `generateDependencyGraph` | Produce and query the stats mirror, README badge inputs, and dependency graphs that feed the coverage dashboard (§CI-publish-scheduled-coverage). |
 | `package` | Zip the `metadata/` directory into the release artifact consumed by native-build-tools (§FS-repository-functional-spec.4). |
+
+Dynamic-access coverage normally marks a call site covered when its stack frame
+carries a source line and JaCoCo covered that line. Some jars are compiled
+without a `LineNumberTable`, so every dynamic-access frame is line-less
+(`Unknown Source`) and line-based matching can never succeed. In that case only
+— the report has call sites but none carries a line number — the harness
+collects a `native-image-agent` trace from a JVM `test` run and falls back to
+matching a call site by the tracked-API method name plus the caller class: a
+call site is covered when a trace event for the same JDK entry-point method name
+fired from exactly that caller class. Line-based matching stays the primary path
+and is unchanged for jars that carry line information.

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -528,12 +528,11 @@ tasks.withType(Test).configureEach { Test testTask ->
     if (skipJacoco) {
         jacoco.enabled = false
     }
-    // §TCK-test-harness.8: when a jar has no line info, the dynamic-access report has no
-    // usable line numbers, so the harness collects a native-image-agent trace from the JVM
-    // `test` run and falls back to matching call sites by tracked-API method plus caller class.
-    if (testTask.name == 'test' && providers.gradleProperty('dynamicAccessTraceOutput').isPresent()) {
-        String traceOutput = providers.gradleProperty('dynamicAccessTraceOutput').get()
-        testTask.jvmArgs "-agentlib:native-image-agent=trace-output=${traceOutput}"
+    // §TCK-test-harness.8: when a jar has no line info, collect the agent's compressed origin
+    // tree so the harness can match exact tracked APIs and reported caller methods on each path.
+    if (testTask.name == 'test' && providers.gradleProperty('dynamicAccessOriginsOutput').isPresent()) {
+        String originsOutput = providers.gradleProperty('dynamicAccessOriginsOutput').get()
+        testTask.jvmArgs "-agentlib:native-image-agent=config-output-dir=${originsOutput},experimental-configuration-with-origins"
         testTask.jacoco.enabled = false
         testTask.outputs.upToDateWhen { false }
     }

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -523,10 +523,19 @@ tasks.register("mergeNativeTraceMetadata", Exec) { Exec task ->
 }
 
 // Ensure detailed exception/stacktrace logging for all Test tasks, including nativeTest
-tasks.withType(Test).configureEach {
+tasks.withType(Test).configureEach { Test testTask ->
     // §TCK-test-harness.3: downstream pass/fail gates can run without coverage instrumentation.
     if (skipJacoco) {
         jacoco.enabled = false
+    }
+    // §TCK-test-harness.8: when a jar has no line info, the dynamic-access report has no
+    // usable line numbers, so the harness collects a native-image-agent trace from the JVM
+    // `test` run and falls back to matching call sites by tracked-API method plus caller class.
+    if (testTask.name == 'test' && providers.gradleProperty('dynamicAccessTraceOutput').isPresent()) {
+        String traceOutput = providers.gradleProperty('dynamicAccessTraceOutput').get()
+        testTask.jvmArgs "-agentlib:native-image-agent=trace-output=${traceOutput}"
+        testTask.jacoco.enabled = false
+        testTask.outputs.upToDateWhen { false }
     }
     systemProperty "junit.jupiter.execution.timeout.default", "${maxJUnitTestTimeoutSeconds} s"
     systemProperty "junit.jupiter.execution.timeout.mode", "enabled"

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -232,11 +232,7 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
                     libraryJars,
                     getDynamicAccessDir(coordinates),
                     getJacocoReport(coordinates),
-                    LibraryStatsSupport.parseAgentOrigins(
-                            originsOutput,
-                            getDynamicAccessDir(coordinates),
-                            libraryJars
-                    )
+                    LibraryStatsSupport.parseAgentOrigins(originsOutput, getDynamicAccessDir(coordinates))
             );
         }
         return LibraryStatsSupport.buildVersionStatsWithoutDynamicAccess(

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -225,17 +226,61 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
 
         boolean dynamicAccessAvailable = generateReportsForCoordinate(coordinates);
         if (dynamicAccessAvailable) {
+            Path tracePath = maybeCollectAgentTrace(coordinates, libraryJars);
             return LibraryStatsSupport.buildVersionStats(
                     coordinates,
                     libraryJars,
                     getDynamicAccessDir(coordinates),
-                    getJacocoReport(coordinates)
+                    getJacocoReport(coordinates),
+                    LibraryStatsSupport.parseAgentTrace(tracePath)
             );
         }
         return LibraryStatsSupport.buildVersionStatsWithoutDynamicAccess(
                 coordinates,
                 getJacocoReport(coordinates)
         );
+    }
+
+    /// §TCK-test-harness.8: agent-trace fallback for coordinates whose dynamic-access frames carry
+    /// no line numbers. Returns null (today's behaviour) unless line-based matching is impossible;
+    /// otherwise runs the JVM-only `javaTest` lane under `native-image-agent` and returns the trace
+    /// path. `javaTest` is used rather than the full `test` lane so the native build (and the
+    /// dynamic-access reports it produced) is not re-run and clobbered. A failed or missing trace
+    /// degrades gracefully to null — it never fails the stats task.
+    protected Path maybeCollectAgentTrace(String coordinates, List<Path> libraryJars) {
+        if (!LibraryStatsSupport.lineMatchingImpossible(getDynamicAccessDir(coordinates), libraryJars)) {
+            return null;
+        }
+        Path tracePath = tckExtension.getTestDir(coordinates)
+                .resolve("build")
+                .resolve("reports")
+                .resolve("dynamic-access")
+                .resolve("agent-trace.json");
+        getLogger().lifecycle(
+                "Dynamic-access frames for {} carry no line numbers; collecting native-image-agent trace.",
+                coordinates
+        );
+        try {
+            // The agent does not create the trace-output parent directory itself.
+            Files.createDirectories(tracePath.getParent());
+            Files.deleteIfExists(tracePath);
+        } catch (IOException e) {
+            getLogger().warn("Could not prepare agent-trace output for {}: {}", coordinates, e.getMessage());
+            return null;
+        }
+        CommandResult trace = runGradle(
+                List.of("javaTest", "-Pcoordinates=" + coordinates, "-PdynamicAccessTraceOutput=" + tracePath),
+                true
+        );
+        if (trace.exitCode() != 0 || !Files.isRegularFile(tracePath)) {
+            getLogger().warn(
+                    "Agent-trace collection for {} failed (exit code {}); falling back to line-based coverage only.",
+                    coordinates,
+                    trace.exitCode()
+            );
+            return null;
+        }
+        return tracePath;
     }
 
     protected void validateCommittedStatsFiles() {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -226,13 +226,17 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
 
         boolean dynamicAccessAvailable = generateReportsForCoordinate(coordinates);
         if (dynamicAccessAvailable) {
-            Path tracePath = maybeCollectAgentTrace(coordinates, libraryJars);
+            Path originsOutput = maybeCollectAgentOrigins(coordinates, libraryJars);
             return LibraryStatsSupport.buildVersionStats(
                     coordinates,
                     libraryJars,
                     getDynamicAccessDir(coordinates),
                     getJacocoReport(coordinates),
-                    LibraryStatsSupport.parseAgentTrace(tracePath)
+                    LibraryStatsSupport.parseAgentOrigins(
+                            originsOutput,
+                            getDynamicAccessDir(coordinates),
+                            libraryJars
+                    )
             );
         }
         return LibraryStatsSupport.buildVersionStatsWithoutDynamicAccess(
@@ -241,46 +245,45 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
         );
     }
 
-    /// §TCK-test-harness.8: agent-trace fallback for coordinates whose dynamic-access frames carry
+    /// §TCK-test-harness.8: agent-origin fallback for coordinates whose dynamic-access frames carry
     /// no line numbers. Returns null (today's behaviour) unless line-based matching is impossible;
-    /// otherwise runs the JVM-only `javaTest` lane under `native-image-agent` and returns the trace
-    /// path. `javaTest` is used rather than the full `test` lane so the native build (and the
-    /// dynamic-access reports it produced) is not re-run and clobbered. A failed or missing trace
-    /// degrades gracefully to null — it never fails the stats task.
-    protected Path maybeCollectAgentTrace(String coordinates, List<Path> libraryJars) {
+    /// otherwise runs the JVM-only `javaTest` lane under `native-image-agent` and returns its
+    /// configuration-origin directory. `javaTest` avoids re-running and clobbering the native
+    /// dynamic-access reports. Failed or missing origins degrade gracefully to today's behaviour.
+    protected Path maybeCollectAgentOrigins(String coordinates, List<Path> libraryJars) {
         if (!LibraryStatsSupport.lineMatchingImpossible(getDynamicAccessDir(coordinates), libraryJars)) {
             return null;
         }
-        Path tracePath = tckExtension.getTestDir(coordinates)
+        Path originsOutput = tckExtension.getTestDir(coordinates)
                 .resolve("build")
                 .resolve("reports")
                 .resolve("dynamic-access")
-                .resolve("agent-trace.json");
+                .resolve("agent-origins");
+        Path originsFile = originsOutput.resolve("reachability-metadata-origins.txt");
         getLogger().lifecycle(
-                "Dynamic-access frames for {} carry no line numbers; collecting native-image-agent trace.",
+                "Dynamic-access frames for {} carry no line numbers; collecting native-image-agent origins.",
                 coordinates
         );
         try {
-            // The agent does not create the trace-output parent directory itself.
-            Files.createDirectories(tracePath.getParent());
-            Files.deleteIfExists(tracePath);
+            Files.createDirectories(originsOutput);
+            Files.deleteIfExists(originsFile);
         } catch (IOException e) {
-            getLogger().warn("Could not prepare agent-trace output for {}: {}", coordinates, e.getMessage());
+            getLogger().warn("Could not prepare agent-origin output for {}: {}", coordinates, e.getMessage());
             return null;
         }
-        CommandResult trace = runGradle(
-                List.of("javaTest", "-Pcoordinates=" + coordinates, "-PdynamicAccessTraceOutput=" + tracePath),
+        CommandResult origins = runGradle(
+                List.of("javaTest", "-Pcoordinates=" + coordinates, "-PdynamicAccessOriginsOutput=" + originsOutput),
                 true
         );
-        if (trace.exitCode() != 0 || !Files.isRegularFile(tracePath)) {
+        if (origins.exitCode() != 0 || !Files.isRegularFile(originsFile)) {
             getLogger().warn(
-                    "Agent-trace collection for {} failed (exit code {}); falling back to line-based coverage only.",
+                    "Agent-origin collection for {} failed (exit code {}); falling back to line-based coverage only.",
                     coordinates,
-                    trace.exitCode()
+                    origins.exitCode()
             );
             return null;
         }
-        return tracePath;
+        return originsOutput;
     }
 
     protected void validateCommittedStatsFiles() {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
@@ -61,13 +61,17 @@ public abstract class GenerateDynamicAccessCoverageReportTask extends AbstractLi
         for (String coordinate : coordinates) {
             generateReportsForCoordinate(coordinate);
             List<Path> libraryJars = listLibraryJars(coordinate);
-            Path tracePath = maybeCollectAgentTrace(coordinate, libraryJars);
+            Path originsOutput = maybeCollectAgentOrigins(coordinate, libraryJars);
             LibraryStatsModels.DynamicAccessCoverageReport report = LibraryStatsSupport.buildDynamicAccessCoverageReport(
                     coordinate,
                     libraryJars,
                     getDynamicAccessDir(coordinate),
                     getJacocoReport(coordinate),
-                    LibraryStatsSupport.parseAgentTrace(tracePath)
+                    LibraryStatsSupport.parseAgentOrigins(
+                            originsOutput,
+                            getDynamicAccessDir(coordinate),
+                            libraryJars
+                    )
             );
             Path outputFile = getDynamicAccessCoverageReport(coordinate);
             LibraryStatsSupport.writeJson(outputFile, report);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
@@ -61,11 +61,13 @@ public abstract class GenerateDynamicAccessCoverageReportTask extends AbstractLi
         for (String coordinate : coordinates) {
             generateReportsForCoordinate(coordinate);
             List<Path> libraryJars = listLibraryJars(coordinate);
+            Path tracePath = maybeCollectAgentTrace(coordinate, libraryJars);
             LibraryStatsModels.DynamicAccessCoverageReport report = LibraryStatsSupport.buildDynamicAccessCoverageReport(
                     coordinate,
                     libraryJars,
                     getDynamicAccessDir(coordinate),
-                    getJacocoReport(coordinate)
+                    getJacocoReport(coordinate),
+                    LibraryStatsSupport.parseAgentTrace(tracePath)
             );
             Path outputFile = getDynamicAccessCoverageReport(coordinate);
             LibraryStatsSupport.writeJson(outputFile, report);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/GenerateDynamicAccessCoverageReportTask.java
@@ -67,11 +67,7 @@ public abstract class GenerateDynamicAccessCoverageReportTask extends AbstractLi
                     libraryJars,
                     getDynamicAccessDir(coordinate),
                     getJacocoReport(coordinate),
-                    LibraryStatsSupport.parseAgentOrigins(
-                            originsOutput,
-                            getDynamicAccessDir(coordinate),
-                            libraryJars
-                    )
+                    LibraryStatsSupport.parseAgentOrigins(originsOutput, getDynamicAccessDir(coordinate))
             );
             Path outputFile = getDynamicAccessCoverageReport(coordinate);
             LibraryStatsSupport.writeJson(outputFile, report);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
@@ -23,6 +23,9 @@ public abstract class JavaTestInvocationTask extends AllCoordinatesExecTask {
         ));
         // §TCK-test-harness.3
         appendProperty(command, "skipJacoco");
+        // §TCK-test-harness.8: forward the agent-trace output path so the inner `test` run
+        // attaches native-image-agent when the dynamic-access fallback needs a trace.
+        appendProperty(command, "dynamicAccessTraceOutput");
         return command;
     }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/JavaTestInvocationTask.java
@@ -23,9 +23,9 @@ public abstract class JavaTestInvocationTask extends AllCoordinatesExecTask {
         ));
         // §TCK-test-harness.3
         appendProperty(command, "skipJacoco");
-        // §TCK-test-harness.8: forward the agent-trace output path so the inner `test` run
-        // attaches native-image-agent when the dynamic-access fallback needs a trace.
-        appendProperty(command, "dynamicAccessTraceOutput");
+        // §TCK-test-harness.8: forward the agent-origin output directory so the inner `test` run
+        // attaches native-image-agent when the dynamic-access fallback needs origin paths.
+        appendProperty(command, "dynamicAccessOriginsOutput");
         return command;
     }
 

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -422,20 +422,17 @@ public final class LibraryStatsSupport {
     }
 
     /// §TCK-test-harness.8: streams the agent's compressed configuration-origin trees and
-    /// retains only statically reported line-less call sites whose exact tracked API and caller
+    /// retains the statically reported call sites whose exact tracked API and caller
     /// class/method occur, in that order, on a path carrying configuration. `originsOutput` may
     /// be one origins file or the agent output directory. Returns an empty set when no origins
-    /// output or no eligible call sites exist.
-    public static Set<AgentCoveredCallSite> parseAgentOrigins(
-            Path originsOutput,
-            Path dynamicAccessDir,
-            List<Path> libraryJars
-    ) {
+    /// output or no reported call sites exist. Candidates are taken from the reports as-is:
+    /// the reports only contain library call sites, and the coverage side only consults the
+    /// result for line-less library frames.
+    public static Set<AgentCoveredCallSite> parseAgentOrigins(Path originsOutput, Path dynamicAccessDir) {
         if (originsOutput == null || !Files.exists(originsOutput)) {
             return Set.of();
         }
-        Set<String> libraryClasses = loadLibraryClasses(libraryJars);
-        Set<AgentCoveredCallSite> candidates = loadAgentOriginCandidates(dynamicAccessDir, libraryClasses);
+        Set<AgentCoveredCallSite> candidates = loadAgentOriginCandidates(dynamicAccessDir);
         if (candidates.isEmpty()) {
             return Set.of();
         }
@@ -457,11 +454,8 @@ public final class LibraryStatsSupport {
         return Set.copyOf(coveredCallSites);
     }
 
-    private static Set<AgentCoveredCallSite> loadAgentOriginCandidates(
-            Path dynamicAccessDir,
-            Set<String> libraryClasses
-    ) {
-        if (!Files.isDirectory(dynamicAccessDir) || libraryClasses.isEmpty()) {
+    private static Set<AgentCoveredCallSite> loadAgentOriginCandidates(Path dynamicAccessDir) {
+        if (!Files.isDirectory(dynamicAccessDir)) {
             return Set.of();
         }
         Set<AgentCoveredCallSite> candidates = new LinkedHashSet<>();
@@ -477,9 +471,7 @@ public final class LibraryStatsSupport {
                     for (Map.Entry<String, List<String>> entry : report.entrySet()) {
                         for (String rawFrame : entry.getValue()) {
                             ParsedStackFrame frame = parseStackFrame(rawFrame);
-                            if (frame != null
-                                    && frame.lineNumber() == null
-                                    && libraryClasses.contains(frame.className())) {
+                            if (frame != null) {
                                 candidates.add(new AgentCoveredCallSite(
                                         entry.getKey(),
                                         frame.className(),

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -327,17 +328,17 @@ public final class LibraryStatsSupport {
             Path dynamicAccessDir,
             Path jacocoReport
     ) {
-        return buildVersionStats(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Map.of());
+        return buildVersionStats(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Set.of());
     }
 
-    /// §TCK-test-harness.8: `traceCallersByFunction` (from `parseAgentTrace`) enables the
-    /// agent-trace fallback for line-less call sites; pass `Map.of()` for the line-based path.
+    /// §TCK-test-harness.8: `agentCoveredCallSites` (from `parseAgentOrigins`) enables the
+    /// agent-origin fallback for line-less call sites; pass `Set.of()` for the line-based path.
     public static LibraryStatsModels.VersionStats buildVersionStats(
             String coordinate,
             List<Path> libraryJars,
             Path dynamicAccessDir,
             Path jacocoReport,
-            Map<String, Set<String>> traceCallersByFunction
+            Set<AgentCoveredCallSite> agentCoveredCallSites
     ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
         if (libraryClasses.isEmpty()) {
@@ -348,7 +349,7 @@ public final class LibraryStatsSupport {
             );
         }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), traceCallersByFunction);
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), agentCoveredCallSites);
         return versionStats(
                 coordinate,
                 LibraryStatsModels.DynamicAccessStatsValue.available(parsedDynamicAccess.dynamicAccessStats()),
@@ -373,7 +374,7 @@ public final class LibraryStatsSupport {
         if (libraryClasses.isEmpty()) {
             return new ExternalDynamicAccessSummary(0L, Map.of());
         }
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Map.of());
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Set.of());
         return new ExternalDynamicAccessSummary(
                 parsedDynamicAccess.dynamicAccessStats().totalCalls(),
                 parsedDynamicAccess.dynamicAccessStats().breakdown()
@@ -386,17 +387,17 @@ public final class LibraryStatsSupport {
             Path dynamicAccessDir,
             Path jacocoReport
     ) {
-        return buildDynamicAccessCoverageReport(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Map.of());
+        return buildDynamicAccessCoverageReport(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Set.of());
     }
 
-    /// §TCK-test-harness.8: `traceCallersByFunction` (from `parseAgentTrace`) enables the
-    /// agent-trace fallback for line-less call sites; pass `Map.of()` for the line-based path.
+    /// §TCK-test-harness.8: `agentCoveredCallSites` (from `parseAgentOrigins`) enables the
+    /// agent-origin fallback for line-less call sites; pass `Set.of()` for the line-based path.
     public static LibraryStatsModels.DynamicAccessCoverageReport buildDynamicAccessCoverageReport(
             String coordinate,
             List<Path> libraryJars,
             Path dynamicAccessDir,
             Path jacocoReport,
-            Map<String, Set<String>> traceCallersByFunction
+            Set<AgentCoveredCallSite> agentCoveredCallSites
     ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
         if (libraryClasses.isEmpty()) {
@@ -408,7 +409,7 @@ public final class LibraryStatsSupport {
             );
         }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), traceCallersByFunction);
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), agentCoveredCallSites);
         return new LibraryStatsModels.DynamicAccessCoverageReport(
                 coordinate,
                 parsedDynamicAccess.dynamicAccessStats().totalCalls() > 0,
@@ -420,38 +421,192 @@ public final class LibraryStatsSupport {
         );
     }
 
-    /// §TCK-test-harness.8: parses a `native-image-agent` trace (a JSON array of event objects,
-    /// each with `tracer`/`function` and usually `caller_class`) into `function name -> caller
-    /// classes`. Entries without a `caller_class` are ignored; the tracer type is not filtered
-    /// because the caller-class equality check downstream already excludes noise. Returns an empty
-    /// map when the file is absent.
-    public static Map<String, Set<String>> parseAgentTrace(Path traceFile) {
-        if (traceFile == null || !Files.isRegularFile(traceFile)) {
-            return Map.of();
+    /// §TCK-test-harness.8: streams the agent's compressed configuration-origin trees and
+    /// retains only statically reported line-less call sites whose exact tracked API and caller
+    /// class/method occur, in that order, on a path carrying configuration. `originsOutput` may
+    /// be one origins file or the agent output directory. Returns an empty set when no origins
+    /// output or no eligible call sites exist.
+    public static Set<AgentCoveredCallSite> parseAgentOrigins(
+            Path originsOutput,
+            Path dynamicAccessDir,
+            List<Path> libraryJars
+    ) {
+        if (originsOutput == null || !Files.exists(originsOutput)) {
+            return Set.of();
         }
-        Map<String, Set<String>> callersByFunction = new HashMap<>();
-        try {
-            JsonNode root = OBJECT_MAPPER.readTree(traceFile.toFile());
-            if (!root.isArray()) {
-                return Map.of();
-            }
-            for (JsonNode entry : root) {
-                JsonNode function = entry.get("function");
-                JsonNode callerClass = entry.get("caller_class");
-                if (function == null || function.isNull() || callerClass == null || callerClass.isNull()) {
-                    continue;
-                }
-                callersByFunction
-                        .computeIfAbsent(function.asText(), ignored -> new LinkedHashSet<>())
-                        .add(callerClass.asText());
-            }
-        } catch (IOException e) {
-            throw new GradleException("Failed to parse native-image-agent trace " + traceFile, e);
+        Set<String> libraryClasses = loadLibraryClasses(libraryJars);
+        Set<AgentCoveredCallSite> candidates = loadAgentOriginCandidates(dynamicAccessDir, libraryClasses);
+        if (candidates.isEmpty()) {
+            return Set.of();
         }
-        return callersByFunction;
+
+        Map<String, List<AgentCoveredCallSite>> candidatesByTrackedApi = new HashMap<>();
+        for (AgentCoveredCallSite candidate : candidates) {
+            candidatesByTrackedApi
+                    .computeIfAbsent(normalizeMethodSignature(candidate.trackedApi()), ignored -> new ArrayList<>())
+                    .add(candidate);
+        }
+
+        Set<AgentCoveredCallSite> coveredCallSites = new LinkedHashSet<>();
+        for (Path originsFile : listAgentOriginsFiles(originsOutput)) {
+            parseAgentOriginsFile(originsFile, candidatesByTrackedApi, candidates.size(), coveredCallSites);
+            if (coveredCallSites.size() == candidates.size()) {
+                break;
+            }
+        }
+        return Set.copyOf(coveredCallSites);
     }
 
-    /// §TCK-test-harness.8: the agent-trace fallback is the only-when-lines-are-absent gate.
+    private static Set<AgentCoveredCallSite> loadAgentOriginCandidates(
+            Path dynamicAccessDir,
+            Set<String> libraryClasses
+    ) {
+        if (!Files.isDirectory(dynamicAccessDir) || libraryClasses.isEmpty()) {
+            return Set.of();
+        }
+        Set<AgentCoveredCallSite> candidates = new LinkedHashSet<>();
+        try (Stream<Path> files = Files.walk(dynamicAccessDir)) {
+            for (Path reportFile : files
+                    .filter(Files::isRegularFile)
+                    .filter(path -> DYNAMIC_ACCESS_REPORT.matcher(path.getFileName().toString()).matches())
+                    .sorted(Comparator.comparing(path -> path.toAbsolutePath().toString()))
+                    .toList()) {
+                try (InputStream inputStream = Files.newInputStream(reportFile)) {
+                    Map<String, List<String>> report = OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {
+                    });
+                    for (Map.Entry<String, List<String>> entry : report.entrySet()) {
+                        for (String rawFrame : entry.getValue()) {
+                            ParsedStackFrame frame = parseStackFrame(rawFrame);
+                            if (frame != null
+                                    && frame.lineNumber() == null
+                                    && libraryClasses.contains(frame.className())) {
+                                candidates.add(new AgentCoveredCallSite(
+                                        entry.getKey(),
+                                        frame.className(),
+                                        frame.methodName()
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new GradleException("Failed to load agent-origin candidates from " + dynamicAccessDir, e);
+        }
+        return candidates;
+    }
+
+    private static List<Path> listAgentOriginsFiles(Path originsOutput) {
+        if (Files.isRegularFile(originsOutput)) {
+            return List.of(originsOutput);
+        }
+        if (!Files.isDirectory(originsOutput)) {
+            return List.of();
+        }
+        try (Stream<Path> files = Files.list(originsOutput)) {
+            return files
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith("-origins.txt"))
+                    .sorted(Comparator.comparing(path -> path.toAbsolutePath().toString()))
+                    .toList();
+        } catch (IOException e) {
+            throw new GradleException("Failed to list native-image-agent origins in " + originsOutput, e);
+        }
+    }
+
+    private static void parseAgentOriginsFile(
+            Path originsFile,
+            Map<String, List<AgentCoveredCallSite>> candidatesByTrackedApi,
+            int candidateCount,
+            Set<AgentCoveredCallSite> coveredCallSites
+    ) {
+        List<AgentOriginMethod> currentPath = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(originsFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                ParsedAgentOriginLine parsedLine = parseAgentOriginLine(line);
+                if (parsedLine == null) {
+                    continue;
+                }
+                if (parsedLine.depth() > currentPath.size()) {
+                    throw new GradleException("Invalid native-image-agent origin depth in " + originsFile);
+                }
+                while (currentPath.size() > parsedLine.depth()) {
+                    currentPath.remove(currentPath.size() - 1);
+                }
+                currentPath.add(parsedLine.method());
+                if (parsedLine.hasConfiguration()) {
+                    matchAgentOriginPath(currentPath, candidatesByTrackedApi, coveredCallSites);
+                    if (coveredCallSites.size() == candidateCount) {
+                        return;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new GradleException("Failed to parse native-image-agent origins " + originsFile, e);
+        }
+    }
+
+    private static ParsedAgentOriginLine parseAgentOriginLine(String line) {
+        int branchIndex = Math.max(line.lastIndexOf("├── "), line.lastIndexOf("└── "));
+        if (branchIndex < 2) {
+            return null;
+        }
+        String branchPrefix = line.substring(2, branchIndex);
+        if (branchPrefix.length() % 4 != 0) {
+            return null;
+        }
+        int depth = branchPrefix.length() / 4;
+        String entry = line.substring(branchIndex + 4);
+        int configurationIndex = entry.indexOf(" - [");
+        boolean hasConfiguration = configurationIndex >= 0;
+        String methodSignature = hasConfiguration ? entry.substring(0, configurationIndex) : entry;
+        int hashIndex = methodSignature.indexOf('#');
+        int parametersIndex = methodSignature.indexOf('(', hashIndex + 1);
+        if (hashIndex < 1 || parametersIndex < 0) {
+            return null;
+        }
+        AgentOriginMethod method = new AgentOriginMethod(
+                normalizeMethodSignature(methodSignature),
+                methodSignature.substring(0, hashIndex),
+                methodSignature.substring(hashIndex + 1, parametersIndex)
+        );
+        return new ParsedAgentOriginLine(depth, method, hasConfiguration);
+    }
+
+    private static void matchAgentOriginPath(
+            List<AgentOriginMethod> originPath,
+            Map<String, List<AgentCoveredCallSite>> candidatesByTrackedApi,
+            Set<AgentCoveredCallSite> coveredCallSites
+    ) {
+        for (int apiIndex = 0; apiIndex < originPath.size(); apiIndex++) {
+            AgentOriginMethod apiMethod = originPath.get(apiIndex);
+            List<AgentCoveredCallSite> candidates = candidatesByTrackedApi.get(apiMethod.signature());
+            if (candidates == null) {
+                continue;
+            }
+            for (int callerIndex = apiIndex - 1; callerIndex >= 0; callerIndex--) {
+                AgentOriginMethod callerMethod = originPath.get(callerIndex);
+                if (candidatesByTrackedApi.containsKey(callerMethod.signature())) {
+                    break;
+                }
+                List<AgentCoveredCallSite> matches = candidates.stream()
+                        .filter(candidate -> candidate.className().equals(callerMethod.className()))
+                        .filter(candidate -> candidate.methodName().equals(callerMethod.methodName()))
+                        .toList();
+                if (!matches.isEmpty()) {
+                    coveredCallSites.addAll(matches);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static String normalizeMethodSignature(String methodSignature) {
+        return methodSignature.replace(" ", "");
+    }
+
+    /// §TCK-test-harness.8: the agent-origin fallback is the only-when-lines-are-absent gate.
     /// Returns true iff the dynamic-access reports contain at least one library call site and
     /// every such call site is line-less, so line-based matching can never succeed. Purely
     /// data-driven — no jar bytecode scanning.
@@ -460,7 +615,7 @@ public final class LibraryStatsSupport {
         if (libraryClasses.isEmpty()) {
             return false;
         }
-        ParsedDynamicAccess parsed = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Map.of());
+        ParsedDynamicAccess parsed = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Set.of());
         if (parsed.dynamicAccessStats().totalCalls() == 0L) {
             return false;
         }
@@ -472,19 +627,6 @@ public final class LibraryStatsSupport {
             }
         }
         return true;
-    }
-
-    /// Extracts the bare method name from a tracked-API key such as
-    /// `java.lang.Class#forName(java.lang.String)` -> `forName`, to compare against the agent
-    /// trace's `function` field. Returns null when the key has no `#...(` method segment.
-    private static String methodNameOfTrackedApi(String trackedApi) {
-        int hash = trackedApi.indexOf('#');
-        if (hash < 0) {
-            return null;
-        }
-        int paren = trackedApi.indexOf('(', hash);
-        String method = paren < 0 ? trackedApi.substring(hash + 1) : trackedApi.substring(hash + 1, paren);
-        return method.isBlank() ? null : method;
     }
 
     private static LibraryStatsModels.VersionStats versionStats(
@@ -753,7 +895,7 @@ public final class LibraryStatsSupport {
             Path dynamicAccessDir,
             Set<String> libraryClasses,
             Map<String, Set<Integer>> coveredLinesBySource,
-            Map<String, Set<String>> traceCallersByFunction
+            Set<AgentCoveredCallSite> agentCoveredCallSites
     ) {
         if (!Files.isDirectory(dynamicAccessDir)) {
             return emptyDynamicAccess();
@@ -766,7 +908,7 @@ public final class LibraryStatsSupport {
                     .filter(Files::isRegularFile)
                     .filter(path -> DYNAMIC_ACCESS_REPORT.matcher(path.getFileName().toString()).matches())
                     .sorted(Comparator.comparing(path -> path.toAbsolutePath().toString()))
-                    .forEach(path -> parseDynamicAccessFile(path, libraryClasses, coveredLinesBySource, traceCallersByFunction, callSitesByKey));
+                    .forEach(path -> parseDynamicAccessFile(path, libraryClasses, coveredLinesBySource, agentCoveredCallSites, callSitesByKey));
         } catch (IOException e) {
             throw new GradleException("Failed to traverse dynamic access directory " + dynamicAccessDir, e);
         }
@@ -824,7 +966,7 @@ public final class LibraryStatsSupport {
             Path path,
             Set<String> libraryClasses,
             Map<String, Set<Integer>> coveredLinesBySource,
-            Map<String, Set<String>> traceCallersByFunction,
+            Set<AgentCoveredCallSite> agentCoveredCallSites,
             Map<String, ParsedDynamicAccessCallSite> callSitesByKey
     ) {
         Matcher matcher = DYNAMIC_ACCESS_REPORT.matcher(path.getFileName().toString());
@@ -847,22 +989,20 @@ public final class LibraryStatsSupport {
                     if (callSitesByKey.containsKey(callSiteKey)) {
                         continue;
                     }
-                    // §TCK-test-harness.8: line-based matching is the primary path. Only when a
-                    // frame carries no line number (line-less jar) do we fall back to the agent
-                    // trace: covered = a trace event for the same JDK entry-point method name was
-                    // performed by exactly this caller class. Matching on method name only (not
-                    // owner class) is deliberate; the agent's `function` field is the intercepted
-                    // method name, and cross-owner name collisions at the same caller class are
-                    // acceptable over-attribution.
+                    // §TCK-test-harness.8: line-based matching is primary. A line-less site falls
+                    // back to an exact tracked API plus caller class/method match from an agent
+                    // configuration-origin path.
                     boolean covered = false;
                     if (parsedFrame.lineNumber() != null) {
                         String sourceKey = sourceKey(parsedFrame.className(), parsedFrame.sourceFile());
                         Set<Integer> coveredLines = coveredLinesBySource.get(sourceKey);
                         covered = coveredLines != null && coveredLines.contains(parsedFrame.lineNumber());
-                    } else if (!traceCallersByFunction.isEmpty()) {
-                        String apiMethod = methodNameOfTrackedApi(trackedApi);
-                        Set<String> callers = apiMethod == null ? null : traceCallersByFunction.get(apiMethod);
-                        covered = callers != null && callers.contains(parsedFrame.className());
+                    } else if (!agentCoveredCallSites.isEmpty()) {
+                        covered = agentCoveredCallSites.contains(new AgentCoveredCallSite(
+                                trackedApi,
+                                parsedFrame.className(),
+                                parsedFrame.methodName()
+                        ));
                     }
                     callSitesByKey.put(
                             callSiteKey,
@@ -1097,9 +1237,13 @@ public final class LibraryStatsSupport {
         );
     }
 
-    /// `methodName` (the caller method) is retained as the designated expansion point for
-    /// per-method agent-trace matching later (§TCK-test-harness.8); v1 matches on caller class.
     private record ParsedStackFrame(String className, String methodName, String sourceFile, Integer lineNumber) {
+    }
+
+    private record AgentOriginMethod(String signature, String className, String methodName) {
+    }
+
+    private record ParsedAgentOriginLine(int depth, AgentOriginMethod method, boolean hasConfiguration) {
     }
 
     private record ParsedDynamicAccess(
@@ -1125,6 +1269,9 @@ public final class LibraryStatsSupport {
             LibraryStatsModels.CoverageMetricValue instruction,
             LibraryStatsModels.CoverageMetricValue method
     ) {
+    }
+
+    public record AgentCoveredCallSite(String trackedApi, String className, String methodName) {
     }
 
     public record ExternalDynamicAccessSummary(

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSupport.java
@@ -327,6 +327,18 @@ public final class LibraryStatsSupport {
             Path dynamicAccessDir,
             Path jacocoReport
     ) {
+        return buildVersionStats(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Map.of());
+    }
+
+    /// §TCK-test-harness.8: `traceCallersByFunction` (from `parseAgentTrace`) enables the
+    /// agent-trace fallback for line-less call sites; pass `Map.of()` for the line-based path.
+    public static LibraryStatsModels.VersionStats buildVersionStats(
+            String coordinate,
+            List<Path> libraryJars,
+            Path dynamicAccessDir,
+            Path jacocoReport,
+            Map<String, Set<String>> traceCallersByFunction
+    ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
         if (libraryClasses.isEmpty()) {
             return new LibraryStatsModels.VersionStats(
@@ -336,7 +348,7 @@ public final class LibraryStatsSupport {
             );
         }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource());
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), traceCallersByFunction);
         return versionStats(
                 coordinate,
                 LibraryStatsModels.DynamicAccessStatsValue.available(parsedDynamicAccess.dynamicAccessStats()),
@@ -361,7 +373,7 @@ public final class LibraryStatsSupport {
         if (libraryClasses.isEmpty()) {
             return new ExternalDynamicAccessSummary(0L, Map.of());
         }
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of());
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Map.of());
         return new ExternalDynamicAccessSummary(
                 parsedDynamicAccess.dynamicAccessStats().totalCalls(),
                 parsedDynamicAccess.dynamicAccessStats().breakdown()
@@ -374,6 +386,18 @@ public final class LibraryStatsSupport {
             Path dynamicAccessDir,
             Path jacocoReport
     ) {
+        return buildDynamicAccessCoverageReport(coordinate, libraryJars, dynamicAccessDir, jacocoReport, Map.of());
+    }
+
+    /// §TCK-test-harness.8: `traceCallersByFunction` (from `parseAgentTrace`) enables the
+    /// agent-trace fallback for line-less call sites; pass `Map.of()` for the line-based path.
+    public static LibraryStatsModels.DynamicAccessCoverageReport buildDynamicAccessCoverageReport(
+            String coordinate,
+            List<Path> libraryJars,
+            Path dynamicAccessDir,
+            Path jacocoReport,
+            Map<String, Set<String>> traceCallersByFunction
+    ) {
         Set<String> libraryClasses = loadLibraryClasses(libraryJars);
         if (libraryClasses.isEmpty()) {
             return new LibraryStatsModels.DynamicAccessCoverageReport(
@@ -384,7 +408,7 @@ public final class LibraryStatsSupport {
             );
         }
         ParsedJacocoReport parsedJacocoReport = parseJacocoReport(jacocoReport);
-        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource());
+        ParsedDynamicAccess parsedDynamicAccess = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, parsedJacocoReport.coveredLinesBySource(), traceCallersByFunction);
         return new LibraryStatsModels.DynamicAccessCoverageReport(
                 coordinate,
                 parsedDynamicAccess.dynamicAccessStats().totalCalls() > 0,
@@ -394,6 +418,73 @@ public final class LibraryStatsSupport {
                 ),
                 parsedDynamicAccess.classCoverage()
         );
+    }
+
+    /// §TCK-test-harness.8: parses a `native-image-agent` trace (a JSON array of event objects,
+    /// each with `tracer`/`function` and usually `caller_class`) into `function name -> caller
+    /// classes`. Entries without a `caller_class` are ignored; the tracer type is not filtered
+    /// because the caller-class equality check downstream already excludes noise. Returns an empty
+    /// map when the file is absent.
+    public static Map<String, Set<String>> parseAgentTrace(Path traceFile) {
+        if (traceFile == null || !Files.isRegularFile(traceFile)) {
+            return Map.of();
+        }
+        Map<String, Set<String>> callersByFunction = new HashMap<>();
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(traceFile.toFile());
+            if (!root.isArray()) {
+                return Map.of();
+            }
+            for (JsonNode entry : root) {
+                JsonNode function = entry.get("function");
+                JsonNode callerClass = entry.get("caller_class");
+                if (function == null || function.isNull() || callerClass == null || callerClass.isNull()) {
+                    continue;
+                }
+                callersByFunction
+                        .computeIfAbsent(function.asText(), ignored -> new LinkedHashSet<>())
+                        .add(callerClass.asText());
+            }
+        } catch (IOException e) {
+            throw new GradleException("Failed to parse native-image-agent trace " + traceFile, e);
+        }
+        return callersByFunction;
+    }
+
+    /// §TCK-test-harness.8: the agent-trace fallback is the only-when-lines-are-absent gate.
+    /// Returns true iff the dynamic-access reports contain at least one library call site and
+    /// every such call site is line-less, so line-based matching can never succeed. Purely
+    /// data-driven — no jar bytecode scanning.
+    public static boolean lineMatchingImpossible(Path dynamicAccessDir, List<Path> libraryJars) {
+        Set<String> libraryClasses = loadLibraryClasses(libraryJars);
+        if (libraryClasses.isEmpty()) {
+            return false;
+        }
+        ParsedDynamicAccess parsed = parseDynamicAccessReports(dynamicAccessDir, libraryClasses, Map.of(), Map.of());
+        if (parsed.dynamicAccessStats().totalCalls() == 0L) {
+            return false;
+        }
+        for (LibraryStatsModels.DynamicAccessClassCoverage classCoverage : parsed.classCoverage()) {
+            for (LibraryStatsModels.DynamicAccessCallSiteCoverage callSite : classCoverage.callSites()) {
+                if (callSite.line() != null) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /// Extracts the bare method name from a tracked-API key such as
+    /// `java.lang.Class#forName(java.lang.String)` -> `forName`, to compare against the agent
+    /// trace's `function` field. Returns null when the key has no `#...(` method segment.
+    private static String methodNameOfTrackedApi(String trackedApi) {
+        int hash = trackedApi.indexOf('#');
+        if (hash < 0) {
+            return null;
+        }
+        int paren = trackedApi.indexOf('(', hash);
+        String method = paren < 0 ? trackedApi.substring(hash + 1) : trackedApi.substring(hash + 1, paren);
+        return method.isBlank() ? null : method;
     }
 
     private static LibraryStatsModels.VersionStats versionStats(
@@ -661,7 +752,8 @@ public final class LibraryStatsSupport {
     private static ParsedDynamicAccess parseDynamicAccessReports(
             Path dynamicAccessDir,
             Set<String> libraryClasses,
-            Map<String, Set<Integer>> coveredLinesBySource
+            Map<String, Set<Integer>> coveredLinesBySource,
+            Map<String, Set<String>> traceCallersByFunction
     ) {
         if (!Files.isDirectory(dynamicAccessDir)) {
             return emptyDynamicAccess();
@@ -674,7 +766,7 @@ public final class LibraryStatsSupport {
                     .filter(Files::isRegularFile)
                     .filter(path -> DYNAMIC_ACCESS_REPORT.matcher(path.getFileName().toString()).matches())
                     .sorted(Comparator.comparing(path -> path.toAbsolutePath().toString()))
-                    .forEach(path -> parseDynamicAccessFile(path, libraryClasses, coveredLinesBySource, callSitesByKey));
+                    .forEach(path -> parseDynamicAccessFile(path, libraryClasses, coveredLinesBySource, traceCallersByFunction, callSitesByKey));
         } catch (IOException e) {
             throw new GradleException("Failed to traverse dynamic access directory " + dynamicAccessDir, e);
         }
@@ -732,6 +824,7 @@ public final class LibraryStatsSupport {
             Path path,
             Set<String> libraryClasses,
             Map<String, Set<Integer>> coveredLinesBySource,
+            Map<String, Set<String>> traceCallersByFunction,
             Map<String, ParsedDynamicAccessCallSite> callSitesByKey
     ) {
         Matcher matcher = DYNAMIC_ACCESS_REPORT.matcher(path.getFileName().toString());
@@ -754,11 +847,22 @@ public final class LibraryStatsSupport {
                     if (callSitesByKey.containsKey(callSiteKey)) {
                         continue;
                     }
+                    // §TCK-test-harness.8: line-based matching is the primary path. Only when a
+                    // frame carries no line number (line-less jar) do we fall back to the agent
+                    // trace: covered = a trace event for the same JDK entry-point method name was
+                    // performed by exactly this caller class. Matching on method name only (not
+                    // owner class) is deliberate; the agent's `function` field is the intercepted
+                    // method name, and cross-owner name collisions at the same caller class are
+                    // acceptable over-attribution.
                     boolean covered = false;
                     if (parsedFrame.lineNumber() != null) {
                         String sourceKey = sourceKey(parsedFrame.className(), parsedFrame.sourceFile());
                         Set<Integer> coveredLines = coveredLinesBySource.get(sourceKey);
                         covered = coveredLines != null && coveredLines.contains(parsedFrame.lineNumber());
+                    } else if (!traceCallersByFunction.isEmpty()) {
+                        String apiMethod = methodNameOfTrackedApi(trackedApi);
+                        Set<String> callers = apiMethod == null ? null : traceCallersByFunction.get(apiMethod);
+                        covered = callers != null && callers.contains(parsedFrame.className());
                     }
                     callSitesByKey.put(
                             callSiteKey,
@@ -797,10 +901,11 @@ public final class LibraryStatsSupport {
             return null;
         }
         String className = matcher.group(1);
+        String methodName = matcher.group(2);
         String sourceFile = matcher.group(3);
         String lineNumberString = matcher.group(4);
         Integer lineNumber = lineNumberString == null ? null : Integer.parseInt(lineNumberString);
-        return new ParsedStackFrame(className, sourceFile, lineNumber);
+        return new ParsedStackFrame(className, methodName, sourceFile, lineNumber);
     }
 
     private static ParsedJacocoReport parseJacocoReport(Path jacocoReport) {
@@ -992,7 +1097,9 @@ public final class LibraryStatsSupport {
         );
     }
 
-    private record ParsedStackFrame(String className, String sourceFile, Integer lineNumber) {
+    /// `methodName` (the caller method) is retained as the designated expansion point for
+    /// per-method agent-trace matching later (§TCK-test-harness.8); v1 matches on caller class.
+    private record ParsedStackFrame(String className, String methodName, String sourceFile, Integer lineNumber) {
     }
 
     private record ParsedDynamicAccess(

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -376,6 +377,117 @@ class LibraryStatsSupportTests {
                 .containsExactly(false, true);
         assertThat(report.classes().get(1).totalCalls()).isEqualTo(2);
         assertThat(report.classes().get(1).coveredCalls()).isEqualTo(1);
+    }
+
+    @Test
+    void agentOriginsMatchDelegatedApiToNearestReportedCaller() throws IOException {
+        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("com/example/Bar.class"));
+        Path dynamicAccessDir = tempDir.resolve("dynamic-access");
+        Files.createDirectories(dynamicAccessDir.resolve("demo"));
+        Files.writeString(
+                dynamicAccessDir.resolve("demo").resolve("resource-calls.json"),
+                """
+                {
+                  "java.lang.Class#getResource(java.lang.String)": [
+                    "com.example.Bar.outer(Unknown Source)",
+                    "com.example.Bar.lookup(Unknown Source)"
+                  ],
+                  "java.lang.ClassLoader#getResource(java.lang.String)": [
+                    "com.example.Bar.lookup(Unknown Source)"
+                  ]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        Path originsFile = tempDir.resolve("reachability-metadata-origins.txt");
+        Files.writeString(
+                originsFile,
+                """
+                {
+                  "resources": root
+                  └── com.example.Bar#outer()
+                      └── com.example.Bar#lookup()
+                          └── java.lang.Class#getResource(java.lang.String)
+                              └── java.lang.ClassLoader#getResource(java.lang.String)
+                                  └── jdk.internal.loader.BuiltinClassLoader#findResource(java.lang.String,java.lang.String) - [{"glob":"demo"}]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(
+                originsFile,
+                dynamicAccessDir,
+                List.of(libraryJar)
+        );
+
+        assertThat(coveredCallSites).containsExactly(new LibraryStatsSupport.AgentCoveredCallSite(
+                "java.lang.Class#getResource(java.lang.String)",
+                "com.example.Bar",
+                "lookup"
+        ));
+
+        LibraryStatsModels.DynamicAccessCoverageReport report = LibraryStatsSupport.buildDynamicAccessCoverageReport(
+                "com.example:demo:1.0.0",
+                List.of(libraryJar),
+                dynamicAccessDir,
+                createJacocoReportWithoutLines(tempDir.resolve("jacoco.xml")),
+                coveredCallSites
+        );
+
+        assertThat(report.totals().totalCalls()).isEqualTo(3);
+        assertThat(report.totals().coveredCalls()).isEqualTo(1);
+        assertThat(report.classes().getFirst().callSites())
+                .filteredOn(LibraryStatsModels.DynamicAccessCallSiteCoverage::covered)
+                .extracting(LibraryStatsModels.DynamicAccessCallSiteCoverage::trackedApi)
+                .containsExactly("java.lang.Class#getResource(java.lang.String)");
+        assertThat(report.classes().getFirst().callSites())
+                .filteredOn(LibraryStatsModels.DynamicAccessCallSiteCoverage::covered)
+                .extracting(LibraryStatsModels.DynamicAccessCallSiteCoverage::frame)
+                .containsExactly("com.example.Bar.lookup(Unknown Source)");
+    }
+
+    @Test
+    void agentOriginsNormalizeTrackedApiParameterSpacing() throws IOException {
+        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("com/example/Foo.class"));
+        Path dynamicAccessDir = tempDir.resolve("dynamic-access");
+        Files.createDirectories(dynamicAccessDir.resolve("demo"));
+        Files.writeString(
+                dynamicAccessDir.resolve("demo").resolve("reflection-calls.json"),
+                """
+                {
+                  "java.lang.reflect.Method#invoke(java.lang.Object, java.lang.Object[])": [
+                    "com.example.Foo.invoke(Unknown Source)"
+                  ]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+        Path originsFile = tempDir.resolve("reachability-metadata-origins.txt");
+        Files.writeString(
+                originsFile,
+                """
+                {
+                  "reflection": root
+                  └── com.example.Foo#invoke()
+                      └── java.lang.reflect.Method#invoke(java.lang.Object,java.lang.Object[]) - [{"type":"com.example.Target"}]
+                }
+                """,
+                StandardCharsets.UTF_8
+        );
+
+        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(
+                originsFile,
+                dynamicAccessDir,
+                List.of(libraryJar)
+        );
+
+        assertThat(coveredCallSites).containsExactly(new LibraryStatsSupport.AgentCoveredCallSite(
+                "java.lang.reflect.Method#invoke(java.lang.Object, java.lang.Object[])",
+                "com.example.Foo",
+                "invoke"
+        ));
     }
 
     @Test
@@ -879,6 +991,21 @@ class LibraryStatsSupportTests {
             }
         }
         return jarPath;
+    }
+
+    private Path createJacocoReportWithoutLines(Path reportPath) throws IOException {
+        Files.writeString(
+                reportPath,
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <report name="demo">
+                  <counter type="INSTRUCTION" missed="1" covered="1"/>
+                  <counter type="METHOD" missed="1" covered="1"/>
+                </report>
+                """,
+                StandardCharsets.UTF_8
+        );
+        return reportPath;
     }
 
     private Path locateRepoFile(String relativePath) throws IOException {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/stats/LibraryStatsSupportTests.java
@@ -416,11 +416,7 @@ class LibraryStatsSupportTests {
                 StandardCharsets.UTF_8
         );
 
-        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(
-                originsFile,
-                dynamicAccessDir,
-                List.of(libraryJar)
-        );
+        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(originsFile, dynamicAccessDir);
 
         assertThat(coveredCallSites).containsExactly(new LibraryStatsSupport.AgentCoveredCallSite(
                 "java.lang.Class#getResource(java.lang.String)",
@@ -450,7 +446,6 @@ class LibraryStatsSupportTests {
 
     @Test
     void agentOriginsNormalizeTrackedApiParameterSpacing() throws IOException {
-        Path libraryJar = createLibraryJar(tempDir.resolve("demo.jar"), List.of("com/example/Foo.class"));
         Path dynamicAccessDir = tempDir.resolve("dynamic-access");
         Files.createDirectories(dynamicAccessDir.resolve("demo"));
         Files.writeString(
@@ -477,11 +472,7 @@ class LibraryStatsSupportTests {
                 StandardCharsets.UTF_8
         );
 
-        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(
-                originsFile,
-                dynamicAccessDir,
-                List.of(libraryJar)
-        );
+        Set<LibraryStatsSupport.AgentCoveredCallSite> coveredCallSites = LibraryStatsSupport.parseAgentOrigins(originsFile, dynamicAccessDir);
 
         assertThat(coveredCallSites).containsExactly(new LibraryStatsSupport.AgentCoveredCallSite(
                 "java.lang.reflect.Method#invoke(java.lang.Object, java.lang.Object[])",


### PR DESCRIPTION
## What this does

Dynamic-access coverage marks a call site covered only when its frame carries a source line that JaCoCo saw executed. Jars compiled without `LineNumberTable` — e.g. `org.hsqldb:hsqldb:2.7.3`, where 0 of 685 classes have one — produce frames like `org.hsqldb.Foo.bar(Unknown Source)` and a line-less JaCoCo report, so coverage is hardwired to **0/N** no matter what the tests exercise. That starved the dynamic-access strategy of guidance and produced misleading PR stats (the closed #8869).

This adds a fallback for exactly that case (§TCK-test-harness.8, [docs/tck.md](docs/tck.md)): when the dynamic-access report has call sites but **none** carries a line number, the harness collects the `native-image-agent` **configuration-origin tree** from a JVM `javaTest` run and matches each statically reported call site against the observed origin paths. Line-based matching stays the primary path and is unchanged for jars with line info.

## How the fallback works

| step | where | what happens |
| --- | --- | --- |
| gate | `LibraryStatsSupport.lineMatchingImpossible` | true iff `totalCalls > 0` and every call site is line-less — data-driven, no per-library config |
| collect | `AbstractLibraryStatsTask.maybeCollectAgentOrigins` | runs the JVM-only `javaTest` lane with `-agentlib:native-image-agent=config-output-dir=...,experimental-configuration-with-origins` (gated by the new `dynamicAccessOriginsOutput` property; JaCoCo disabled for that run); any failure degrades gracefully to today's behaviour |
| candidates | `loadAgentOriginCandidates` | statically reported call sites, taken from the reports as-is (the reports only contain library call sites; the coverage side only consults the result for line-less library frames) |
| match | `parseAgentOrigins` / `matchAgentOriginPath` | streams the compressed origin tree keeping only the current branch in memory; on every configuration-bearing path, a call site is covered when its **exact tracked API** appears on the path with its **caller class#method** above it — nearest caller wins, and a nested tracked API stops the caller walk |
| consume | `parseDynamicAccessFile` | line-less site covered ⇔ its exact `(trackedApi, callerClass, callerMethod)` triple was matched |

Matching on the full origin path is what makes delegated JDK calls attributable: for `Class#getResource` the agent registers the configuration on the delegated `ClassLoader#getResource` frame, so any immediate-caller scheme sees `caller_class=java.lang.Class` and can never credit the library caller. The origin path retains the whole chain (`lib caller → Class#getResource → ClassLoader#getResource[config]`), so the matcher walks up from the tracked API to the nearest reported caller. The walk stopping at nested tracked APIs prevents the reverse error — the delegated `ClassLoader#getResource` hop can never be credited to a caller that actually invoked `Class#getResource`. Matching is per exact tracked-API signature plus caller class **and method**, so coverage cannot leak across APIs sharing a method name or across call sites sharing a class.

Both consumers are wired: `generateDynamicAccessCoverageReport` (strategy guidance) and `computeVersionStats` (published PR stats), so the numbers agree. Existing signatures are untouched; the matched call-site set threads through new overloads defaulting to `Set.of()`.

## What it changes in practice

- `org.hsqldb:hsqldb:2.7.3`: **0/82 → 63/82** in a full Forge run (#9010), including every delegated-resource call site the generated tests exercise — e.g. `Class#getResource ← org.hsqldb.lib.FileAccessRes.isStreamElement` and the deep `ResourceBundle#getBundle ← ResourceBundleHandler.getBundle` chain whose configuration lands 20+ frames down in `ServiceLoader` machinery.
- Precision spot-check: `Method#invoke ← ResourceBundleHandler.getBundle` (same caller method, unfired API) correctly stays uncovered.
- Regression tests: a realistic delegated `Class#getResource` origin fixture asserts nearest-caller attribution and the nested-tracked-API guard (`agentOriginsMatchDelegatedApiToNearestReportedCaller`), plus tracked-API parameter-spacing normalization.
- Jars with line info are untouched: the agent run and origin matching only ever start when line matching is impossible.
