### PR TITLE
Preserve dynamic-access class checkpoints

### DIFF
--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -806,7 +806,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             f"native-test gate {result.status} for {class_name} after {result.iterations_used} cycles",
             indent_level=2,
         )
-        self._commit_library_metadata(f"Native metadata for {class_name}")
+        self._commit_test_sources(f"Native-test gate fixes for {class_name}")
+        self._latest_class_checkpoint = self._commit_library_metadata(
+            f"Native metadata for {class_name}"
+        )
         return True
 
     def _refresh_report_after_gate(self, class_name: str):
@@ -1021,8 +1024,13 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             text=True,
         ).strip()
 
-    def _commit_library_metadata(self, message: str) -> None:
-        """Stage and commit durable library metadata created by the class gate."""
+    def _commit_library_metadata(self, message: str) -> str:
+        """Stage and commit durable library metadata created by the class gate.
+
+        Returns the resulting `HEAD` SHA so a passing gate can advance the
+        whole-phase recovery checkpoint past the verified test and metadata
+        commits, per §WF-dynamic-access-fallback-and-failure.
+        """
         metadata_version = resolve_metadata_version(
             self.reachability_repo_path,
             self.group,
@@ -1044,13 +1052,17 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             cwd=self.reachability_repo_path,
             capture_output=True, check=False,
         ).returncode
-        if diff_rc == 0:
-            return
-        subprocess.run(
-            ["git", "commit", "-m", message, "--", metadata_dir],
+        if diff_rc != 0:
+            subprocess.run(
+                ["git", "commit", "-m", message, "--", metadata_dir],
+                cwd=self.reachability_repo_path,
+                capture_output=True, check=False,
+            )
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
             cwd=self.reachability_repo_path,
-            capture_output=True, check=False,
-        )
+            text=True,
+        ).strip()
 
     def _generate_dynamic_access_report(self, indent_level: int = 0):
         """Generate and load the dynamic-access report used as strategy guidance.

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -857,6 +857,15 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         self._run_exhaust_report_git_command(
             ["git", "commit", "-m", message, "--", self.dynamic_access_exhaust_report_path]
         )
+        # The exhaust-report commit records terminal class state above the last
+        # test/metadata commit, so advance the whole-phase recovery checkpoint
+        # past it too; otherwise a later reset drops the completed-class marker
+        # while keeping its tests, per §WF-dynamic-access-fallback-and-failure.
+        self._latest_class_checkpoint = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.reachability_repo_path,
+            text=True,
+        ).strip()
 
     def _run_exhaust_report_git_command(self, command: list[str]) -> None:
         result = subprocess.run(

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -85,6 +85,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
         self.chunk_class_count = int(self.context.get("chunk_class_count") or 0)
         self._last_phase_status = RUN_STATUS_SUCCESS
+        self._latest_class_checkpoint: str | None = None
         self.dynamic_access_report_path = os.path.join(
             self.reachability_repo_path,
             "tests",
@@ -105,6 +106,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         available; once the class loop begins, report loss and gate failure are
         hard workflow failures, per §WF-dynamic-access-fallback-and-failure.
         """
