### PR TITLE
Make post-success publication failures resumable

### DIFF
--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -182,13 +182,24 @@ Continuation does not change the human-intervention contract
 (§FS-human-intervention-policy). A logical failure still preserves the work
 branch and labels the issue `human-intervention`, so a maintainer always retains
 the existing safety signal and diagnostics. This holds even when the failure
-halts the worktree mid-rebase — for example a publication `git rebase` that stops
-on an `index.json` conflict from a sibling same-artifact PR that landed while the
-run was in flight: preservation first aborts any in-progress rebase so the
-generated tree still commits to the preserved branch instead of the branch being
-silently dropped. The marker rides that same preserved
-branch, giving a later automated run — or the maintainer — a precise place to
-continue. A repeated failure in the same resumed phase only removes
+halts the worktree mid-rebase, in either publication rebase mode: the rebase
+*starts* and then stops on an `index.json` conflict from a sibling same-artifact
+PR that landed while the run was in flight, or the rebase *refuses to start*
+because the worktree carries changes outside the narrowly staged expected paths
+(§GIT-expected-paths). Preservation first aborts any in-progress rebase — a no-op
+in the refuse-to-start mode, where no sequencer state exists — then commits the
+generated tree (including those unstaged changes) to the preserved branch, so the
+branch is never silently dropped. The marker rides that same preserved branch,
+giving a later automated run — or the maintainer — a precise place to continue.
+
+Because publication runs only after the workflow has already produced a
+PR-eligible result, a publication failure carries a *successful* workflow status
+and therefore no generation-analysis candidate. Forge still labels the issue
+`human-intervention` and `resumable` whenever the preserved branch carries a
+continuation marker, rather than treating the successful workflow status as a
+non-failure and reverting the issue to `Todo` with the marker orphaned: the
+`resumable` label is the precondition resume discovery requires (§3). A repeated
+failure in the same resumed phase only removes
 `resumable`; it leaves the earlier `human-intervention` signal and comment in
 place instead of adding another report. External or transient failures take no
 issue action and write no marker, exactly as today.

--- a/forge/docs/continuation.md
+++ b/forge/docs/continuation.md
@@ -195,11 +195,13 @@ giving a later automated run — or the maintainer — a precise place to contin
 Because publication runs only after the workflow has already produced a
 PR-eligible result, a publication failure carries a *successful* workflow status
 and therefore no generation-analysis candidate. Forge still labels the issue
