### PR TITLE
Handle Maven relocations during metadata finalization

### DIFF
--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -5,13 +5,16 @@
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 import groovy.json.JsonSlurper
+import org.graalvm.internal.tck.Coordinates
 import org.graalvm.internal.tck.utils.DynamicAccessUtils
+import org.graalvm.internal.tck.utils.MetadataGenerationUtils
 import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import org.graalvm.buildtools.gradle.tasks.NativeRunTask
 import org.gradle.api.tasks.PathSensitivity
 
+import java.nio.file.Path
 import java.util.jar.JarFile
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -311,38 +314,40 @@ dependencies {
 }
 
 Closure<List<File>> resolveTestedLibraryJars = {
-    String targetGroup = ""
-    String targetArtifact = ""
-    String targetVersion = ""
-    def coordsParts = (libraryGAV ?: "").split(":")
-    if (coordsParts.length >= 3) {
-        targetGroup = coordsParts[0]
-        targetArtifact = coordsParts[1]
-        targetVersion = coordsParts[2]
+    if (libraryGAV == null || libraryGAV.isBlank()) {
+        throw new GradleException("No eligible artifacts found on the classpath for ${libraryGAV}.\nPlease verify that the provided artifact exists.")
+    }
+    try {
+        List<File> libraryJars = MetadataGenerationUtils.resolveLibraryJars(
+                project,
+                Coordinates.parse(libraryGAV)
+        ).collect { Path path -> path.toFile() }
+        if (!libraryJars.isEmpty()) {
+            return libraryJars.sort { File file -> file.absolutePath }
+        }
+    } catch (IOException exception) {
+        throw new GradleException("Failed to resolve library JARs for ${libraryGAV}.", exception)
     }
 
+    // Preserve compatibility with wrapper/substitution POMs that expose the tested JAR only
+    // through the resolved test runtime classpath and do not declare Maven relocation metadata.
+    String[] coordinates = libraryGAV.split(":")
+    String targetGroup = coordinates.length >= 1 ? coordinates[0] : ""
+    String targetArtifact = coordinates.length >= 2 ? coordinates[1] : ""
+    String targetVersion = coordinates.length >= 3 ? coordinates[2] : ""
     def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
     Set<File> matched = new LinkedHashSet<>(artifacts.findAll { artifact ->
         (artifact.moduleVersion.id.group == targetGroup) && (artifact.moduleVersion.id.name == targetArtifact)
-    }.collect { artifact ->
-        artifact.file
-    })
-
+    }.collect { artifact -> artifact.file })
     if (matched.isEmpty()) {
-        // Fallback for relocated or substituted modules: the requested G:A coordinates may resolve
-        // to a different group in published metadata, so no resolved artifact carries the original group.
         matched.addAll(artifacts.findAll { artifact ->
             (artifact.moduleVersion.id.name == targetArtifact) && (artifact.moduleVersion.id.version == targetVersion)
-        }.collect { artifact ->
-            artifact.file
-        })
+        }.collect { artifact -> artifact.file })
     }