+        self._latest_class_checkpoint = checkpoint_commit_hash
         initial_report = self._generate_dynamic_access_report()
         if self._should_fallback_to_basic_flow(initial_report):
             self._print_dynamic_access_message(
@@ -121,7 +123,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         if self._last_phase_status == RUN_STATUS_CHUNK_READY:
             return RUN_STATUS_CHUNK_READY, global_iterations, 1
         if not phase_ok:
-            subprocess.run(["git", "reset", "--hard", checkpoint_commit_hash], check=False)
+            recovery_checkpoint = self._latest_class_checkpoint or checkpoint_commit_hash
+            subprocess.run(["git", "reset", "--hard", recovery_checkpoint], check=False)
             return RUN_STATUS_FAILURE, global_iterations, 0
 
         return RUN_STATUS_SUCCESS, global_iterations, 1
@@ -463,7 +466,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 if updated_class is None:
                     if current_report.covered_calls > previous_report.covered_calls:
                         self._print_dynamic_access_detail("result: resolved", indent_level=2)
-                        self._commit_test_sources(
+                        self._latest_class_checkpoint = self._commit_test_sources(
                             f"Dynamic-access coverage for {class_name} "
                             f"({current_report.covered_calls}/{current_report.total_calls})"
                         )
@@ -491,7 +494,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     break
                 if updated_class.uncovered_calls == 0:
                     self._print_dynamic_access_detail("result: resolved", indent_level=2)
-                    self._commit_test_sources(
+                    self._latest_class_checkpoint = self._commit_test_sources(
                         f"Dynamic-access coverage for {class_name} "
                         f"({current_report.covered_calls}/{current_report.total_calls})"
                     )
@@ -520,14 +523,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         ),
                         indent_level=2,
                     )
-                    self._commit_test_sources(
+                    class_checkpoint = self._commit_test_sources(
                         f"Partial dynamic-access coverage for {class_name} "
                         f"({updated_class.covered_calls}/{updated_class.total_calls})"
                     )
+                    self._latest_class_checkpoint = class_checkpoint
                     class_committed = True
-                    class_checkpoint = subprocess.check_output(
-                        ["git", "rev-parse", "HEAD"], text=True,
-                    ).strip()
                     if not self._queue_native_test_verification_step(
                             pending_native_test_classes,
                             class_name,
@@ -996,7 +997,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
         return "\n".join([tracked_diff.stdout, "--untracked--", untracked_files.stdout])
 
-    def _commit_test_sources(self, message: str) -> None:
+    def _commit_test_sources(self, message: str) -> str:
         """Stage and commit test sources so the next class has a clean checkpoint."""
         tests_dir = os.path.join(
             self.reachability_repo_path, "tests", "src",
@@ -1014,6 +1015,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             cwd=self.reachability_repo_path,
             capture_output=True, check=False,
         )
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.reachability_repo_path,
+            text=True,
+        ).strip()
 
     def _commit_library_metadata(self, message: str) -> None:
         """Stage and commit durable library metadata created by the class gate."""

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -579,7 +579,7 @@ Every workflow records one of these statuses:
 | `RUN_STATUS_SUCCESS` | All generation gates and the local CI-equivalent verification passed; metadata and tests committed (see §FS-local-ci-equivalent-verification). |
 | `SUCCESS_WITH_INTERVENTION_STATUS` | Tests succeeded after the built-in post-generation recovery modified the working tree (a Codex metadata fix, then Pi removing failing tests as a last resort), and the local CI-equivalent verification (§FS-local-ci-equivalent-verification) passed. The intervention's record is included in the run-metrics and PR description. PR-eligible; distinct from the `human-intervention` label unless §FS-human-intervention-policy separately requires that label. |
 | `RUN_STATUS_CHUNK_READY` | A chunked dynamic-access run reached a reviewable class boundary and §FS-local-ci-equivalent-verification passed for the current part. The current part is PR-eligible, and the issue must not be resumed until the part PR has merged. |
-| `RUN_STATUS_FAILURE` | The workflow could not converge or a quality gate failed; the feature branch is reset to the scaffold checkpoint and no PR is opened. |
+| `RUN_STATUS_FAILURE` | The workflow could not converge or a quality gate failed; the feature branch is reset to its workflow recovery checkpoint and no PR is opened. Iterative dynamic-access exploration advances that checkpoint after each committed class (§WF-dynamic-access-fallback-and-failure); other workflows retain their specified checkpoint behavior. |
 
 The exit code is `0` for PR-eligible statuses and `1` for failure.
 

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -217,8 +217,9 @@ State held for one strategy `run(...)` invocation, independent of chunking:
   back a failed class iteration without losing previously committed classes.
 - `latest_class_checkpoint` — newest git SHA returned after committing resolved
   or partial class progress, advanced again when a passing native-test gate
-  commits verified test fixes and durable metadata (§6.4); initialized to the
-  scaffold checkpoint and used by whole-phase failure recovery.
+  commits verified test fixes and durable metadata (§6.4) and when a terminal
+  class transition commits the chunk exhaust report; initialized to the scaffold
+  checkpoint and used by whole-phase failure recovery.
 - `prompt_iterations` — total agent prompts sent (returned to the caller as
   `global_iterations`).
 - `successful_classes` — count of classes that contributed at least one newly
@@ -593,6 +594,12 @@ reprocessing classes and to resume safely:
 - class threshold and the current chunk count
 - completed/skipped/exhausted/failed class names
 - latest chunk PR number and commit
+
+Each terminal class transition (completed, skipped, exhausted, or failed)
+commits the updated exhaust report and advances `latest_class_checkpoint` past
+that commit, so a later whole-phase failure reset (§WF-dynamic-access-fallback-and-failure)
+preserves the recorded chunk state instead of resurrecting an already-processed
+class.
 
 It does not store a precomputed chunk manifest. Every resume regenerates the
 dynamic-access report and filters out classes recorded in the exhaust report.

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -108,10 +108,13 @@ Dynamic-access workflows must fail when any of these conditions occur:
 5. Chunked mode reaches a chunk boundary but cannot pass the local
    CI-equivalent verification required for a reviewable chunk PR.
 
-Failures return `RUN_STATUS_FAILURE` and the driver resets the feature
-branch to the scaffold checkpoint. A composite workflow with a primary workflow
-preserves and returns the primary workflow failure instead of starting the
-dynamic-access coverage phase.
+Failures return `RUN_STATUS_FAILURE`. After iterative exploration has started,
+the engine resets the feature branch to the latest committed class checkpoint,
+or to the scaffold checkpoint when no class has been committed. This preserves
+accepted class progress while discarding the failing class's uncommitted work.
+Bulk exploration retains its scaffold checkpoint behavior. A composite workflow
+with a primary workflow preserves and returns the primary workflow failure
+instead of starting the dynamic-access coverage phase.
 
 ## 2. Inputs
 
@@ -192,8 +195,9 @@ The following preconditions are established by `add_new_library_support.main`
 5. `prepare_source_contexts(...)` has downloaded and extracted the artifacts
    declared by the strategy's `source-context-types`. Their files become the
    agent's read-only context.
-6. Scaffold commit recorded as `checkpoint_commit_hash`. Failure recovery
-   uses `git reset --hard <checkpoint_commit_hash>`.
+6. Scaffold commit recorded as `checkpoint_commit_hash`. It is the initial
+   failure-recovery checkpoint; iterative exploration advances recovery to each
+   committed class checkpoint.
 
 ## 5. State Model
 
@@ -209,6 +213,9 @@ State held for one strategy `run(...)` invocation, independent of chunking:
   again within the run.
 - `class_checkpoint` — git SHA captured before each class attempt; used to roll
   back a failed class iteration without losing previously committed classes.
+- `latest_class_checkpoint` — newest git SHA returned after committing resolved
+  or partial class progress; initialized to the scaffold checkpoint and used by
+  whole-phase failure recovery.
 - `prompt_iterations` — total agent prompts sent (returned to the caller as
   `global_iterations`).
 - `successful_classes` — count of classes that contributed at least one newly
@@ -396,8 +403,9 @@ fields with the full dynamic-access report.
 
 A missing or unparsable `dynamic-access-coverage.json` after the initial
 phase is a hard failure: the workflow engine returns `RUN_STATUS_FAILURE` with
-the prompt-iteration count, and the workflow driver resets the branch to
-`checkpoint_commit_hash`.
+the prompt-iteration count, and the workflow engine resets the branch to the
+latest committed class checkpoint, falling back to `checkpoint_commit_hash`
+when no class has been committed.
 
 ### 6.4 Per-class native-test verification gate
 
@@ -449,9 +457,10 @@ Effects within this workflow:
    (§WF-native-test-verification-gate).
    Native Image must always work; partial dynamic-access coverage with a
    broken `nativeTest` is not an acceptable terminal state. The entry
-   script resets the feature branch to `checkpoint_commit_hash`, records
-   the gate's `last_native_test_log_path` and `intervention_records` in
-   the run metrics, and exits non-zero.
+   script records the gate's `last_native_test_log_path` and
+   `intervention_records` in the run metrics, resets to the latest committed
+   class checkpoint (or the scaffold checkpoint before the first class commit),
+   and exits non-zero.
 4. Metadata remains cumulative across chunks. The gate's final durable merge
    includes any existing durable metadata from prior merged chunk PRs and the
    staged metadata generated for the current chunk.
@@ -471,7 +480,7 @@ flowchart TD
 
     PhaseOK --> Final[Workflow engine returns RUN_STATUS_SUCCESS]
     KeepOK --> Final
-    PhaseFail --> Reset[git reset --hard checkpoint_commit_hash]
+    PhaseFail --> Reset[git reset --hard latest_class_checkpoint]
     Reset --> FinalFail[Workflow engine returns RUN_STATUS_FAILURE]
 
     Final --> EntryFinalize[add_new_library_support.main]
@@ -654,5 +663,7 @@ support iff **all** requirements for its selected engine hold at exit:
    behavior were correct.
 10. The metrics record validates against the active schema.
 
-Any deviation produces `RUN_STATUS_FAILURE` and a feature branch reset to the
-scaffold checkpoint.
+Any deviation produces `RUN_STATUS_FAILURE`. Iterative exploration resets to
+the latest committed class checkpoint, or to the scaffold checkpoint if no
+class progress was committed; other dynamic-access engines retain their
+specified recovery behavior.

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -216,8 +216,9 @@ State held for one strategy `run(...)` invocation, independent of chunking:
 - `class_checkpoint` — git SHA captured before each class attempt; used to roll
   back a failed class iteration without losing previously committed classes.
 - `latest_class_checkpoint` — newest git SHA returned after committing resolved
-  or partial class progress; initialized to the scaffold checkpoint and used by
-  whole-phase failure recovery.
+  or partial class progress, advanced again when a passing native-test gate
+  commits verified test fixes and durable metadata (§6.4); initialized to the
+  scaffold checkpoint and used by whole-phase failure recovery.
 - `prompt_iterations` — total agent prompts sent (returned to the caller as
   `global_iterations`).
 - `successful_classes` — count of classes that contributed at least one newly
@@ -451,7 +452,11 @@ Effects within this workflow:
    merged trace output is written to `<output_dir>/trace`. Only after the
    gate passes are existing durable metadata, staged agent metadata, and
    staged trace metadata merged into the durable
-   `metadata/<group>/<artifact>/<version>/` directory.
+   `metadata/<group>/<artifact>/<version>/` directory. A passing gate then
+   commits the coordinate's test sources (including any fixes the gate's
+   verification cycles applied) and the merged durable metadata, and advances
+   `latest_class_checkpoint` past both commits, so whole-phase failure
+   recovery never separates verified tests from the metadata they require.
 2. The dynamic-access coverage report is regenerated **after** the gate so
    that any call sites covered by JVM-agent, traced, or Codex-supplied metadata are
    reflected in the next class's prompt delta.

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -110,8 +110,10 @@ Dynamic-access workflows must fail when any of these conditions occur:
 
 Failures return `RUN_STATUS_FAILURE`. After iterative exploration has started,
 the engine resets the feature branch to the latest committed class checkpoint,
-or to the scaffold checkpoint when no class has been committed. This preserves
-accepted class progress while discarding the failing class's uncommitted work.
+or to the scaffold checkpoint when no class has been committed. The latest class
+commit is used because it is the last coherent checkpoint from which exploration
+can resume: it preserves accepted class progress and the corresponding
+exploration information while discarding the failing class's uncommitted work.
 Bulk exploration retains its scaffold checkpoint behavior. A composite workflow
 with a primary workflow preserves and returns the primary workflow failure
 instead of starting the dynamic-access coverage phase.

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -86,6 +86,9 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
 
             def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
                 calls.append(list(cmd))
+                # `check_output` for `git rev-parse HEAD` delegates to `subprocess.run`.
+                if "rev-parse" in cmd:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n")
                 # Simulate `git diff --cached --quiet` finding staged changes (rc=1).
                 if "diff" in cmd and "--quiet" in cmd:
                     return subprocess.CompletedProcess(cmd, 1)
@@ -95,8 +98,9 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                     "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.run",
                     side_effect=fake_run,
             ):
