### PR TITLE
Ensure zero-call javac fixes run normal metadata finalization

### DIFF
--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -505,7 +505,13 @@ class WorkflowStrategy(ABC):
     def _finalize_successful_iteration(self, base_commit: str | None = None) -> tuple[str, str | None]:
         """Generate metadata, run follow-up Gradle tasks, and commit the iteration."""
         log_stage("generate-metadata", f"Running generateMetadata for {self.library}")
-        self._run_command(f"./gradlew generateMetadata -Pcoordinates={self.library} --agentAllowedPackages=fromJar")
+        if not self._run_gradle_command([
+            "./gradlew",
+            "generateMetadata",
+            f"-Pcoordinates={self.library}",
+            "--agentAllowedPackages=fromJar",
+        ]):
+            return RUN_STATUS_FAILURE, None
         final_status = RUN_STATUS_SUCCESS
         finalization_libraries = self._finalization_libraries()
         for library in finalization_libraries:

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -506,6 +506,13 @@ resort before the run fails. Native tracing is **not** part of finalization —
 it runs earlier, in the per-class native test verification gate (§6.4,
 §WF-native-test-verification-gate), which is where missing reachability
 metadata is collected from a real native run.
+Finalization must run `generateMetadata` even when the initial dynamic-access
+
+report is unavailable or reports zero calls. Those report states do not prove
+that the library or its transitive dependencies need no metadata. A failed
+`generateMetadata` task is a hard finalization failure: Forge must not continue
+to testing, validation, or stats collection with a missing metadata artifact.
+
 
 The `--keep-tests-without-dynamic-access` flag is the only mechanism for
 producing a successful run when no class achieved coverage gain. It is

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -137,7 +137,7 @@ class WorkflowStrategyTests(unittest.TestCase):
             finalized_libraries.append(kwargs["library"])
             return True
 
-        with patch.object(strategy, "_run_command"), \
+        with patch.object(strategy, "_run_gradle_command", return_value=True), \
                 patch.object(
                     strategy,
                     "_run_test_with_retry",
@@ -157,6 +157,26 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(checkpoint, "checkpoint")
         self.assertEqual(tested_libraries, expected_libraries)
         self.assertEqual(finalized_libraries, expected_libraries)
+
+    def test_finalize_successful_iteration_stops_when_metadata_generation_fails(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+
+        strategy.library = "org.example:demo:1.0.0"
+        with patch.object(strategy, "_run_gradle_command", return_value=False), \
+                patch.object(strategy, "_run_test_with_retry") as run_test, \
+                patch("ai_workflows.core.workflow_strategy.run_library_finalization") as finalization, \
+                patch.object(strategy, "_commit_library_iteration") as commit:
+            status, checkpoint = strategy._finalize_successful_iteration()
+
+        self.assertEqual(status, RUN_STATUS_FAILURE)
+        self.assertIsNone(checkpoint)
+        run_test.assert_not_called()
+        finalization.assert_not_called()
+        commit.assert_not_called()
 
     def test_finalize_run_merges_finalization_status_for_all_driver_cases(self) -> None:
         strategy = _TestWorkflowStrategy(


### PR DESCRIPTION
## Summary

- make final metadata generation failures explicit instead of allowing a later confusing validation failure
- document that unavailable or zero-call dynamic-access reports still follow normal metadata generation and stats collection
- add regression coverage for failed final metadata generation

## Follow-up in this draft

The remaining work is a workflow-level regression test proving that a successful javac repair with zero detected dynamic-access calls reaches normal finalization (`generateMetadata`, validation, and `generateLibraryStats`). Issue #8848 indicates that the failing run did not reach that path.

## Verification

- `cd forge && PYTHONPATH=$PWD python3 -m unittest tests.test_workflow_strategy`
- `cd forge && grund check` remains blocked by existing workspace configuration diagnostics: outdated init block and unknown `root` project alias.

Fixes #9022