### PR TITLE
Improve code coverage for org.jooq:jooq:3.20.0

### DIFF
--- a/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/DeepSqlExecutionCoverageTest.java
+++ b/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/DeepSqlExecutionCoverageTest.java
@@ -1,0 +1,300 @@
+package org_jooq.jooq.coverage;
+
+import org.jooq.Cursor;
+import org.jooq.DSLContext;
+import org.jooq.EnumType;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Record3;
+import org.jooq.SQLDialect;
+import org.jooq.SchemaMapping;
+import org.jooq.Table;
+import org.jooq.conf.MappedCatalog;
+import org.jooq.conf.MappedSchema;
+import org.jooq.conf.RenderMapping;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeepSqlExecutionCoverageTest {
+
+    private enum Status implements EnumType {
+        ACTIVE;
+
+        @Override
+        public String getLiteral() {
+            return "active";
+        }
+
+        @Override
+        public String getName() {
+            return "status";
+        }
+    }
+
+    @Test
+    void executesAliasedJoinsSubqueriesAndLazyCursors() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:jooq_deep;DB_CLOSE_DELAY=-1")) {
+            DSLContext dsl = DSL.using(connection, SQLDialect.H2);
+            dsl.execute("create table authors (id int primary key, name varchar(30))");
+            dsl.execute("create table books (id int primary key, author_id int, title varchar(30), price int)");
+            dsl.batch(
+                    dsl.insertInto(DSL.table("authors")).columns(DSL.field("id"), DSL.field("name"))
+                            .values(1, "Ada"),
+                    dsl.insertInto(DSL.table("authors")).columns(DSL.field("id"), DSL.field("name"))
+                            .values(2, "Bob"),
+                    dsl.insertInto(DSL.table("books")).columns(DSL.field("id"), DSL.field("author_id"),
+                            DSL.field("title"), DSL.field("price")).values(10, 1, "Compiler", 20),
+                    dsl.insertInto(DSL.table("books")).columns(DSL.field("id"), DSL.field("author_id"),
+                            DSL.field("title"), DSL.field("price")).values(11, 1, "Types", 30)
+            ).execute();
+
+            Table<Record> authors = DSL.table(DSL.name("AUTHORS")).as("a");
+            Table<Record> books = DSL.table(DSL.name("BOOKS")).as("b");
+            Field<Integer> authorId = DSL.field(DSL.name("a", "ID"), Integer.class);
+            Field<Integer> bookAuthorId = DSL.field(DSL.name("b", "AUTHOR_ID"), Integer.class);
+            Field<String> authorName = DSL.field(DSL.name("a", "NAME"), String.class).as("author_name");
+            Field<String> title = DSL.field(DSL.name("b", "TITLE"), String.class).as("book_title");
+            Field<Integer> price = DSL.field(DSL.name("b", "PRICE"), Integer.class);
+
+            try (Cursor<Record3<String, String, Integer>> cursor = dsl.select(authorName, title, price)
+                    .from(authors.leftJoin(books).on(authorId.eq(bookAuthorId)))
+                    .where(price.in(dsl.select(DSL.field("PRICE", Integer.class)).from("BOOKS")))
+                    .orderBy(price.desc())
+                    .fetchLazy()) {
+                List<Record3<String, String, Integer>> rows = cursor.fetchNext(10);
+                assertThat(rows).hasSize(2);
+                assertThat(rows.get(0).get(authorName)).isEqualTo("Ada");
+                assertThat(rows).extracting(row -> row.get(title)).containsExactly("Types", "Compiler");
+            }
+        }
+    }
+
+    @Test
+    void rendersCtesWindowsRowsAndDmlThroughPublicDsl() {
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        Field<Integer> id = DSL.field(DSL.name("id"), Integer.class);
+        Table<Record> input = DSL.table(DSL.name("input")).as("i");
+        String selectSql = postgres.renderInlined(
+                DSL.with("recent").as(DSL.select(id).from(input).where(id.in(1, 2, 3)))
+                        .select(id, DSL.count().over().as("total"))
+                        .from(DSL.table("recent"))
+                        .where(DSL.row(id, DSL.inline("active")).in(DSL.row(1, "active"))));
+        String insertSql = postgres.renderInlined(
+                DSL.insertInto(DSL.table("input"), id, DSL.field("state"))
+                        .values(1, "active").values(2, "active"));
+        String deleteSql = postgres.renderInlined(
+                DSL.deleteFrom(DSL.table("input")).where(id.in(DSL.select(id).from(input))));
+
+        assertThat(selectSql).contains("with", "count", "over");
+        assertThat(insertSql).contains("insert into", "values");
+        assertThat(deleteSql).contains("delete from", "select");
+    }
+
+    @Test
+    void rendersScalarFunctionsAndTypedCastsThroughPublicDsl() {
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        Field<Integer> number = DSL.val(2);
+        String sql = postgres.renderInlined(DSL.select(
+                DSL.acos(number), DSL.acosh(number), DSL.acoth(number), DSL.asin(number), DSL.asinh(number),
+                DSL.atan(number), DSL.atan2(number, 1), DSL.atanh(number), DSL.ascii("jooq"), DSL.avg(number),
+                DSL.cast(number, SQLDataType.VARCHAR),
+                DSL.cast(DSL.val(new Integer[] {1, 2}), SQLDataType.INTEGER.getArrayDataType())));
+
+        assertThat(sql).contains("acos", "ascii", "cast");
+    }
+
+    @Test
+    void rendersArrayExpressionsAndDialectSpecificDdlThroughPublicDsl() {
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        Field<Integer[]> values = DSL.val(new Integer[] {1, 2, 3});
+        Field<Integer[]> replacement = DSL.val(new Integer[] {2, 3, 4});
+        String arraySql = postgres.renderInlined(DSL.select(
+                DSL.arrayAppend(values, 4), DSL.arrayPrepend(0, values), DSL.arrayConcat(values, replacement),
+                DSL.arrayRemove(values, 2), DSL.arrayReplace(values, DSL.val(2), DSL.val(9)),
+                DSL.arrayGet(values, 1))
+                .where(DSL.arrayOverlap(values, replacement)));
+        String ddlSql = postgres.renderInlined(DSL.alterTable("items").add("tags",
+                SQLDataType.INTEGER.getArrayDataType()));
+        String schemaSql = postgres.renderInlined(DSL.alterSchema("old_schema").renameTo("new_schema"));
+        String sequenceSql = postgres.renderInlined(DSL.alterSequence("old_sequence").renameTo("new_sequence"));
+        String typeSql = postgres.renderInlined(DSL.alterType("status").addValue("active"));
+        String viewSql = postgres.renderInlined(DSL.alterView("items_view").as(DSL.selectOne()));
+        String indexSql = postgres.renderInlined(DSL.alterIndex("items_idx").on("items").renameTo("new_items_idx"));
+
+        assertThat(arraySql).contains("array", "select");
+        assertThat(ddlSql).contains("alter table", "tags");
+        assertThat(schemaSql).contains("alter schema");
+        assertThat(sequenceSql).contains("alter sequence");
+        assertThat(typeSql).contains("alter type");
+        assertThat(viewSql).contains("drop view", "create view");
+        assertThat(indexSql).contains("alter index");
+    }
+
+    @Test
+    void rendersConstraintsAndStringAndBitExpressionsThroughPublicDsl() {
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        Field<Integer> number = DSL.val(6);
+        Field<String> text = DSL.val("  jooq  ");
+        Field<Status> status = DSL.val(Status.ACTIVE, SQLDataType.VARCHAR.asEnumDataType(Status.class));
+        String ddl = postgres.renderInlined(DSL.createTable("child")
+                .column("parent_id", SQLDataType.INTEGER)
+                .constraints(
+                        DSL.constraint("child_parent").foreignKey("parent_id").references("parent", "id"),
+                        DSL.constraint("positive_parent").check(DSL.field("parent_id", Integer.class).ge(0))));
+        String expressions = postgres.renderInlined(DSL.select(
+                DSL.concat(text, "!"), DSL.binaryLength(new byte[] {1, 2}), DSL.ltrim(text), DSL.rtrim(text),
+                DSL.trim(text), DSL.md5(text), DSL.octetLength(text), DSL.overlay(text, "x", 2, 1),
+                DSL.position(text, "q"), DSL.substring(text, 2, 3), DSL.charLength(text), DSL.chr(number),
+                DSL.cbrt(number), DSL.ceil(number), DSL.bitAnd(number, 3), DSL.bitCount(number),
+                DSL.bitGet(number, 1), DSL.bitNot(number), DSL.bitOr(number, 3), DSL.bitSet(number, 1),
+                DSL.bitXor(number, 3), DSL.bitNand(number, 3), DSL.bitNor(number, 3),
+                DSL.bitXNor(number, 3), DSL.cardinality(DSL.val(new Integer[] {1, 2})),
+                DSL.case_().when(number.gt(0), "positive").otherwise("negative"), DSL.choose(1, "a", "b"),
+                DSL.bitAndAgg(number), DSL.bitNandAgg(number), DSL.bitNorAgg(number), DSL.bitOrAgg(number),
+                DSL.bitXNorAgg(number), DSL.bitXorAgg(number), DSL.boolAnd(number.gt(0)),
+                DSL.boolOr(number.gt(0)), DSL.listAgg(number).withinGroupOrderBy(number), status));
+        String arrayTable = postgres.renderInlined(DSL.selectFrom(DSL.unnest(new Integer[] {1, 2}).as("n")));
+        String derbyCast = DSL.using(SQLDialect.DERBY).renderInlined(DSL.select(DSL.cast(text, SQLDataType.VARCHAR)));
+
+        assertThat(ddl).contains("foreign key", "check");
+        assertThat(expressions).contains("||", "bit", "case", "substring");
+        assertThat(arrayTable).contains("unnest");
+        assertThat(derbyCast).contains("cast");
+    }
+
+    @Test
+    void rendersDialectBranchesForDdlAggregatesAndScalarExpressions() {
+        Field<Integer> number = DSL.field(DSL.name("amount"), Integer.class);
+        Field<String> text = DSL.field(DSL.name("label"), String.class);
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        DSLContext mysql = DSL.using(SQLDialect.MYSQL);
+        DSLContext clickHouse = DSL.using(SQLDialect.CLICKHOUSE);
+
+        String aggregates = postgres.renderInlined(DSL.select(
+                DSL.anyValue(number), DSL.covarPop(number, number), DSL.covarSamp(number, number),
+                DSL.binaryListAgg(text).withinGroupOrderBy(text), DSL.cumeDist().over(),
+                DSL.count().filterWhere(number.gt(0)), DSL.coalesce(text, "missing"), DSL.cos(number),
+                DSL.cosh(number), DSL.cot(number), DSL.coth(number), DSL.corr(number, number),
+                DSL.currentCatalog(), DSL.currentSchema(), DSL.currentUser(), DSL.currentDate(),
+                DSL.currentTime(), DSL.currentTimestamp()).from("sales").groupBy(DSL.cube(number)));
+        String windows = postgres.renderInlined(DSL.select(DSL.count().over(DSL.name("w"))).from("sales")
+                .window(DSL.name("w").as(DSL.partitionBy(number))));
+        String postgresDdl = postgres.renderInlined(DSL.alterTableIfExists("sales").addColumnIfNotExists("note",
+                SQLDataType.VARCHAR(40)));
+        String mysqlDdl = mysql.renderInlined(DSL.alterTableIfExists("sales").dropColumnIfExists("note").cascade());
+        String renamed = mysql.renderInlined(DSL.alterTable("sales").renameColumn("amount").to("total"));
+        String altered = postgres.renderInlined(DSL.alterTable("sales").alterColumn("amount")
+                .set(SQLDataType.DECIMAL(12, 2).nullable(false)));
+        String views = mysql.renderInlined(DSL.alterViewIfExists("sales_view").as(DSL.selectFrom("sales")));
+        String create = postgres.renderInlined(DSL.createTableIfNotExists("sales_copy").as(DSL.selectFrom("sales")));
+        String objects = postgres.renderInlined(DSL.createDatabaseIfNotExists("archive"))
+                + postgres.renderInlined(DSL.createDomainIfNotExists("money").as(SQLDataType.DECIMAL(12, 2)))
+                + postgres.renderInlined(DSL.createIndexIfNotExists("sales_amount").on("sales", "amount"))
+                + postgres.renderInlined(DSL.createSequenceIfNotExists("sales_sequence"))
+                + postgres.renderInlined(DSL.createTypeIfNotExists("sales_status").asEnum("new", "closed"));
+        String arrays = postgres.renderInlined(DSL.selectFrom(DSL.unnest(new Integer[] {1, 2}).as("values")))
+                + clickHouse.renderInlined(DSL.selectFrom(DSL.unnest(new Integer[] {1, 2}).as("values")));
+
+        assertThat(aggregates).contains("any_value", "covar", "coalesce", "current");
+        assertThat(windows).contains("window", "partition by");
+        assertThat(postgresDdl).contains("alter table", "if not exists");
+        assertThat(mysqlDdl).contains("drop");
+        assertThat(renamed).contains("rename");
+        assertThat(altered).contains("decimal");
+        assertThat(views).contains("view");
+        assertThat(create).contains("create table", "as select");
+        assertThat(objects).contains("create", "archive", "money");
+        assertThat(arrays).contains("unnest");
+    }
+
+    @Test
+    void executesConvertedValuesAndAttachesPublicQueryParts() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:jooq_binding;DB_CLOSE_DELAY=-1")) {
+            DSLContext dsl = DSL.using(connection, SQLDialect.H2);
+            Field<String> converted = DSL.val(7, SQLDataType.INTEGER.asConvertedDataType(
+                    String.class, Object::toString, Integer::valueOf));
+            org.jooq.Select<?> query = dsl.select(converted.as("value")).where(converted.eq("7"));
+            query.attach(dsl.configuration());
+
+            assertThat(query.fetchOne(0, String.class)).isEqualTo("7");
+        }
+    }
+
+    @Test
+    void rendersDomainsDefaultsAndDialectSpecificPublicExpressions() {
+        DSLContext postgres = DSL.using(SQLDialect.POSTGRES);
+        org.jooq.Domain<Integer> quantity = DSL.domain(DSL.name("inventory", "quantity"), SQLDataType.INTEGER);
+        org.jooq.Domain<?> unresolvedDomain = DSL.domain(DSL.name("inventory", "unresolved_quantity"));
+        Field<Integer> amount = DSL.field(DSL.name("amount"), Integer.class);
+        String expressions = postgres.renderInlined(DSL.select(
+                DSL.dateAdd(Date.valueOf("2024-01-01"), 2, org.jooq.DatePart.DAY),
+                DSL.dateDiff(org.jooq.DatePart.DAY, Date.valueOf("2024-01-01"), Date.valueOf("2024-01-03")),
+                DSL.digits(amount), DSL.denseRank().over().as("rank")));
+        String createDomainTable = postgres.renderInlined(DSL.createTable("inventory_item")
+                .column("quantity", quantity.getDataType().default_(DSL.inline(1)))
+                .column("unresolved_quantity", unresolvedDomain.getDataType())
+                .column("optional_quantity", SQLDataType.INTEGER.default_(DSL.inline(2))));
+        String index = postgres.renderInlined(DSL.alterIndexIfExists("inventory_idx").on("inventory_item")
+                .renameTo("inventory_item_idx"));
+        String view = postgres.renderInlined(DSL.createViewIfNotExists("inventory_view", "quantity")
+                .as(DSL.select(DSL.inline(1).as("quantity"))));
+
+        assertThat(expressions).contains("date", "lpad", "dense_rank");
+        assertThat(createDomainTable).contains("inventory_item", "quantity", "default");
+        assertThat(index).contains("alter index", "if exists");
+        assertThat(view).contains("create view", "exception");
+    }
+
+    @Test
+    void mapsPublicRecordShapesAndExecutesTheFailurePath() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:jooq_mapping;DB_CLOSE_DELAY=-1")) {
+            DSLContext dsl = DSL.using(connection, SQLDialect.H2);
+            dsl.execute("create table mapped_scores (id int primary key, score int)");
+            dsl.execute("insert into mapped_scores values (1, 10), (2, 20)");
+
+            List<MutableScore> mutable = dsl.select(DSL.field("id"), DSL.field("score"))
+                    .from("mapped_scores").orderBy(DSL.field("id")).fetchInto(MutableScore.class);
+            List<ImmutableScore> immutable = dsl.select(DSL.field("id"), DSL.field("score"))
+                    .from("mapped_scores").orderBy(DSL.field("id")).fetchInto(ImmutableScore.class);
+            Integer scalar = dsl.select(DSL.field("score", Integer.class)).from("mapped_scores")
+                    .where(DSL.field("id").eq(1)).fetchOneInto(Integer.class);
+
+            assertThat(mutable).extracting(score -> score.score).containsExactly(10, 20);
+            assertThat(immutable).extracting(ImmutableScore::score).containsExactly(10, 20);
+            assertThat(scalar).isEqualTo(10);
+            org.junit.jupiter.api.Assertions.assertThrows(org.jooq.exception.DataAccessException.class,
+                    () -> dsl.fetch("select missing_column from mapped_scores"));
+        }
+    }
+
+    public static final class MutableScore {
+        public Integer id;
+        public Integer score;
+    }
+
+    public record ImmutableScore(Integer id, Integer score) {
+    }
+
+    @Test
+    void mapsCatalogAndSchemaNamesWhileRenderingPublicTables() {
+        MappedSchema schema = new MappedSchema().withInput("legacy").withOutput("application");
+        MappedCatalog catalog = new MappedCatalog().withInput("old_catalog").withOutput("new_catalog")
+                .withSchemata(schema);
+        Settings settings = new Settings().withRenderMapping(new RenderMapping().withCatalogs(catalog));
+        DSLContext dsl = DSL.using(SQLDialect.POSTGRES, settings);
+        SchemaMapping mapping = dsl.configuration().schemaMapping();
+        String sql = dsl.render(DSL.selectFrom(DSL.table(DSL.name("old_catalog", "legacy", "items")).as("item")));
+
+        assertThat(mapping).isNotNull();
+        assertThat(sql).contains("new_catalog", "application", "items", "item");
+    }
+}