-
-    if (matched.isEmpty()) {
-        throw new GradleException("No eligible artifacts found on the classpath for ${libraryGAV}.\nPlease verify that the provided artifact exists.")
+    if (!matched.isEmpty()) {
+        return matched.toList().sort { File file -> file.absolutePath }
     }
-
-    return matched.toList().sort { File file -> file.absolutePath }
+    throw new GradleException("No eligible artifacts found on the classpath for ${libraryGAV}.\nPlease verify that the provided artifact exists.")
 }
 
 tasks.register("listLibraryJars") { task ->

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -28,6 +28,9 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.process.ExecOperations;
 import org.gradle.util.internal.VersionNumber;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,6 +50,10 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.xml.sax.SAXException;
 
 /**
  * Static utility class for operations shared by metadata-generation tasks.
@@ -93,40 +100,13 @@ public final class MetadataGenerationUtils {
     }
 
     /**
-     * Resolves the binary JAR for the given coordinates and derives minimal package roots.
+     * Resolves the selected binary JAR for the given coordinates and derives minimal package roots.
+     *
+     * <p>When a Maven coordinate is a relocation POM rather than a JAR, resolve its declared
+     * relocation target. Ordinary transitive dependencies are deliberately not considered.</p>
      */
     public static List<String> derivePackageRootsFromJar(Project project, Coordinates coordinates) throws IOException {
-        DependencyHandler dependencies = project.getDependencies();
-        Configuration configuration = project.getConfigurations().detachedConfiguration(
-                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version())
-        );
-        configuration.setTransitive(false);
-        configuration.attributes(attributes -> {
-            attributes.attribute(
-                    Category.CATEGORY_ATTRIBUTE,
-                    project.getObjects().named(Category.class, Category.LIBRARY)
-            );
-            attributes.attribute(
-                    Bundling.BUNDLING_ATTRIBUTE,
-                    project.getObjects().named(Bundling.class, Bundling.EXTERNAL)
-            );
-            attributes.attribute(
-                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                    project.getObjects().named(LibraryElements.class, LibraryElements.JAR)
-            );
-            attributes.attribute(
-                    Usage.USAGE_ATTRIBUTE,
-                    project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME)
-            );
-            attributes.attribute(
-                    TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
-                    project.getObjects().named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM)
-            );
-        });
-
-        List<Path> jars = configuration.resolve().stream()
-                .map(file -> file.toPath().toAbsolutePath())
-                .toList();
+        List<Path> jars = resolveLibraryJars(project, coordinates);
 
         if (jars.isEmpty()) {
             throw new GradleException("Failed to resolve JAR for " + coordinates);
@@ -142,6 +122,80 @@ public final class MetadataGenerationUtils {
 
         project.getLogger().log(LogLevel.INFO, "Derived package roots for {}: {}", coordinates, roots);
         return roots;
+    }
+
+    /**
+     * Resolves binary JARs for a library coordinate, following any declared Maven relocations.
+     */
+    public static List<Path> resolveLibraryJars(Project project, Coordinates coordinates) throws IOException {
+        Coordinates currentCoordinates = coordinates;
+        Set<String> resolvedCoordinates = new LinkedHashSet<>();
+        while (resolvedCoordinates.add(currentCoordinates.toString())) {
+            List<Path> jars = resolveBinaryJars(project, currentCoordinates);
+            if (!jars.isEmpty()) {
+                return jars;
+            }
+            Coordinates relocatedCoordinates = resolveRelocationTarget(project, currentCoordinates);
+            if (relocatedCoordinates == null) {
+                return List.of();
+            }
+            currentCoordinates = relocatedCoordinates;
+        }
+        throw new GradleException("Circular Maven relocation for " + coordinates);
+    }
+
+    private static List<Path> resolveBinaryJars(Project project, Coordinates coordinates) {
+        DependencyHandler dependencies = project.getDependencies();
+        Configuration configuration = project.getConfigurations().detachedConfiguration(
+                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version())
+        );
+        configuration.setTransitive(false);
+        configuration.attributes(attributes -> {
+            attributes.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.LIBRARY));
+            attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
+            attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.getObjects().named(LibraryElements.class, LibraryElements.JAR));
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+            attributes.attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.getObjects().named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM));
+        });
+        return configuration.resolve().stream().map(file -> file.toPath().toAbsolutePath()).toList();
+    }
+
+    private static Coordinates resolveRelocationTarget(Project project, Coordinates coordinates) throws IOException {
+        DependencyHandler dependencies = project.getDependencies();
+        Configuration configuration = project.getConfigurations().detachedConfiguration(
+                dependencies.create(coordinates.group() + ":" + coordinates.artifact() + ":" + coordinates.version() + "@pom")
+        );
+        configuration.setTransitive(false);
+        File pom = configuration.resolve().stream().findFirst().orElse(null);
+        if (pom == null) {
+            return null;
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Document document = factory.newDocumentBuilder().parse(pom);
+            NodeList relocations = document.getElementsByTagNameNS("*", "relocation");
+            if (relocations.getLength() == 0) {
+                return null;
+            }
+            Element relocation = (Element) relocations.item(0);
+            String group = relocationValue(relocation, "groupId", coordinates.group());
+            String artifact = relocationValue(relocation, "artifactId", coordinates.artifact());
+            String version = relocationValue(relocation, "version", coordinates.version());
+            return Coordinates.parse(group + ":" + artifact + ":" + version);
+        } catch (ParserConfigurationException | SAXException exception) {
+            throw new IOException("Failed to read relocation POM for " + coordinates, exception);
+        }
+    }
+
+    private static String relocationValue(Element relocation, String name, String defaultValue) {
+        NodeList values = relocation.getElementsByTagNameNS("*", name);
+        if (values.getLength() == 0) {
+            return defaultValue;
+        }
+        String value = values.item(0).getTextContent().trim();
+        return value.isEmpty() ? defaultValue : value;
     }
 
     /**

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -20,6 +20,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -298,6 +300,50 @@ class MetadataGenerationUtilsTests {
                 .containsExactly("io_grpc.grpc_auth");
     }
 
+    @Test
+    void derivePackageRootsFromJarFollowsMavenRelocationWithoutIncludingDependencies() throws IOException {
+        Path repository = tempDir.resolve("repository");
+        writePom(
+                repository.resolve("com/example/legacy-library/1.0.0/legacy-library-1.0.0.pom"),
+                """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>legacy-library</artifactId>
+                  <version>1.0.0</version>
+                  <distributionManagement>
+                    <relocation>
+                      <artifactId>library</artifactId>
+                    </relocation>
+                  </distributionManagement>
+                </project>
+                """
+        );
+        writePom(
+                repository.resolve("com/example/library/1.0.0/library-1.0.0.pom"),
+                """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>library</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """
+        );
+        writeJar(
+                repository.resolve("com/example/library/1.0.0/library-1.0.0.jar"),
+                "com/relocated/Library.class"
+        );
+
+        Project project = createProject();
+        project.getRepositories().maven(repositoryHandler -> repositoryHandler.setUrl(repository.toUri()));
+
+        assertThat(MetadataGenerationUtils.derivePackageRootsFromJar(
+                project,
+                Coordinates.parse("com.example:legacy-library:1.0.0")
+        )).containsExactly("com.relocated");
+    }
+
     private Project createProject() {
         return ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
@@ -307,6 +353,20 @@ class MetadataGenerationUtilsTests {
     private void writeSource(Path file, String content) throws IOException {
         Files.createDirectories(file.getParent());
         Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
+    }
+
+    private void writePom(Path file, String content) throws IOException {
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
+    }
+
+    private void writeJar(Path file, String entry) throws IOException {
+        Files.createDirectories(file.getParent());
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(file))) {
+            output.putNextEntry(new JarEntry(entry));
+            output.write(new byte[]{0});
+            output.closeEntry();
+        }
     }
 
     private void writeIndex(String group, String artifact, String content) throws IOException {


### PR DESCRIPTION
## Summary

Fixes [#9024](https://github.com/oracle/graalvm-reachability-metadata/issues/9024), discovered while processing [#8848](https://github.com/oracle/graalvm-reachability-metadata/issues/8848).

Some Maven coordinates resolve to relocation POMs instead of binary JARs. For example, `io.github.pdvrieze.xmlutil:core-jvmcommon:1.0.0` relocates to `io.github.pdvrieze.xmlutil:core-jvm:1.0.0`. Normal Gradle test dependency resolution follows this relocation, but metadata `fromJar` resolution and stats JAR lookup previously searched only for the original artifact.

This caused finalization to stop with `Failed to resolve JAR` during metadata generation, or `No eligible artifacts found` during stats generation, even though compilation and tests could pass.

## Changes

- Follow Maven relocation POMs when resolving binary JARs.
- Reuse the relocation-aware resolver for stats and `listLibraryJars`.
- Keep resolution non-transitive so unrelated dependencies are not included.
- Retain the resolved-runtime-classpath fallback for wrapper/substitution POMs that do not declare standard Maven relocation metadata.
- Add regression coverage for relocation with omitted group/version values.

## Validation

- Focused `MetadataGenerationUtilsTests` pass.
- Build logic compiles and `git diff --check` passes.
- The relocated example was validated locally with metadata generation, stats generation, `-H:TrackDynamicAccess` using the resolved target JAR, and the complete targeted native test.

Closes #9024