### PR TITLE
[GenAI] Mark com.netflix.graphql.dgs:dgs-starter as not for Native Image

### DIFF
--- a/metadata/com.netflix.graphql.dgs/dgs-starter/index.json
+++ b/metadata/com.netflix.graphql.dgs/dgs-starter/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #8963

This PR records `com.netflix.graphql.dgs:dgs-starter` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `06e0749caf489d876a88bdab80347b0e5ab86a32`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