-                strategy._commit_library_metadata("Native metadata for org.example.Demo")
+                head_sha = strategy._commit_library_metadata("Native metadata for org.example.Demo")
 
+        self.assertEqual(head_sha, "abc123")
         self.assertEqual(calls[0][:3], ["git", "add", "-A"])
         self.assertEqual(calls[0][3], metadata_dir)
         # Diff and commit must both be scoped to the metadata dir to avoid
@@ -118,6 +122,9 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
 
             def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
                 calls.append(list(cmd))
+                # `check_output` for `git rev-parse HEAD` delegates to `subprocess.run`.
+                if "rev-parse" in cmd:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n")
                 # rc=0 from `git diff --cached --quiet` means nothing to commit.
                 return subprocess.CompletedProcess(cmd, 0)
 
@@ -127,7 +134,7 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             ):
                 strategy._commit_library_metadata("Native metadata for org.example.Demo")
 
-        self.assertEqual([cmd[1] for cmd in calls], ["add", "diff"])
+        self.assertEqual([cmd[1] for cmd in calls], ["add", "diff", "rev-parse"])
         self.assertFalse(any("commit" in cmd for cmd in calls))
 
     def test_report_path_uses_indexed_test_version_for_reused_test_project(self) -> None:

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -155,6 +155,46 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             strategy.dynamic_access_report_path,
         )
 
