### PR TITLE
Improve code coverage for io.grpc:grpc-api:1.27.2

### DIFF
--- a/metadata/io.grpc/grpc-api/1.27.2/reachability-metadata.json
+++ b/metadata/io.grpc/grpc-api/1.27.2/reachability-metadata.json
@@ -1,1 +1,90 @@
-{ }
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "io.grpc.ServiceProviders"
+      },
+      "type": "android.app.Application"
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.ManagedChannelProvider$HardcodedClasses"
+      },
+      "type": "io.grpc.netty.NettyChannelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.ServiceProviders"
+      },
+      "type": "io.grpc.netty.NettyChannelProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.ManagedChannelProvider$HardcodedClasses"
+      },
+      "type": "io.grpc.okhttp.OkHttpChannelProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.ServiceProviders"
+      },
+      "type": "io.grpc.okhttp.OkHttpChannelProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.Context$LazyStorage"
+      },
+      "type": "io.grpc.override.ContextStorageOverride"
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.InternalServiceProviders"
+      },
+      "type": "io_grpc.grpc_api.ServiceProvidersTest$HardcodedProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "io.grpc.ServiceProviders"
+      },
+      "type": "io_grpc.grpc_api.ServiceProvidersTest$HardcodedProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "io_grpc.grpc_api.GrpcApiChannelzLifecycleTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.configuration.Configuration"
+    },
+    {
+      "condition": {
+        "typeReached": "io_grpc.grpc_api.GrpcApiChannelzLifecycleTest"
+      },
+      "glob": "META-INF/services/org.assertj.core.presentation.Representation"
+    }
+  ]
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/android/app/Application.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/android/app/Application.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package android.app;
+
+/** Makes grpc-api use its Android provider-discovery public API path in this test suite. */
+public class Application {}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io/grpc/netty/NettyChannelProvider.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io/grpc/netty/NettyChannelProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io.grpc.netty;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ManagedChannelProvider;
+
+/** Test-only optional Android transport discovered through grpc-api's public provider API. */
+public class NettyChannelProvider extends ManagedChannelProvider {
+    @Override
+    protected boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    protected int priority() {
+        return 7;
+    }
+
+    @Override
+    protected ManagedChannelBuilder<?> builderForAddress(String name, int port) {
+        return null;
+    }
+
+    @Override
+    protected ManagedChannelBuilder<?> builderForTarget(String target) {
+        return null;
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io.grpc.okhttp;
+
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.ManagedChannelProvider;
+
+/** Test-only Android fallback transport discovered through grpc-api's public provider API. */
+public class OkHttpChannelProvider extends ManagedChannelProvider {
+    @Override
+    protected boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    protected int priority() {
+        return 3;
+    }
+
+    @Override
+    protected ManagedChannelBuilder<?> builderForAddress(String name, int port) {
+        return null;
+    }
+
+    @Override
+    protected ManagedChannelBuilder<?> builderForTarget(String target) {
+        return null;
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiChannelzLifecycleTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiChannelzLifecycleTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.ChannelLogger;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ConnectivityState;
+import io.grpc.InternalChannelz;
+import io.grpc.InternalInstrumented;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
+import io.grpc.Metadata;
+import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
+import io.grpc.SynchronizationContext;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.junit.jupiter.api.Test;
+
+/** Exercises Channelz's public diagnostics model with a realistic transport lifecycle. */
+public class GrpcApiChannelzLifecycleTest {
+    @Test
+    void channelzTracksAndPaginatesRegisteredTransportResources() {
+        InternalChannelz channelz = new InternalChannelz();
+        Instrumented<InternalChannelz.ChannelStats> root = new Instrumented<>("root");
+        Instrumented<InternalChannelz.ChannelStats> subchannel = new Instrumented<>("subchannel");
+        Instrumented<InternalChannelz.ServerStats> server = new Instrumented<>("server");
+        Instrumented<InternalChannelz.SocketStats> clientSocket = new Instrumented<>("client-socket");
+        Instrumented<InternalChannelz.SocketStats> listenSocket = new Instrumented<>("listen-socket");
+
+        channelz.addRootChannel(root);
+        channelz.addSubchannel(subchannel);
+        channelz.addServer(server);
+        channelz.addClientSocket(clientSocket);
+        channelz.addListenSocket(listenSocket);
+        channelz.addServerSocket(server, listenSocket);
+
+        assertThat(channelz.getRootChannel(InternalChannelz.id(root))).isSameAs(root);
+        assertThat(channelz.getChannel(InternalChannelz.id(root))).isSameAs(root);
+        assertThat(channelz.getSubchannel(InternalChannelz.id(subchannel))).isSameAs(subchannel);
+        assertThat(channelz.getSocket(InternalChannelz.id(clientSocket))).isSameAs(clientSocket);
+        assertThat(channelz.containsServer(server.getLogId())).isTrue();
+        assertThat(channelz.containsSubchannel(subchannel.getLogId())).isTrue();
+        assertThat(channelz.containsClientSocket(clientSocket.getLogId())).isTrue();
+        assertThat(channelz.getRootChannels(0, 10).channels).containsExactly(root);
+        assertThat(channelz.getServers(0, 10).servers).containsExactly(server);
+        assertThat(channelz.getServerSockets(InternalChannelz.id(server), 0, 10).sockets)
+                .containsExactly(listenSocket);
+
+        channelz.removeServerSocket(server, listenSocket);
+        channelz.removeListenSocket(listenSocket);
+        channelz.removeClientSocket(clientSocket);
+        channelz.removeServer(server);
+        channelz.removeSubchannel(subchannel);
+        channelz.removeRootChannel(root);
+        assertThat(channelz.getRootChannels(0, 10).channels).isEmpty();
+        assertThat(channelz.getServers(0, 10).servers).isEmpty();
+        assertThat(channelz.getSocket(InternalChannelz.id(clientSocket))).isNull();
+        assertThat(channelz.getSubchannel(InternalChannelz.id(subchannel))).isNull();
+        assertThat(InternalChannelz.instance()).isNotNull();
+    }
+
+    @Test
+    void channelzValueBuildersDescribeSocketAndServerStatistics() {
+        InternalChannelz.TcpInfo tcp = new InternalChannelz.TcpInfo.Builder()
+                .setState(1).setCaState(2).setRetransmits(3).setProbes(4).setBackoff(5).setOptions(6)
+                .setSndWscale(7).setRcvWscale(8).setRto(9).setAto(10).setSndMss(11).setRcvMss(12)
+                .setUnacked(13).setSacked(14).setLost(15).setRetrans(16).setFackets(17)
+                .setLastDataSent(18).setLastAckSent(19).setLastDataRecv(20).setLastAckRecv(21)
+                .setPmtu(22).setRcvSsthresh(23).setRtt(24).setRttvar(25).setSndSsthresh(26)
+                .setSndCwnd(27).setAdvmss(28).setReordering(29).build();
+        InternalChannelz.TransportStats transport = new InternalChannelz.TransportStats(
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+        InternalChannelz.Security security = new InternalChannelz.Security(
+                new InternalChannelz.OtherSecurity("in-process", null));
+        InternalChannelz.SocketOptions options = new InternalChannelz.SocketOptions.Builder().setTcpInfo(tcp).build();
+        InternalChannelz.SocketStats socketStats = new InternalChannelz.SocketStats(transport,
+                new InetSocketAddress("localhost", 1000), new InetSocketAddress("localhost", 2000), options, security);
+        Instrumented<InternalChannelz.SocketStats> socket = new Instrumented<>("socket");
+        InternalChannelz.ServerStats stats = new InternalChannelz.ServerStats.Builder().setCallsStarted(9)
+                .setCallsSucceeded(7).setCallsFailed(2).setLastCallStartedNanos(42)
+                .addListenSockets(Collections.singletonList(socket)).build();
+        InternalChannelz.ChannelStats channel = new InternalChannelz.ChannelStats.Builder().setTarget("dns:///orders")
+                .setState(ConnectivityState.READY).setSockets(Collections.singletonList(socket)).build();
+
+        assertThat(tcp.reordering).isEqualTo(29);
+        assertThat(transport.messagesReceived).isEqualTo(7);
+        assertThat(socketStats.security.other.name).isEqualTo("in-process");
+        assertThat(stats.callsStarted).isEqualTo(9);
+        assertThat(stats.listenSockets).containsExactly(socket);
+        assertThat(channel.sockets).containsExactly(socket);
+    }
+
+    @Test
+    void resolverArgumentsAndTracerFactoryExposeConfiguredRuntimeServices() {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            SynchronizationContext context = new SynchronizationContext((thread, failure) -> {
+                throw new AssertionError(failure);
+            });
+            ChannelLogger logger = new ChannelLogger() {
+                @Override public void log(ChannelLogLevel level, String message) {}
+                @Override public void log(ChannelLogLevel level, String message, Object... args) {}
+            };
+            Executor executor = Runnable::run;
+            ProxyDetector detector = address -> null;
+            NameResolver.Args args = NameResolver.Args.newBuilder().setDefaultPort(8443)
+                    .setProxyDetector(detector).setSynchronizationContext(context).setScheduledExecutorService(scheduler)
+                    .setServiceConfigParser(new NameResolver.ServiceConfigParser() {
+                        @Override
+                        public NameResolver.ConfigOrError parseServiceConfig(java.util.Map<String, ?> rawConfig) {
+                            return NameResolver.ConfigOrError.fromConfig(rawConfig);
+                        }
+                    }).setChannelLogger(logger).setOffloadExecutor(executor).build();
+            ClientStreamTracer tracer = new ClientStreamTracer() {};
+            ClientStreamTracer.Factory factory = new ClientStreamTracer.Factory() {
+                @Override public ClientStreamTracer newClientStreamTracer(
+                        CallOptions options, Metadata headers) { return tracer; }
+                @Override public ClientStreamTracer newClientStreamTracer(
+                        ClientStreamTracer.StreamInfo info, Metadata headers) { return tracer; }
+            };
+
+            assertThat(args.getDefaultPort()).isEqualTo(8443);
+            assertThat(args.toBuilder().build().getChannelLogger()).isSameAs(logger);
+            assertThat(args.getProxyDetector()).isSameAs(detector);
+            assertThat(args.getSynchronizationContext()).isSameAs(context);
+            assertThat(args.getScheduledExecutorService()).isSameAs(scheduler);
+            assertThat(args.getOffloadExecutor()).isSameAs(executor);
+            assertThat(args.getServiceConfigParser().parseServiceConfig(Collections.singletonMap("policy", "pick_first"))
+                    .getConfig()).isEqualTo(Collections.singletonMap("policy", "pick_first"));
+            assertThat(factory.newClientStreamTracer(CallOptions.DEFAULT, new Metadata())).isSameAs(tracer);
+            assertThat(factory.newClientStreamTracer(ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata()))
+                    .isSameAs(tracer);
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private static final class Instrumented<T> implements InternalInstrumented<T> {
+        private final InternalLogId id;
+
+        private Instrumented(String name) {
+            id = InternalLogId.allocate(name, "coverage");
+        }
+
+        @Override
+        public InternalLogId getLogId() {
+            return id;
+        }
+
+        @Override
+        public com.google.common.util.concurrent.ListenableFuture<T> getStats() {
+            return null;
+        }
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiDefaultsTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiDefaultsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Attributes;
+import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.LoadBalancer;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StreamTracer;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class GrpcApiDefaultsTest {
+    @Test
+    void credentialsAndCallOptionsCarryAuthenticationAndExecutionPolicy() {
+        AtomicReference<String> applied = new AtomicReference<>();
+        CallCredentials credential = new CallCredentials2() {
+            @Override
+            public void applyRequestMetadata(RequestInfo requestInfo, Executor executor, MetadataApplier applier) {
+                executor.execute(() -> {
+                    Metadata headers = new Metadata();
+                    headers.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer token");
+                    applier.apply(headers);
+                });
+            }
+
+            @Override
+            public void thisUsesUnstableApi() {}
+        };
+        CallOptions options = CallOptions.DEFAULT.withCallCredentials(credential).withExecutor(Runnable::run)
+                .withStreamTracerFactory(new ClientStreamTracer.Factory() {});
+        assertThat(options.getCredentials()).isSameAs(credential);
+        assertThat(options.getExecutor()).isNotNull();
+        assertThat(options.getStreamTracerFactories()).hasSize(1);
+
+        credential.applyRequestMetadata(null, options.getExecutor(), new CallCredentials.MetadataApplier() {
+            @Override
+            public void apply(Metadata headers) {
+                applied.set(headers.get(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER)));
+            }
+
+            @Override
+            public void fail(Status status) {
+                throw new AssertionError(status);
+            }
+        });
+        assertThat(applied).hasValue("Bearer token");
+        assertThat(CallOptions.Key.create("request-id").toString()).isEqualTo("request-id");
+    }
+
+    @Test
+    void tracerDefaultsAndLoadBalancerPickResultsProvideNeutralBehavior() {
+        ClientStreamTracer tracer = new ClientStreamTracer() {};
+        tracer.outboundHeaders();
+        tracer.inboundHeaders();
+        tracer.inboundTrailers(new Metadata());
+        StreamTracer streamTracer = tracer;
+        streamTracer.outboundMessage(1);
+        streamTracer.outboundMessageSent(1, 2, 3);
+        streamTracer.outboundWireSize(4);
+        streamTracer.outboundUncompressedSize(5);
+        streamTracer.inboundMessage(6);
+        streamTracer.inboundMessageRead(6, 7, 8);
+        streamTracer.inboundWireSize(9);
+        streamTracer.inboundUncompressedSize(10);
+        streamTracer.streamClosed(Status.OK);
+
+        LoadBalancer.PickResult noResult = LoadBalancer.PickResult.withNoResult();
+        LoadBalancer.PickResult error = LoadBalancer.PickResult.withError(Status.UNAVAILABLE);
+        LoadBalancer.PickResult drop = LoadBalancer.PickResult.withDrop(Status.RESOURCE_EXHAUSTED);
+        assertThat(noResult.getSubchannel()).isNull();
+        assertThat(error.getStatus()).isEqualTo(Status.UNAVAILABLE);
+        assertThat(drop.isDrop()).isTrue();
+        assertThat(error).isEqualTo(LoadBalancer.PickResult.withError(Status.UNAVAILABLE));
+        assertThat(error.hashCode()).isEqualTo(LoadBalancer.PickResult.withError(Status.UNAVAILABLE).hashCode());
+        assertThat(drop.toString()).contains("RESOURCE_EXHAUSTED");
+    }
+
+    @Test
+    void cancelledContextsExposeCancellationStatusAndPreserveCallAttributes() {
+        Context.CancellableContext cancelled = Context.current().withCancellation();
+        cancelled.cancel(new IllegalStateException("client stopped"));
+        Status cancellationStatus = Contexts.statusFromCancelled(cancelled);
+        assertThat(cancellationStatus.getCode()).isEqualTo(Status.Code.CANCELLED);
+        assertThat(cancellationStatus.getDescription()).isEqualTo("Context cancelled");
+        assertThat(cancellationStatus.getCause()).isSameAs(cancelled.cancellationCause());
+
+        ClientCall<String, String> call = new ClientCall<String, String>() {
+            @Override public void start(Listener<String> listener, Metadata headers) {}
+            @Override public void request(int count) {}
+            @Override public void cancel(String message, Throwable cause) {}
+            @Override public void halfClose() {}
+            @Override public void sendMessage(String message) {}
+        };
+        assertThat(call.getAttributes()).isEqualTo(Attributes.EMPTY);
+        assertThat(call.isReady()).isTrue();
+        call.setMessageCompression(true);
+        new ClientCall.Listener<String>() {}.onMessage("response");
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiForwardingBuilderTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiForwardingBuilderTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.grpc.BinaryLog;
+import io.grpc.ClientInterceptor;
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.ForwardingChannelBuilder;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolver;
+import io.grpc.ProxyDetector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/** Exercises forwarding configuration as a user would wrap a transport-specific channel builder. */
+public class GrpcApiForwardingBuilderTest {
+    @Test
+    void forwardingBuilderPassesEverySupportedConfigurationToItsDelegate() {
+        RecordingBuilder delegate = new RecordingBuilder();
+        Wrapper builder = new Wrapper(delegate);
+        Executor executor = Runnable::run;
+        ClientInterceptor interceptor = new ClientInterceptor() {
+            @Override
+            public <ReqT, RespT> io.grpc.ClientCall<ReqT, RespT> interceptCall(
+                    io.grpc.MethodDescriptor<ReqT, RespT> method, io.grpc.CallOptions options,
+                    io.grpc.Channel channel) {
+                return channel.newCall(method, options);
+            }
+        };
+        NameResolver.Factory resolverFactory = new NameResolver.Factory() {
+            @Override public String getDefaultScheme() { return "test"; }
+            @Override public NameResolver newNameResolver(java.net.URI uri, NameResolver.Args args) { return null; }
+        };
+        ProxyDetector proxyDetector = targetServerAddress -> null;
+        BinaryLog binaryLog = new BinaryLog() {
+            @Override public io.grpc.Channel wrapChannel(io.grpc.Channel channel) { return channel; }
+            @Override public <ReqT, RespT> io.grpc.ServerMethodDefinition<ReqT, RespT> wrapMethodDefinition(io.grpc.ServerMethodDefinition<ReqT, RespT> methodDefinition) { return methodDefinition; }
+            @Override public void close() {}
+        };
+
+        assertThat(builder.directExecutor()).isSameAs(builder);
+        assertThat(builder.executor(executor)).isSameAs(builder);
+        assertThat(builder.offloadExecutor(executor)).isSameAs(builder);
+        assertThat(builder.blockingExecutor(executor)).isSameAs(builder);
+        assertThat(builder.intercept(interceptor)).isSameAs(builder);
+        assertThat(builder.intercept(Collections.singletonList(interceptor))).isSameAs(builder);
+        assertThat(builder.userAgent("coverage-client").overrideAuthority("authority").usePlaintext()
+                .useTransportSecurity().nameResolverFactory(resolverFactory).defaultLoadBalancingPolicy("pick_first")
+                .enableFullStreamDecompression().decompressorRegistry(DecompressorRegistry.getDefaultInstance())
+                .compressorRegistry(CompressorRegistry.getDefaultInstance()).idleTimeout(1, TimeUnit.SECONDS)
+                .maxInboundMessageSize(1).maxInboundMetadataSize(1).keepAliveTime(1, TimeUnit.SECONDS)
+                .keepAliveTimeout(1, TimeUnit.SECONDS).keepAliveWithoutCalls(true).maxRetryAttempts(2)
+                .maxHedgedAttempts(2).retryBufferSize(2).perRpcBufferLimit(1).disableRetry().enableRetry()
+                .setBinaryLog(binaryLog).maxTraceEvents(2).proxyDetector(proxyDetector)
+                .defaultServiceConfig(Collections.singletonMap("loadBalancingPolicy", "pick_first"))
+                .disableServiceConfigLookUp()).isSameAs(builder);
+        assertThat(builder.build()).isSameAs(delegate.channel);
+        assertThat(builder.toString()).contains("delegate");
+        assertThat(delegate.calls).containsAll(Arrays.asList("directExecutor", "executor", "offloadExecutor",
+                "blockingExecutor", "intercept-array", "intercept-list", "userAgent", "overrideAuthority",
+                "usePlaintext", "useTransportSecurity", "nameResolverFactory", "defaultLoadBalancingPolicy",
+                "enableFullStreamDecompression", "decompressorRegistry", "compressorRegistry", "idleTimeout",
+                "maxInboundMessageSize", "maxInboundMetadataSize", "keepAliveTime", "keepAliveTimeout",
+                "keepAliveWithoutCalls", "maxRetryAttempts", "maxHedgedAttempts", "retryBufferSize",
+                "perRpcBufferLimit", "disableRetry", "enableRetry", "setBinaryLog", "maxTraceEvents",
+                "proxyDetector", "defaultServiceConfig", "disableServiceConfigLookUp", "build"));
+        assertThatThrownBy(() -> ForwardingChannelBuilder.forAddress("localhost", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> ForwardingChannelBuilder.forTarget("dns:///localhost"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private static final class Wrapper extends ForwardingChannelBuilder<Wrapper> {
+        private final ManagedChannelBuilder<?> delegate;
+        Wrapper(ManagedChannelBuilder<?> delegate) { this.delegate = delegate; }
+        @Override protected ManagedChannelBuilder<?> delegate() { return delegate; }
+    }
+
+    private static final class RecordingBuilder extends ManagedChannelBuilder<RecordingBuilder> {
+        final Set<String> calls = new LinkedHashSet<>();
+        final ManagedChannel channel = new ManagedChannel() {
+            @Override public ManagedChannel shutdown() { return this; }
+            @Override public boolean isShutdown() { return false; }
+            @Override public boolean isTerminated() { return false; }
+            @Override public ManagedChannel shutdownNow() { return this; }
+            @Override public boolean awaitTermination(long timeout, TimeUnit unit) { return true; }
+            @Override public String authority() { return "coverage"; }
+            @Override public <ReqT, RespT> io.grpc.ClientCall<ReqT, RespT> newCall(io.grpc.MethodDescriptor<ReqT, RespT> method, io.grpc.CallOptions options) { return null; }
+        };
+        private RecordingBuilder called(String name) { calls.add(name); return this; }
+        @Override public RecordingBuilder directExecutor() { return called("directExecutor"); }
+        @Override public RecordingBuilder executor(Executor value) { return called("executor"); }
+        @Override public RecordingBuilder offloadExecutor(Executor value) { return called("offloadExecutor"); }
+        @Override public RecordingBuilder blockingExecutor(Executor value) { return called("blockingExecutor"); }
+        @Override public RecordingBuilder intercept(List<ClientInterceptor> value) { return called("intercept-list"); }
+        @Override public RecordingBuilder intercept(ClientInterceptor... value) { return called("intercept-array"); }
+        @Override public RecordingBuilder userAgent(String value) { return called("userAgent"); }
+        @Override public RecordingBuilder overrideAuthority(String value) { return called("overrideAuthority"); }
+        @Override public RecordingBuilder usePlaintext() { return called("usePlaintext"); }
+        @Override public RecordingBuilder useTransportSecurity() { return called("useTransportSecurity"); }
+        @Override public RecordingBuilder nameResolverFactory(NameResolver.Factory value) { return called("nameResolverFactory"); }
+        @Override public RecordingBuilder defaultLoadBalancingPolicy(String value) { return called("defaultLoadBalancingPolicy"); }
+        @Override public RecordingBuilder enableFullStreamDecompression() { return called("enableFullStreamDecompression"); }
+        @Override public RecordingBuilder decompressorRegistry(DecompressorRegistry value) { return called("decompressorRegistry"); }
+        @Override public RecordingBuilder compressorRegistry(CompressorRegistry value) { return called("compressorRegistry"); }
+        @Override public RecordingBuilder idleTimeout(long value, TimeUnit unit) { return called("idleTimeout"); }
+        @Override public RecordingBuilder maxInboundMessageSize(int value) { return called("maxInboundMessageSize"); }
+        @Override public RecordingBuilder maxInboundMetadataSize(int value) { return called("maxInboundMetadataSize"); }
+        @Override public RecordingBuilder keepAliveTime(long value, TimeUnit unit) { return called("keepAliveTime"); }
+        @Override public RecordingBuilder keepAliveTimeout(long value, TimeUnit unit) { return called("keepAliveTimeout"); }
+        @Override public RecordingBuilder keepAliveWithoutCalls(boolean value) { return called("keepAliveWithoutCalls"); }
+        @Override public RecordingBuilder maxRetryAttempts(int value) { return called("maxRetryAttempts"); }
+        @Override public RecordingBuilder maxHedgedAttempts(int value) { return called("maxHedgedAttempts"); }
+        @Override public RecordingBuilder retryBufferSize(long value) { return called("retryBufferSize"); }
+        @Override public RecordingBuilder perRpcBufferLimit(long value) { return called("perRpcBufferLimit"); }
+        @Override public RecordingBuilder disableRetry() { return called("disableRetry"); }
+        @Override public RecordingBuilder enableRetry() { return called("enableRetry"); }
+        @Override public RecordingBuilder setBinaryLog(BinaryLog value) { return called("setBinaryLog"); }
+        @Override public RecordingBuilder maxTraceEvents(int value) { return called("maxTraceEvents"); }
+        @Override public RecordingBuilder proxyDetector(ProxyDetector value) { return called("proxyDetector"); }
+        @Override public RecordingBuilder defaultServiceConfig(Map<String, ?> value) { return called("defaultServiceConfig"); }
+        @Override public RecordingBuilder disableServiceConfigLookUp() { return called("disableServiceConfigLookUp"); }
+        @Override public ManagedChannel build() { calls.add("build"); return channel; }
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiInfrastructureTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiInfrastructureTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.ClientStreamTracer;
+import io.grpc.Codec;
+import io.grpc.ConnectivityState;
+import io.grpc.DecompressorRegistry;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.HttpConnectProxiedSocketAddress;
+import io.grpc.InternalChannelz;
+import io.grpc.InternalLogId;
+import io.grpc.InternalWithLogId;
+import io.grpc.LoadBalancer;
+import io.grpc.ManagedChannelProvider;
+import io.grpc.Metadata;
+import io.grpc.SynchronizationContext;
+import java.io.ByteArrayInputStream;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+public class GrpcApiInfrastructureTest {
+    @Test
+    void streamAndSubchannelArgumentsPreserveTransportConfiguration() throws Exception {
+        Attributes transport = Attributes.newBuilder().set(Attributes.Key.create("transport"), "local").build();
+        CallOptions options = CallOptions.DEFAULT.withOption(CallOptions.Key.createWithDefault("tenant", "public"), "private");
+        ClientStreamTracer.StreamInfo streamInfo = ClientStreamTracer.StreamInfo.newBuilder()
+                .setTransportAttrs(transport).setCallOptions(options).build();
+        assertThat(streamInfo.getTransportAttrs()).isEqualTo(transport);
+        assertThat(streamInfo.toBuilder().build().getCallOptions()).isEqualTo(options);
+        assertThat(streamInfo.toString()).contains("transportAttrs");
+
+        EquivalentAddressGroup endpoint = new EquivalentAddressGroup(new InetSocketAddress("localhost", 8443));
+        LoadBalancer.CreateSubchannelArgs.Key<String> zone =
+                LoadBalancer.CreateSubchannelArgs.Key.createWithDefault("zone", "default");
+        LoadBalancer.CreateSubchannelArgs args = LoadBalancer.CreateSubchannelArgs.newBuilder()
+                .setAddresses(Collections.singletonList(endpoint)).setAttributes(transport)
+                .addOption(zone, "blue").build();
+        assertThat(args.getAddresses()).containsExactly(endpoint);
+        assertThat(args.getAttributes()).isEqualTo(transport);
+        assertThat(args.getOption(zone)).isEqualTo("blue");
+        assertThat(args.toBuilder().build().toString()).contains("blue");
+        assertThat(zone.getDefault()).isEqualTo("default");
+        assertThat(zone.toString()).isEqualTo("zone");
+
+        assertThat(Codec.Identity.NONE.decompress(new ByteArrayInputStream(new byte[] {3})).read())
+                .isEqualTo(3);
+        assertThat(DecompressorRegistry.getDefaultInstance().getKnownMessageEncodings())
+                .contains("identity", "gzip");
+    }
+
+    @Test
+    void publicSchedulingMetadataAndProviderFlowsExerciseDeferredOperations() throws Exception {
+        AtomicBoolean ran = new AtomicBoolean();
+        SynchronizationContext context = new SynchronizationContext((thread, failure) -> {
+            throw new AssertionError(failure);
+        });
+        AtomicReference<String> scheduledDescription = new AtomicReference<>();
+        ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(1) {
+            @Override
+            public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                scheduledDescription.set(String.valueOf(command));
+                return super.schedule(command, delay, unit);
+            }
+        };
+        try {
+            context.schedule(() -> ran.set(true), 0, TimeUnit.MILLISECONDS, scheduler);
+            scheduler.shutdown();
+            assertThat(scheduler.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(ran).isTrue();
+            assertThat(scheduledDescription.get()).contains("scheduled in SynchronizationContext");
+        } finally {
+            scheduler.shutdownNow();
+        }
+
+        Metadata metadata = new Metadata();
+        Metadata.Key<String> key = Metadata.Key.of("attempt", Metadata.ASCII_STRING_MARSHALLER);
+        metadata.put(key, "value");
+        Iterator<String> values = metadata.getAll(key).iterator();
+        assertThat(values.next()).isEqualTo("value");
+        assertThatThrownBy(values::remove)
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThat(ManagedChannelProvider.provider()).isInstanceOf(ManagedChannelProvider.class);
+    }
+
+    @Test
+    void proxyAddressBuilderExposesConfiguredRouteAndIdentity() {
+        InetSocketAddress proxy = new InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 8080);
+        InetSocketAddress target = new InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 443);
+        HttpConnectProxiedSocketAddress route = HttpConnectProxiedSocketAddress.newBuilder()
+                .setProxyAddress(proxy).setTargetAddress(target).setUsername("alice").setPassword("secret").build();
+        HttpConnectProxiedSocketAddress equivalent = HttpConnectProxiedSocketAddress.newBuilder()
+                .setProxyAddress(proxy).setTargetAddress(target).setUsername("alice").setPassword("secret").build();
+        assertThat(route.getProxyAddress()).isEqualTo(proxy);
+        assertThat(route.getTargetAddress()).isEqualTo(target);
+        assertThat(route.getUsername()).isEqualTo("alice");
+        assertThat(route.getPassword()).isEqualTo("secret");
+        assertThat(route).isEqualTo(equivalent);
+        assertThat(route.hashCode()).isEqualTo(equivalent.hashCode());
+        assertThat(route.toString()).contains("8080", "443");
+    }
+
+    @Test
+    void channelzBuildersRetainOperationalStatistics() {
+        InternalWithLogId channel = () -> InternalLogId.allocate("channel", "one");
+        InternalChannelz.ChannelTrace.Event event = new InternalChannelz.ChannelTrace.Event.Builder()
+                .setDescription("connected").setTimestampNanos(12)
+                .setSeverity(InternalChannelz.ChannelTrace.Event.Severity.CT_INFO)
+                .setChannelRef(channel).build();
+        InternalChannelz.ChannelTrace trace = new InternalChannelz.ChannelTrace.Builder()
+                .setCreationTimeNanos(10).setNumEventsLogged(1).setEvents(Collections.singletonList(event)).build();
+        InternalChannelz.ChannelStats stats = new InternalChannelz.ChannelStats.Builder()
+                .setTarget("dns:///service").setState(ConnectivityState.READY).setChannelTrace(trace)
+                .setCallsStarted(5).setCallsSucceeded(4).setCallsFailed(1).setLastCallStartedNanos(11)
+                .setSubchannels(Collections.singletonList(channel)).build();
+        assertThat(event).isEqualTo(new InternalChannelz.ChannelTrace.Event.Builder()
+                .setDescription("connected").setTimestampNanos(12)
+                .setSeverity(InternalChannelz.ChannelTrace.Event.Severity.CT_INFO).setChannelRef(channel).build());
+        assertThat(event.toString()).contains("connected");
+        assertThat(trace.events).containsExactly(event);
+        assertThat(stats.target).isEqualTo("dns:///service");
+        assertThat(stats.callsStarted).isEqualTo(5);
+        assertThat(stats.callsSucceeded).isEqualTo(4);
+        assertThat(stats.callsFailed).isEqualTo(1);
+    }
+
+    @Test
+    void socketOptionBuildersProduceInspectableNetworkConfiguration() {
+        InternalChannelz.TcpInfo tcpInfo = new InternalChannelz.TcpInfo.Builder()
+                .setState(1).setCaState(2).setRtt(3).setRttvar(4).setSndCwnd(5).setUnacked(6).build();
+        InternalChannelz.SocketOptions options = new InternalChannelz.SocketOptions.Builder()
+                .setSocketOptionTimeoutMillis(500).setSocketOptionLingerSeconds(3).setTcpInfo(tcpInfo)
+                .addOption("keepAlive", true).addOption("retries", 2).addOption("mode", "active").build();
+        assertThat(options.soTimeoutMillis).isEqualTo(500);
+        assertThat(options.lingerSeconds).isEqualTo(3);
+        assertThat(options.tcpInfo).isSameAs(tcpInfo);
+        assertThat(options.others).containsEntry("keepAlive", "true").containsEntry("retries", "2")
+                .containsEntry("mode", "active");
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiInterceptorsTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiInterceptorsTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+public class GrpcApiInterceptorsTest {
+    private static final MethodDescriptor.Marshaller<String> MARSHALLER = new MethodDescriptor.Marshaller<String>() {
+        @Override
+        public InputStream stream(String value) {
+            return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String parse(InputStream stream) {
+            try {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (java.io.IOException exception) {
+                throw new AssertionError(exception);
+            }
+        }
+    };
+
+    private static final MethodDescriptor<String, String> METHOD = MethodDescriptor.create(
+            MethodDescriptor.MethodType.UNARY, "demo.Echo/Say", MARSHALLER, MARSHALLER);
+
+    @Test
+    void clientInterceptorsWrapCallsInDeclaredOrderAndDelegateMessages() {
+        RecordingCall call = new RecordingCall();
+        Channel base = new Channel() {
+            @Override
+            public String authority() {
+                return "demo";
+            }
+
+            @Override
+            public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+                    MethodDescriptor<ReqT, RespT> method, CallOptions callOptions) {
+                assertThat(method).isEqualTo(METHOD);
+                return (ClientCall<ReqT, RespT>) call;
+            }
+        };
+        AtomicBoolean first = new AtomicBoolean();
+        AtomicBoolean second = new AtomicBoolean();
+        ClientInterceptor markFirst = new MarkingInterceptor(first);
+        ClientInterceptor markSecond = new MarkingInterceptor(second);
+        Channel reverse = ClientInterceptors.intercept(base, markFirst, markSecond);
+        ClientCall<String, String> intercepted = reverse.newCall(METHOD, CallOptions.DEFAULT);
+        intercepted.start(new ClientCall.Listener<String>() {}, new Metadata());
+        intercepted.sendMessage("hello");
+        assertThat(first).isTrue();
+        assertThat(second).isTrue();
+        assertThat(call.started).isTrue();
+        assertThat(call.message).isEqualTo("hello");
+
+        first.set(false);
+        second.set(false);
+        ClientInterceptors.interceptForward(base, Arrays.asList(markFirst, markSecond))
+                .newCall(METHOD, CallOptions.DEFAULT);
+        assertThat(first).isTrue();
+        assertThat(second).isTrue();
+    }
+
+    @Test
+    void forwardingCallsAndListenersRetainUnderlyingSemantics() {
+        RecordingCall delegate = new RecordingCall();
+        ClientCall<String, String> forwarding = new ForwardingClientCall.SimpleForwardingClientCall<String, String>(delegate) {};
+        AtomicBoolean delivered = new AtomicBoolean();
+        ClientCall.Listener<String> listener = new ForwardingClientCallListener.SimpleForwardingClientCallListener<String>(
+                new ClientCall.Listener<String>() {
+                    @Override
+                    public void onMessage(String message) {
+                        delivered.set(true);
+                    }
+                }) {};
+        forwarding.start(listener, new Metadata());
+        forwarding.sendMessage("forwarded");
+        forwarding.request(2);
+        forwarding.setMessageCompression(true);
+        forwarding.halfClose();
+        forwarding.cancel("finished", null);
+        listener.onHeaders(new Metadata());
+        listener.onMessage("response");
+        listener.onReady();
+        listener.onClose(Status.OK, new Metadata());
+        assertThat(delegate.started).isTrue();
+        assertThat(delegate.message).isEqualTo("forwarded");
+        assertThat(delegate.requested).isEqualTo(2);
+        assertThat(delegate.messageCompression).isTrue();
+        assertThat(delegate.halfClosed).isTrue();
+        assertThat(delegate.cancelled).isTrue();
+        assertThat(delivered).isTrue();
+        assertThat(forwarding.getAttributes()).isEqualTo(Attributes.EMPTY);
+        assertThat(forwarding.isReady()).isTrue();
+        assertThat(forwarding.toString()).contains("delegate");
+        assertThat(listener.toString()).contains("delegate");
+    }
+
+    @Test
+    void serverInterceptorsKeepMethodDefinitionsAndInvokeHandler() {
+        AtomicBoolean invoked = new AtomicBoolean();
+        ServerCallHandler<String, String> handler = (call, headers) -> {
+            invoked.set(true);
+            return new ServerCall.Listener<String>() {};
+        };
+        ServerMethodDefinition<String, String> definition = ServerMethodDefinition.create(METHOD, handler);
+        ServerServiceDefinition service = ServerServiceDefinition.builder("demo.Echo").addMethod(definition).build();
+        ServerServiceDefinition wrapped = ServerInterceptors.intercept(service, new PassingServerInterceptor());
+        assertThat(wrapped.getServiceDescriptor().getName()).isEqualTo("demo.Echo");
+        assertThat(wrapped.getMethod(METHOD.getFullMethodName()).getMethodDescriptor()).isEqualTo(METHOD);
+        assertThat(wrapped.getMethods()).hasSize(1);
+        @SuppressWarnings("unchecked")
+        ServerMethodDefinition<String, String> wrappedMethod = (ServerMethodDefinition<String, String>)
+                (ServerMethodDefinition<?, ?>) wrapped.getMethod(METHOD.getFullMethodName());
+        wrappedMethod.getServerCallHandler().startCall(new ServerCall<String, String>() {
+                    @Override public void request(int count) {}
+                    @Override public void sendHeaders(Metadata headers) {}
+                    @Override public void sendMessage(String message) {}
+                    @Override public void close(Status status, Metadata trailers) {}
+                    @Override public boolean isCancelled() { return false; }
+                    @Override public MethodDescriptor<String, String> getMethodDescriptor() { return METHOD; }
+                }, new Metadata());
+        assertThat(invoked).isTrue();
+        assertThat(definition.withServerCallHandler(handler).getServerCallHandler()).isSameAs(handler);
+    }
+
+    private static final class MarkingInterceptor implements ClientInterceptor {
+        private final AtomicBoolean invoked;
+
+        private MarkingInterceptor(AtomicBoolean invoked) {
+            this.invoked = invoked;
+        }
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                MethodDescriptor<ReqT, RespT> method, CallOptions options, Channel next) {
+            invoked.set(true);
+            return next.newCall(method, options);
+        }
+    }
+
+    private static final class PassingServerInterceptor implements ServerInterceptor {
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            return next.startCall(call, headers);
+        }
+    }
+
+    private static final class RecordingCall extends ClientCall<String, String> {
+        private boolean started;
+        private boolean cancelled;
+        private boolean halfClosed;
+        private boolean messageCompression;
+        private int requested;
+        private String message;
+
+        @Override public void start(Listener<String> listener, Metadata headers) { started = true; }
+        @Override public void request(int count) { requested += count; }
+        @Override public void cancel(String message, Throwable cause) { cancelled = true; }
+        @Override public void halfClose() { halfClosed = true; }
+        @Override public void setMessageCompression(boolean enabled) { messageCompression = enabled; }
+        @Override public void sendMessage(String message) { this.message = message; }
+        @Override public boolean isReady() { return true; }
+        @Override public Attributes getAttributes() { return Attributes.EMPTY; }
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiValueObjectsTest.java
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/src/test/java/io_grpc/grpc_api/GrpcApiValueObjectsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_grpc.grpc_api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Codec;
+import io.grpc.CompressorRegistry;
+import io.grpc.ConnectivityState;
+import io.grpc.ConnectivityStateInfo;
+import io.grpc.Deadline;
+import io.grpc.DecompressorRegistry;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.InternalLogId;
+import io.grpc.InternalMetadata;
+import io.grpc.LoadBalancer;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.NameResolver;
+import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class GrpcApiValueObjectsTest {
+    private static final MethodDescriptor.Marshaller<String> STRING_MARSHALLER =
+            new MethodDescriptor.Marshaller<String>() {
+                @Override
+                public InputStream stream(String value) {
+                    return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public String parse(InputStream stream) {
+                    try {
+                        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                    } catch (java.io.IOException exception) {
+                        throw new AssertionError(exception);
+                    }
+                }
+            };
+
+    @Test
+    void attributesAndCallOptionsPreserveConfiguredValues() {
+        Attributes.Key<String> name = Attributes.Key.create("name");
+        Attributes.Key<Integer> count = Attributes.Key.of("count");
+        Attributes original = Attributes.newBuilder().set(name, "grpc").set(count, 2).build();
+        Attributes derived = original.toBuilder().discard(count).setAll(original).build();
+
+        assertThat(derived).isEqualTo(original);
+        assertThat(derived.get(name)).isEqualTo("grpc");
+        assertThat(derived.keys()).containsExactlyInAnyOrder(name, count);
+        assertThat(derived.toString()).contains("name");
+        assertThat(name.toString()).isEqualTo("name");
+        assertThat(original.hashCode()).isEqualTo(derived.hashCode());
+
+        CallOptions.Key<String> option = CallOptions.Key.createWithDefault("tenant", "default");
+        CallOptions options = CallOptions.DEFAULT
+                .withAuthority("api.example")
+                .withCompression("gzip")
+                .withDeadline(Deadline.after(2, TimeUnit.SECONDS))
+                .withDeadlineAfter(1, TimeUnit.SECONDS)
+                .withMaxInboundMessageSize(1024)
+                .withMaxOutboundMessageSize(2048)
+                .withOption(option, "blue")
+                .withWaitForReady()
+                .withoutWaitForReady();
+
+        assertThat(options.getAuthority()).isEqualTo("api.example");
+        assertThat(options.getCompressor()).isEqualTo("gzip");
+        assertThat(options.getDeadline()).isNotNull();
+        assertThat(options.getMaxInboundMessageSize()).isEqualTo(1024);
+        assertThat(options.getMaxOutboundMessageSize()).isEqualTo(2048);
+        assertThat(options.getOption(option)).isEqualTo("blue");
+        assertThat(options.isWaitForReady()).isFalse();
+        assertThat(options.getStreamTracerFactories()).isEmpty();
+        assertThat(options.toString()).contains("api.example");
+        assertThat(option.getDefault()).isEqualTo("default");
+        assertThat(CallOptions.Key.of("fallback", "value").toString()).isEqualTo("fallback");
+    }
+
+    @Test
+    void codecsRegistriesAndMetadataRoundTripUserData() throws Exception {
+        byte[] message = "compressed grpc payload".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+        try (java.io.OutputStream stream = new Codec.Gzip().compress(compressed)) {
+            stream.write(message);
+        }
+        byte[] restored;
+        try (InputStream stream = new Codec.Gzip().decompress(new ByteArrayInputStream(compressed.toByteArray()))) {
+            restored = stream.readAllBytes();
+        }
+        assertThat(restored).isEqualTo(message);
+        assertThat(Codec.Identity.NONE.compress(compressed)).isSameAs(compressed);
+        assertThat(Codec.Identity.NONE.getMessageEncoding()).isEqualTo("identity");
+        assertThat(new Codec.Gzip().getMessageEncoding()).isEqualTo("gzip");
+        CompressorRegistry compressors = CompressorRegistry.newEmptyInstance();
+        compressors.register(new Codec.Gzip());
+        assertThat(compressors.lookupCompressor("gzip")).isNotNull();
+        assertThat(CompressorRegistry.getDefaultInstance().lookupCompressor("gzip")).isNotNull();
+        assertThat(DecompressorRegistry.emptyInstance().with(new Codec.Gzip(), true)
+                .lookupDecompressor("gzip")).isNotNull();
+
+        Metadata.Key<String> header = Metadata.Key.of("x-tenant", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key<byte[]> binary = Metadata.Key.of("trace-bin", Metadata.BINARY_BYTE_MARSHALLER);
+        Metadata metadata = new Metadata();
+        metadata.put(header, "blue");
+        metadata.put(header, "green");
+        metadata.put(binary, new byte[] {1, 2});
+        assertThat(metadata.containsKey(header)).isTrue();
+        assertThat(metadata.get(header)).isEqualTo("green");
+        assertThat(metadata.getAll(header)).containsExactly("blue", "green");
+        assertThat(metadata.remove(header, "blue")).isTrue();
+        assertThat(metadata.removeAll(header)).containsExactly("green");
+        metadata.merge(new Metadata());
+        metadata.discardAll(binary);
+        assertThat(metadata.keys()).doesNotContain("trace-bin");
+        assertThat(header.name()).isEqualTo("x-tenant");
+        assertThat(header.originalName()).isEqualTo("x-tenant");
+        assertThat(header).isEqualTo(Metadata.Key.of("x-tenant", Metadata.ASCII_STRING_MARSHALLER));
+    }
+
+    @Test
+    void descriptorsAndResolverValuesRetainTheirSemanticConfiguration() {
+        MethodDescriptor<String, String> method = MethodDescriptor.newBuilder(STRING_MARSHALLER, STRING_MARSHALLER)
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName(MethodDescriptor.generateFullMethodName("echo.Echo", "Say"))
+                .setSchemaDescriptor("schema")
+                .setIdempotent(true)
+                .setSafe(true)
+                .setSampledToLocalTracing(true)
+                .build();
+        assertThat(method.getServiceName()).isEqualTo("echo.Echo");
+        assertThat(MethodDescriptor.extractFullServiceName(method.getFullMethodName())).isEqualTo("echo.Echo");
+        assertThat(method.parseRequest(method.streamRequest("request"))).isEqualTo("request");
+        assertThat(method.parseResponse(method.streamResponse("response"))).isEqualTo("response");
+        assertThat(method.isIdempotent()).isTrue();
+        assertThat(method.isSafe()).isTrue();
+        assertThat(method.isSampledToLocalTracing()).isTrue();
+        MethodDescriptor<String, String> rebuilt = method.toBuilder().build();
+        assertThat(rebuilt.getFullMethodName()).isEqualTo(method.getFullMethodName());
+        assertThat(rebuilt.getSchemaDescriptor()).isEqualTo("schema");
+
+        ServiceDescriptor service = ServiceDescriptor.newBuilder("echo.Echo").setSchemaDescriptor("schema")
+                .addMethod(method).build();
+        assertThat(service.getName()).isEqualTo("echo.Echo");
+        assertThat(service.getMethods()).containsExactly(method);
+        assertThat(service.toString()).contains("echo.Echo");
+
+        EquivalentAddressGroup address = new EquivalentAddressGroup(new InetSocketAddress("localhost", 443));
+        EquivalentAddressGroup attributedAddress = new EquivalentAddressGroup(
+                Collections.singletonList(new InetSocketAddress("localhost", 443)), Attributes.EMPTY);
+        assertThat(attributedAddress.getAddresses()).containsExactly(new InetSocketAddress("localhost", 443));
+        assertThat(attributedAddress.getAttributes()).isEqualTo(Attributes.EMPTY);
+        assertThat(attributedAddress.hashCode()).isEqualTo(new EquivalentAddressGroup(
+                Collections.singletonList(new InetSocketAddress("localhost", 443)), Attributes.EMPTY).hashCode());
+        LoadBalancer.ResolvedAddresses addresses = LoadBalancer.ResolvedAddresses.newBuilder()
+                .setAddresses(Collections.singletonList(address)).setAttributes(Attributes.EMPTY)
+                .setLoadBalancingPolicyConfig("round_robin").build();
+        assertThat(addresses.toBuilder().build()).isEqualTo(addresses);
+        assertThat(addresses.getAddresses()).containsExactly(address);
+        assertThat(addresses.getLoadBalancingPolicyConfig()).isEqualTo("round_robin");
+
+        NameResolver.ConfigOrError config = NameResolver.ConfigOrError.fromConfig("service-config");
+        NameResolver.ResolutionResult result = NameResolver.ResolutionResult.newBuilder()
+                .setAddresses(Collections.singletonList(address)).setAttributes(Attributes.EMPTY)
+                .setServiceConfig(config).build();
+        assertThat(result.toBuilder().build()).isEqualTo(result);
+        assertThat(result.getServiceConfig().getConfig()).isEqualTo("service-config");
+        assertThat(NameResolver.ConfigOrError.fromError(Status.UNAVAILABLE).getError()).isEqualTo(Status.UNAVAILABLE);
+    }
+
+    @Test
+    void internalMetadataAndLogIdentifiersExposeWireAndDiagnosticValues() {
+        Metadata.Key<String> key = InternalMetadata.keyOf("x-route", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata original = new Metadata();
+        original.put(key, "blue");
+        byte[][] serialized = InternalMetadata.serialize(original);
+        Metadata restored = InternalMetadata.newMetadata(serialized);
+        assertThat(InternalMetadata.headerCount(restored)).isEqualTo(1);
+        assertThat(restored.get(key)).isEqualTo("blue");
+        assertThat(InternalMetadata.serializePartial(restored)).hasSize(2);
+        Object[] parsedValues = InternalMetadata.serializePartial(restored);
+        assertThat(InternalMetadata.newMetadataWithParsedValues(1, parsedValues)).isNotNull();
+
+        InternalLogId id = InternalLogId.allocate(GrpcApiValueObjectsTest.class, "test");
+        assertThat(id.getTypeName()).isEqualTo("GrpcApiValueObjectsTest");
+        assertThat(id.getDetails()).isEqualTo("test");
+        assertThat(id.getId()).isPositive();
+        assertThat(id.shortName()).contains("GrpcApiValueObjectsTest");
+        assertThat(id.toString()).contains("test");
+    }
+
+    @Test
+    void synchronizationContextSerializesImmediateAndScheduledWork() {
+        AtomicInteger completed = new AtomicInteger();
+        SynchronizationContext context = new SynchronizationContext((thread, error) -> {
+            throw new AssertionError(error);
+        });
+        context.executeLater(completed::incrementAndGet);
+        assertThat(completed).hasValue(0);
+        context.drain();
+        assertThat(completed).hasValue(1);
+        context.execute(completed::incrementAndGet);
+        assertThat(completed).hasValue(2);
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            SynchronizationContext.ScheduledHandle handle = context.schedule(
+                    completed::incrementAndGet, 1, TimeUnit.DAYS, scheduler);
+            assertThat(handle.isPending()).isTrue();
+            handle.cancel();
+            assertThat(handle.isPending()).isFalse();
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    void statusAndConnectivityExposeFailureDetails() {
+        IllegalStateException cause = new IllegalStateException("offline");
+        Status status = Status.UNAVAILABLE.withDescription("backend unavailable").withCause(cause)
+                .augmentDescription("retry later");
+        assertThat(status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+        assertThat(status.getDescription()).contains("backend unavailable", "retry later");
+        assertThat(status.getCause()).isSameAs(cause);
+        assertThat(Status.fromCodeValue(14)).isEqualTo(Status.UNAVAILABLE);
+        assertThat(Status.fromThrowable(status.asRuntimeException())).isEqualTo(status);
+        assertThat(Status.trailersFromThrowable(status.asException())).isNull();
+        assertThat(status.asException().getStatus()).isEqualTo(status);
+        assertThat(status.asRuntimeException().getStatus()).isEqualTo(status);
+
+        ConnectivityStateInfo ready = ConnectivityStateInfo.forNonError(ConnectivityState.READY);
+        ConnectivityStateInfo failure = ConnectivityStateInfo.forTransientFailure(Status.UNAVAILABLE);
+        assertThat(ready.getState()).isEqualTo(ConnectivityState.READY);
+        assertThat(ready.getStatus()).isEqualTo(Status.OK);
+        assertThat(failure.getStatus()).isEqualTo(Status.UNAVAILABLE);
+        assertThat(ready).isEqualTo(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
+        assertThat(failure.toString()).contains("UNAVAILABLE");
+    }
+}

--- a/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/suite.json
+++ b/tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+  "coordinates": "io.grpc:grpc-api:1.27.2"
+}


### PR DESCRIPTION
## Code coverage improvement

- Source issue: #9043
- Coordinate: `io.grpc:grpc-api:1.27.2`
- Coverage suite path: `tests/src/io.grpc/grpc-api/1.27.2/code-coverage-improvement`
- Needs human intervention: no

## JaCoCo coverage

### Public API entries

- Baseline: 1/667 (0.15%)
- Final: 453/667 (67.92%)
- Delta: +67.77pp
- Remaining uncovered: 214

### Deep internal methods

- Baseline: 148/316 (46.84%)
- Final: 168/316 (53.16%)
- Delta: +6.32pp
- Remaining uncovered: 148

## Sampled PGO guidance only

Sampled PGO is navigation evidence only. Sample counts do not measure coverage, and sample absence does not prove non-execution.

- Baseline: 122 contexts, 702 sampled methods, 157 samples, 9 sampled joins
- Final: 130 contexts, 781 sampled methods, 165 samples, 0 sampled joins

## Completed targets (472)

- [api] `io.grpc.Attributes#equals(java.lang.Object):boolean`
- [api] `io.grpc.Attributes#get(io.grpc.Attributes$Key):java.lang.Object`
- [api] `io.grpc.Attributes#hashCode():int`
- [api] `io.grpc.Attributes#keys():java.util.Set`
- [api] `io.grpc.Attributes#newBuilder():io.grpc.Attributes$Builder`
- [api] `io.grpc.Attributes#toBuilder():io.grpc.Attributes$Builder`
- [api] `io.grpc.Attributes#toString():java.lang.String`
- [api] `io.grpc.Attributes$Builder#build():io.grpc.Attributes`
- [api] `io.grpc.Attributes$Builder#discard(io.grpc.Attributes$Key):io.grpc.Attributes$Builder`
- [api] `io.grpc.Attributes$Builder#set(io.grpc.Attributes$Key,java.lang.Object):io.grpc.Attributes$Builder`
- [api] `io.grpc.Attributes$Builder#setAll(io.grpc.Attributes):io.grpc.Attributes$Builder`
- [api] `io.grpc.Attributes$Key#create(java.lang.String):io.grpc.Attributes$Key`
- [api] `io.grpc.Attributes$Key#of(java.lang.String):io.grpc.Attributes$Key`
- [api] `io.grpc.Attributes$Key#toString():java.lang.String`
- [api] `io.grpc.BinaryLog#<init>():void`
- [api] `io.grpc.CallCredentials#<init>():void`
- [api] `io.grpc.CallCredentials$MetadataApplier#<init>():void`
- [api] `io.grpc.CallCredentials2#<init>():void`
- [api] `io.grpc.CallCredentials2#applyRequestMetadata(io.grpc.CallCredentials$RequestInfo,java.util.concurrent.Executor,io.grpc.CallCredentials$MetadataApplier):void`
- [api] `io.grpc.CallCredentials2$MetadataApplier#<init>():void`
- [api] `io.grpc.CallOptions#getAuthority():java.lang.String`
- [api] `io.grpc.CallOptions#getCompressor():java.lang.String`
- [api] `io.grpc.CallOptions#getCredentials():io.grpc.CallCredentials`
- [api] `io.grpc.CallOptions#getDeadline():io.grpc.Deadline`
- [api] `io.grpc.CallOptions#getExecutor():java.util.concurrent.Executor`
- [api] `io.grpc.CallOptions#getMaxInboundMessageSize():java.lang.Integer`
- [api] `io.grpc.CallOptions#getMaxOutboundMessageSize():java.lang.Integer`
- [api] `io.grpc.CallOptions#getOption(io.grpc.CallOptions$Key):java.lang.Object`
- [api] `io.grpc.CallOptions#getStreamTracerFactories():java.util.List`
- [api] `io.grpc.CallOptions#isWaitForReady():boolean`
- [api] `io.grpc.CallOptions#toString():java.lang.String`
- [api] `io.grpc.CallOptions#withAuthority(java.lang.String):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withCallCredentials(io.grpc.CallCredentials):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withCompression(java.lang.String):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withDeadline(io.grpc.Deadline):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withDeadlineAfter(long,java.util.concurrent.TimeUnit):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withExecutor(java.util.concurrent.Executor):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withMaxInboundMessageSize(int):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withMaxOutboundMessageSize(int):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withOption(io.grpc.CallOptions$Key,java.lang.Object):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withStreamTracerFactory(io.grpc.ClientStreamTracer$Factory):io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withWaitForReady():io.grpc.CallOptions`
- [api] `io.grpc.CallOptions#withoutWaitForReady():io.grpc.CallOptions`
- [api] `io.grpc.CallOptions$Key#create(java.lang.String):io.grpc.CallOptions$Key`
- [api] `io.grpc.CallOptions$Key#createWithDefault(java.lang.String,java.lang.Object):io.grpc.CallOptions$Key`
- [api] `io.grpc.CallOptions$Key#getDefault():java.lang.Object`
- [api] `io.grpc.CallOptions$Key#of(java.lang.String,java.lang.Object):io.grpc.CallOptions$Key`
- [api] `io.grpc.CallOptions$Key#toString():java.lang.String`
- [api] `io.grpc.Channel#<init>():void`
- [api] `io.grpc.ChannelLogger#<init>():void`
- [api] `io.grpc.ClientCall#<init>():void`
- [api] `io.grpc.ClientCall#getAttributes():io.grpc.Attributes`
- [api] `io.grpc.ClientCall#isReady():boolean`
- [api] `io.grpc.ClientCall#setMessageCompression(boolean):void`
- [api] `io.grpc.ClientCall$Listener#<init>():void`
- [api] `io.grpc.ClientCall$Listener#onClose(io.grpc.Status,io.grpc.Metadata):void`
- [api] `io.grpc.ClientCall$Listener#onHeaders(io.grpc.Metadata):void`
- [api] `io.grpc.ClientCall$Listener#onMessage(java.lang.Object):void`
- [api] `io.grpc.ClientCall$Listener#onReady():void`
- [api] `io.grpc.ClientInterceptors#intercept(io.grpc.Channel,io.grpc.ClientInterceptor[]):io.grpc.Channel`
- [api] `io.grpc.ClientInterceptors#intercept(io.grpc.Channel,java.util.List):io.grpc.Channel`
- [api] `io.grpc.ClientInterceptors#interceptForward(io.grpc.Channel,java.util.List):io.grpc.Channel`
- [api] `io.grpc.ClientStreamTracer#<init>():void`
- [api] `io.grpc.ClientStreamTracer#inboundHeaders():void`
- [api] `io.grpc.ClientStreamTracer#inboundTrailers(io.grpc.Metadata):void`
- [api] `io.grpc.ClientStreamTracer#outboundHeaders():void`
- [api] `io.grpc.ClientStreamTracer$Factory#<init>():void`
- [api] `io.grpc.ClientStreamTracer$StreamInfo#getCallOptions():io.grpc.CallOptions`
- [api] `io.grpc.ClientStreamTracer$StreamInfo#getTransportAttrs():io.grpc.Attributes`
- [api] `io.grpc.ClientStreamTracer$StreamInfo#newBuilder():io.grpc.ClientStreamTracer$StreamInfo$Builder`
- [api] `io.grpc.ClientStreamTracer$StreamInfo#toBuilder():io.grpc.ClientStreamTracer$StreamInfo$Builder`
- [api] `io.grpc.ClientStreamTracer$StreamInfo#toString():java.lang.String`
- [api] `io.grpc.ClientStreamTracer$StreamInfo$Builder#build():io.grpc.ClientStreamTracer$StreamInfo`
- [api] `io.grpc.ClientStreamTracer$StreamInfo$Builder#setCallOptions(io.grpc.CallOptions):io.grpc.ClientStreamTracer$StreamInfo$Builder`
- [api] `io.grpc.ClientStreamTracer$StreamInfo$Builder#setTransportAttrs(io.grpc.Attributes):io.grpc.ClientStreamTracer$StreamInfo$Builder`
- [api] `io.grpc.Codec$Gzip#<init>():void`
- [api] `io.grpc.Codec$Gzip#compress(java.io.OutputStream):java.io.OutputStream`
- [api] `io.grpc.Codec$Gzip#decompress(java.io.InputStream):java.io.InputStream`
- [api] `io.grpc.Codec$Gzip#getMessageEncoding():java.lang.String`
- [api] `io.grpc.Codec$Identity#compress(java.io.OutputStream):java.io.OutputStream`
- [api] `io.grpc.Codec$Identity#decompress(java.io.InputStream):java.io.InputStream`
- [api] `io.grpc.Codec$Identity#getMessageEncoding():java.lang.String`
- [api] `io.grpc.CompressorRegistry#getDefaultInstance():io.grpc.CompressorRegistry`
- [api] `io.grpc.CompressorRegistry#lookupCompressor(java.lang.String):io.grpc.Compressor`
- [api] `io.grpc.CompressorRegistry#newEmptyInstance():io.grpc.CompressorRegistry`
- [api] `io.grpc.CompressorRegistry#register(io.grpc.Compressor):void`
- [api] `io.grpc.ConnectivityStateInfo#equals(java.lang.Object):boolean`
- [api] `io.grpc.ConnectivityStateInfo#forNonError(io.grpc.ConnectivityState):io.grpc.ConnectivityStateInfo`
- [api] `io.grpc.ConnectivityStateInfo#forTransientFailure(io.grpc.Status):io.grpc.ConnectivityStateInfo`
- [api] `io.grpc.ConnectivityStateInfo#getState():io.grpc.ConnectivityState`
- [api] `io.grpc.ConnectivityStateInfo#getStatus():io.grpc.Status`
- [api] `io.grpc.ConnectivityStateInfo#toString():java.lang.String`
- [api] `io.grpc.Contexts#statusFromCancelled(io.grpc.Context):io.grpc.Status`
- [api] `io.grpc.DecompressorRegistry#emptyInstance():io.grpc.DecompressorRegistry`
- [api] `io.grpc.DecompressorRegistry#getAdvertisedMessageEncodings():java.util.Set`
- [api] `io.grpc.DecompressorRegistry#getDefaultInstance():io.grpc.DecompressorRegistry`
- [api] `io.grpc.DecompressorRegistry#getKnownMessageEncodings():java.util.Set`
- [api] `io.grpc.DecompressorRegistry#lookupDecompressor(java.lang.String):io.grpc.Decompressor`
- [api] `io.grpc.DecompressorRegistry#with(io.grpc.Decompressor,boolean):io.grpc.DecompressorRegistry`
- [api] `io.grpc.EquivalentAddressGroup#<init>(java.net.SocketAddress):void`
- [api] `io.grpc.EquivalentAddressGroup#<init>(java.net.SocketAddress,io.grpc.Attributes):void`
- [api] `io.grpc.EquivalentAddressGroup#<init>(java.util.List,io.grpc.Attributes):void`
- [api] `io.grpc.EquivalentAddressGroup#equals(java.lang.Object):boolean`
- [api] `io.grpc.EquivalentAddressGroup#getAddresses():java.util.List`
- [api] `io.grpc.EquivalentAddressGroup#getAttributes():io.grpc.Attributes`
- [api] `io.grpc.EquivalentAddressGroup#hashCode():int`
- [api] `io.grpc.EquivalentAddressGroup#toString():java.lang.String`
- [api] `io.grpc.ForwardingChannelBuilder#blockingExecutor(java.util.concurrent.Executor):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#build():io.grpc.ManagedChannel`
- [api] `io.grpc.ForwardingChannelBuilder#compressorRegistry(io.grpc.CompressorRegistry):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#decompressorRegistry(io.grpc.DecompressorRegistry):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#defaultLoadBalancingPolicy(java.lang.String):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#defaultServiceConfig(java.util.Map):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#directExecutor():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#disableRetry():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#disableServiceConfigLookUp():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#enableFullStreamDecompression():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#enableRetry():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#executor(java.util.concurrent.Executor):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#forAddress(java.lang.String,int):io.grpc.ManagedChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#forTarget(java.lang.String):io.grpc.ManagedChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#idleTimeout(long,java.util.concurrent.TimeUnit):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#intercept(io.grpc.ClientInterceptor[]):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#intercept(java.util.List):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#keepAliveTime(long,java.util.concurrent.TimeUnit):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#keepAliveTimeout(long,java.util.concurrent.TimeUnit):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#keepAliveWithoutCalls(boolean):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#maxHedgedAttempts(int):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#maxInboundMessageSize(int):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#maxInboundMetadataSize(int):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#maxRetryAttempts(int):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#maxTraceEvents(int):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#nameResolverFactory(io.grpc.NameResolver$Factory):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#offloadExecutor(java.util.concurrent.Executor):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#overrideAuthority(java.lang.String):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#perRpcBufferLimit(long):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#proxyDetector(io.grpc.ProxyDetector):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#retryBufferSize(long):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#setBinaryLog(io.grpc.BinaryLog):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#toString():java.lang.String`
- [api] `io.grpc.ForwardingChannelBuilder#usePlaintext():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#useTransportSecurity():io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingChannelBuilder#userAgent(java.lang.String):io.grpc.ForwardingChannelBuilder`
- [api] `io.grpc.ForwardingClientCall#<init>():void`
- [api] `io.grpc.ForwardingClientCall#sendMessage(java.lang.Object):void`
- [api] `io.grpc.ForwardingClientCall#start(io.grpc.ClientCall$Listener,io.grpc.Metadata):void`
- [api] `io.grpc.ForwardingClientCallListener#<init>():void`
- [api] `io.grpc.ForwardingClientCallListener#onMessage(java.lang.Object):void`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#equals(java.lang.Object):boolean`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#getPassword():java.lang.String`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#getProxyAddress():java.net.SocketAddress`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#getTargetAddress():java.net.InetSocketAddress`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#getUsername():java.lang.String`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#hashCode():int`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#newBuilder():io.grpc.HttpConnectProxiedSocketAddress$Builder`
- [api] `io.grpc.HttpConnectProxiedSocketAddress#toString():java.lang.String`
- [api] `io.grpc.HttpConnectProxiedSocketAddress$Builder#build():io.grpc.HttpConnectProxiedSocketAddress`
- [api] `io.grpc.HttpConnectProxiedSocketAddress$Builder#setPassword(java.lang.String):io.grpc.HttpConnectProxiedSocketAddress$Builder`
- [api] `io.grpc.HttpConnectProxiedSocketAddress$Builder#setProxyAddress(java.net.SocketAddress):io.grpc.HttpConnectProxiedSocketAddress$Builder`
- [api] `io.grpc.HttpConnectProxiedSocketAddress$Builder#setTargetAddress(java.net.InetSocketAddress):io.grpc.HttpConnectProxiedSocketAddress$Builder`
- [api] `io.grpc.HttpConnectProxiedSocketAddress$Builder#setUsername(java.lang.String):io.grpc.HttpConnectProxiedSocketAddress$Builder`
- [api] `io.grpc.InternalChannelz#<init>():void`
- [api] `io.grpc.InternalChannelz#addClientSocket(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#addListenSocket(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#addRootChannel(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#addServer(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#addServerSocket(io.grpc.InternalInstrumented,io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#addSubchannel(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#containsClientSocket(io.grpc.InternalLogId):boolean`
- [api] `io.grpc.InternalChannelz#containsServer(io.grpc.InternalLogId):boolean`
- [api] `io.grpc.InternalChannelz#containsSubchannel(io.grpc.InternalLogId):boolean`
- [api] `io.grpc.InternalChannelz#getChannel(long):io.grpc.InternalInstrumented`
- [api] `io.grpc.InternalChannelz#getRootChannel(long):io.grpc.InternalInstrumented`
- [api] `io.grpc.InternalChannelz#getRootChannels(long,int):io.grpc.InternalChannelz$RootChannelList`
- [api] `io.grpc.InternalChannelz#getServerSockets(long,long,int):io.grpc.InternalChannelz$ServerSocketsList`
- [api] `io.grpc.InternalChannelz#getServers(long,int):io.grpc.InternalChannelz$ServerList`
- [api] `io.grpc.InternalChannelz#getSocket(long):io.grpc.InternalInstrumented`
- [api] `io.grpc.InternalChannelz#getSubchannel(long):io.grpc.InternalInstrumented`
- [api] `io.grpc.InternalChannelz#id(io.grpc.InternalWithLogId):long`
- [api] `io.grpc.InternalChannelz#instance():io.grpc.InternalChannelz`
- [api] `io.grpc.InternalChannelz#removeClientSocket(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#removeListenSocket(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#removeRootChannel(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#removeServer(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#removeServerSocket(io.grpc.InternalInstrumented,io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz#removeSubchannel(io.grpc.InternalInstrumented):void`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#build():io.grpc.InternalChannelz$ChannelStats`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setCallsFailed(long):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setCallsStarted(long):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setCallsSucceeded(long):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setChannelTrace(io.grpc.InternalChannelz$ChannelTrace):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setLastCallStartedNanos(long):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setSockets(java.util.List):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setState(io.grpc.ConnectivityState):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setSubchannels(java.util.List):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelStats$Builder#setTarget(java.lang.String):io.grpc.InternalChannelz$ChannelStats$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Builder#build():io.grpc.InternalChannelz$ChannelTrace`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Builder#setCreationTimeNanos(long):io.grpc.InternalChannelz$ChannelTrace$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Builder#setEvents(java.util.List):io.grpc.InternalChannelz$ChannelTrace$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Builder#setNumEventsLogged(long):io.grpc.InternalChannelz$ChannelTrace$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event#equals(java.lang.Object):boolean`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event#toString():java.lang.String`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#build():io.grpc.InternalChannelz$ChannelTrace$Event`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#setChannelRef(io.grpc.InternalWithLogId):io.grpc.InternalChannelz$ChannelTrace$Event$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#setDescription(java.lang.String):io.grpc.InternalChannelz$ChannelTrace$Event$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#setSeverity(io.grpc.InternalChannelz$ChannelTrace$Event$Severity):io.grpc.InternalChannelz$ChannelTrace$Event$Builder`
- [api] `io.grpc.InternalChannelz$ChannelTrace$Event$Builder#setTimestampNanos(long):io.grpc.InternalChannelz$ChannelTrace$Event$Builder`
- [api] `io.grpc.InternalChannelz$OtherSecurity#<init>(java.lang.String,java.lang.Object):void`
- [api] `io.grpc.InternalChannelz$RootChannelList#<init>(java.util.List,boolean):void`
- [api] `io.grpc.InternalChannelz$Security#<init>(io.grpc.InternalChannelz$OtherSecurity):void`
- [api] `io.grpc.InternalChannelz$ServerList#<init>(java.util.List,boolean):void`
- [api] `io.grpc.InternalChannelz$ServerSocketsList#<init>(java.util.List,boolean):void`
- [api] `io.grpc.InternalChannelz$ServerStats#<init>(long,long,long,long,java.util.List):void`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#addListenSockets(java.util.List):io.grpc.InternalChannelz$ServerStats$Builder`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#build():io.grpc.InternalChannelz$ServerStats`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#setCallsFailed(long):io.grpc.InternalChannelz$ServerStats$Builder`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#setCallsStarted(long):io.grpc.InternalChannelz$ServerStats$Builder`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#setCallsSucceeded(long):io.grpc.InternalChannelz$ServerStats$Builder`
- [api] `io.grpc.InternalChannelz$ServerStats$Builder#setLastCallStartedNanos(long):io.grpc.InternalChannelz$ServerStats$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions#<init>(java.lang.Integer,java.lang.Integer,io.grpc.InternalChannelz$TcpInfo,java.util.Map):void`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#addOption(java.lang.String,boolean):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#addOption(java.lang.String,int):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#addOption(java.lang.String,java.lang.String):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#build():io.grpc.InternalChannelz$SocketOptions`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#setSocketOptionLingerSeconds(java.lang.Integer):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#setSocketOptionTimeoutMillis(java.lang.Integer):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketOptions$Builder#setTcpInfo(io.grpc.InternalChannelz$TcpInfo):io.grpc.InternalChannelz$SocketOptions$Builder`
- [api] `io.grpc.InternalChannelz$SocketStats#<init>(io.grpc.InternalChannelz$TransportStats,java.net.SocketAddress,java.net.SocketAddress,io.grpc.InternalChannelz$SocketOptions,io.grpc.InternalChannelz$Security):void`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#<init>():void`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#build():io.grpc.InternalChannelz$TcpInfo`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setAdvmss(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setAto(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setBackoff(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setCaState(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setFackets(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setLastAckRecv(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setLastAckSent(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setLastDataRecv(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setLastDataSent(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setLost(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setOptions(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setPmtu(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setProbes(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRcvMss(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRcvSsthresh(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRcvWscale(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setReordering(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRetrans(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRetransmits(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRto(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRtt(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setRttvar(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setSacked(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setSndCwnd(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setSndMss(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setSndSsthresh(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setSndWscale(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setState(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TcpInfo$Builder#setUnacked(int):io.grpc.InternalChannelz$TcpInfo$Builder`
- [api] `io.grpc.InternalChannelz$TransportStats#<init>(long,long,long,long,long,long,long,long,long,long,long,long):void`
- [api] `io.grpc.InternalLogId#allocate(java.lang.Class,java.lang.String):io.grpc.InternalLogId`
- [api] `io.grpc.InternalLogId#allocate(java.lang.String,java.lang.String):io.grpc.InternalLogId`
- [api] `io.grpc.InternalLogId#getDetails():java.lang.String`
- [api] `io.grpc.InternalLogId#getId():long`
- [api] `io.grpc.InternalLogId#getTypeName():java.lang.String`
- [api] `io.grpc.InternalLogId#shortName():java.lang.String`
- [api] `io.grpc.InternalLogId#toString():java.lang.String`
- [api] `io.grpc.InternalMetadata#headerCount(io.grpc.Metadata):int`
- [api] `io.grpc.InternalMetadata#keyOf(java.lang.String,io.grpc.Metadata$AsciiMarshaller):io.grpc.Metadata$Key`
- [api] `io.grpc.InternalMetadata#newMetadata(byte[][]):io.grpc.Metadata`
- [api] `io.grpc.InternalMetadata#newMetadataWithParsedValues(int,java.lang.Object[]):io.grpc.Metadata`
- [api] `io.grpc.InternalMetadata#serialize(io.grpc.Metadata):byte[][]`
- [api] `io.grpc.InternalMetadata#serializePartial(io.grpc.Metadata):java.lang.Object[]`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#getAddresses():java.util.List`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#getAttributes():io.grpc.Attributes`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#getOption(io.grpc.LoadBalancer$CreateSubchannelArgs$Key):java.lang.Object`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#newBuilder():io.grpc.LoadBalancer$CreateSubchannelArgs$Builder`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#toBuilder():io.grpc.LoadBalancer$CreateSubchannelArgs$Builder`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs#toString():java.lang.String`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Builder#addOption(io.grpc.LoadBalancer$CreateSubchannelArgs$Key,java.lang.Object):io.grpc.LoadBalancer$CreateSubchannelArgs$Builder`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Builder#build():io.grpc.LoadBalancer$CreateSubchannelArgs`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Builder#setAddresses(java.util.List):io.grpc.LoadBalancer$CreateSubchannelArgs$Builder`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Builder#setAttributes(io.grpc.Attributes):io.grpc.LoadBalancer$CreateSubchannelArgs$Builder`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Key#createWithDefault(java.lang.String,java.lang.Object):io.grpc.LoadBalancer$CreateSubchannelArgs$Key`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Key#getDefault():java.lang.Object`
- [api] `io.grpc.LoadBalancer$CreateSubchannelArgs$Key#toString():java.lang.String`
- [api] `io.grpc.LoadBalancer$PickResult#equals(java.lang.Object):boolean`
- [api] `io.grpc.LoadBalancer$PickResult#getStatus():io.grpc.Status`
- [api] `io.grpc.LoadBalancer$PickResult#getSubchannel():io.grpc.LoadBalancer$Subchannel`
- [api] `io.grpc.LoadBalancer$PickResult#hashCode():int`
- [api] `io.grpc.LoadBalancer$PickResult#isDrop():boolean`
- [api] `io.grpc.LoadBalancer$PickResult#toString():java.lang.String`
- [api] `io.grpc.LoadBalancer$PickResult#withDrop(io.grpc.Status):io.grpc.LoadBalancer$PickResult`
- [api] `io.grpc.LoadBalancer$PickResult#withError(io.grpc.Status):io.grpc.LoadBalancer$PickResult`
- [api] `io.grpc.LoadBalancer$PickResult#withNoResult():io.grpc.LoadBalancer$PickResult`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses#equals(java.lang.Object):boolean`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses#getAddresses():java.util.List`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses#getLoadBalancingPolicyConfig():java.lang.Object`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses#newBuilder():io.grpc.LoadBalancer$ResolvedAddresses$Builder`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses#toBuilder():io.grpc.LoadBalancer$ResolvedAddresses$Builder`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses$Builder#build():io.grpc.LoadBalancer$ResolvedAddresses`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses$Builder#setAddresses(java.util.List):io.grpc.LoadBalancer$ResolvedAddresses$Builder`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses$Builder#setAttributes(io.grpc.Attributes):io.grpc.LoadBalancer$ResolvedAddresses$Builder`
- [api] `io.grpc.LoadBalancer$ResolvedAddresses$Builder#setLoadBalancingPolicyConfig(java.lang.Object):io.grpc.LoadBalancer$ResolvedAddresses$Builder`
- [api] `io.grpc.ManagedChannel#<init>():void`
- [api] `io.grpc.ManagedChannelBuilder#<init>():void`
- [api] `io.grpc.Metadata#<init>():void`
- [api] `io.grpc.Metadata#containsKey(io.grpc.Metadata$Key):boolean`
- [api] `io.grpc.Metadata#discardAll(io.grpc.Metadata$Key):void`
- [api] `io.grpc.Metadata#get(io.grpc.Metadata$Key):java.lang.Object`
- [api] `io.grpc.Metadata#getAll(io.grpc.Metadata$Key):java.lang.Iterable`
- [api] `io.grpc.Metadata#keys():java.util.Set`
- [api] `io.grpc.Metadata#merge(io.grpc.Metadata):void`
- [api] `io.grpc.Metadata#put(io.grpc.Metadata$Key,java.lang.Object):void`
- [api] `io.grpc.Metadata#remove(io.grpc.Metadata$Key,java.lang.Object):boolean`
- [api] `io.grpc.Metadata#removeAll(io.grpc.Metadata$Key):java.lang.Iterable`
- [api] `io.grpc.Metadata$Key#equals(java.lang.Object):boolean`
- [api] `io.grpc.Metadata$Key#name():java.lang.String`
- [api] `io.grpc.Metadata$Key#of(java.lang.String,io.grpc.Metadata$AsciiMarshaller):io.grpc.Metadata$Key`
- [api] `io.grpc.Metadata$Key#of(java.lang.String,io.grpc.Metadata$BinaryMarshaller):io.grpc.Metadata$Key`
- [api] `io.grpc.Metadata$Key#originalName():java.lang.String`
- [api] `io.grpc.MethodDescriptor#create(io.grpc.MethodDescriptor$MethodType,java.lang.String,io.grpc.MethodDescriptor$Marshaller,io.grpc.MethodDescriptor$Marshaller):io.grpc.MethodDescriptor`
- [api] `io.grpc.MethodDescriptor#extractFullServiceName(java.lang.String):java.lang.String`
- [api] `io.grpc.MethodDescriptor#generateFullMethodName(java.lang.String,java.lang.String):java.lang.String`
- [api] `io.grpc.MethodDescriptor#getFullMethodName():java.lang.String`
- [api] `io.grpc.MethodDescriptor#getSchemaDescriptor():java.lang.Object`
- [api] `io.grpc.MethodDescriptor#getServiceName():java.lang.String`
- [api] `io.grpc.MethodDescriptor#isIdempotent():boolean`
- [api] `io.grpc.MethodDescriptor#isSafe():boolean`
- [api] `io.grpc.MethodDescriptor#isSampledToLocalTracing():boolean`
- [api] `io.grpc.MethodDescriptor#newBuilder():io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor#newBuilder(io.grpc.MethodDescriptor$Marshaller,io.grpc.MethodDescriptor$Marshaller):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor#parseRequest(java.io.InputStream):java.lang.Object`
- [api] `io.grpc.MethodDescriptor#parseResponse(java.io.InputStream):java.lang.Object`
- [api] `io.grpc.MethodDescriptor#streamRequest(java.lang.Object):java.io.InputStream`
- [api] `io.grpc.MethodDescriptor#streamResponse(java.lang.Object):java.io.InputStream`
- [api] `io.grpc.MethodDescriptor#toBuilder():io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor#toBuilder(io.grpc.MethodDescriptor$Marshaller,io.grpc.MethodDescriptor$Marshaller):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor#toString():java.lang.String`
- [api] `io.grpc.MethodDescriptor$Builder#build():io.grpc.MethodDescriptor`
- [api] `io.grpc.MethodDescriptor$Builder#setFullMethodName(java.lang.String):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setIdempotent(boolean):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setRequestMarshaller(io.grpc.MethodDescriptor$Marshaller):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setResponseMarshaller(io.grpc.MethodDescriptor$Marshaller):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setSafe(boolean):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setSampledToLocalTracing(boolean):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setSchemaDescriptor(java.lang.Object):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.MethodDescriptor$Builder#setType(io.grpc.MethodDescriptor$MethodType):io.grpc.MethodDescriptor$Builder`
- [api] `io.grpc.NameResolver$Args#getChannelLogger():io.grpc.ChannelLogger`
- [api] `io.grpc.NameResolver$Args#getDefaultPort():int`
- [api] `io.grpc.NameResolver$Args#getOffloadExecutor():java.util.concurrent.Executor`
- [api] `io.grpc.NameResolver$Args#getProxyDetector():io.grpc.ProxyDetector`
- [api] `io.grpc.NameResolver$Args#getScheduledExecutorService():java.util.concurrent.ScheduledExecutorService`
- [api] `io.grpc.NameResolver$Args#getServiceConfigParser():io.grpc.NameResolver$ServiceConfigParser`
- [api] `io.grpc.NameResolver$Args#getSynchronizationContext():io.grpc.SynchronizationContext`
- [api] `io.grpc.NameResolver$Args#newBuilder():io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args#toBuilder():io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#build():io.grpc.NameResolver$Args`
- [api] `io.grpc.NameResolver$Args$Builder#setChannelLogger(io.grpc.ChannelLogger):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setDefaultPort(int):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setOffloadExecutor(java.util.concurrent.Executor):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setProxyDetector(io.grpc.ProxyDetector):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setScheduledExecutorService(java.util.concurrent.ScheduledExecutorService):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setServiceConfigParser(io.grpc.NameResolver$ServiceConfigParser):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$Args$Builder#setSynchronizationContext(io.grpc.SynchronizationContext):io.grpc.NameResolver$Args$Builder`
- [api] `io.grpc.NameResolver$ConfigOrError#fromConfig(java.lang.Object):io.grpc.NameResolver$ConfigOrError`
- [api] `io.grpc.NameResolver$ConfigOrError#fromError(io.grpc.Status):io.grpc.NameResolver$ConfigOrError`
- [api] `io.grpc.NameResolver$ConfigOrError#getConfig():java.lang.Object`
- [api] `io.grpc.NameResolver$ConfigOrError#getError():io.grpc.Status`
- [api] `io.grpc.NameResolver$Factory#<init>():void`
- [api] `io.grpc.NameResolver$ResolutionResult#equals(java.lang.Object):boolean`
- [api] `io.grpc.NameResolver$ResolutionResult#getServiceConfig():io.grpc.NameResolver$ConfigOrError`
- [api] `io.grpc.NameResolver$ResolutionResult#newBuilder():io.grpc.NameResolver$ResolutionResult$Builder`
- [api] `io.grpc.NameResolver$ResolutionResult#toBuilder():io.grpc.NameResolver$ResolutionResult$Builder`
- [api] `io.grpc.NameResolver$ResolutionResult$Builder#build():io.grpc.NameResolver$ResolutionResult`
- [api] `io.grpc.NameResolver$ResolutionResult$Builder#setAddresses(java.util.List):io.grpc.NameResolver$ResolutionResult$Builder`
- [api] `io.grpc.NameResolver$ResolutionResult$Builder#setAttributes(io.grpc.Attributes):io.grpc.NameResolver$ResolutionResult$Builder`
- [api] `io.grpc.NameResolver$ResolutionResult$Builder#setServiceConfig(io.grpc.NameResolver$ConfigOrError):io.grpc.NameResolver$ResolutionResult$Builder`
- [api] `io.grpc.NameResolver$ServiceConfigParser#<init>():void`
- [api] `io.grpc.ProxiedSocketAddress#<init>():void`
- [api] `io.grpc.ServerCall#<init>():void`
- [api] `io.grpc.ServerCall$Listener#<init>():void`
- [api] `io.grpc.ServerInterceptors#intercept(io.grpc.ServerServiceDefinition,io.grpc.ServerInterceptor[]):io.grpc.ServerServiceDefinition`
- [api] `io.grpc.ServerInterceptors#intercept(io.grpc.ServerServiceDefinition,java.util.List):io.grpc.ServerServiceDefinition`
- [api] `io.grpc.ServerMethodDefinition#create(io.grpc.MethodDescriptor,io.grpc.ServerCallHandler):io.grpc.ServerMethodDefinition`
- [api] `io.grpc.ServerMethodDefinition#getMethodDescriptor():io.grpc.MethodDescriptor`
- [api] `io.grpc.ServerMethodDefinition#getServerCallHandler():io.grpc.ServerCallHandler`
- [api] `io.grpc.ServerMethodDefinition#withServerCallHandler(io.grpc.ServerCallHandler):io.grpc.ServerMethodDefinition`
- [api] `io.grpc.ServerServiceDefinition#builder(io.grpc.ServiceDescriptor):io.grpc.ServerServiceDefinition$Builder`
- [api] `io.grpc.ServerServiceDefinition#builder(java.lang.String):io.grpc.ServerServiceDefinition$Builder`
- [api] `io.grpc.ServerServiceDefinition#getMethod(java.lang.String):io.grpc.ServerMethodDefinition`
- [api] `io.grpc.ServerServiceDefinition#getMethods():java.util.Collection`
- [api] `io.grpc.ServerServiceDefinition#getServiceDescriptor():io.grpc.ServiceDescriptor`
- [api] `io.grpc.ServerServiceDefinition$Builder#addMethod(io.grpc.ServerMethodDefinition):io.grpc.ServerServiceDefinition$Builder`
- [api] `io.grpc.ServerServiceDefinition$Builder#build():io.grpc.ServerServiceDefinition`
- [api] `io.grpc.ServiceDescriptor#<init>(java.lang.String,java.util.Collection):void`
- [api] `io.grpc.ServiceDescriptor#getMethods():java.util.Collection`
- [api] `io.grpc.ServiceDescriptor#getName():java.lang.String`
- [api] `io.grpc.ServiceDescriptor#newBuilder(java.lang.String):io.grpc.ServiceDescriptor$Builder`
- [api] `io.grpc.ServiceDescriptor#toString():java.lang.String`
- [api] `io.grpc.ServiceDescriptor$Builder#addMethod(io.grpc.MethodDescriptor):io.grpc.ServiceDescriptor$Builder`
- [api] `io.grpc.ServiceDescriptor$Builder#build():io.grpc.ServiceDescriptor`
- [api] `io.grpc.ServiceDescriptor$Builder#setName(java.lang.String):io.grpc.ServiceDescriptor$Builder`
- [api] `io.grpc.ServiceDescriptor$Builder#setSchemaDescriptor(java.lang.Object):io.grpc.ServiceDescriptor$Builder`
- [api] `io.grpc.Status#asException():io.grpc.StatusException`
- [api] `io.grpc.Status#asRuntimeException():io.grpc.StatusRuntimeException`
- [api] `io.grpc.Status#augmentDescription(java.lang.String):io.grpc.Status`
- [api] `io.grpc.Status#equals(java.lang.Object):boolean`
- [api] `io.grpc.Status#fromCodeValue(int):io.grpc.Status`
- [api] `io.grpc.Status#fromThrowable(java.lang.Throwable):io.grpc.Status`
- [api] `io.grpc.Status#getCause():java.lang.Throwable`
- [api] `io.grpc.Status#getCode():io.grpc.Status$Code`
- [api] `io.grpc.Status#getDescription():java.lang.String`
- [api] `io.grpc.Status#hashCode():int`
- [api] `io.grpc.Status#isOk():boolean`
- [api] `io.grpc.Status#toString():java.lang.String`
- [api] `io.grpc.Status#trailersFromThrowable(java.lang.Throwable):io.grpc.Metadata`
- [api] `io.grpc.Status#withCause(java.lang.Throwable):io.grpc.Status`
- [api] `io.grpc.Status#withDescription(java.lang.String):io.grpc.Status`
- [api] `io.grpc.Status$Code#toStatus():io.grpc.Status`
- [api] `io.grpc.Status$Code#value():int`
- [api] `io.grpc.StatusException#<init>(io.grpc.Status):void`
- [api] `io.grpc.StatusException#<init>(io.grpc.Status,io.grpc.Metadata):void`
- [api] `io.grpc.StatusException#fillInStackTrace():java.lang.Throwable`
- [api] `io.grpc.StatusException#getStatus():io.grpc.Status`
- [api] `io.grpc.StatusException#getTrailers():io.grpc.Metadata`
- [api] `io.grpc.StatusRuntimeException#<init>(io.grpc.Status):void`
- [api] `io.grpc.StatusRuntimeException#<init>(io.grpc.Status,io.grpc.Metadata):void`
- [api] `io.grpc.StatusRuntimeException#fillInStackTrace():java.lang.Throwable`
- [api] `io.grpc.StatusRuntimeException#getStatus():io.grpc.Status`
- [api] `io.grpc.StreamTracer#<init>():void`
- [api] `io.grpc.StreamTracer#inboundMessage(int):void`
- [api] `io.grpc.StreamTracer#inboundMessageRead(int,long,long):void`
- [api] `io.grpc.StreamTracer#inboundUncompressedSize(long):void`
- [api] `io.grpc.StreamTracer#inboundWireSize(long):void`
- [api] `io.grpc.StreamTracer#outboundMessage(int):void`
- [api] `io.grpc.StreamTracer#outboundMessageSent(int,long,long):void`
- [api] `io.grpc.StreamTracer#outboundUncompressedSize(long):void`
- [api] `io.grpc.StreamTracer#outboundWireSize(long):void`
- [api] `io.grpc.StreamTracer#streamClosed(io.grpc.Status):void`
- [api] `io.grpc.SynchronizationContext#<init>(java.lang.Thread$UncaughtExceptionHandler):void`
- [api] `io.grpc.SynchronizationContext#drain():void`
- [api] `io.grpc.SynchronizationContext#execute(java.lang.Runnable):void`
- [api] `io.grpc.SynchronizationContext#executeLater(java.lang.Runnable):void`
- [api] `io.grpc.SynchronizationContext#schedule(java.lang.Runnable,long,java.util.concurrent.TimeUnit,java.util.concurrent.ScheduledExecutorService):io.grpc.SynchronizationContext$ScheduledHandle`
- [api] `io.grpc.SynchronizationContext$ScheduledHandle#cancel():void`
- [api] `io.grpc.SynchronizationContext$ScheduledHandle#isPending():boolean`
- [deep] `io.grpc.ManagedChannelProvider#<clinit>():void`
- [deep] `io.grpc.ManagedChannelProvider$1#<init>():void`
- [deep] `io.grpc.ManagedChannelProvider$1#getPriority(io.grpc.ManagedChannelProvider):int` — attempts: 3, last attempted iteration: 3
- [deep] `io.grpc.ManagedChannelProvider$1#isAvailable(io.grpc.ManagedChannelProvider):boolean`
- [deep] `io.grpc.ManagedChannelProvider$HardcodedClasses#iterator():java.util.Iterator` — attempts: 2, last attempted iteration: 2
- [deep] `io.grpc.Metadata$IterableAt$1#remove():void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCall#cancel(java.lang.String,java.lang.Throwable):void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCall#halfClose():void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCall#request(int):void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCall#setMessageCompression(boolean):void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCall#toString():java.lang.String` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.PartialForwardingClientCallListener#toString():java.lang.String` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.ServiceProviders#isAndroid(java.lang.ClassLoader):boolean`
- [deep] `io.grpc.ServiceProviders#load(java.lang.Class,java.lang.Iterable,java.lang.ClassLoader,io.grpc.ServiceProviders$PriorityAccessor):java.lang.Object`
- [deep] `io.grpc.ServiceProviders#loadAll(java.lang.Class,java.lang.Iterable,java.lang.ClassLoader,io.grpc.ServiceProviders$PriorityAccessor):java.util.List`
- [deep] `io.grpc.ServiceProviders$1#<init>(io.grpc.ServiceProviders$PriorityAccessor):void`
- [deep] `io.grpc.ServiceProviders$1#compare(java.lang.Object,java.lang.Object):int` — attempts: 3, last attempted iteration: 3
- [deep] `io.grpc.SynchronizationContext$1#run():void` — attempts: 1, last attempted iteration: 1
- [deep] `io.grpc.SynchronizationContext$1#toString():java.lang.String` — attempts: 2, last attempted iteration: 2
- [deep] `io.grpc.SynchronizationContext$ManagedRunnable#run():void` — attempts: 1, last attempted iteration: 1

## Skipped targets (0)

_None recorded._

## Exhausted targets (0)

_None recorded._

## Failed targets (0)

_None recorded._

## Validation commands

```console
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-9043-grpc-api/gradlew javaTest -Pcoordinates=io.grpc:grpc-api:1.27.2 --stacktrace
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-9043-grpc-api/gradlew codeCoverageTest -Pcoordinates=io.grpc:grpc-api:1.27.2 --stacktrace
```

Refs #9043.