-`human-intervention` and `resumable` whenever the preserved branch carries a
-continuation marker, rather than treating the successful workflow status as a
-non-failure and reverting the issue to `Todo` with the marker orphaned: the
-`resumable` label is the precondition resume discovery requires (§3). A repeated
-failure in the same resumed phase only removes
+`human-intervention` and `resumable` when the preserved branch carries a
+continuation marker whose authoritative `continueFrom` is `publication`, rather
+than treating the successful workflow status as a non-failure and reverting the
+issue to `Todo` with the marker orphaned. Markers for earlier phases do not
+trigger this publication-specific fallback. The `resumable` label is the
+precondition resume discovery requires (§3). A repeated failure in the same
+resumed phase only removes
 `resumable`; it leaves the earlier `human-intervention` signal and comment in
 place instead of adding another report. External or transient failures take no
 issue action and write no marker, exactly as today.

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4660,6 +4660,24 @@ def maybe_apply_human_intervention_follow_up(
     return True
 
 
+def _build_finalization_failure_comment(claimed_issue: ClaimedIssue) -> str:
+    """Explain a post-success finalization/publication failure for maintainers.
+
+    The workflow produced a PR-ready result, so there is no generation gap to
+    analyze; publication simply did not complete. The preserved branch carries a
+    continuation marker, so this issue is resumable. §FS-forge-run-continuation
+    """
+    return (
+        f"Automated generation for `{claimed_issue.issue_coordinates}` completed, but "
+        "publishing the pull request did not finish during finalization (for example a "
+        "publication `git rebase` that could not complete on the work branch). The "
+        "generated work and a continuation marker are preserved on the branch below, so "
+        f"a later Forge run can resume from the publication phase; the `{LABEL_RESUMABLE}` "
+        "label marks it for that resume. A maintainer can also finish publication "
+        "manually from the preserved branch."
+    )
+
+
 def apply_failed_run_follow_up(
         claimed_issue: ClaimedIssue,
         started_at: float | None = None,
@@ -4668,7 +4686,9 @@ def apply_failed_run_follow_up(
     """Run Codex failure analysis and apply the `human-intervention` follow-up.
 
     Only reached for logical failures; external failures are released upstream
-    without any issue action. §FS-human-intervention-policy
+    without any issue action. A successful workflow that fails during
+    finalization/publication carries no analysis candidate but still preserves a
+    continuation marker, so it is labeled resumable. §FS-human-intervention-policy
     """
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
@@ -4678,6 +4698,23 @@ def apply_failed_run_follow_up(
         workflow_success=False,
     )
     if candidate is None:
+        # No generation-analysis candidate normally means a non-library issue or a
+        # workflow that never produced coverage to analyze. But a *successful*
+        # workflow that fails only during finalization or publication — whether the
+        # publication `git rebase` halts mid-sequence on a conflict (aborted) or
+        # refuses a dirty worktree before it starts (failed) — still preserves a
+        # continuation marker on the work branch. Label it human-intervention +
+        # resumable so a later run can resume the publication phase instead of
+        # orphaning the marker. §FS-forge-run-continuation §FS-human-intervention-policy
+        if preservation_result_has_continuation_marker(preservation_result):
+            post_human_intervention_comment_and_label(
+                claimed_issue.issue["number"],
+                ensure_preserved_branch_link_in_comment(
+                    _build_finalization_failure_comment(claimed_issue),
+                    preservation_result,
+                ),
+                resumable=True,
+            )
         return
 
     try:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4621,6 +4621,17 @@ def preservation_result_has_continuation_marker(preservation_result: FailurePres
     return os.path.isfile(continuation_marker_path(preservation_result.reviewable_worktree_path))
 
 
+def load_preservation_result_continuation_marker(
+        preservation_result: FailurePreservationResult | None,
+) -> ContinuationMarker | None:
+    """Load the continuation marker carried by preserved work."""
+    if preservation_result is None or preservation_result.reviewable_worktree_path is None:
+        return None
+    return load_continuation_marker(
+        continuation_marker_path(preservation_result.reviewable_worktree_path),
+    )
+
+
 def maybe_apply_human_intervention_follow_up(
         claimed_issue: ClaimedIssue,
         workflow_success: bool = True,
@@ -4698,15 +4709,11 @@ def apply_failed_run_follow_up(
         workflow_success=False,
     )
     if candidate is None:
-        # No generation-analysis candidate normally means a non-library issue or a
-        # workflow that never produced coverage to analyze. But a *successful*
-        # workflow that fails only during finalization or publication — whether the
-        # publication `git rebase` halts mid-sequence on a conflict (aborted) or
-        # refuses a dirty worktree before it starts (failed) — still preserves a
-        # continuation marker on the work branch. Label it human-intervention +
-        # resumable so a later run can resume the publication phase instead of
-        # orphaning the marker. §FS-forge-run-continuation §FS-human-intervention-policy
-        if preservation_result_has_continuation_marker(preservation_result):
+        marker = load_preservation_result_continuation_marker(preservation_result)
+        # A successful workflow that fails during publication has no generation-analysis
+        # candidate. Gate this fallback on the authoritative marker phase so earlier
+        # workflow failures are not presented as PR-ready. §FS-forge-run-continuation.2
+        if marker is not None and marker.continue_from == PHASE_PUBLICATION:
             post_human_intervention_comment_and_label(
                 claimed_issue.issue["number"],
                 ensure_preserved_branch_link_in_comment(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -13,6 +13,12 @@ from unittest.mock import call, patch
 
 import forge_metadata
 from git_scripts import common_git
+from utility_scripts.continuation_marker import (
+    PHASE_EXPLORE,
+    PHASE_FINALIZATION,
+    PHASE_PUBLICATION,
+    PHASE_SETUP,
+)
 from utility_scripts.fixture_github import FixtureGitHubState, FixtureIssue
 from utility_scripts.dynamic_access_report import DynamicAccessClass, DynamicAccessCoverageReport
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
@@ -2564,6 +2570,78 @@ class EnvironmentValidationTests(unittest.TestCase):
             call(forge_metadata.POST_GENERATION_GRAALVM_ENV_VAR),
             call(forge_metadata.LATEST_EA_GRAALVM_ENV_VAR),
         ])
+
+
+class FailedRunFollowUpTests(unittest.TestCase):
+    def test_publication_marker_applies_publication_failure_follow_up(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_JAVAC_FAIL)
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            marker = forge_metadata.ContinuationMarker.create(
+                strategy_name="strategy",
+                issue_number=1412,
+                label=claimed_issue.label,
+                coordinate=claimed_issue.issue_coordinates,
+                new_version=None,
+            )
+            marker.mark_setup_done(skip_fix_phase=True)
+            marker.mark_phase_skipped(PHASE_EXPLORE)
+            marker.mark_phase_completed(PHASE_FINALIZATION)
+            self.assertEqual(marker.continue_from, PHASE_PUBLICATION)
+            marker.save(forge_metadata.continuation_marker_path(repo_path))
+            preservation_result = forge_metadata.FailurePreservationResult(
+                branch_name="ai/test/preserved",
+                branch_url="https://github.com/oracle/graalvm-reachability-metadata/tree/ai/test/preserved",
+                committed_changes=True,
+                reviewable_worktree_path=repo_path,
+            )
+
+            with patch.object(forge_metadata, "resolve_human_intervention_candidate", return_value=None), \
+                    patch.object(
+                        forge_metadata,
+                        "post_human_intervention_comment_and_label",
+                    ) as post_follow_up:
+                forge_metadata.apply_failed_run_follow_up(
+                    claimed_issue,
+                    preservation_result=preservation_result,
+                )
+
+        post_follow_up.assert_called_once()
+        self.assertEqual(post_follow_up.call_args.args[0], 1412)
+        self.assertIn("publishing the pull request did not finish", post_follow_up.call_args.args[1])
+        self.assertEqual(post_follow_up.call_args.kwargs, {"resumable": True})
+
+    def test_setup_marker_does_not_apply_publication_failure_follow_up(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_JAVAC_FAIL)
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            marker = forge_metadata.ContinuationMarker.create(
+                strategy_name="strategy",
+                issue_number=1412,
+                label=claimed_issue.label,
+                coordinate=claimed_issue.issue_coordinates,
+                new_version=None,
+            )
+            self.assertEqual(marker.continue_from, PHASE_SETUP)
+            marker.save(forge_metadata.continuation_marker_path(repo_path))
+            preservation_result = forge_metadata.FailurePreservationResult(
+                branch_name="ai/test/preserved",
+                branch_url="https://github.com/oracle/graalvm-reachability-metadata/tree/ai/test/preserved",
+                committed_changes=True,
+                reviewable_worktree_path=repo_path,
+            )
+
+            with patch.object(forge_metadata, "resolve_human_intervention_candidate", return_value=None), \
+                    patch.object(
+                        forge_metadata,
+                        "post_human_intervention_comment_and_label",
+                    ) as post_follow_up:
+                forge_metadata.apply_failed_run_follow_up(
+                    claimed_issue,
+                    preservation_result=preservation_result,
+                )
+
+        post_follow_up.assert_not_called()
 
 
 class InterruptHandlingTests(unittest.TestCase):


### PR DESCRIPTION
## What this does

A workflow that succeeds but then fails during finalization/publication (e.g. the publication `git rebase` refusing a dirty worktree, as happened twice for issue #7760 with `io.fabric8:kubernetes-client:7.5.2`) currently reverts the issue to `Todo` with **no labels at all** — even though the failed work and its continuation marker were pushed to a preservation branch. The marker is orphaned: resume discovery requires the `resumable` label (§FS-forge-run-continuation.3), so no later run can ever pick the work back up, and each retry regenerates everything from scratch.

The gap is a classification mismatch in `apply_failed_run_follow_up`: it resolves the human-intervention candidate from the *workflow* status in `.pending_metrics.json`, which is `success` for a run that only failed at publication — so it returns without labeling anything.

## How the follow-up now behaves

When no generation-analysis candidate exists but the preserved branch carries a continuation marker, the follow-up:

- posts a deterministic comment (no agent analysis — the workflow succeeded, there is no generation gap to analyze) explaining that publication did not finish and linking the preserved branch,
- applies `human-intervention` + `resumable`, so publication-phase resume (§FS-forge-run-continuation.1) can find the branch.

`docs/continuation.md` §4 now states this contract explicitly, including both publication-rebase failure modes: a rebase that starts and halts on a conflict, and one that refuses to start on a dirty worktree (changes outside the narrowly staged expected paths, §GIT-expected-paths). External failures and runs without a marker keep today's behavior — silent release for retry (§FS-human-intervention-policy).