+    def test_phase_failure_resets_to_latest_committed_class_checkpoint(self) -> None:
+        """Preserve class commits on late failure. §WF-dynamic-access-fallback-and-failure"""
+        class FakeAgent:
+            def send_prompt(self, prompt: str) -> None:
+                pass
+
+            def run_test_command(self, command: str) -> str:
+                return "BUILD SUCCESSFUL"
+
+            def clear_context(self) -> None:
+                pass
+
+        class_names = ["org.example.A", "org.example.B"]
+        initial_report = self._report_for_class_names(class_names, [])
+        after_first_class = self._report_for_class_names(class_names, ["org.example.A"])
+        strategy = self._strategy()
+
+        with patch.object(strategy, "_render_prompt", return_value="prompt"), \
+                patch.object(
+                    strategy,
+                    "_generate_dynamic_access_report",
+                    side_effect=[initial_report, after_first_class, None],
+                ), \
+                patch.object(strategy, "_commit_test_sources", return_value="class-a-checkpoint"), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="scaffold-checkpoint\n",
+                ), \
+                patch(
+                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.run",
+                ) as run_command:
+            result = strategy.run(FakeAgent(), "scaffold-checkpoint")
+
+        self.assertEqual(result, (RUN_STATUS_FAILURE, 2, 0))
+        run_command.assert_called_once_with(
+            ["git", "reset", "--hard", "class-a-checkpoint"],
+            check=False,
+        )
+
     def test_issue_requested_metadata_phase_commits_when_native_test_is_reached(self) -> None:
         class FakeAgent:
             def __init__(self) -> None:

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -155,46 +155,6 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             strategy.dynamic_access_report_path,
         )
 
