### PR TITLE
[GenAI] Add support for io.sundr:sundr-model-repo:0.230.1 using gpt-5.6-terra

### DIFF
--- a/metadata/io.sundr/sundr-model-repo/0.230.1/reachability-metadata.json
+++ b/metadata/io.sundr/sundr-model-repo/0.230.1/reachability-metadata.json
@@ -1,0 +1,32 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.repo.MethodReference"
+      },
+      "type" : "io.sundr.model.ClassRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.sundr.model.ClassRef"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.sundr.model.repo.MethodReference"
+      },
+      "type" : "io.sundr.model.MethodCallBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.sundr.model.MethodCall"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.sundr/sundr-model-repo/index.json
+++ b/metadata/io.sundr/sundr-model-repo/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "0.230.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/sundr/sundr-model-repo/$version$/sundr-model-repo-$version$-sources.jar",
+    "repository-url" : "https://github.com/sundrio/sundrio",
+    "test-code-url" : "https://github.com/sundrio/sundrio/tree/$version$/model/repo/src/test",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/sundr/sundr-model-repo/$version$/sundr-model-repo-$version$-javadoc.jar",
+    "description" : "Sundr Model Repository provides a repository for indexing and retrieving Sundr type definitions used by model and code-generation workflows. It also models and collects method references so callers can resolve method calls against those definitions.",
+    "tested-versions" : [
+      "0.230.1"
+    ],
+    "allowed-packages" : [
+      "io.sundr.model.repo"
+    ]
+  }
+]

--- a/stats/io.sundr/sundr-model-repo/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-model-repo/0.230.1/execution-metrics.json
@@ -1,0 +1,84 @@
+{
+  "add_new_library_support:2026-07-16": {
+    "timestamp": "2026-07-16T01:11:46.649562Z",
+    "library": "io.sundr:sundr-model-repo:0.230.1",
+    "starting_commit": "04b54933e2f259fd236f2e088c0ede88a84b6e30",
+    "ending_commit": "ce4ff9cd8c1ba91bfd2d2b8c89b2b8d8e1c62259",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "0.230.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 886,
+          "missed": 278,
+          "ratio": 0.761168,
+          "total": 1164
+        },
+        "line": {
+          "covered": 206,
+          "missed": 60,
+          "ratio": 0.774436,
+          "total": 266
+        },
+        "method": {
+          "covered": 46,
+          "missed": 6,
+          "ratio": 0.884615,
+          "total": 52
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 7792,
+      "issue_label": "library-new-request",
+      "library": "io.sundr:sundr-model-repo:0.230.1",
+      "summary": "The artifact is a self-contained in-memory model repository; its only runtime dependencies (sundr-core and sundr-model) resolve transitively.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7792 Support for io.sundr:sundr-model-repo:0.230.1; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.6-terra",
+      "input_tokens_used": 58937,
+      "output_tokens_used": 1845,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.sundr:sundr-model-repo:0.230.1/library-preparation-preflight/pi-generation-2026-07-16T00-44-17-380446Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 102899,
+      "cached_input_tokens_used": 1066496,
+      "output_tokens_used": 10455,
+      "iterations": 7,
+      "cost_usd": 0.6806,
+      "generated_loc": 149,
+      "tested_library_loc": 206,
+      "metadata_entries": 4,
+      "test_only_metadata_entries": 5,
+      "code_coverage_percent": 77.44
+    },
+    "artifacts": {
+      "metadata_file": "metadata/io.sundr/sundr-model-repo/0.230.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.sundr/sundr-model-repo/0.230.1/stats.json
+++ b/stats/io.sundr/sundr-model-repo/0.230.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "0.230.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 886,
+        "missed" : 278,
+        "ratio" : 0.761168,
+        "total" : 1164
+      },
+      "line" : {
+        "covered" : 206,
+        "missed" : 60,
+        "ratio" : 0.774436,
+        "total" : 266
+      },
+      "method" : {
+        "covered" : 46,
+        "missed" : 6,
+        "ratio" : 0.884615,
+        "total" : 52
+      }
+    }
+  } ]
+}

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/.gitignore
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/build.gradle
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.sundr:sundr-model-repo:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/gradle.properties
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.sundr:sundr-model-repo:0.230.1
+library.version = 0.230.1
+metadata.dir = io.sundr/sundr-model-repo/0.230.1/

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/settings.gradle
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.sundr.sundr-model-repo_tests'

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_sundr.sundr_model_repo;
+
+import org.junit.jupiter.api.Test;
+
+class Sundr_model_repoTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
@@ -65,6 +65,19 @@ public class Sundr_model_repoTest {
     }
 
     @Test