--- a/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiDataAndQueryTest.java
+++ b/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiDataAndQueryTest.java
@@ -1,0 +1,125 @@
+package org_jooq.jooq.coverage;
+
+import org.jooq.DSLContext;
+import org.jooq.DataType;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.jooq.SQLDialect;
+import org.jooq.conf.AutoAliasExpressions;
+import org.jooq.conf.FetchIntermediateResult;
+import org.jooq.conf.InvocationOrder;
+import org.jooq.conf.MigrationDefaultContentType;
+import org.jooq.conf.MigrationSchema;
+import org.jooq.conf.ParseNameCase;
+import org.jooq.conf.ParseUnsupportedSyntax;
+import org.jooq.conf.ParseWithMetaLookups;
+import org.jooq.conf.Settings;
+import org.jooq.conf.Transformation;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicApiDataAndQueryTest {
+
+    @Test
+    void convertsDataTypesThroughDirectionalPublicConverters() {
+        DataType<Integer> integers = SQLDataType.INTEGER;
+        DataType<String> strings = integers.asConvertedDataType(String.class, Object::toString, Integer::valueOf);
+        DataType<String> fromOnly = integers.asConvertedDataTypeFrom(String.class, Object::toString);
+        DataType<String> inferredFrom = integers.asConvertedDataTypeFrom(Object::toString);
+        DataType<String> toOnly = integers.asConvertedDataTypeTo(String.class, Integer::valueOf);
+        DataType<String> inferredTo = integers.asConvertedDataTypeTo(Integer::valueOf);
+
+        assertThat(strings.convert("12")).isEqualTo("12");
+        assertThat(strings.getConverter().to("12")).isEqualTo(12);
+        assertThat(fromOnly.convert(7)).isEqualTo("7");
+        assertThat(inferredFrom.convert(8)).isEqualTo("8");
+        assertThat(toOnly.getConverter().to("9")).isEqualTo(9);
+        assertThat(inferredTo.getConverter().to("10")).isEqualTo(10);
+    }
+
+    @Test
+    void collectsAndStreamsDatabaseResultsUsingPublicCollectors() throws Exception {
+        try (Connection connection = DriverManager.getConnection("jdbc:h2:mem:jooq_coverage;DB_CLOSE_DELAY=-1")) {
+            DSLContext dsl = DSL.using(connection, SQLDialect.H2);
+            dsl.execute("create table scores (id int primary key, name varchar(20), score int)");
+            dsl.execute("insert into scores values (1, 'Ada', 10), (2, 'Bob', 20), (3, 'Ava', 30)");
+
+            Result<Record> rows = dsl.fetch("select id, name, score from scores order by id");
+            assertThat(rows.stream().collect(org.jooq.Records.intoList(record -> record.get("NAME", String.class))))
+                    .containsExactly("Ada", "Bob", "Ava");
+            assertThat(rows.stream().collect(org.jooq.Records.intoSet(record -> record.get("NAME", String.class))))
+                    .containsExactlyInAnyOrder("Ada", "Bob", "Ava");
+            Map<Integer, String> names = rows.stream().collect(org.jooq.Records.intoMap(
+                    record -> record.get("ID", Integer.class), record -> record.get("NAME", String.class)));
+            assertThat(names).containsEntry(2, "Bob");
+            Map<String, List<Integer>> scores = rows.stream().collect(org.jooq.Records.intoGroups(
+                    record -> record.get("NAME", String.class).substring(0, 1),
+                    record -> record.get("SCORE", Integer.class)));
+            assertThat(scores).containsEntry("A", List.of(10, 30));
+            assertThat(rows.stream().collect(org.jooq.Records.intoArray(String.class,
+                    record -> record.get("NAME", String.class)))).containsExactly("Ada", "Bob", "Ava");
+
+            ArrayList<Integer> ids = new ArrayList<>();
+            dsl.select(DSL.field("id", Integer.class)).from("scores").orderBy(DSL.field("id")).forEach(
+                    record -> ids.add(record.value1()));
+            assertThat(ids).containsExactly(1, 2, 3);
+            assertThat(dsl.select(DSL.field("id", Integer.class)).from("scores").spliterator().estimateSize())
+                    .isGreaterThanOrEqualTo(0);
+        }
+    }
+
+    @Test
+    void preservesRenderingParsingAndMigrationSettings() {
+        MigrationSchema schema = new MigrationSchema().withCatalog("app").withSchema("history");
+        Settings settings = new Settings()
+                .withRenderLocale(Locale.CANADA_FRENCH)
+                .withRenderFormatted(true)
+                .withRenderAutoAliasedDerivedTableExpressions(AutoAliasExpressions.NEVER)
+                .withFetchIntermediateResult(FetchIntermediateResult.WHEN_RESULT_REQUESTED)
+                .withBatchSize(50)
+                .withParseDialect(SQLDialect.H2)
+                .withParseLocale(Locale.JAPAN)
+                .withParseNameCase(ParseNameCase.LOWER)
+                .withParseWithMetaLookups(ParseWithMetaLookups.IGNORE_ON_FAILURE)
+                .withParseUnsupportedSyntax(ParseUnsupportedSyntax.IGNORE)
+                .withTransformGroupByColumnIndex(Transformation.ALWAYS)
+                .withTransformInlineCTE(Transformation.NEVER)
+                .withTransformQualify(Transformation.ALWAYS)
+                .withTransformRownum(Transformation.NEVER)
+                .withMigrationHistorySchema(schema)
+                .withMigrationDefaultSchema(schema)
+                .withMigrationDefaultContentType(MigrationDefaultContentType.SCRIPT)
+                .withMigrationListenerStartInvocationOrder(InvocationOrder.REVERSE)
+                .withMigrationListenerEndInvocationOrder(InvocationOrder.DEFAULT);
+
+        assertThat(settings.getRenderLocale()).isEqualTo(Locale.CANADA_FRENCH);
+        assertThat(settings.isRenderFormatted()).isTrue();
+        assertThat(settings.getRenderAutoAliasedDerivedTableExpressions()).isEqualTo(AutoAliasExpressions.NEVER);
+        assertThat(settings.getFetchIntermediateResult()).isEqualTo(FetchIntermediateResult.WHEN_RESULT_REQUESTED);
+        assertThat(settings.getBatchSize()).isEqualTo(50);
+        assertThat(settings.getParseDialect()).isEqualTo(SQLDialect.H2);
+        assertThat(settings.getParseLocale()).isEqualTo(Locale.JAPAN);
+        assertThat(settings.getParseNameCase()).isEqualTo(ParseNameCase.LOWER);
+        assertThat(settings.getParseWithMetaLookups()).isEqualTo(ParseWithMetaLookups.IGNORE_ON_FAILURE);
+        assertThat(settings.getParseUnsupportedSyntax()).isEqualTo(ParseUnsupportedSyntax.IGNORE);
+        assertThat(settings.getTransformGroupByColumnIndex()).isEqualTo(Transformation.ALWAYS);
+        assertThat(settings.getTransformInlineCTE()).isEqualTo(Transformation.NEVER);
+        assertThat(settings.getTransformQualify()).isEqualTo(Transformation.ALWAYS);
+        assertThat(settings.getTransformRownum()).isEqualTo(Transformation.NEVER);
+        assertThat(settings.getMigrationHistorySchema()).isEqualTo(schema);
+        assertThat(settings.getMigrationDefaultSchema()).isEqualTo(schema);
+        assertThat(settings.getMigrationDefaultContentType()).isEqualTo(MigrationDefaultContentType.SCRIPT);
+        assertThat(settings.getMigrationListenerStartInvocationOrder()).isEqualTo(InvocationOrder.REVERSE);
+        assertThat(settings.getMigrationListenerEndInvocationOrder()).isEqualTo(InvocationOrder.DEFAULT);
+    }
+}

