### PR TITLE
Improve code coverage for io.jsonwebtoken:jjwt-jackson:0.12.7

### DIFF
--- a/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/src/test/java/io_jsonwebtoken/jjwt_jackson/JacksonDeserializerCoverageTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/src/test/java/io_jsonwebtoken/jjwt_jackson/JacksonDeserializerCoverageTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_jsonwebtoken.jjwt_jackson;
+
+import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonDeserializerCoverageTest {
+    @Test
+    void deserializesConfiguredClaimIntoApplicationType() {
+        Map<String, Class<?>> claimTypes = Map.of("user", User.class);
+        JacksonDeserializer<Map<String, Object>> deserializer = new JacksonDeserializer<>(claimTypes);
+
+        Map<String, Object> claims = deserializer.deserialize(new StringReader("""
+                {"issuer":"https://issuer.example.com","user":{"firstName":"Jill","lastName":"Coder"}}
+                """));
+
+        assertThat(claims).containsEntry("issuer", "https://issuer.example.com");
+        assertThat(claims.get("user"))
+                .isInstanceOfSatisfying(User.class, user -> {
+                    assertThat(user.getFirstName()).isEqualTo("Jill");
+                    assertThat(user.getLastName()).isEqualTo("Coder");
+                });
+    }
+
+    public static final class User {
+        private String firstName;
+        private String lastName;
+
+        public User() {
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+}

--- a/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/src/test/java/io_jsonwebtoken/jjwt_jackson/JacksonDeserializerCoverageTest.java
+++ b/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/src/test/java/io_jsonwebtoken/jjwt_jackson/JacksonDeserializerCoverageTest.java
@@ -7,6 +7,8 @@
 package io_jsonwebtoken.jjwt_jackson;
 
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
+import io.jsonwebtoken.jackson.io.JacksonSerializer;
+import io.jsonwebtoken.lang.Supplier;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
@@ -30,6 +32,16 @@ class JacksonDeserializerCoverageTest {
                     assertThat(user.getFirstName()).isEqualTo("Jill");
                     assertThat(user.getLastName()).isEqualTo("Coder");
                 });
+    }
+
+    @Test
+    void serializesSupplierValueThroughJacksonSerializer() {
+        Supplier<String> supplier = () -> "resolved-value";
+        JacksonSerializer<Supplier<String>> serializer = new JacksonSerializer<>();
+
+        byte[] serialized = serializer.serialize(supplier);
+
+        assertThat(serialized).asString().isEqualTo("\"resolved-value\"");
     }
 
     public static final class User {

--- a/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/suite.json
+++ b/tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+  "coordinates": "io.jsonwebtoken:jjwt-jackson:0.12.7"
+}


### PR DESCRIPTION
## Code coverage improvement

- Source issue: #8495
- Coordinate: `io.jsonwebtoken:jjwt-jackson:0.12.7`
- Coverage suite path: `tests/src/io.jsonwebtoken/jjwt-jackson/0.12.0/code-coverage-improvement`
- Needs human intervention: no

## JaCoCo coverage

### Public API entries

- Baseline: 5/5 (100.0%)
- Final: 5/5 (100.0%)
- Delta: 0.0pp
- Remaining uncovered: 0

### Deep internal methods

- Baseline: 10/11 (90.91%)
- Final: 11/11 (100.0%)
- Delta: +9.09pp
- Remaining uncovered: 0

## Sampled PGO guidance only

Sampled PGO is navigation evidence only. Sample counts do not measure coverage, and sample absence does not prove non-execution.

- Baseline: 1148 contexts, 1283 sampled methods, 48201 samples, 1 sampled joins
- Final: 1227 contexts, 1282 sampled methods, 116136 samples, 0 sampled joins

## Completed targets (1)

- [deep] `io.jsonwebtoken.jackson.io.JacksonSupplierSerializer#serialize(io.jsonwebtoken.lang.Supplier,com.fasterxml.jackson.core.JsonGenerator,com.fasterxml.jackson.databind.SerializerProvider):void` — attempts: 1, last attempted iteration: 1

## Skipped targets (0)

_None recorded._

## Exhausted targets (0)

_None recorded._

## Failed targets (0)

_None recorded._

## Validation commands

```console
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-8495-jjwt-jackson/gradlew javaTest -Pcoordinates=io.jsonwebtoken:jjwt-jackson:0.12.7 --stacktrace
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-8495-jjwt-jackson/gradlew codeCoverageTest -Pcoordinates=io.jsonwebtoken:jjwt-jackson:0.12.7 --stacktrace
```

Refs #8495.


Remaining follow-up: the issue remains open for maintainer review; finalization did not assert that this PR resolves it.