+    void preservesTheFirstDirectlyRegisteredDefinition() {
+        DefinitionRepository repository = DefinitionRepository.createRepository();
+        TypeDef original = type("stable", "Definition");
+        TypeDef replacement = type("stable", "Definition", method("replacement", null));
+
+        repository.registerIfAbsent(original);
+        repository.registerIfAbsent(replacement);
+
+        assertThat(repository.getDefinition("stable.Definition")).isSameAs(original);
+        assertThat(repository.getDefinitions()).containsExactly(original);
+    }
+
+    @Test
     void createsReferenceMapAndTemporarilyScopesRepository() {
         DefinitionRepository repository = DefinitionRepository.createRepository();
         repository.register(type("one", "Duplicate"));

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
@@ -65,6 +65,22 @@ public class Sundr_model_repoTest {
     }
 
     @Test
+    void createsAnIsolatedRepositoryForCallableWork() throws Exception {
+        DefinitionRepository globalRepository = DefinitionRepository.getRepository();
+        TypeDef scopedType = type("scoped", "OnlyHere");
+
+        TypeDef resolved = DefinitionRepository.withNewRepository().call(() -> {
+            DefinitionRepository scopedRepository = DefinitionRepository.getRepository();
+            scopedRepository.register(scopedType);
+            return scopedRepository.getDefinition("scoped.OnlyHere");
+        });
+
+        assertThat(resolved).isSameAs(scopedType);
+        assertThat(DefinitionRepository.getRepository()).isSameAs(globalRepository);
+        assertThat(globalRepository.hasDefinition("scoped.OnlyHere")).isFalse();
+    }
+
+    @Test
     void preservesTheFirstDirectlyRegisteredDefinition() {
         DefinitionRepository repository = DefinitionRepository.createRepository();
         TypeDef original = type("stable", "Definition");

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/java/io_sundr/sundr_model_repo/Sundr_model_repoTest.java
@@ -6,11 +6,140 @@
  */
 package io_sundr.sundr_model_repo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.sundr.model.AttributeKey;
+import io.sundr.model.Block;
+import io.sundr.model.BlockBuilder;
+import io.sundr.model.Method;
+import io.sundr.model.MethodBuilder;
+import io.sundr.model.MethodCall;
+import io.sundr.model.MethodCallBuilder;
+import io.sundr.model.TypeDef;
+import io.sundr.model.TypeDefBuilder;
+import io.sundr.model.repo.DefinitionRepository;
+import io.sundr.model.repo.MethodCallCollector;
+import io.sundr.model.repo.MethodReference;
 import org.junit.jupiter.api.Test;
 
-class Sundr_model_repoTest {
+public class Sundr_model_repoTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void storesFiltersAndLazilyResolvesDefinitions() {
+        DefinitionRepository repository = DefinitionRepository.createRepository();
+        TypeDef included = type("example", "Included");
+        TypeDef excluded = type("example", "Excluded");
+        AttributeKey<Boolean> generated = new AttributeKey<>("generated", Boolean.class);
+        AttributeKey<Boolean> other = new AttributeKey<>("other", Boolean.class);
+        AtomicInteger supplierCalls = new AtomicInteger();
+
+        assertThat(repository.register(included, generated)).isNotSameAs(included);
+        repository.register(excluded, other);
+        repository.registerIfAbsent("example.Lazy", () -> {
+            supplierCalls.incrementAndGet();
+            return type("example", "Lazy");
+        });
+        repository.registerIfAbsent("example.Lazy", () -> type("example", "Replacement"));
+
+        assertThat(repository.hasDefinition("example.Lazy")).isTrue();
+        assertThat(supplierCalls).hasValue(0);
+        assertThat(repository.getDefinitions(generated)).extracting(TypeDef::getName)
+                .containsExactly("Included");
+        assertThat(repository.getDefinitions(other)).extracting(TypeDef::getName)
+                .containsExactly("Excluded");
+
+        TypeDef lazy = repository.getDefinition("example.Lazy");
+        assertThat(lazy.getName()).isEqualTo("Lazy");
+        assertThat(repository.getDefinition("example.Lazy", false)).isSameAs(lazy);
+        assertThat(supplierCalls).hasValue(1);
+        assertThat(repository.getDefinition(lazy.toReference())).isSameAs(lazy);
+        assertThat(repository.getDefinitions()).extracting(TypeDef::getName)
+                .containsExactlyInAnyOrder("Included", "Excluded", "Lazy");
+
+        repository.clear();
+        assertThat(repository.getDefinitions()).isEmpty();
+        assertThat(repository.hasDefinition("example.Lazy")).isFalse();
+    }
+
+    @Test
+    void createsReferenceMapAndTemporarilyScopesRepository() {
+        DefinitionRepository repository = DefinitionRepository.createRepository();
+        repository.register(type("one", "Duplicate"));
+        repository.register(type("two", "Duplicate"));
+        repository.register(type("three", "Unique"));
+
+        Map<String, String> references = repository.getReferenceMap();
+        assertThat(references).containsEntry("Duplicate", "one.Duplicate")
+                .containsEntry("Unique", "three.Unique");
+
+        repository.register(type("four", "Later"));
+        assertThat(repository.getReferenceMap()).doesNotContainKey("Later");
+        repository.updateReferenceMap();
+        assertThat(repository.getReferenceMap()).containsEntry("Later", "four.Later");
+
+        DefinitionRepository original = DefinitionRepository.getRepository();
+        DefinitionRepository scoped = DefinitionRepository.withRepository(repository)
+                .apply(ignored -> DefinitionRepository.getRepository());
+        assertThat(scoped).isSameAs(repository);
+        assertThat(DefinitionRepository.getRepository()).isSameAs(original);
+    }
+
+    @Test
+    void collectsCallsAndResolvesDirectAndTransitiveMethodRelationships() {
+        Method leaf = method("leaf", null);
+        TypeDef leafType = type("graph", "Leaf", leaf);
+        Method middle = method("middle", call("leaf", leafType));
+        TypeDef middleType = type("graph", "Middle", middle);
+        Method entry = method("entry", call("middle", middleType));
+        TypeDef entryType = type("graph", "Entry", entry);
+        DefinitionRepository repository = DefinitionRepository.createRepository();
+        repository.register(leafType);
+        repository.register(middleType);
+        repository.register(entryType);
+        MethodReference leafReference = new MethodReference(leaf, leafType);
+        MethodReference middleReference = new MethodReference(middle, middleType);
+
+        MethodCallCollector collector = new MethodCallCollector();
+        MethodCall middleCall = call("middle", middleType);
+        collector.visit(new MethodCallBuilder(middleCall));
+        collector.visit(new MethodCallBuilder(middleCall));
+        assertThat(collector.getMethodCalls()).extracting(MethodCall::getName)
+                .containsExactly("middle", "middle");
+        collector.clear();
+        assertThat(collector.getMethodCalls()).isEmpty();
+
+        assertThat(MethodReference.getDirectMethodReferences(entry, repository))
+                .containsExactly(middleReference);
+        assertThat(MethodReference.getMethodReferences(entry, repository))
+                .containsExactlyInAnyOrder(middleReference, leafReference);
+        assertThat(MethodReference.getDirectMethodCallers(leafReference, repository))
+                .containsExactly(middleReference);
+        assertThat(MethodReference.getMethodCallers(leafReference, repository))
+                .containsExactlyInAnyOrder(middleReference, new MethodReference(entry, entryType));
+        MethodReference.clearCache();
+    }
+
+    private static TypeDef type(String packageName, String name, Method... methods) {
+        return new TypeDefBuilder()
+                .withPackageName(packageName)
+                .withName(name)
+                .withMethods(methods)
+                .build();
+    }
+
+    private static Method method(String name, MethodCall call) {
+        MethodBuilder builder = new MethodBuilder().withName(name);
+        if (call != null) {
+            Block block = new BlockBuilder().withStatements(call).build();
+            builder.withBlock(block);
+        }
+        return builder.build();
+    }
+
+    private static MethodCall call(String name, TypeDef scope) {
+        return new MethodCall(name, scope.toReference());
     }
 }

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,40 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_model_repo.Sundr_model_repoTest"
+      },
+      "type" : "io.sundr.model.ClassRefBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.sundr.model.ClassRef"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_model_repo.Sundr_model_repoTest"
+      },
+      "type" : "io.sundr.model.MethodCallBuilder",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "io.sundr.model.MethodCall"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "io_sundr.sundr_model_repo.Sundr_model_repoTest"
+      },
+      "glob" : "META-INF/services/io.sundr.builder.VisitorListener"
+    }
+  ]
+}

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.sundr.model.repo.**"
+      "includeClasses" : "io.sundr.model.repo.**"
+    },
+    {
+      "includeClasses" : "io_sundr.sundr_model_repo.**"
     }
   ]
 }

--- a/tests/src/io.sundr/sundr-model-repo/0.230.1/user-code-filter.json
+++ b/tests/src/io.sundr/sundr-model-repo/0.230.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.sundr.model.repo.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7792

This PR introduces tests and metadata for io.sundr:sundr-model-repo:0.230.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 102899
- Cached input tokens: 1066496
- Output tokens: 10455
- Metadata entries: 4
- Test-only metadata entries: 5
- Iterations: 7
- Library coverage percentage: 77.44
- Generated lines of code: 149
- Tested library lines of code: 206

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `55d1fd86fd0afd631f77ac02f8200aad8853f40f`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 886/1164 (76.12%)
- Line: 206/266 (77.44%)
- Method: 46/52 (88.46%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
