### PR TITLE
Stop prioritizing transitive dependency issues

### DIFF
--- a/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
+++ b/.github/workflows/scripts/open-dependency-issues-and-link-blockers.js
@@ -133,29 +133,6 @@ function buildIssueBody() {
 }
 
 /**
- * Normalizes GitHub issue labels into a de-duplicated list of label names.
- */
-function normalizeIssueLabelNames(labels) {
-  return uniqueStrings(
-    (Array.isArray(labels) ? labels : []).map((label) =>
-      typeof label === 'string' ? label : label?.name
-    )
-  );
-}
-
-/**
- * Returns the labels to apply to newly created dependency issues.
- */
-function buildCreatedIssueLabels(context) {
-  const createdIssueLabels = ['library-new-request'];
-  const sourceIssueLabelNames = normalizeIssueLabelNames(context?.payload?.issue?.labels);
-  if (sourceIssueLabelNames.includes('priority')) {
-    createdIssueLabels.push('priority');
-  }
-  return createdIssueLabels;
-}
-
-/**
  * Extracts the requested Maven coordinates from an issue title.
  */
 function extractCoordinatesFromIssueTitle(title) {
@@ -600,7 +577,6 @@ module.exports = async function openDependencyIssuesAndLinkBlockers({ github, co
   const repo = context.repo.repo;
   const sourceIssueNumber = context.issue.number;
   const workspaceDir = resolveWorkspaceDir();
-  const createdIssueLabels = buildCreatedIssueLabels(context);
 
   const rawDependencyGraph = loadRawDependencyGraph();
   if (isEmptyObject(rawDependencyGraph)) {
@@ -884,7 +860,7 @@ module.exports = async function openDependencyIssuesAndLinkBlockers({ github, co
         repo,
         title,
         body,
-        labels: createdIssueLabels
+        labels: ['library-new-request']
       });
       issueNumber = created.data.number;
       createdCount++;

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -184,7 +184,9 @@ per-version `tested-versions`. It then — via
 `open-dependency-issues-and-link-blockers.js`
 (§CI-shared-scripts) — generates a deps.dev dependency graph and opens or reuses
 `library-new-request` issues for unsupported transitive dependencies, linking
-them as blockers. The label vocabulary it applies is defined in
+them as blockers. Newly created transitive dependency issues do not receive
+`priority`, even when the direct request has it. The label vocabulary it applies
+is defined in
 §FS-repository-functional-spec.4.
 
 ## Composite actions


### PR DESCRIPTION
## Keep the priority queue user-focused

Closes #9091

The dependency expander inherited `priority` from the direct request, so one user request could promote every automation-generated transitive blocker. Newly created transitive issues now always receive only `library-new-request`; issue templates and direct-request triage remain unchanged.

The CI contract records this behavior under [`§CI-triage-new-issues`](https://github.com/oracle/graalvm-reachability-metadata/blob/master/docs/ci.md#ci-triage-new-issues-triage-new-issues).