-    def test_phase_failure_resets_to_latest_committed_class_checkpoint(self) -> None:
-        """Preserve class commits on late failure. §WF-dynamic-access-fallback-and-failure"""
-        class FakeAgent:
-            def send_prompt(self, prompt: str) -> None:
-                pass
-
-            def run_test_command(self, command: str) -> str:
-                return "BUILD SUCCESSFUL"
-
-            def clear_context(self) -> None:
-                pass
-
-        class_names = ["org.example.A", "org.example.B"]
-        initial_report = self._report_for_class_names(class_names, [])
-        after_first_class = self._report_for_class_names(class_names, ["org.example.A"])
-        strategy = self._strategy()
-
-        with patch.object(strategy, "_render_prompt", return_value="prompt"), \
-                patch.object(
-                    strategy,
-                    "_generate_dynamic_access_report",
-                    side_effect=[initial_report, after_first_class, None],
-                ), \
-                patch.object(strategy, "_commit_test_sources", return_value="class-a-checkpoint"), \
-                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
-                patch(
-                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
-                    return_value="scaffold-checkpoint\n",
-                ), \
-                patch(
-                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.run",
-                ) as run_command:
-            result = strategy.run(FakeAgent(), "scaffold-checkpoint")
-
-        self.assertEqual(result, (RUN_STATUS_FAILURE, 2, 0))
-        run_command.assert_called_once_with(
-            ["git", "reset", "--hard", "class-a-checkpoint"],
-            check=False,
-        )
-
     def test_issue_requested_metadata_phase_commits_when_native_test_is_reached(self) -> None:
         class FakeAgent:
             def __init__(self) -> None:


### PR DESCRIPTION
## What this does

Fixes: #9062

An iterative dynamic-access run could commit several completed classes, then lose its refreshed coverage report or fail a native gate and reset the entire branch to scaffold. That made resumable runs preserve exploration state while throwing away the corresponding generated tests.

The class loop already defines the durable unit of progress, so failure recovery now follows that same boundary. The latest class commit is the last coherent checkpoint from which exploration can resume: it keeps accepted class progress and the corresponding exploration information aligned while discarding only later uncommitted work. This updates [§WF-dynamic-access-fallback-and-failure](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/workflows/dynamic-access.md#WF-dynamic-access-fallback-and-failure).

## Recovery boundary

| Situation | Recovery checkpoint |
| --- | --- |
| No class committed yet | Scaffold commit |
| Resolved or partial class committed | Latest class commit |
| Later report refresh or native gate fails | Latest class commit |