--- a/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiFormatTest.java
+++ b/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiFormatTest.java
@@ -1,0 +1,358 @@
+package org_jooq.jooq.coverage;
+
+import org.jooq.Binding;
+import org.jooq.CSVFormat;
+import org.jooq.Comparator;
+import org.jooq.ChartFormat;
+import org.jooq.ContextConverter;
+import org.jooq.Converter;
+import org.jooq.Converters;
+import org.jooq.DDLExportConfiguration;
+import org.jooq.DDLFlag;
+import org.jooq.DatePart;
+import org.jooq.FilePattern;
+import org.jooq.FormattingProvider;
+import org.jooq.SchemaMapping;
+import org.jooq.Geography;
+import org.jooq.Geometry;
+import org.jooq.JSON;
+import org.jooq.JSONB;
+import org.jooq.JSONFormat;
+import org.jooq.JoinType;
+import org.jooq.MigrationConfiguration;
+import org.jooq.Operator;
+import org.jooq.SQLDialect;
+import org.jooq.SQLDialectCategory;
+import org.jooq.Source;
+import org.jooq.TXTFormat;
+import org.jooq.TableOptions;
+import org.jooq.XML;
+import org.jooq.XMLFormat;
+import org.jooq.conf.InterpreterSearchSchema;
+import org.jooq.conf.MappedCatalog;
+import org.jooq.conf.MappedSchema;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublicApiFormatTest {
+
+    @Test
+    void configuresCsvAndChartOutput() {
+        CSVFormat csv = new CSVFormat()
+                .delimiter(';')
+                .nullString("NULL")
+                .emptyString("EMPTY")
+                .newline("\r\n")
+                .quoteString("'")
+                .quote(CSVFormat.Quote.ALWAYS)
+                .header(true);
+
+        assertThat(csv.delimiter()).isEqualTo(";");
+        assertThat(csv.nullString()).isEqualTo("NULL");
+        assertThat(csv.emptyString()).isEqualTo("EMPTY");
+        assertThat(csv.newline()).isEqualTo("\r\n");
+        assertThat(csv.quoteString()).isEqualTo("'");
+        assertThat(csv.quote()).isEqualTo(CSVFormat.Quote.ALWAYS);
+        assertThat(csv.header()).isTrue();
+
+        DecimalFormat numbers = new DecimalFormat("0.00");
+        DecimalFormat percentages = new DecimalFormat("0%");
+        ChartFormat chart = new ChartFormat()
+                .output(ChartFormat.Output.ASCII)
+                .type(ChartFormat.Type.AREA)
+                .display(ChartFormat.Display.STACKED)
+                .dimensions(80, 20)
+                .category(1)
+                .categoryAsText(true)
+                .values(2, 3)
+                .shades('#', '+')
+                .showLegends(true, false)
+                .newline("\n")
+                .numericFormat(numbers)
+                .percentFormat(percentages);
+
+        assertThat(chart.output()).isEqualTo(ChartFormat.Output.ASCII);
+        assertThat(chart.type()).isEqualTo(ChartFormat.Type.AREA);
+        assertThat(chart.display()).isEqualTo(ChartFormat.Display.STACKED);
+        assertThat(chart.width()).isEqualTo(80);
+        assertThat(chart.height()).isEqualTo(20);
+        assertThat(chart.category()).isEqualTo(1);
+        assertThat(chart.categoryAsText()).isTrue();
+        assertThat(chart.values()).containsExactly(2, 3);
+        assertThat(chart.shades()).containsExactly('#', '+');
+        assertThat(chart.showHorizontalLegend()).isTrue();
+        assertThat(chart.showVerticalLegend()).isFalse();
+        assertThat(chart.newline()).isEqualTo("\n");
+        assertThat(chart.numericFormat()).isSameAs(numbers);
+        assertThat(chart.percentFormat()).isSameAs(percentages);
+    }
+
+    @Test
+    void configuresJsonAndDdlExport() {
+        JSONFormat json = new JSONFormat().mutable(true).format(true).newline("\n")
+                .globalIndent(4).indent(2).header(true)
+                .recordFormat(JSONFormat.RecordFormat.OBJECT)
+                .wrapSingleColumnRecords(true).quoteNested(true);
+        assertThat(json.mutable()).isTrue();
+        assertThat(json.format()).isTrue();
+        assertThat(json.newline()).isEqualTo("\n");
+        assertThat(json.globalIndent()).isEqualTo(4);
+        assertThat(json.indent()).isEqualTo(2);
+        assertThat(json.indentString(3)).isEqualTo("          ");
+        assertThat(json.header()).isTrue();
+        assertThat(json.recordFormat()).isEqualTo(JSONFormat.RecordFormat.OBJECT);
+        assertThat(json.wrapSingleColumnRecords()).isTrue();
+        assertThat(json.quoteNested()).isTrue();
+
+        DDLExportConfiguration ddl = new DDLExportConfiguration().flags(DDLFlag.TABLE, DDLFlag.INDEX)
+                .createSchemaIfNotExists(true).createTableIfNotExists(true).createIndexIfNotExists(true)
+                .createDomainIfNotExists(true).createSequenceIfNotExists(true).createViewIfNotExists(true)
+                .createOrReplaceView(true).respectCatalogOrder(true).respectSchemaOrder(true)
+                .respectTableOrder(true).respectColumnOrder(true).respectConstraintOrder(true)
+                .respectIndexOrder(true).respectDomainOrder(true).respectSequenceOrder(true)
+                .defaultSequenceFlags(true).includeConstraintsOnViews(true);
+        assertThat(ddl.flags()).containsExactlyInAnyOrder(DDLFlag.TABLE, DDLFlag.INDEX);
+        assertThat(ddl.createSchemaIfNotExists() && ddl.createTableIfNotExists() && ddl.createIndexIfNotExists()).isTrue();
+        assertThat(ddl.createDomainIfNotExists() && ddl.createSequenceIfNotExists() && ddl.createViewIfNotExists()).isTrue();
+        assertThat(ddl.createOrReplaceView()).isTrue();
+        assertThat(ddl.respectCatalogOrder() && ddl.respectSchemaOrder() && ddl.respectTableOrder()
+                && ddl.respectColumnOrder() && ddl.respectConstraintOrder() && ddl.respectIndexOrder()
+                && ddl.respectDomainOrder() && ddl.respectSequenceOrder()).isTrue();
+        assertThat(ddl.defaultSequenceFlags() && ddl.includeConstraintsOnViews()).isTrue();
+    }
+
+    @Test
+    void convertsValuesAndArraysInBothDirections() {
+        Converter<String, Integer> converter = Converter.of(String.class, Integer.class, Integer::valueOf, Object::toString);
+        assertThat(converter.from("42")).isEqualTo(42);
+        assertThat(converter.to(42)).isEqualTo("42");
+        assertThat(converter.inverse().from(42)).isEqualTo("42");
+        assertThat(converter.andThen(Converter.of(Integer.class, BigDecimal.class, BigDecimal::valueOf, BigDecimal::intValue))
+                .from("42")).isEqualTo(new BigDecimal("42"));
+        assertThat(converter.forArrays().from(new String[] { "1", "2" })).containsExactly(1, 2);
+        assertThat(Converter.from(String.class, Integer.class, Integer::valueOf).from("7")).isEqualTo(7);
+        assertThat(Converter.to(String.class, Integer.class, Object::toString).to(7)).isEqualTo("7");
+        assertThat(Converter.ofNullable(String.class, Integer.class, Integer::valueOf, Object::toString).from(null)).isNull();
+        assertThat(Converter.fromNullable(String.class, Integer.class, Integer::valueOf).from(null)).isNull();
+        assertThat(Converter.toNullable(String.class, Integer.class, Object::toString).to(null)).isNull();
+
+        ContextConverter<String, Integer> contextual = ContextConverter.of(String.class, Integer.class,
+                (value, context) -> Integer.valueOf(value), (value, context) -> value.toString());
+        assertThat(contextual.from("9")).isEqualTo(9);
+        assertThat(contextual.to(9)).isEqualTo("9");
+        assertThat(contextual.inverse().from(9)).isEqualTo("9");
+        assertThat(contextual.forArrays().from(new String[] { "3" })).containsExactly(3);
+        assertThat(ContextConverter.from(String.class, Integer.class,
+                (value, context) -> Integer.valueOf(value)).from("6")).isEqualTo(6);
+        assertThat(ContextConverter.to(String.class, Integer.class,
+                (value, context) -> value.toString()).to(6)).isEqualTo("6");
+        assertThat(ContextConverter.fromNullable(String.class, Integer.class,
+                (value, context) -> Integer.valueOf(value)).from(null)).isNull();
+        assertThat(ContextConverter.toNullable(String.class, Integer.class,
+                (value, context) -> value.toString()).to(null)).isNull();
+        assertThat(Converters.of(converter).from("8")).isEqualTo(8);
+        assertThat(Converters.forArrays(converter).from(new String[] { "4" })).containsExactly(4);
+        assertThat(Converters.forArrayComponents(Converters.forArrays(converter)).from("5")).isEqualTo(5);
+
+        Binding<String, Integer> basicBinding = Binding.of(converter, context -> { }, context -> { }, context -> { });
+        Binding<String, Integer> statementBinding = Binding.of(converter, context -> { }, context -> { }, context -> { },
+                context -> { }, context -> { });
+        Binding<String, Integer> completeBinding = Binding.of(converter, context -> { }, context -> { }, context -> { },
+                context -> { }, context -> { }, context -> { }, context -> { });
+        assertThat(basicBinding.converter()).isSameAs(converter);
+        assertThat(statementBinding.converter()).isSameAs(converter);
+        assertThat(completeBinding.converter()).isSameAs(converter);
+    }
+
+    @Test
+    void representsDataValuesAndMigrationOptions() {
+        assertThat(JSON.json("{\"a\":1}")).isEqualTo(JSON.valueOf("{\"a\":1}"));
+        assertThat(JSON.jsonOrNull(null)).isNull();
+        assertThat(JSONB.jsonb("{\"a\":1}").data()).isEqualTo("{\"a\":1}");
+        assertThat(JSONB.jsonbOrNull(null)).isNull();
+        assertThat(Geometry.geometry("POINT (1 2)")).isEqualTo(Geometry.valueOf("POINT (1 2)"));
+        assertThat(Geometry.geometryOrNull(null)).isNull();
+        assertThat(Geography.geography("POINT (1 2)")).isEqualTo(Geography.valueOf("POINT (1 2)"));
+        assertThat(Geography.geographyOrNull(null)).isNull();
+
+        MigrationConfiguration migration = new MigrationConfiguration().alterTableAddMultiple(true)
+                .alterTableDropMultiple(true).dropSchemaCascade(true).dropTableCascade(true)
+                .alterTableDropCascade(true).createOrReplaceView(true).respectColumnOrder(true);
+        assertThat(migration.alterTableAddMultiple() && migration.alterTableDropMultiple()
+                && migration.dropSchemaCascade() && migration.dropTableCascade() && migration.alterTableDropCascade()
+                && migration.createOrReplaceView() && migration.respectColumnOrder()).isTrue();
+    }
+
+    @Test
+    void configuresAdditionalFormatsAndValueSemantics() {
+        TXTFormat text = new TXTFormat().minColWidth(3).horizontalTableBorder(false)
+                .horizontalHeaderBorder(false).horizontalCellBorder(true).verticalTableBorder(false)
+                .verticalCellBorder(true).intersectLines(true);
+        assertThat(text.minColWidth()).isEqualTo(3);
+        assertThat(text.horizontalTableBorder() && text.horizontalHeaderBorder()).isFalse();
+        assertThat(text.horizontalCellBorder() && text.verticalCellBorder() && text.intersectLines()).isTrue();
+        assertThat(text.verticalTableBorder()).isFalse();
+
+        XMLFormat xmlFormat = new XMLFormat().mutable(true).xmlns(true).format(true).newline("\\n")
+                .globalIndent(2).indent(3).header(true).recordFormat(XMLFormat.RecordFormat.COLUMN_NAME_ELEMENTS)
+                .quoteNested(true);
+        assertThat(xmlFormat.mutable() && xmlFormat.xmlns() && xmlFormat.format() && xmlFormat.header()
+                && xmlFormat.quoteNested()).isTrue();
+        assertThat(xmlFormat.newline()).isEqualTo("\\n");
+        assertThat(xmlFormat.globalIndent()).isEqualTo(2);
+        assertThat(xmlFormat.indent()).isEqualTo(3);
+        assertThat(xmlFormat.indentString(2)).isEmpty();
+        assertThat(xmlFormat.recordFormat()).isEqualTo(XMLFormat.RecordFormat.COLUMN_NAME_ELEMENTS);
+
+        assertThat(JSON.json("{\"a\":1}").data()).isEqualTo("{\"a\":1}");
+        assertThat(JSON.json("{\"a\":1}").toString()).isEqualTo("{\"a\":1}");
+        assertThat(JSONB.valueOf("{\"a\":1}")).isEqualTo(JSONB.jsonb("{\"a\":1}"));
+        assertThat(JSONB.valueOf("{\"a\":1}").toString()).isEqualTo("{\"a\":1}");
+        assertThat(Geometry.geometry("POINT (1 2)").toString()).isEqualTo("POINT (1 2)");
+        assertThat(Geography.geography("POINT (1 2)").toString()).isEqualTo("POINT (1 2)");
+        assertThat(XML.xml("<a/>")).isEqualTo(XML.valueOf("<a/>"));
+        assertThat(XML.xmlOrNull(null)).isNull();
+    }
+
+    @Test
+    void readsSourcesAcrossPublicInputForms() throws Exception {
+        byte[] bytes = "café".getBytes(StandardCharsets.UTF_8);
+        assertThat(Source.of("plain").readString()).isEqualTo("plain");
+        assertThat(Source.of(bytes).readString()).isEqualTo("café");
+        assertThat(Source.of(bytes, "UTF-8").readString()).isEqualTo("café");
+        assertThat(Source.of(bytes, StandardCharsets.UTF_8).readString()).isEqualTo("café");
+        assertThat(Source.of(bytes, StandardCharsets.UTF_8.newDecoder()).readString()).isEqualTo("café");
+        assertThat(Source.of(new StringReader("reader"), 2).readString()).isEqualTo("re");
+        assertThat(Source.of(new ByteArrayInputStream(bytes), 2, StandardCharsets.UTF_8).readString()).isEqualTo("ca");
+        assertThat(Source.of(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8.newDecoder()).readString()).isEqualTo("café");
+
+        File file = File.createTempFile("jooq-source", ".txt");
+        java.nio.file.Files.writeString(file.toPath(), "file", StandardCharsets.UTF_8);
+        Source source = Source.of(file, StandardCharsets.UTF_8);
+        assertThat(source.readString()).isEqualTo("file");
+        assertThat(source.toString()).contains(file.getName());
+        assertThat(file.delete()).isTrue();
+    }
+
+    @Test
+    void exposesComparisonDialectTableAndJaxbConfiguration() throws Exception {
+        assertThat(Comparator.EQUALS.toSQL()).isEqualTo("=");
+        assertThat(Comparator.EQUALS.toKeyword()).isNotNull();
+        assertThat(Comparator.EQUALS.inverse()).isEqualTo(Comparator.NOT_EQUALS);
+        assertThat(Comparator.LESS.mirror()).isEqualTo(Comparator.GREATER);
+        assertThat(Comparator.IN.supportsNulls()).isFalse();
+        boolean supportsQuantifier = Comparator.IN.supportsQuantifier();
+        boolean supportsSubselect = Comparator.IN.supportsSubselect();
+        assertThat(supportsQuantifier && supportsSubselect).isFalse();
+        assertThat(SQLDialect.H2.precedes(SQLDialect.H2)).isTrue();
+        assertThat(SQLDialect.H2.precedesStrictly(SQLDialect.H2)).isFalse();
+        assertThat(SQLDialect.H2.supports(List.of(SQLDialect.H2))).isTrue();
+        assertThat(SQLDialect.H2.supportsDatabaseVersion(2, 1, null)).isFalse();
+        assertThat(SQLDialect.H2.thirdParty().driver()).isNotBlank();
+        assertThat(SQLDialectCategory.OTHER.dialects()).contains(SQLDialect.H2);
+        assertThat(SQLDialectCategory.OTHER.families()).contains(SQLDialect.H2);
+
+        TableOptions table = TableOptions.temporaryTable(TableOptions.OnCommit.DELETE_ROWS);
+        assertThat(table.type().isTable()).isTrue();
+        assertThat(table.onCommit()).isEqualTo(TableOptions.OnCommit.DELETE_ROWS);
+        assertThat(TableOptions.function("f").source()).isEqualTo("f");
+        assertThat(TableOptions.function()).isEqualTo(TableOptions.function());
+        assertThat(TableOptions.view()).isEqualTo(TableOptions.view());
+        assertThat(TableOptions.materializedView()).isEqualTo(TableOptions.materializedView());
+        assertThat(TableOptions.of(TableOptions.TableType.TEMPORARY)).isEqualTo(TableOptions.temporaryTable());
+        assertThat(table.toString()).contains("TEMPORARY");
+
+        InterpreterSearchSchema searchSchema = new InterpreterSearchSchema().withCatalog("catalog").withSchema("schema");
+        assertThat(searchSchema.getCatalog()).isEqualTo("catalog");
+        assertThat(searchSchema.getSchema()).isEqualTo("schema");
+        InterpreterSearchSchema sameSearchSchema = new InterpreterSearchSchema();
+        sameSearchSchema.setCatalog("catalog");
+        sameSearchSchema.setSchema("schema");
+        assertThat(searchSchema).isEqualTo(sameSearchSchema);
+        MappedSchema mappedSchema = new MappedSchema().withInput("in").withInputExpression(Pattern.compile("in.*"))
+                .withOutput("out");
+        MappedCatalog mappedCatalog = new MappedCatalog().withInput("catalog").withOutput("target")
+                .withSchemata(mappedSchema);
+        assertThat(mappedCatalog.getSchemata()).containsExactly(mappedSchema);
+        assertThat(mappedCatalog.getInputExpression()).isNull();
+        assertThat(mappedCatalog.toString()).contains("catalog");
+    }
+
+    @Test
+    void usesFormattingCallbacksAndJaxbAdapters() throws Exception {
+        FormattingProvider provider = FormattingProvider.onTxtFormat(() -> new TXTFormat().minColWidth(4))
+                .onCsvFormat(() -> new CSVFormat().delimiter(';'))
+                .onJsonFormatForResults(() -> new JSONFormat().header(true))
+                .onJsonFormatForRecords(() -> new JSONFormat().format(true))
+                .onXmlFormatForResults(() -> new XMLFormat().header(true))
+                .onXmlFormatForRecords(() -> new XMLFormat().format(true))
+                .onChartFormat(() -> new ChartFormat().width(72))
+                .onWidth(String::length);
+        assertThat(provider.txtFormat().minColWidth()).isEqualTo(4);
+        assertThat(provider.csvFormat().delimiter()).isEqualTo(";");
+        assertThat(provider.jsonFormatForResults().header()).isTrue();
+        assertThat(provider.jsonFormatForRecords().format()).isTrue();
+        assertThat(provider.xmlFormatForResults().header()).isTrue();
+        assertThat(provider.xmlFormatForRecords().format()).isTrue();
+        assertThat(provider.chartFormat().width()).isEqualTo(72);
+        assertThat(provider.width("jOOQ")).isEqualTo(4);
+
+    }
+
+    @Test
+    void mapsSchemasAndFilesForSqlRendering() {
+        org.jooq.Schema source = DSL.schema("legacy");
+        org.jooq.Schema target = DSL.schema("application");
+        SchemaMapping mapping = new SchemaMapping(new DefaultConfiguration());
+        mapping.add(source, target);
+        mapping.setDefaultSchema("application");
+        assertThat(mapping.toString()).isNotEmpty();
+
+        FilePattern pattern = new FilePattern().basedir(new File(".")).pattern("*.gradle")
+                .sort(FilePattern.Sort.SEMANTIC);
+        File build = new File("build.gradle");
+        assertThat(pattern.sort()).isEqualTo(FilePattern.Sort.SEMANTIC);
+        assertThat(pattern.path(build)).isEqualTo("build.gradle");
+        assertThat(pattern.pathFile(build)).isEqualTo(build);
+        assertThat(pattern.fileComparator().compare(new File("a2.sql"), new File("a10.sql"))).isLessThan(0);
+    }
+
+    @Test
+    void resolvesPatternsAndDialectPresentation() {
+        FilePattern pattern = new FilePattern().basedir(new File(".")).pattern("*.gradle").encoding("UTF-8")
+                .sort(FilePattern.Sort.SEMANTIC);
+        assertThat(pattern.basedir()).isEqualTo(new File("."));
+        assertThat(pattern.pattern()).isEqualTo("*.gradle");
+        assertThat(pattern.encoding()).isEqualTo("UTF-8");
+        assertThat(pattern.matches("build.gradle")).isTrue();
+        assertThat(pattern.collect()).isNotEmpty();
+        assertThat(pattern.toString()).contains("*.gradle");
+        assertThat(FilePattern.Sort.of("semantic")).isEqualTo(FilePattern.Sort.SEMANTIC);
+
+        assertThat(SQLDialect.H2.supported()).isTrue();
+        assertThat(SQLDialect.H2.supports(SQLDialect.H2)).isTrue();
+        assertThat(SQLDialect.H2.getNameLC()).isEqualTo("h2");
+        assertThat(SQLDialect.H2.getNameUC()).isEqualTo("H2");
+        assertThat(SQLDialect.H2.getName()).isNotBlank();
+        assertThat(SQLDialect.H2.category()).isNotNull();
+        assertThat(SQLDialect.H2.thirdParty()).isNotNull();
+        assertThat(DatePart.YEAR.toSQL()).isEqualTo("year");
+        assertThat(DatePart.YEAR.toKeyword()).isNotNull();
+        assertThat(DatePart.YEAR.toName()).isNotNull();
+        assertThat(JoinType.LEFT_OUTER_JOIN.toSQL()).contains("left");
+        assertThat(JoinType.LEFT_OUTER_JOIN.toKeyword(true)).isNotNull();
+        assertThat(Operator.AND.identity()).isNotNull();
+    }
+}

