### PR TITLE
Add Codex fallback for metadata validation

### DIFF
--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -245,7 +245,8 @@ re-implement the status merge at their call sites.
 Per-coordinate finalization repairs missing `allowed-packages`
 deterministically. If `checkMetadataFiles` still fails, Forge runs up to three
 Codex metadata fix and validation attempts before failing the run. Each Codex
-invocation is limited to 20 minutes.
+invocation is limited to 20 minutes, and its combined output is written to a
+printed coordinate-scoped metadata-fix log path (§FS-durable-generation-logs).
 
 Run metrics flow through the shared writer
 (`metrics_writer.write_workflow_run_metrics`): it appends the run entry to the

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -242,6 +242,11 @@ finalization succeeds, otherwise the finalization status becomes the run
 status. Drivers must not call the private finalization internals and must not
 re-implement the status merge at their call sites.
 
+Per-coordinate finalization repairs missing `allowed-packages`
+deterministically. If `checkMetadataFiles` still fails, Forge runs one Codex
+metadata fix, then reruns test-only metadata splitting and validation before
+failing the run.
+
 Run metrics flow through the shared writer
 (`metrics_writer.write_workflow_run_metrics`): it appends the run entry to the
 execution-metrics store (or to the local fallback file named by the driver's

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -243,9 +243,8 @@ status. Drivers must not call the private finalization internals and must not
 re-implement the status merge at their call sites.
 
 Per-coordinate finalization repairs missing `allowed-packages`
-deterministically. If `checkMetadataFiles` still fails, Forge runs one Codex
-metadata fix, then reruns test-only metadata splitting and validation before
-failing the run.
+deterministically. If `checkMetadataFiles` still fails, Forge runs up to three
+Codex metadata fix and validation attempts before failing the run.
 
 Run metrics flow through the shared writer
 (`metrics_writer.write_workflow_run_metrics`): it appends the run entry to the

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -244,7 +244,8 @@ re-implement the status merge at their call sites.
 
 Per-coordinate finalization repairs missing `allowed-packages`
 deterministically. If `checkMetadataFiles` still fails, Forge runs up to three
-Codex metadata fix and validation attempts before failing the run.
+Codex metadata fix and validation attempts before failing the run. Each Codex
+invocation is limited to 20 minutes.
 
 Run metrics flow through the shared writer
 (`metrics_writer.write_workflow_run_metrics`): it appends the run entry to the

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -32,54 +32,6 @@ def _commit_all(repo_path: str, message: str) -> str:
 
 
 class LibraryFinalizationTests(unittest.TestCase):
-    def test_runs_codex_once_when_metadata_validation_fails(self) -> None:
-        with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True) as gradle, \
-                patch(
-                    "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
-                    side_effect=[False, True],
-                ) as check_metadata, \
-                patch(
-                    "utility_scripts.library_finalization._run_codex_check_metadata_fix",
-                    return_value=True,
-                ) as codex, \
-                patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True):
-            result = run_library_finalization(
-                repo_path=os.getcwd(),
-                library="org.example:demo:1.0.0",
-                group="org.example",
-                artifact="demo",
-                library_version="1.0.0",
-            )
-
-        self.assertTrue(result)
-        self.assertEqual(check_metadata.call_count, 2)
-        codex.assert_called_once_with(os.getcwd(), "org.example:demo:1.0.0")
-        self.assertEqual(gradle.call_count, 3)
-
-    def test_fails_when_codex_cannot_fix_metadata_validation(self) -> None:
-        with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
-                patch(
-                    "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
-                    return_value=False,
-                ) as check_metadata, \
-                patch(
-                    "utility_scripts.library_finalization._run_codex_check_metadata_fix",
-                    return_value=False,
-                ) as codex, \
-                patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks:
-            result = run_library_finalization(
-                repo_path=os.getcwd(),
-                library="org.example:demo:1.0.0",
-                group="org.example",
-                artifact="demo",
-                library_version="1.0.0",
-            )
-
-        self.assertFalse(result)
-        check_metadata.assert_called_once()
-        codex.assert_called_once()
-        style_checks.assert_not_called()
-
     def test_rejects_legacy_test_resource_native_image_config_after_split(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             _git(repo_path, "init")

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -39,8 +39,7 @@ class LibraryFinalizationTests(unittest.TestCase):
                     side_effect=[False, True],
                 ) as check_metadata, \
                 patch(
-                    "ai_workflows.core.fix_metadata_codex.run_codex_metadata_fix",
-                    return_value=(0, "codex.log", False),
+                    "ai_workflows.agents.codex_agent.CodexAgent",
                 ) as codex, \
                 patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True):
             result = run_library_finalization(
@@ -54,10 +53,12 @@ class LibraryFinalizationTests(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(check_metadata.call_count, 2)
         codex.assert_called_once_with(
-            os.getcwd(),
-            "org.example:demo:1.0.0",
-            reproduction_command="./gradlew checkMetadataFiles -Pcoordinates=org.example:demo:1.0.0",
+            model_name="gpt-5.6-terra",
+            working_dir=os.getcwd(),
+            task_type="check-metadata-files",
+            library="org.example:demo:1.0.0",
         )
+        codex.return_value.send_prompt.assert_called_once()
         self.assertEqual(gradle.call_count, 3)
 
     def test_fails_when_codex_cannot_fix_metadata_validation(self) -> None:
@@ -67,10 +68,10 @@ class LibraryFinalizationTests(unittest.TestCase):
                     return_value=False,
                 ) as check_metadata, \
                 patch(
-                    "ai_workflows.core.fix_metadata_codex.run_codex_metadata_fix",
-                    return_value=(1, "codex.log", False),
+                    "ai_workflows.agents.codex_agent.CodexAgent",
                 ) as codex, \
                 patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks:
+            codex.return_value.send_prompt.side_effect = RuntimeError("failed")
             result = run_library_finalization(
                 repo_path=os.getcwd(),
                 library="org.example:demo:1.0.0",

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -32,6 +32,58 @@ def _commit_all(repo_path: str, message: str) -> str:
 
 
 class LibraryFinalizationTests(unittest.TestCase):
+    def test_runs_codex_once_when_metadata_validation_fails(self) -> None:
+        with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True) as gradle, \
+                patch(
+                    "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
+                    side_effect=[False, True],
+                ) as check_metadata, \
+                patch(
+                    "ai_workflows.core.fix_metadata_codex.run_codex_metadata_fix",
+                    return_value=(0, "codex.log", False),
+                ) as codex, \
+                patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True):
+            result = run_library_finalization(
+                repo_path=os.getcwd(),
+                library="org.example:demo:1.0.0",
+                group="org.example",
+                artifact="demo",
+                library_version="1.0.0",
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(check_metadata.call_count, 2)
+        codex.assert_called_once_with(
+            os.getcwd(),
+            "org.example:demo:1.0.0",
+            reproduction_command="./gradlew checkMetadataFiles -Pcoordinates=org.example:demo:1.0.0",
+        )
+        self.assertEqual(gradle.call_count, 3)
+
+    def test_fails_when_codex_cannot_fix_metadata_validation(self) -> None:
+        with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
+                patch(
+                    "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
+                    return_value=False,
+                ) as check_metadata, \
+                patch(
+                    "ai_workflows.core.fix_metadata_codex.run_codex_metadata_fix",
+                    return_value=(1, "codex.log", False),
+                ) as codex, \
+                patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks:
+            result = run_library_finalization(
+                repo_path=os.getcwd(),
+                library="org.example:demo:1.0.0",
+                group="org.example",
+                artifact="demo",
+                library_version="1.0.0",
+            )
+
+        self.assertFalse(result)
+        check_metadata.assert_called_once()
+        codex.assert_called_once()
+        style_checks.assert_not_called()
+
     def test_rejects_legacy_test_resource_native_image_config_after_split(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             _git(repo_path, "init")

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -39,7 +39,8 @@ class LibraryFinalizationTests(unittest.TestCase):
                     side_effect=[False, True],
                 ) as check_metadata, \
                 patch(
-                    "ai_workflows.agents.codex_agent.CodexAgent",
+                    "utility_scripts.library_finalization._run_codex_check_metadata_fix",
+                    return_value=True,
                 ) as codex, \
                 patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True):
             result = run_library_finalization(
@@ -52,13 +53,7 @@ class LibraryFinalizationTests(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(check_metadata.call_count, 2)
-        codex.assert_called_once_with(
-            model_name="gpt-5.6-terra",
-            working_dir=os.getcwd(),
-            task_type="check-metadata-files",
-            library="org.example:demo:1.0.0",
-        )
-        codex.return_value.send_prompt.assert_called_once()
+        codex.assert_called_once_with(os.getcwd(), "org.example:demo:1.0.0")
         self.assertEqual(gradle.call_count, 3)
 
     def test_fails_when_codex_cannot_fix_metadata_validation(self) -> None:
@@ -68,10 +63,10 @@ class LibraryFinalizationTests(unittest.TestCase):
                     return_value=False,
                 ) as check_metadata, \
                 patch(
-                    "ai_workflows.agents.codex_agent.CodexAgent",
+                    "utility_scripts.library_finalization._run_codex_check_metadata_fix",
+                    return_value=False,
                 ) as codex, \
                 patch("utility_scripts.library_finalization.run_style_fix_and_checks") as style_checks:
-            codex.return_value.send_prompt.side_effect = RuntimeError("failed")
             result = run_library_finalization(
                 repo_path=os.getcwd(),
                 library="org.example:demo:1.0.0",

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -258,20 +258,20 @@ def run_library_finalization(
         library_version=library_version,
         log_stage_name="check-metadata-files",
     ):
-        log_stage("check-metadata-files", f"Running Codex metadata fix for {library}")
-        if not _run_codex_check_metadata_fix(repo_path, library):
-            return False
-        log_stage("split-test-only-metadata", f"Rerunning splitTestOnlyMetadata for {library}")
-        if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):
-            return False
-        if not _run_check_metadata_files_with_allowed_packages_fix(
-            repo_path=repo_path,
-            library=library,
-            group=group,
-            artifact=artifact,
-            library_version=library_version,
-            log_stage_name="check-metadata-files",
-        ):
+        for attempt in range(1, 4):
+            log_stage("check-metadata-files", f"Running Codex metadata fix attempt {attempt}/3 for {library}")
+            if not _run_codex_check_metadata_fix(repo_path, library):
+                continue
+            if _run_check_metadata_files_with_allowed_packages_fix(
+                repo_path=repo_path,
+                library=library,
+                group=group,
+                artifact=artifact,
+                library_version=library_version,
+                log_stage_name="check-metadata-files",
+            ):
+                break
+        else:
             return False
     log_stage("style-checks", f"Running style checks for {library}")
     if not run_style_fix_and_checks(repo_path, library, model_name=model_name):

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -19,6 +19,7 @@ from utility_scripts.native_image_config_policy import (
 )
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.stage_logger import log_stage
+from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 from utility_scripts.test_quality_checks import (
     collect_generated_test_validity_issues,
     format_generated_test_validity_issue,
@@ -52,25 +53,30 @@ def _run_gradle_command(repo_path: str, command: list[str]) -> bool:
 
 def _run_codex_check_metadata_fix(repo_path: str, library: str) -> bool:
     """Ask Codex to repair an unresolved metadata validation failure."""
+    log_path = build_timestamped_task_log_path("metadata-fix", library, "check-metadata-codex")
     prompt = (
         f"Fix the checkMetadataFiles failure for {library}. "
         f"Reproduce it with ./gradlew checkMetadataFiles -Pcoordinates={library}, "
         "make the minimal fix, and rerun the command until it passes."
     )
+    print(f"[Codex running... Output: {display_log_path(log_path)}]")
     try:
-        result = subprocess.run(
-            [
-                "codex",
-                "exec",
-                "--dangerously-bypass-approvals-and-sandbox",
-                "-m",
-                "gpt-5.6-terra",
-                prompt,
-            ],
-            cwd=repo_path,
-            timeout=CODEX_CHECK_METADATA_TIMEOUT_SECONDS,
-            check=False,
-        )
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            result = subprocess.run(
+                [
+                    "codex",
+                    "exec",
+                    "--dangerously-bypass-approvals-and-sandbox",
+                    "-m",
+                    "gpt-5.6-terra",
+                    prompt,
+                ],
+                cwd=repo_path,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                timeout=CODEX_CHECK_METADATA_TIMEOUT_SECONDS,
+                check=False,
+            )
     except subprocess.TimeoutExpired:
         print(
             f"ERROR: Codex metadata fix timed out after {CODEX_CHECK_METADATA_TIMEOUT_SECONDS} "

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -207,7 +207,10 @@ def run_library_finalization(
         model_name: str | None = None,
         base_commit: str | None = None,
 ) -> bool:
-    """Run the shared end-of-workflow finalization steps for one library."""
+    """Run the shared end-of-workflow finalization steps for one library.
+
+    §WF-forge-workflow-drivers.3
+    """
     del log_prefix
     log_stage("split-test-only-metadata", f"Running splitTestOnlyMetadata for {library}")
     if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):
@@ -230,7 +233,31 @@ def run_library_finalization(
         library_version=library_version,
         log_stage_name="check-metadata-files",
     ):
-        return False
+        # Avoid the workflow core's import back into this finalization module.
+        from ai_workflows.core.fix_metadata_codex import (  # pylint: disable=import-outside-toplevel
+            run_codex_metadata_fix,
+        )
+
+        log_stage("check-metadata-files", f"Running Codex metadata fix for {library}")
+        codex_rc, _codex_log_path, codex_timed_out = run_codex_metadata_fix(
+            repo_path,
+            library,
+            reproduction_command=f"./gradlew checkMetadataFiles -Pcoordinates={library}",
+        )
+        if codex_timed_out or codex_rc != 0:
+            return False
+        log_stage("split-test-only-metadata", f"Rerunning splitTestOnlyMetadata for {library}")
+        if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):
+            return False
+        if not _run_check_metadata_files_with_allowed_packages_fix(
+            repo_path=repo_path,
+            library=library,
+            group=group,
+            artifact=artifact,
+            library_version=library_version,
+            log_stage_name="check-metadata-files",
+        ):
+            return False
     log_stage("style-checks", f"Running style checks for {library}")
     if not run_style_fix_and_checks(repo_path, library, model_name=model_name):
         return False

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -48,6 +48,31 @@ def _run_gradle_command(repo_path: str, command: list[str]) -> bool:
     return True
 
 
+def _run_codex_check_metadata_fix(repo_path: str, library: str) -> bool:
+    """Ask Codex to repair an unresolved metadata validation failure."""
+    prompt = (
+        f"Fix the checkMetadataFiles failure for {library}. "
+        f"Reproduce it with ./gradlew checkMetadataFiles -Pcoordinates={library}, "
+        "make the minimal fix, and rerun the command until it passes."
+    )
+    result = subprocess.run(
+        [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "-m",
+            "gpt-5.6-terra",
+            prompt,
+        ],
+        cwd=repo_path,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: Codex metadata fix failed for {library}.", file=sys.stderr)
+        return False
+    return True
+
+
 def _extract_missing_allowed_packages(check_metadata_output: str) -> set[str]:
     """Extract package names from TypeReached entries for index.json allowed-packages."""
     packages: set[str] = set()
@@ -233,23 +258,8 @@ def run_library_finalization(
         library_version=library_version,
         log_stage_name="check-metadata-files",
     ):
-        from ai_workflows.agents.codex_agent import CodexAgent  # pylint: disable=import-outside-toplevel
-
         log_stage("check-metadata-files", f"Running Codex metadata fix for {library}")
-        codex = CodexAgent(
-            model_name="gpt-5.6-terra",
-            working_dir=repo_path,
-            task_type="check-metadata-files",
-            library=library,
-        )
-        try:
-            codex.send_prompt(
-                f"Fix the checkMetadataFiles failure for {library}. "
-                f"Reproduce it with ./gradlew checkMetadataFiles -Pcoordinates={library}, "
-                "make the minimal fix, and rerun the command until it passes."
-            )
-        except RuntimeError as exception:
-            print(f"ERROR: Codex metadata fix failed for {library}: {exception}", file=sys.stderr)
+        if not _run_codex_check_metadata_fix(repo_path, library):
             return False
         log_stage("split-test-only-metadata", f"Rerunning splitTestOnlyMetadata for {library}")
         if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -233,18 +233,23 @@ def run_library_finalization(
         library_version=library_version,
         log_stage_name="check-metadata-files",
     ):
-        # Avoid the workflow core's import back into this finalization module.
-        from ai_workflows.core.fix_metadata_codex import (  # pylint: disable=import-outside-toplevel
-            run_codex_metadata_fix,
-        )
+        from ai_workflows.agents.codex_agent import CodexAgent  # pylint: disable=import-outside-toplevel
 
         log_stage("check-metadata-files", f"Running Codex metadata fix for {library}")
-        codex_rc, _codex_log_path, codex_timed_out = run_codex_metadata_fix(
-            repo_path,
-            library,
-            reproduction_command=f"./gradlew checkMetadataFiles -Pcoordinates={library}",
+        codex = CodexAgent(
+            model_name="gpt-5.6-terra",
+            working_dir=repo_path,
+            task_type="check-metadata-files",
+            library=library,
         )
-        if codex_timed_out or codex_rc != 0:
+        try:
+            codex.send_prompt(
+                f"Fix the checkMetadataFiles failure for {library}. "
+                f"Reproduce it with ./gradlew checkMetadataFiles -Pcoordinates={library}, "
+                "make the minimal fix, and rerun the command until it passes."
+            )
+        except RuntimeError as exception:
+            print(f"ERROR: Codex metadata fix failed for {library}: {exception}", file=sys.stderr)
             return False
         log_stage("split-test-only-metadata", f"Rerunning splitTestOnlyMetadata for {library}")
         if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -24,6 +24,8 @@ from utility_scripts.test_quality_checks import (
     format_generated_test_validity_issue,
 )
 
+CODEX_CHECK_METADATA_TIMEOUT_SECONDS = 1200
+
 
 def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a Gradle command in the reachability repo and capture combined output."""
@@ -55,18 +57,27 @@ def _run_codex_check_metadata_fix(repo_path: str, library: str) -> bool:
         f"Reproduce it with ./gradlew checkMetadataFiles -Pcoordinates={library}, "
         "make the minimal fix, and rerun the command until it passes."
     )
-    result = subprocess.run(
-        [
-            "codex",
-            "exec",
-            "--dangerously-bypass-approvals-and-sandbox",
-            "-m",
-            "gpt-5.6-terra",
-            prompt,
-        ],
-        cwd=repo_path,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "codex",
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-m",
+                "gpt-5.6-terra",
+                prompt,
+            ],
+            cwd=repo_path,
+            timeout=CODEX_CHECK_METADATA_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"ERROR: Codex metadata fix timed out after {CODEX_CHECK_METADATA_TIMEOUT_SECONDS} "
+            f"seconds for {library}.",
+            file=sys.stderr,
+        )
+        return False
     if result.returncode != 0:
         print(f"ERROR: Codex metadata fix failed for {library}.", file=sys.stderr)
         return False


### PR DESCRIPTION
Summary:
- retain deterministic missing allowed-package repair
- run up to three Codex metadata repair attempts for remaining checkMetadataFiles failures
- limit each Codex invocation to 20 minutes
- write combined Codex output to a printed coordinate-scoped metadata-fix log
- rerun metadata validation after each repair

Tests were not run per request.

Fixes #9040