--- a/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiValueAndConfigurationTest.java
+++ b/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/src/test/java/org_jooq/jooq/coverage/PublicApiValueAndConfigurationTest.java
@@ -1,0 +1,192 @@
+package org_jooq.jooq.coverage;
+
+import org.jooq.ChartFormat;
+import org.jooq.ContextConverter;
+import org.jooq.Converter;
+import org.jooq.Converters;
+import org.jooq.DDLExportConfiguration;
+import org.jooq.Decfloat;
+import org.jooq.JSONFormat;
+import org.jooq.SQLDialect;
+import org.jooq.Source;
+import org.jooq.conf.AutoAliasExpressions;
+import org.jooq.conf.BackslashEscaping;
+import org.jooq.conf.DiagnosticsConnection;
+import org.jooq.conf.ExecuteWithoutWhere;
+import org.jooq.conf.FetchIntermediateResult;
+import org.jooq.conf.FetchTriggerValuesAfterReturning;
+import org.jooq.conf.InterpreterNameLookupCaseSensitivity;
+import org.jooq.conf.InterpreterSearchSchema;
+import org.jooq.conf.InvocationOrder;
+import org.jooq.conf.MappedCatalog;
+import org.jooq.conf.MappedSchema;
+import org.jooq.conf.MappedTable;
+import org.jooq.conf.MappedUDT;
+import org.jooq.conf.MigrationDefaultContentType;
+import org.jooq.conf.MigrationSchema;
+import org.jooq.conf.MigrationType;
+import org.jooq.conf.NestedCollectionEmulation;
+import org.jooq.conf.ObjectFactory;
+import org.jooq.conf.ParamCastMode;
+import org.jooq.conf.ParamType;
+import org.jooq.conf.ParseNameCase;
+import org.jooq.conf.ParseSearchSchema;
+import org.jooq.conf.ParseUnknownFunctions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PublicApiValueAndConfigurationTest {
+
+    @Test
+    void configuresChartAndDdlMaterializedViewOptions() {
+        ChartFormat chart = new ChartFormat().width(120).height(40)
+                .showHorizontalLegend(false).showVerticalLegend(true);
+        assertThat(chart.width()).isEqualTo(120);
+        assertThat(chart.height()).isEqualTo(40);
+        assertThat(chart.showHorizontalLegend()).isFalse();
+        assertThat(chart.showVerticalLegend()).isTrue();
+
+        DDLExportConfiguration ddl = new DDLExportConfiguration()
+                .createMaterializedViewIfNotExists(true)
+                .createOrReplaceMaterializedView(true)
+                .inlineForeignKeyConstraints(DDLExportConfiguration.InlineForeignKeyConstraints.ALWAYS);
+        assertThat(ddl.createMaterializedViewIfNotExists()).isTrue();
+        assertThat(ddl.createOrReplaceMaterializedView()).isTrue();
+        assertThat(ddl.inlineForeignKeyConstraints())
+                .isEqualTo(DDLExportConfiguration.InlineForeignKeyConstraints.ALWAYS);
+    }
+
+    @Test
+    void convertsNullableValuesAndComposesConverters() {
+        Converter<String, Integer> numbers = Converter.ofNullable(String.class, Integer.class,
+                Integer::valueOf, Object::toString, true, true);
+        Converter<Integer, Long> longs = Converter.of(Integer.class, Long.class, Long::valueOf, Long::intValue);
+        Converter<String, Long> composed = numbers.andThen(longs);
+        assertThat(numbers.fromSupported()).isTrue();
+        assertThat(numbers.toSupported()).isTrue();
+        assertThat(composed.from("42")).isEqualTo(42L);
+        assertThat(numbers.inverse().from(7)).isEqualTo("7");
+        assertThat(numbers.forArrays().to(new Integer[] { 1, 2 })).containsExactly("1", "2");
+
+        ContextConverter<String, Integer> contextual = ContextConverter.ofNullable(String.class, Integer.class,
+                (value, context) -> Integer.valueOf(value), (value, context) -> value.toString(), true, true);
+        assertThat(contextual.from("11")).isEqualTo(11);
+        assertThat(contextual.to(11)).isEqualTo("11");
+        assertThat(Converters.inverse(numbers).from(12)).isEqualTo("12");
+        assertThatThrownBy(Converters::of).isInstanceOf(ArrayIndexOutOfBoundsException.class);
+        assertThat(Converters.of(numbers, longs, Converter.of(Long.class, String.class, Object::toString, Long::valueOf))
+                .from("4")).isEqualTo("4");
+        ContextConverter<String, Integer> wrapped = Converters.of(numbers);
+        assertThat(wrapped.to(3, null)).isEqualTo("3");
+        assertThat(wrapped.toSupported()).isTrue();
+        assertThat(wrapped.fromSupported()).isTrue();
+        assertThat(wrapped.toString()).contains("Converters");
+    }
+
+    @Test
+    void representsDecimalFloatingPointSpecialValues() {
+        Decfloat finite = Decfloat.decfloat("42.5");
+        assertThat(finite.data()).isEqualTo("42.5");
+        assertThat(Decfloat.valueOf("42.5")).isEqualTo(finite);
+        assertThat(finite.doubleValue()).isEqualTo(42.5d);
+        assertThat(finite.floatValue()).isEqualTo(42.5f);
+        assertThat(finite.intValue()).isEqualTo(42);
+        assertThat(finite.longValue()).isEqualTo(42L);
+        assertThat(finite.hashCode()).isEqualTo(Decfloat.decfloat("42.5").hashCode());
+        assertThat(finite.toString()).isEqualTo("4.25E1");
+        assertThat(Decfloat.decfloatOrNull(null)).isNull();
+        assertThat(Decfloat.decfloat("NaN").isNaN()).isTrue();
+        assertThat(Decfloat.decfloat("Infinity").isPositiveInfinity()).isTrue();
+        assertThat(Decfloat.decfloat("-Infinity").isNegativeInfinity()).isTrue();
+    }
+
+    @Test
+    void preservesJsonNullPoliciesAndSourceIdentity() throws Exception {
+        JSONFormat format = new JSONFormat().objectNulls(JSONFormat.NullFormat.NULL_ON_NULL)
+                .arrayNulls(JSONFormat.NullFormat.ABSENT_ON_NULL);
+        assertThat(format.objectNulls()).isEqualTo(JSONFormat.NullFormat.NULL_ON_NULL);
+        assertThat(format.arrayNulls()).isEqualTo(JSONFormat.NullFormat.ABSENT_ON_NULL);
+
+        File file = File.createTempFile("jooq-source", ".sql");
+        java.nio.file.Files.writeString(file.toPath(), "select 1", StandardCharsets.UTF_8);
+        Source fromFile = Source.of(file);
+        assertThat(fromFile.file()).isEqualTo(file);
+        assertThat(fromFile.name()).isEqualTo(file.getName());
+        assertThat(Source.of(new ByteArrayInputStream("select 2".getBytes(StandardCharsets.UTF_8))).readString())
+                .isEqualTo("select 2");
+        assertThat(Source.resolve(file.getAbsolutePath()).readString()).isEqualTo("select 1");
+        assertThat(file.delete()).isTrue();
+    }
+
+    @Test
+    void configuresJaxbMappingObjectsAndFactoryProducts() throws Exception {
+        Pattern users = Pattern.compile("users_.*");
+        MappedTable table = new MappedTable().withInput("users").withInputExpression(users).withOutput("app_users");
+        MappedUDT udt = new MappedUDT().withInput("address").withInputExpression(Pattern.compile("address"))
+                .withOutput("app_address");
+        MappedSchema schema = new MappedSchema().withInput("public").withOutput("app")
+                .withTables(List.of(table)).withUdts(List.of(udt));
+        MappedCatalog catalog = new MappedCatalog().withInput("database").withOutput("app_database")
+                .withSchemata(List.of(schema));
+        assertThat(table.getInput()).isEqualTo("users");
+        assertThat(table.getInputExpression()).isEqualTo(users);
+        assertThat(table.getOutput()).isEqualTo("app_users");
+        assertThat(table).isEqualTo(new MappedTable().withInput("users").withInputExpression(users).withOutput("app_users"));
+        assertThat(udt.getOutput()).isEqualTo("app_address");
+        assertThat(schema.getTables()).containsExactly(table);
+        assertThat(schema.getUdts()).containsExactly(udt);
+        assertThat(catalog.getSchemata()).containsExactly(schema);
+
+        MigrationSchema migrationSchema = new MigrationSchema().withCatalog("database").withSchema("public");
+        MigrationType migration = new MigrationType().withSchemata(migrationSchema);
+        ParseSearchSchema parseSchema = new ParseSearchSchema().withCatalog("database").withSchema("public");
+        InterpreterSearchSchema interpreter = new InterpreterSearchSchema().withCatalog("database").withSchema("public");
+        assertThat(migration.getSchemata()).containsExactly(migrationSchema);
+        assertThat(parseSchema).isEqualTo(new ParseSearchSchema().withCatalog("database").withSchema("public"));
+        assertThat(interpreter.toString()).contains("database");
+
+        ObjectFactory factory = new ObjectFactory();
+        assertThat(factory.createSettings().getRenderMapping()).isNull();
+        assertThat(factory.createMappedCatalog()).isNotNull();
+        assertThat(factory.createMappedSchema()).isNotNull();
+        assertThat(factory.createMappedTable()).isNotNull();
+        assertThat(factory.createMappedUDT()).isNotNull();
+        assertThat(factory.createMigrationSchema()).isNotNull();
+        assertThat(factory.createParseSearchSchema()).isNotNull();
+        assertThat(factory.createInterpreterSearchSchema()).isNotNull();
+        assertThat(factory.createRenderFormatting()).isNotNull();
+        assertThat(factory.createRenderMapping()).isNotNull();
+    }
+
+    @Test
+    void serializesConfigurationEnums() {
+        assertThat(AutoAliasExpressions.fromValue(AutoAliasExpressions.NEVER.value())).isEqualTo(AutoAliasExpressions.NEVER);
+        assertThat(BackslashEscaping.fromValue(BackslashEscaping.DEFAULT.value())).isEqualTo(BackslashEscaping.DEFAULT);
+        assertThat(DiagnosticsConnection.fromValue(DiagnosticsConnection.DEFAULT.value())).isEqualTo(DiagnosticsConnection.DEFAULT);
+        assertThat(ExecuteWithoutWhere.fromValue(ExecuteWithoutWhere.LOG_DEBUG.value())).isEqualTo(ExecuteWithoutWhere.LOG_DEBUG);
+        assertThat(FetchIntermediateResult.fromValue(FetchIntermediateResult.WHEN_RESULT_REQUESTED.value()))
+                .isEqualTo(FetchIntermediateResult.WHEN_RESULT_REQUESTED);
+        assertThat(FetchTriggerValuesAfterReturning.fromValue(FetchTriggerValuesAfterReturning.WHEN_NEEDED.value()))
+                .isEqualTo(FetchTriggerValuesAfterReturning.WHEN_NEEDED);
+        assertThat(InterpreterNameLookupCaseSensitivity.fromValue(InterpreterNameLookupCaseSensitivity.DEFAULT.value()))
+                .isEqualTo(InterpreterNameLookupCaseSensitivity.DEFAULT);
+        assertThat(InvocationOrder.fromValue(InvocationOrder.DEFAULT.value())).isEqualTo(InvocationOrder.DEFAULT);
+        assertThat(MigrationDefaultContentType.fromValue(MigrationDefaultContentType.SCRIPT.value()))
+                .isEqualTo(MigrationDefaultContentType.SCRIPT);
+        assertThat(NestedCollectionEmulation.fromValue(NestedCollectionEmulation.DEFAULT.value()))
+                .isEqualTo(NestedCollectionEmulation.DEFAULT);
+        assertThat(ParamCastMode.fromValue(ParamCastMode.DEFAULT.value())).isEqualTo(ParamCastMode.DEFAULT);
+        assertThat(ParamType.fromValue(ParamType.INDEXED.value())).isEqualTo(ParamType.INDEXED);
+        assertThat(ParseNameCase.fromValue(ParseNameCase.AS_IS.value())).isEqualTo(ParseNameCase.AS_IS);
+        assertThat(ParseUnknownFunctions.fromValue(ParseUnknownFunctions.FAIL.value())).isEqualTo(ParseUnknownFunctions.FAIL);
+        assertThat(SQLDialect.H2.commercial()).isFalse();
+    }
+}

--- a/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/suite.json
+++ b/tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+  "coordinates": "org.jooq:jooq:3.20.0"
+}


### PR DESCRIPTION
## Code coverage improvement

- Source issue: #9050
- Coordinate: `org.jooq:jooq:3.20.0`
- Coverage suite path: `tests/src/org.jooq/jooq/3.18.2/code-coverage-improvement`
- Needs human intervention: no

## JaCoCo coverage

### Public API entries

- Baseline: 395/9275 (4.26%)
- Final: 975/9275 (10.51%)
- Delta: +6.25pp
- Remaining uncovered: 8300

### Deep internal methods

- Baseline: 1690/21546 (7.84%)
- Final: 2691/21546 (12.49%)
- Delta: +4.65pp
- Remaining uncovered: 18855

## Sampled PGO guidance only

Sampled PGO is navigation evidence only. Sample counts do not measure coverage, and sample absence does not prove non-execution.

- Baseline: 1,136 contexts, 1,765 sampled methods, 4,755 samples, 100 sampled joins
- Final: 1,298 contexts, 2,072 sampled methods, 4,889 samples, 100 sampled joins

### Open question

- This focused suite depends on #9049 to wire the `code-coverage-improvement` workflow into Forge.

## Token usage

| Phase | Input | Input (cached) | Output |
|---|--:|--:|--:|
| convert | 68,242 | 740,864 | 5,426 |
| prepare | 92,242 | 720,896 | 5,806 |
| api-inventory | 77,812 | 389,120 | 4,700 |
| api-coverage | 549,702 | 6,661,120 | 37,556 |
| prepare-native-metadata | 38,156 | 147,456 | 3,177 |
| deep-coverage | 685,778 | 8,647,168 | 46,771 |
| publication | 85,249 | 499,712 | 5,262 |
| **Total** | **1,597,181** | **17,806,336** | **108,698** |

Input is uncached input tokens; Input (cached) is cache reads (cache writes were 0). Model: gpt-5.6, 19 invocations total.

Refs #9050
