### PR TITLE
Add repository issue status report tool

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ all of its IDs in that one file.
 - [grund.md](grund.md) — `GRUND-repository-motivation`: why this repository exists.
 - [goals.md](goals.md) — the outcome goals: tested metadata, broad version coverage, fresh releases, and no regressions.
 - [functional-spec.md](functional-spec.md) — `FS-repository-functional-spec`: the system's behavior, requirements, the native-build-tools interface contract, library-version compatibility automation, and how each audience uses the repository.
+- [repository-status.md](repository-status.md) — `FS-repository-status-report` and `AR-repository-status-tool`: the issue progress measurements and their HTML/JSON reporting component.
 - [architecture.md](architecture.md) — `AR-repository-architecture`: the component map and high-level implementation overview.
 - [build-infra.md](build-infra.md) — `AR-build-infrastructure`: the two-layer Gradle build, convention plugins, and scaffolding.
 - [tck.md](tck.md) — `TCK-test-harness`: the harness task groups.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ all of its IDs in that one file.
 - [grund.md](grund.md) — `GRUND-repository-motivation`: why this repository exists.
 - [goals.md](goals.md) — the outcome goals: tested metadata, broad version coverage, fresh releases, and no regressions.
 - [functional-spec.md](functional-spec.md) — `FS-repository-functional-spec`: the system's behavior, requirements, the native-build-tools interface contract, library-version compatibility automation, and how each audience uses the repository.
-- [repository-status.md](repository-status.md) — `FS-repository-status-report` and `AR-repository-status-tool`: the issue progress measurements and their HTML/JSON reporting component.
+- [repository-status.md](repository-status.md) — `FS-repository-status-report`: issue progress measurements and their HTML/JSON representations.
 - [architecture.md](architecture.md) — `AR-repository-architecture`: the component map and high-level implementation overview.
 - [build-infra.md](build-infra.md) — `AR-build-infrastructure`: the two-layer Gradle build, convention plugins, and scaffolding.
 - [tck.md](tck.md) — `TCK-test-harness`: the harness task groups.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,7 @@ patching, no `Feature` classes, no untested metadata) are specified in
 | Infrastructure E2E tests | `testInfra`/`testAllInfra`, which exercise the whole task surface to prove the infrastructure itself works. | §E2E-infrastructure-tests |
 | CI | GitHub Actions workflows that gate PRs, sweep metadata on a schedule, track upstream versions, scan images, and publish coverage and releases. | §CI-repository-ci |
 | Forge | The automation subproject that turns labeled issues into review-ready PRs. | §forge/AR-forge-architecture |
+| Repository status | `repository_status/` reports weighted unresolved issue state and recent progress for humans and agents. | §AR-repository-status-tool |
 
 ## 3. How work flows through the system
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,6 @@ patching, no `Feature` classes, no untested metadata) are specified in
 | Infrastructure E2E tests | `testInfra`/`testAllInfra`, which exercise the whole task surface to prove the infrastructure itself works. | §E2E-infrastructure-tests |
 | CI | GitHub Actions workflows that gate PRs, sweep metadata on a schedule, track upstream versions, scan images, and publish coverage and releases. | §CI-repository-ci |
 | Forge | The automation subproject that turns labeled issues into review-ready PRs. | §forge/AR-forge-architecture |
-| Repository status | `repository_status/` reports weighted unresolved issue state and recent progress for humans and agents. | §AR-repository-status-tool |
 
 ## 3. How work flows through the system
 

--- a/docs/repository-status.md
+++ b/docs/repository-status.md
@@ -1,0 +1,113 @@
+# FS-repository-status-report: Repository issue progress and state
+
+Maintainers and agents must be able to inspect the repository's unresolved issue
+state from one deterministic report. The report measures both the current
+weighted backlog and the time that unresolved work has accumulated, helping
+maintainers shorten the path from an issue to shipped metadata while continuing
+to broaden tested library coverage.
+§GOAL-broad-version-coverage §forge/GOAL-shorten-issue-to-shipped-metadata
+
+## 1. Issue scope and priority
+
+The report includes every open GitHub issue in
+`oracle/graalvm-reachability-metadata` and excludes pull requests. Priority is
+classified into exactly one tier, in this order:
+
+1. `high`: the issue has the exact `high-priority` label; weight `10`.
+2. `priority`: the issue does not have `high-priority` and has the exact
+   `priority` label; weight `5`.
+3. `normal`: the issue has neither priority label; weight `1`.
+
+An issue carrying both labels is classified as `high` and reported as a
+data-quality warning. Priority and age remain independent facts: age never
+changes an issue's label-derived tier.
+
+## 2. Age and debt
+
+The unresolved age is the number of complete UTC days between an issue's
+`createdAt` value and report generation, clamped to zero. This is the issue's
+full lifetime and not the duration since its most recent reopening.
+
+Each open issue contributes its priority weight to the weighted backlog and its
+priority weight multiplied by its age in days to weighted age debt. Reports
+must provide both totals and per-tier values.
+
+Standing priority pressure is summarized as **priority age debt**: the weighted
+age debt of the `high` and `priority` tiers only, excluding `normal`. A single
+neglected high- or priority-labelled issue must dominate this figure, while a
+large pile of aging `normal` issues must not. The human report renders it as a
+fixed-scale fill meter from `0` to the policy's age-debt meter maximum, placed
+directly below the recent-flow meter; values at or above the maximum saturate
+the meter at full. The recent flow and the priority age debt are independent
+signals: flow tracks whether the backlog is shrinking this window, while
+priority age debt tracks how much neglected high-value work has accumulated.
+
+Age bands are inclusive:
+
+| Band | Age |
+| --- | --- |
+| `fresh` | 0–7 days |
+| `aging` | 8–30 days |
+| `old` | 31–90 days |
+| `stale` | 91 days or more |
+
+The attention queue is ordered by priority tier (`high`, `priority`, `normal`),
+then oldest first, then issue number. Thus age exposes neglected work without
+allowing an old normal issue to outrank high-priority work.
+
+## 3. Project state and recent flow
+
+When GitHub exposes the issue's item in the configured repository project, the
+report records its `Todo`, `In Progress`, or `Done` status. Open issues reported
+as `Done` and issues carrying both priority labels remain in the backlog and are
+surfaced as data-quality warnings. Issues with an unknown or missing project
+status are still counted in the project-state totals but are not warned about.
+
+For a configurable recent window, defaulting to 30 days, the report measures:
+
+- issues opened during the window;
+- issues resolved during the window;
+- the corresponding priority-weighted opened and resolved totals;
+- weighted net change (`opened - resolved`); and
+- weighted burn ratio (`resolved / opened`), represented as `null` when no
+  weighted issues were opened.
+
+These flow measures describe recent progress; the weighted backlog and age debt
+describe current state.
+
+The human report represents recent flow on a fixed 0–100 meter:
+
+`weighted resolved / (weighted opened + weighted resolved) × 100`.
+
+Zero means all measured pressure came from opened work, 50 means weighted
+arrivals and resolutions were balanced, and 100 means all measured pressure
+went toward resolutions. When neither occurred, the meter rests at 50.
+
+## 4. Human and agent representations
+
+The command exposes exactly one required representation mode:
+
+- `--human` writes a self-contained HTML report whose first and dominant section
+  is priority pressure, followed by the recent-flow meter and the ordered
+  attention queue. It must not put a general unresolved-issue summary ahead of
+  priority pressure. Data-quality warnings remain compact and secondary.
+- `--agent` writes a stable, schema-versioned JSON document containing numeric
+  values, explicit calculation policy, warnings, and the ordered issue records.
+
+Both representations must be rendered from the same normalized snapshot and
+measurements. In agent mode stdout contains only the JSON document; diagnostics
+go to stderr. Fetch or validation failures return a non-zero exit status.
+
+# AR-repository-status-tool: Repository status tool
+
+The repository status implementation lives in the root
+`repository_status/` directory as a small Python standard-library application.
+It invokes the authenticated GitHub CLI for issue data, normalizes GitHub values
+into typed internal records, computes the measurements in pure functions, and
+passes one report model to separate HTML and JSON renderers.
+§FS-repository-status-report
+
+The versioned policy file owns the repository, project title, priority weights,
+age-band boundaries, default flow window, and the age-debt meter maximum. Fixture-based unit tests exercise
+classification, age calculations, flow, warning detection, deterministic
+ordering, and both renderers without accessing GitHub.

--- a/docs/repository-status.md
+++ b/docs/repository-status.md
@@ -1,11 +1,12 @@
 # FS-repository-status-report: Repository issue progress and state
 
+The repository status report helps shorten the path from an issue to shipped
+metadata by making unresolved work and recent progress visible.
+§forge/GOAL-shorten-issue-to-shipped-metadata
+
 Maintainers and agents must be able to inspect the repository's unresolved issue
 state from one deterministic report. The report measures both the current
-weighted backlog and the time that unresolved work has accumulated, helping
-maintainers shorten the path from an issue to shipped metadata while continuing
-to broaden tested library coverage.
-§GOAL-broad-version-coverage §forge/GOAL-shorten-issue-to-shipped-metadata
+weighted backlog and the time that unresolved work has accumulated.
 
 ## 1. Issue scope and priority
 
@@ -91,23 +92,12 @@ The command exposes exactly one required representation mode:
   is priority pressure, followed by the recent-flow meter and the ordered
   attention queue. It must not put a general unresolved-issue summary ahead of
   priority pressure. Data-quality warnings remain compact and secondary.
-- `--agent` writes a stable, schema-versioned JSON document containing numeric
-  values, explicit calculation policy, warnings, and the ordered issue records.
+- `--agent` writes a stable, schema-versioned JSON document containing the
+  priority labels and weights, priority tiers, recent flow, the priority
+  age-debt meter, project state, warnings, and at most the first three ordered
+  issue records. It omits the aggregate backlog summary, aggregate age-band
+  totals, age-band thresholds, and attention-order description.
 
 Both representations must be rendered from the same normalized snapshot and
 measurements. In agent mode stdout contains only the JSON document; diagnostics
 go to stderr. Fetch or validation failures return a non-zero exit status.
-
-# AR-repository-status-tool: Repository status tool
-
-The repository status implementation lives in the root
-`repository_status/` directory as a small Python standard-library application.
-It invokes the authenticated GitHub CLI for issue data, normalizes GitHub values
-into typed internal records, computes the measurements in pure functions, and
-passes one report model to separate HTML and JSON renderers.
-§FS-repository-status-report
-
-The versioned policy file owns the repository, project title, priority weights,
-age-band boundaries, default flow window, and the age-debt meter maximum. Fixture-based unit tests exercise
-classification, age calculations, flow, warning detection, deterministic
-ordering, and both renderers without accessing GitHub.

--- a/repository_status/README.md
+++ b/repository_status/README.md
@@ -1,0 +1,70 @@
+# Repository status
+
+This directory contains the issue progress reporter specified by
+§FS-repository-status-report. It uses the authenticated GitHub CLI and has no
+third-party Python dependencies.
+
+## Run it
+
+Create the self-contained human dashboard:
+
+```bash
+./repository_status/repository_status.py --human
+```
+
+The default destination is `build/reports/repository-status.html`. Choose a
+different file or write HTML to stdout:
+
+```bash
+./repository_status/repository_status.py --human --output /tmp/repository-status.html
+./repository_status/repository_status.py --human --output -
+```
+
+Write the agent contract as JSON to stdout:
+
+```bash
+./repository_status/repository_status.py --agent
+```
+
+The command requires `gh` to be authenticated for GitHub. Authentication and
+API failures are written to stderr and return a non-zero status. Agent mode
+never mixes diagnostics into its JSON stdout stream.
+
+Use another recent-flow window when needed:
+
+```bash
+./repository_status/repository_status.py --human --window-days 90
+```
+
+## Measurements
+
+Priority is label-derived and independent from age:
+
+| Tier | Label rule | Weight |
+| --- | --- | ---: |
+| High | `high-priority` | 10 |
+| Priority | `priority`, without `high-priority` | 5 |
+| Normal | neither priority label | 1 |
+
+The current-state measurements are:
+
+```text
+weighted backlog = sum(priority weight)
+weighted age debt = sum(priority weight × complete days since creation)
+```
+
+The attention queue always orders priority tier first, then oldest first. A very
+old normal issue therefore contributes visible age debt but never moves above a
+high-priority issue.
+
+The default age bands are fresh (0–7 days), aging (8–30), old (31–90), and stale
+(91+). The versioned values, labels, project title, and flow window live in
+[`policy.json`](policy.json).
+
+## Test it
+
+Tests use fixed GitHub-shaped fixtures and do not access the network:
+
+```bash
+python3 -m unittest repository_status.test_repository_status
+```

--- a/repository_status/__init__.py
+++ b/repository_status/__init__.py
@@ -1,0 +1,1 @@
+"""Repository issue status reporting. §FS-repository-status-report"""

--- a/repository_status/__init__.py
+++ b/repository_status/__init__.py
@@ -1,1 +1,6 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Repository issue status reporting. §FS-repository-status-report"""

--- a/repository_status/github_source.py
+++ b/repository_status/github_source.py
@@ -1,0 +1,98 @@
+"""GitHub CLI data source for repository issue status. §FS-repository-status-report.1"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+from typing import Any
+
+from repository_status.model import Issue, Policy, StatusReportError, issue_from_github
+
+
+ISSUE_FIELDS: str = (
+    "number,title,url,state,createdAt,closedAt,updatedAt,labels,projectItems"
+)
+GITHUB_SEARCH_MAX_RESULTS: int = 1_000
+
+
+def fetch_snapshot(
+        policy: Policy,
+        generated_at: datetime,
+        window_days: int,
+        issue_limit: int,
+) -> tuple[list[Issue], list[Issue]]:
+    """Fetch open issues and recently closed issues used by the flow window."""
+    if shutil.which("gh") is None:
+        raise StatusReportError("GitHub CLI 'gh' is required but was not found")
+
+    open_payload: list[dict[str, Any]] = _run_issue_list(
+        repository=policy.repository,
+        state="open",
+        limit=issue_limit,
+    )
+    cutoff_date: str = (generated_at - timedelta(days=window_days)).date().isoformat()
+    closed_payload: list[dict[str, Any]] = _run_issue_list(
+        repository=policy.repository,
+        state="closed",
+        limit=issue_limit,
+        search=f"closed:>={cutoff_date}",
+    )
+    return (
+        [issue_from_github(item, policy.project_title) for item in open_payload],
+        [issue_from_github(item, policy.project_title) for item in closed_payload],
+    )
+
+
+def _run_issue_list(
+        repository: str,
+        state: str,
+        limit: int,
+        search: str | None = None,
+) -> list[dict[str, Any]]:
+    """Run one bounded `gh issue list` query and validate its JSON shape."""
+    query_limit: int = min(limit, GITHUB_SEARCH_MAX_RESULTS) if search else limit
+    command: list[str] = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repository,
+        "--state",
+        state,
+        "--limit",
+        str(query_limit),
+        "--json",
+        ISSUE_FIELDS,
+    ]
+    if search is not None:
+        command.extend(["--search", search])
+    try:
+        result: subprocess.CompletedProcess[str] = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=180,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise StatusReportError(f"GitHub issue query timed out for state '{state}'") from exc
+    if result.returncode != 0:
+        detail: str = (result.stderr or result.stdout).strip()
+        raise StatusReportError(
+            f"GitHub issue query failed for state '{state}': {detail or 'unknown error'}"
+        )
+    try:
+        payload: Any = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise StatusReportError("GitHub CLI returned invalid JSON") from exc
+    if not isinstance(payload, list) or any(not isinstance(item, dict) for item in payload):
+        raise StatusReportError("GitHub CLI issue result must be an array of objects")
+    if len(payload) >= query_limit:
+        limit_kind: str = "GitHub search" if search else "configured query"
+        raise StatusReportError(
+            f"GitHub query reached the {limit_kind} limit of {query_limit}; "
+            "reduce --window-days or increase --issue-limit where applicable"
+        )
+    return payload

--- a/repository_status/github_source.py
+++ b/repository_status/github_source.py
@@ -1,3 +1,8 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """GitHub CLI data source for repository issue status. §FS-repository-status-report.1"""
 
 from __future__ import annotations

--- a/repository_status/measurements.py
+++ b/repository_status/measurements.py
@@ -1,0 +1,248 @@
+"""Pure repository issue measurements. §FS-repository-status-report.2"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from statistics import median
+from typing import Any
+
+from repository_status.model import PROJECT_STATUSES, TIERS, Issue, Policy, StatusReportError
+
+
+TIER_RANK: dict[str, int] = {tier: rank for rank, tier in enumerate(TIERS)}
+
+
+def build_report(
+        policy: Policy,
+        open_issues: list[Issue],
+        recently_closed_issues: list[Issue],
+        generated_at: datetime,
+        window_days: int,
+) -> dict[str, Any]:
+    """Build the shared machine-readable report model."""
+    if generated_at.tzinfo is None:
+        raise StatusReportError("Report generation time must include a timezone")
+    normalized_at: datetime = generated_at.astimezone(timezone.utc)
+    current_open_issues: list[Issue] = [issue for issue in open_issues if issue.state == "OPEN"]
+    issue_records: list[dict[str, Any]] = [
+        _open_issue_record(policy, issue, normalized_at) for issue in current_open_issues
+    ]
+    issue_records.sort(
+        key=lambda item: (
+            TIER_RANK[item["priority"]],
+            -item["ageDays"],
+            item["number"],
+        )
+    )
+
+    tiers: dict[str, dict[str, Any]] = {
+        tier: _tier_measurements(policy, issue_records, tier) for tier in TIERS
+    }
+    age_bands: dict[str, int] = {
+        age_band.name: sum(
+            1 for issue_record in issue_records if issue_record["ageBand"] == age_band.name
+        )
+        for age_band in policy.age_bands
+    }
+    warnings: list[dict[str, Any]] = _warnings(policy, issue_records)
+    flow: dict[str, Any] = _flow_measurements(
+        policy,
+        current_open_issues,
+        recently_closed_issues,
+        normalized_at,
+        window_days,
+    )
+    project: dict[str, int] = _project_measurements(issue_records)
+    age_debt_meter: dict[str, Any] = _age_debt_meter(policy, issue_records)
+
+    return {
+        "schemaVersion": f"{policy.schema_version}.0",
+        "generatedAt": _isoformat(normalized_at),
+        "repository": policy.repository,
+        "calculationPolicy": {
+            "priorityLabels": dict(policy.priority_labels),
+            "priorityWeights": dict(policy.priority_weights),
+            "ageBasis": "complete days since createdAt",
+            "ageBands": [
+                {
+                    "name": age_band.name,
+                    "minimumDays": age_band.minimum_days,
+                    "maximumDays": age_band.maximum_days,
+                }
+                for age_band in policy.age_bands
+            ],
+            "attentionOrder": ["priority tier", "oldest first", "issue number"],
+        },
+        "summary": {
+            "openIssues": len(issue_records),
+            "weightedBacklog": sum(item["weight"] for item in issue_records),
+            "totalOpenDays": sum(item["ageDays"] for item in issue_records),
+            "weightedAgeDebt": sum(item["ageDebt"] for item in issue_records),
+            "priorityAgeDebt": age_debt_meter["value"],
+            "flowDirection": flow["direction"],
+        },
+        "tiers": tiers,
+        "ageBands": age_bands,
+        "flow": flow,
+        "ageDebtMeter": age_debt_meter,
+        "project": project,
+        "warnings": warnings,
+        "attentionQueue": issue_records,
+    }
+
+
+def _open_issue_record(policy: Policy, issue: Issue, generated_at: datetime) -> dict[str, Any]:
+    """Calculate all display-independent values for one unresolved issue."""
+    age_days: int = max(0, (generated_at - issue.created_at).days)
+    tier: str = policy.priority_for(issue.labels)
+    weight: int = policy.weight_for(tier)
+    return {
+        "number": issue.number,
+        "title": issue.title,
+        "url": issue.url,
+        "priority": tier,
+        "weight": weight,
+        "ageDays": age_days,
+        "ageBand": policy.age_band_for(age_days),
+        "ageDebt": weight * age_days,
+        "projectStatus": issue.project_status,
+        "createdAt": _isoformat(issue.created_at),
+        "updatedAt": _isoformat(issue.updated_at),
+        "labels": list(issue.labels),
+    }
+
+
+def _tier_measurements(
+        policy: Policy,
+        issue_records: list[dict[str, Any]],
+        tier: str,
+) -> dict[str, Any]:
+    """Aggregate current state for one priority tier."""
+    records: list[dict[str, Any]] = [
+        issue_record for issue_record in issue_records if issue_record["priority"] == tier
+    ]
+    ages: list[int] = [issue_record["ageDays"] for issue_record in records]
+    return {
+        "weight": policy.weight_for(tier),
+        "open": len(records),
+        "weightedBacklog": sum(issue_record["weight"] for issue_record in records),
+        "totalOpenDays": sum(ages),
+        "weightedAgeDebt": sum(issue_record["ageDebt"] for issue_record in records),
+        "oldestAgeDays": max(ages) if ages else None,
+        "medianAgeDays": median(ages) if ages else None,
+        "ageBands": {
+            age_band.name: sum(
+                1 for issue_record in records if issue_record["ageBand"] == age_band.name
+            )
+            for age_band in policy.age_bands
+        },
+    }
+
+
+def _flow_measurements(
+        policy: Policy,
+        open_issues: list[Issue],
+        recently_closed_issues: list[Issue],
+        generated_at: datetime,
+        window_days: int,
+) -> dict[str, Any]:
+    """Calculate recent issue arrival and resolution flow."""
+    cutoff: datetime = generated_at - timedelta(days=window_days)
+    all_recent_candidates: list[Issue] = [*open_issues, *recently_closed_issues]
+    opened: list[Issue] = [
+        issue
+        for issue in all_recent_candidates
+        if cutoff <= issue.created_at <= generated_at
+    ]
+    resolved: list[Issue] = [
+        issue
+        for issue in recently_closed_issues
+        if issue.closed_at is not None and cutoff <= issue.closed_at <= generated_at
+    ]
+    weighted_opened: int = sum(
+        policy.weight_for(policy.priority_for(issue.labels)) for issue in opened
+    )
+    weighted_resolved: int = sum(
+        policy.weight_for(policy.priority_for(issue.labels)) for issue in resolved
+    )
+    weighted_net_change: int = weighted_opened - weighted_resolved
+    weighted_activity: int = weighted_opened + weighted_resolved
+    weighted_balance_percent: float = (
+        round(weighted_resolved / weighted_activity * 100, 1)
+        if weighted_activity else 50.0
+    )
+    direction: str = (
+        "growing" if weighted_net_change > 0 else "shrinking" if weighted_net_change < 0 else "stable"
+    )
+    return {
+        "windowDays": window_days,
+        "startsAt": _isoformat(cutoff),
+        "opened": len(opened),
+        "resolved": len(resolved),
+        "weightedOpened": weighted_opened,
+        "weightedResolved": weighted_resolved,
+        "weightedNetChange": weighted_net_change,
+        "weightedBurnRatio": (
+            round(weighted_resolved / weighted_opened, 4) if weighted_opened else None
+        ),
+        "weightedBalancePercent": weighted_balance_percent,
+        "direction": direction,
+    }
+
+
+def _age_debt_meter(policy: Policy, issue_records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize standing high- and priority-tier age debt on a fixed meter."""
+    value: int = sum(
+        item["ageDebt"] for item in issue_records if item["priority"] != "normal"
+    )
+    maximum: int = policy.age_debt_meter_maximum
+    fill_percent: float = round(min(value / maximum, 1.0) * 100, 1)
+    return {"value": value, "maximum": maximum, "fillPercent": fill_percent}
+
+
+def _project_measurements(issue_records: list[dict[str, Any]]) -> dict[str, int]:
+    """Count current project states without removing inconsistent issues."""
+    return {
+        "todo": sum(item["projectStatus"] == "Todo" for item in issue_records),
+        "inProgress": sum(item["projectStatus"] == "In Progress" for item in issue_records),
+        "done": sum(item["projectStatus"] == "Done" for item in issue_records),
+        "unknown": sum(item["projectStatus"] not in PROJECT_STATUSES for item in issue_records),
+    }
+
+
+def _warnings(policy: Policy, issue_records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return aggregated, deterministic data-quality warnings."""
+    high_label: str = policy.priority_labels["high"]
+    priority_label: str = policy.priority_labels["priority"]
+    checks: tuple[tuple[str, str, Any], ...] = (
+        (
+            "BOTH_PRIORITY_LABELS",
+            "Issue carries both priority labels and is classified as high.",
+            lambda item: high_label in item["labels"] and priority_label in item["labels"],
+        ),
+        (
+            "OPEN_ISSUE_DONE",
+            "Open issue has project status Done and remains in the backlog.",
+            lambda item: item["projectStatus"] == "Done",
+        ),
+    )
+    warnings: list[dict[str, Any]] = []
+    for code, message, predicate in checks:
+        issue_numbers: list[int] = sorted(
+            item["number"] for item in issue_records if predicate(item)
+        )
+        if issue_numbers:
+            warnings.append(
+                {
+                    "code": code,
+                    "message": message,
+                    "count": len(issue_numbers),
+                    "issueNumbers": issue_numbers,
+                }
+            )
+    return warnings
+
+
+def _isoformat(value: datetime) -> str:
+    """Format a timestamp as canonical UTC ISO-8601."""
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/repository_status/measurements.py
+++ b/repository_status/measurements.py
@@ -1,3 +1,8 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Pure repository issue measurements. §FS-repository-status-report.2"""
 
 from __future__ import annotations

--- a/repository_status/model.py
+++ b/repository_status/model.py
@@ -1,0 +1,217 @@
+"""Typed policy and GitHub issue models. §FS-repository-status-report"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+TIERS: tuple[str, ...] = ("high", "priority", "normal")
+PROJECT_STATUSES: tuple[str, ...] = ("Todo", "In Progress", "Done")
+
+
+class StatusReportError(RuntimeError):
+    """Raised when status input or configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class AgeBand:
+    """An inclusive issue-age range."""
+
+    name: str
+    minimum_days: int
+    maximum_days: int | None
+
+    def contains(self, age_days: int) -> bool:
+        """Return whether an age falls inside this band."""
+        return age_days >= self.minimum_days and (
+            self.maximum_days is None or age_days <= self.maximum_days
+        )
+
+
+@dataclass(frozen=True)
+class Policy:
+    """Versioned calculation policy."""
+
+    schema_version: int
+    repository: str
+    project_title: str
+    default_window_days: int
+    age_debt_meter_maximum: int
+    priority_labels: dict[str, str]
+    priority_weights: dict[str, int]
+    age_bands: tuple[AgeBand, ...]
+
+    def priority_for(self, labels: tuple[str, ...]) -> str:
+        """Classify labels into one mutually exclusive priority tier."""
+        label_set: set[str] = set(labels)
+        if self.priority_labels["high"] in label_set:
+            return "high"
+        if self.priority_labels["priority"] in label_set:
+            return "priority"
+        return "normal"
+
+    def weight_for(self, tier: str) -> int:
+        """Return the configured positive weight for a tier."""
+        return self.priority_weights[tier]
+
+    def age_band_for(self, age_days: int) -> str:
+        """Return the configured age band for an age."""
+        for age_band in self.age_bands:
+            if age_band.contains(age_days):
+                return age_band.name
+        raise StatusReportError(f"No age band covers {age_days} day(s)")
+
+
+@dataclass(frozen=True)
+class Issue:
+    """Normalized GitHub issue data used by all calculations."""
+
+    number: int
+    title: str
+    url: str
+    state: str
+    created_at: datetime
+    closed_at: datetime | None
+    updated_at: datetime
+    labels: tuple[str, ...]
+    project_status: str | None
+
+
+def parse_datetime(value: Any, field_name: str) -> datetime:
+    """Parse a required GitHub ISO-8601 timestamp."""
+    if not isinstance(value, str) or not value:
+        raise StatusReportError(f"Issue field '{field_name}' must be a timestamp")
+    normalized_value: str = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        timestamp: datetime = datetime.fromisoformat(normalized_value)
+    except ValueError as exc:
+        raise StatusReportError(
+            f"Issue field '{field_name}' has invalid timestamp '{value}'"
+        ) from exc
+    if timestamp.tzinfo is None:
+        raise StatusReportError(f"Issue field '{field_name}' must include a timezone")
+    return timestamp
+
+
+def issue_from_github(payload: dict[str, Any], project_title: str) -> Issue:
+    """Normalize one `gh issue list --json` record."""
+    labels_payload: list[Any] = payload.get("labels", [])
+    labels: tuple[str, ...] = tuple(
+        sorted(
+            label["name"]
+            for label in labels_payload
+            if isinstance(label, dict) and isinstance(label.get("name"), str)
+        )
+    )
+    project_status: str | None = None
+    project_items: list[Any] = payload.get("projectItems", [])
+    for project_item in project_items:
+        if not isinstance(project_item, dict) or project_item.get("title") != project_title:
+            continue
+        status_payload: Any = project_item.get("status")
+        if isinstance(status_payload, dict) and isinstance(status_payload.get("name"), str):
+            project_status = status_payload["name"]
+        break
+
+    closed_value: Any = payload.get("closedAt")
+    return Issue(
+        number=int(payload["number"]),
+        title=str(payload["title"]),
+        url=str(payload["url"]),
+        state=str(payload["state"]).upper(),
+        created_at=parse_datetime(payload.get("createdAt"), "createdAt"),
+        closed_at=parse_datetime(closed_value, "closedAt") if closed_value else None,
+        updated_at=parse_datetime(payload.get("updatedAt"), "updatedAt"),
+        labels=labels,
+        project_status=project_status,
+    )
+
+
+def load_policy(path: Path) -> Policy:
+    """Load and assert the complete policy contract."""
+    try:
+        payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StatusReportError(f"Cannot load policy '{path}': {exc}") from exc
+    if not isinstance(payload, dict):
+        raise StatusReportError("Policy root must be an object")
+
+    labels: Any = payload.get("priorityLabels")
+    weights: Any = payload.get("priorityWeights")
+    bands_payload: Any = payload.get("ageBands")
+    if not isinstance(labels, dict) or set(labels) != {"high", "priority"}:
+        raise StatusReportError("priorityLabels must define exactly high and priority")
+    if not isinstance(weights, dict) or set(weights) != set(TIERS):
+        raise StatusReportError("priorityWeights must define high, priority, and normal")
+    if any(not isinstance(weights[tier], int) or weights[tier] <= 0 for tier in TIERS):
+        raise StatusReportError("Every priority weight must be a positive integer")
+    if not isinstance(bands_payload, list) or not bands_payload:
+        raise StatusReportError("ageBands must be a non-empty array")
+
+    age_bands: tuple[AgeBand, ...] = tuple(
+        AgeBand(
+            name=str(band["name"]),
+            minimum_days=int(band["minimumDays"]),
+            maximum_days=(
+                int(band["maximumDays"])
+                if band.get("maximumDays") is not None
+                else None
+            ),
+        )
+        for band in bands_payload
+        if isinstance(band, dict)
+    )
+    if len(age_bands) != len(bands_payload):
+        raise StatusReportError("Every age band must be an object")
+    _validate_age_bands(age_bands)
+
+    repository: Any = payload.get("repository")
+    project_title: Any = payload.get("projectTitle")
+    default_window_days: Any = payload.get("defaultWindowDays")
+    age_debt_meter_maximum: Any = payload.get("ageDebtMeterMaximum")
+    schema_version: Any = payload.get("schemaVersion")
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise StatusReportError("repository must use owner/name format")
+    if not isinstance(project_title, str) or not project_title:
+        raise StatusReportError("projectTitle must be a non-empty string")
+    if not isinstance(default_window_days, int) or default_window_days <= 0:
+        raise StatusReportError("defaultWindowDays must be a positive integer")
+    if not isinstance(age_debt_meter_maximum, int) or age_debt_meter_maximum <= 0:
+        raise StatusReportError("ageDebtMeterMaximum must be a positive integer")
+    if not isinstance(schema_version, int) or schema_version <= 0:
+        raise StatusReportError("schemaVersion must be a positive integer")
+
+    return Policy(
+        schema_version=schema_version,
+        repository=repository,
+        project_title=project_title,
+        default_window_days=default_window_days,
+        age_debt_meter_maximum=age_debt_meter_maximum,
+        priority_labels={key: str(value) for key, value in labels.items()},
+        priority_weights={tier: int(weights[tier]) for tier in TIERS},
+        age_bands=age_bands,
+    )
+
+
+def _validate_age_bands(age_bands: tuple[AgeBand, ...]) -> None:
+    """Assert that age bands cover every non-negative day exactly once."""
+    expected_minimum: int = 0
+    seen_names: set[str] = set()
+    for index, age_band in enumerate(age_bands):
+        if not age_band.name or age_band.name in seen_names:
+            raise StatusReportError("Age band names must be non-empty and unique")
+        seen_names.add(age_band.name)
+        if age_band.minimum_days != expected_minimum:
+            raise StatusReportError("Age bands must be contiguous and begin at zero")
+        if age_band.maximum_days is None:
+            if index != len(age_bands) - 1:
+                raise StatusReportError("Only the final age band may be unbounded")
+            return
+        if age_band.maximum_days < age_band.minimum_days:
+            raise StatusReportError("Age band maximum cannot precede its minimum")
+        expected_minimum = age_band.maximum_days + 1
+    raise StatusReportError("The final age band must be unbounded")

--- a/repository_status/model.py
+++ b/repository_status/model.py
@@ -1,3 +1,8 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Typed policy and GitHub issue models. §FS-repository-status-report"""
 
 from __future__ import annotations

--- a/repository_status/policy.json
+++ b/repository_status/policy.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "repository": "oracle/graalvm-reachability-metadata",
+  "projectTitle": "GraalVM Reachability Metadata",
+  "defaultWindowDays": 30,
+  "ageDebtMeterMaximum": 20000,
+  "priorityLabels": {
+    "high": "high-priority",
+    "priority": "priority"
+  },
+  "priorityWeights": {
+    "high": 10,
+    "priority": 5,
+    "normal": 1
+  },
+  "ageBands": [
+    {
+      "name": "fresh",
+      "minimumDays": 0,
+      "maximumDays": 7
+    },
+    {
+      "name": "aging",
+      "minimumDays": 8,
+      "maximumDays": 30
+    },
+    {
+      "name": "old",
+      "minimumDays": 31,
+      "maximumDays": 90
+    },
+    {
+      "name": "stale",
+      "minimumDays": 91,
+      "maximumDays": null
+    }
+  ]
+}

--- a/repository_status/renderers.py
+++ b/repository_status/renderers.py
@@ -1,0 +1,248 @@
+"""Human and agent report renderers. §FS-repository-status-report.4"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import Any
+
+
+def render_json(report: dict[str, Any]) -> str:
+    """Render the stable agent representation."""
+    return json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+
+
+def render_html(report: dict[str, Any]) -> str:
+    """Render a self-contained operations-ledger dashboard."""
+    flow: dict[str, Any] = report["flow"]
+    age_debt_meter: dict[str, Any] = report["ageDebtMeter"]
+    tiers: dict[str, dict[str, Any]] = report["tiers"]
+    warnings: list[dict[str, Any]] = report["warnings"]
+    attention_queue: list[dict[str, Any]] = report["attentionQueue"]
+
+    tier_cards: str = "".join(
+        _tier_card(tier_name, tiers[tier_name])
+        for tier_name in ("high", "priority", "normal")
+    )
+    warning_markup: str = _warnings_html(warnings)
+    issue_rows: str = "".join(_issue_row(issue) for issue in attention_queue)
+    direction: str = flow["direction"]
+    balance_percent: float = flow["weightedBalancePercent"]
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Repository issue status</title>
+  <style>
+    :root {{
+      --bg: #ffffff;
+      --ink: #1a1a1a;
+      --muted: #6b7280;
+      --rule: #e5e7eb;
+      --high: #b91c1c;
+      --priority: #b45309;
+      --normal: #15803d;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      color: var(--ink);
+      background: var(--bg);
+      font: 15px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    }}
+    a {{ color: inherit; }}
+    .shell {{ width: min(1080px, calc(100% - 40px)); margin: 0 auto; padding: 40px 0 64px; }}
+    header {{ margin-bottom: 40px; }}
+    h1 {{ margin: 0; font-size: 1.5rem; font-weight: 600; }}
+    .repo {{ margin: 0 0 6px; font-size: .8rem; color: var(--muted); }}
+    section {{ margin-top: 40px; }}
+    h2 {{ margin: 0 0 16px; font-size: 1rem; font-weight: 600; }}
+    .tier-grid {{ display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }}
+    .tier-card {{ padding: 18px; border: 1px solid var(--rule); border-top: 3px solid var(--tone); border-radius: 6px; }}
+    .tier-card.high {{ --tone: var(--high); }}
+    .tier-card.priority {{ --tone: var(--priority); }}
+    .tier-card.normal {{ --tone: var(--normal); }}
+    .tier-top {{ display: flex; justify-content: space-between; align-items: baseline; }}
+    .tier-card h3 {{ margin: 0; font-size: .95rem; font-weight: 600; text-transform: capitalize; }}
+    .weight {{ font-size: .72rem; color: var(--muted); }}
+    .tier-number {{ display: block; margin: 12px 0 2px; font-size: 2rem; font-weight: 600; }}
+    .tier-number + span {{ font-size: .8rem; color: var(--muted); }}
+    .tier-details {{ display: grid; grid-template-columns: 1fr 1fr; gap: 8px 16px; margin-top: 16px; font-size: .82rem; }}
+    .tier-details span {{ color: var(--muted); }}
+    .tier-details strong {{ display: block; color: var(--ink); font-weight: 600; margin-top: 1px; }}
+    .flow-head {{ display: flex; align-items: baseline; gap: 12px; }}
+    .direction-pill {{ font-size: .75rem; font-weight: 600; text-transform: capitalize; color: var(--dir); }}
+    .direction-pill.growing {{ --dir: var(--high); }}
+    .direction-pill.stable {{ --dir: var(--priority); }}
+    .direction-pill.shrinking {{ --dir: var(--normal); }}
+    .meter-track {{ position: relative; height: 8px; margin: 16px 0 8px; border-radius: 4px; background: linear-gradient(90deg, var(--high), var(--priority) 50%, var(--normal)); }}
+    .meter-marker {{ position: absolute; left: var(--meter); top: 50%; width: 3px; height: 18px; background: var(--ink); transform: translate(-50%, -50%); }}
+    .meter-labels {{ display: grid; grid-template-columns: 1fr 1fr 1fr; color: var(--muted); font-size: .72rem; }}
+    .meter-labels span:nth-child(2) {{ text-align: center; }}
+    .meter-labels span:last-child {{ text-align: right; }}
+    .flow-stats {{ display: flex; gap: 32px; margin-top: 20px; }}
+    .flow-stat span {{ display: block; color: var(--muted); font-size: .78rem; }}
+    .flow-stat strong {{ display: block; margin-top: 2px; font-size: 1.25rem; font-weight: 600; }}
+    .debt {{ margin-top: 28px; padding-top: 20px; border-top: 1px solid var(--rule); }}
+    .debt-head {{ display: flex; align-items: baseline; gap: 10px; }}
+    .debt-head span {{ color: var(--muted); font-size: .78rem; }}
+    .debt-head strong {{ font-size: 1.25rem; font-weight: 600; }}
+    .debt-track {{ height: 8px; margin: 12px 0 8px; border-radius: 4px; background: var(--rule); overflow: hidden; }}
+    .debt-fill {{ height: 100%; width: var(--fill); background: var(--high); border-radius: 4px; }}
+    .warnings {{ margin-top: 20px; border: 1px solid var(--rule); border-radius: 6px; }}
+    .warning {{ display: grid; grid-template-columns: auto 1fr auto; gap: 12px; padding: 10px 14px; align-items: center; border-bottom: 1px solid var(--rule); font-size: .85rem; }}
+    .warning:last-child {{ border-bottom: 0; }}
+    .warning code {{ font-size: .75rem; color: var(--priority); }}
+    .warning p {{ margin: 0; }}
+    .warning strong {{ font-weight: 600; }}
+    .section-head {{ display: flex; justify-content: space-between; align-items: center; gap: 16px; margin-bottom: 16px; }}
+    .section-head h2 {{ margin: 0; }}
+    .search input {{ width: min(280px, 50vw); border: 1px solid var(--rule); border-radius: 6px; padding: 7px 10px; font-size: .85rem; color: var(--ink); outline: none; }}
+    .search input:focus {{ border-color: var(--ink); }}
+    table {{ width: 100%; border-collapse: collapse; }}
+    th {{ padding: 8px 12px; border-bottom: 1px solid var(--rule); font-size: .72rem; text-align: left; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .03em; }}
+    td {{ padding: 10px 12px; border-bottom: 1px solid var(--rule); vertical-align: middle; font-size: .88rem; }}
+    tbody tr:last-child td {{ border-bottom: 0; }}
+    td.num {{ font-variant-numeric: tabular-nums; white-space: nowrap; }}
+    .issue-title a {{ text-underline-offset: 2px; }}
+    .chip {{ font-size: .72rem; font-weight: 600; text-transform: capitalize; color: var(--chip); }}
+    .chip.high {{ --chip: var(--high); }}
+    .chip.priority {{ --chip: var(--priority); }}
+    .chip.normal {{ --chip: var(--normal); }}
+    .chip.age {{ --chip: var(--muted); font-weight: 400; }}
+    .empty {{ padding: 20px; color: var(--muted); text-align: center; }}
+    @media (max-width: 720px) {{
+      .tier-grid {{ grid-template-columns: 1fr; }}
+      .flow-stats {{ flex-wrap: wrap; gap: 20px 32px; }}
+      table {{ display: block; overflow-x: auto; }}
+    }}
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header>
+      <p class="repo">{_escape(report["repository"])}</p>
+      <h1>Priority pressure</h1>
+    </header>
+
+    <section>
+      <div class="tier-grid">{tier_cards}</div>
+    </section>
+
+    <section>
+      <div class="flow-head">
+        <h2>{flow["windowDays"]}-day flow</h2>
+        <span class="direction-pill {_escape(direction)}">{_escape(direction)}</span>
+      </div>
+      <div class="meter-track" role="meter" aria-label="Weighted flow balance" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{balance_percent:.1f}">
+        <div class="meter-marker" style="--meter: {balance_percent:.1f}%"></div>
+      </div>
+      <div class="meter-labels">
+        <span>Growing</span>
+        <span>Balanced</span>
+        <span>Shrinking</span>
+      </div>
+      <div class="flow-stats">
+        <div class="flow-stat"><span>Weighted opened</span><strong>{flow["weightedOpened"]:,}</strong></div>
+        <div class="flow-stat"><span>Weighted resolved</span><strong>{flow["weightedResolved"]:,}</strong></div>
+        <div class="flow-stat"><span>Net backlog</span><strong>{flow["weightedNetChange"]:+,}</strong></div>
+      </div>
+
+      <div class="debt">
+        <div class="debt-head">
+          <span>Priority age debt</span>
+          <strong>{age_debt_meter["value"]:,}</strong>
+        </div>
+        <div class="debt-track" role="meter" aria-label="Priority age debt" aria-valuemin="0" aria-valuemax="{age_debt_meter["maximum"]}" aria-valuenow="{age_debt_meter["value"]}">
+          <div class="debt-fill" style="--fill: {age_debt_meter["fillPercent"]:.1f}%"></div>
+        </div>
+        <div class="meter-labels">
+          <span>0</span>
+          <span></span>
+          <span>{age_debt_meter["maximum"]:,}</span>
+        </div>
+      </div>
+      {warning_markup}
+    </section>
+
+    <section>
+      <div class="section-head">
+        <h2>Attention queue</h2>
+        <label class="search"><input id="issue-filter" type="search" placeholder="Filter…" aria-label="Filter attention queue"></label>
+      </div>
+      <table>
+        <thead><tr><th>Issue</th><th>Priority</th><th>Age</th><th>Age debt</th><th>Project</th><th>Title</th></tr></thead>
+        <tbody id="issue-rows">{issue_rows or '<tr><td colspan="6" class="empty">No unresolved issues.</td></tr>'}</tbody>
+      </table>
+    </section>
+  </main>
+  <script>
+    const filter = document.getElementById("issue-filter");
+    const rows = Array.from(document.querySelectorAll("#issue-rows tr[data-search]"));
+    filter.addEventListener("input", () => {{
+      const query = filter.value.trim().toLowerCase();
+      rows.forEach((row) => {{ row.hidden = !row.dataset.search.includes(query); }});
+    }});
+  </script>
+</body>
+</html>
+"""
+
+
+def _tier_card(tier_name: str, tier: dict[str, Any]) -> str:
+    """Render one priority tier summary."""
+    oldest: str = "—" if tier["oldestAgeDays"] is None else f'{tier["oldestAgeDays"]:,}d'
+    return f"""
+      <article class="tier-card {_escape(tier_name)}">
+        <div class="tier-top"><h3>{_escape(tier_name)}</h3><span class="weight">weight {tier["weight"]}</span></div>
+        <strong class="tier-number">{tier["open"]:,}</strong><span>open issues</span>
+        <div class="tier-details">
+          <span>Age debt<strong>{tier["weightedAgeDebt"]:,}</strong></span>
+          <span>Oldest<strong>{oldest}</strong></span>
+          <span>Open days<strong>{tier["totalOpenDays"]:,}</strong></span>
+          <span>Backlog weight<strong>{tier["weightedBacklog"]:,}</strong></span>
+        </div>
+      </article>"""
+
+
+def _warnings_html(warnings: list[dict[str, Any]]) -> str:
+    """Render data-quality warnings, or a terse clean result."""
+    if not warnings:
+        return ""
+    items: str = "".join(
+        f'<div class="warning"><code>{_escape(warning["code"])}</code>'
+        f'<p>{_escape(warning["message"])}</p><strong>{warning["count"]:,}</strong></div>'
+        for warning in warnings
+    )
+    return f'<div class="warnings">{items}</div>'
+
+
+def _issue_row(issue: dict[str, Any]) -> str:
+    """Render one escaped, filterable attention queue row."""
+    project_status: str = issue["projectStatus"] or "Unknown"
+    search_value: str = " ".join(
+        (
+            str(issue["number"]),
+            issue["title"],
+            issue["priority"],
+            issue["ageBand"],
+            project_status,
+            *issue["labels"],
+        )
+    ).lower()
+    return f"""
+      <tr data-search="{_escape(search_value)}">
+        <td class="num">#{issue["number"]}</td>
+        <td><span class="chip {_escape(issue["priority"])}">{_escape(issue["priority"])}</span></td>
+        <td class="num">{issue["ageDays"]:,}d <span class="chip age">{_escape(issue["ageBand"])}</span></td>
+        <td class="num">{issue["ageDebt"]:,}</td>
+        <td>{_escape(project_status)}</td>
+        <td class="issue-title"><a href="{_escape(issue["url"])}">{_escape(issue["title"])}</a></td>
+      </tr>"""
+
+
+def _escape(value: Any) -> str:
+    """Escape a value for HTML text or a quoted attribute."""
+    return html.escape(str(value), quote=True)

--- a/repository_status/renderers.py
+++ b/repository_status/renderers.py
@@ -14,7 +14,24 @@ from typing import Any
 
 def render_json(report: dict[str, Any]) -> str:
     """Render the stable agent representation."""
-    return json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    calculation_policy: dict[str, Any] = report["calculationPolicy"]
+    agent_report: dict[str, Any] = {
+        "schemaVersion": report["schemaVersion"],
+        "generatedAt": report["generatedAt"],
+        "repository": report["repository"],
+        "calculationPolicy": {
+            "priorityLabels": calculation_policy["priorityLabels"],
+            "priorityWeights": calculation_policy["priorityWeights"],
+            "ageBasis": calculation_policy["ageBasis"],
+        },
+        "tiers": report["tiers"],
+        "flow": report["flow"],
+        "ageDebtMeter": report["ageDebtMeter"],
+        "project": report["project"],
+        "warnings": report["warnings"],
+        "attentionQueue": report["attentionQueue"][:3],
+    }
+    return json.dumps(agent_report, indent=2, ensure_ascii=False) + "\n"
 
 
 def render_html(report: dict[str, Any]) -> str:

--- a/repository_status/renderers.py
+++ b/repository_status/renderers.py
@@ -1,3 +1,8 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Human and agent report renderers. §FS-repository-status-report.4"""
 
 from __future__ import annotations

--- a/repository_status/repository_status.py
+++ b/repository_status/repository_status.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Report repository issue progress for humans or agents. §FS-repository-status-report"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+SCRIPT_DIRECTORY: Path = Path(__file__).resolve().parent
+REPOSITORY_ROOT: Path = SCRIPT_DIRECTORY.parent
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from repository_status.github_source import fetch_snapshot  # noqa: E402
+from repository_status.measurements import build_report  # noqa: E402
+from repository_status.model import Policy, StatusReportError, load_policy  # noqa: E402
+from repository_status.renderers import render_html, render_json  # noqa: E402
+
+
+DEFAULT_POLICY: Path = SCRIPT_DIRECTORY / "policy.json"
+DEFAULT_HUMAN_OUTPUT: Path = REPOSITORY_ROOT / "build/reports/repository-status.html"
+
+
+def positive_integer(value: str) -> int:
+    """Parse an argparse positive integer."""
+    try:
+        parsed_value: int = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed_value <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed_value
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line contract."""
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description=(
+            "Measure unresolved issue priority, duration, age debt, project state, "
+            "and recent issue flow."
+        )
+    )
+    mode: argparse._MutuallyExclusiveGroup = parser.add_mutually_exclusive_group(
+        required=True
+    )
+    mode.add_argument(
+        "--human",
+        action="store_true",
+        help="write the self-contained HTML dashboard",
+    )
+    mode.add_argument(
+        "--agent",
+        action="store_true",
+        help="write the schema-versioned JSON report to stdout",
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "HTML destination for --human; defaults to "
+            "build/reports/repository-status.html, use '-' for stdout"
+        ),
+    )
+    parser.add_argument(
+        "--window-days",
+        type=positive_integer,
+        help="recent-flow window; defaults to the policy value",
+    )
+    parser.add_argument(
+        "--issue-limit",
+        type=positive_integer,
+        default=10_000,
+        help="fail rather than silently truncate when either GitHub query reaches this limit",
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=DEFAULT_POLICY,
+        help=f"measurement policy path (default: {DEFAULT_POLICY})",
+    )
+    return parser
+
+
+def run(arguments: Sequence[str] | None = None) -> int:
+    """Fetch, measure, and render one status report."""
+    parser: argparse.ArgumentParser = create_parser()
+    options: argparse.Namespace = parser.parse_args(arguments)
+    if options.agent and options.output is not None:
+        parser.error("--output is only valid with --human; --agent always writes JSON to stdout")
+
+    try:
+        policy: Policy = load_policy(options.policy)
+        window_days: int = options.window_days or policy.default_window_days
+        generated_at: datetime = datetime.now(timezone.utc)
+        open_issues, recently_closed_issues = fetch_snapshot(
+            policy=policy,
+            generated_at=generated_at,
+            window_days=window_days,
+            issue_limit=options.issue_limit,
+        )
+        report = build_report(
+            policy=policy,
+            open_issues=open_issues,
+            recently_closed_issues=recently_closed_issues,
+            generated_at=generated_at,
+            window_days=window_days,
+        )
+        if options.agent:
+            sys.stdout.write(render_json(report))
+            return 0
+
+        html_report: str = render_html(report)
+        output_value: str = options.output or str(DEFAULT_HUMAN_OUTPUT)
+        if output_value == "-":
+            sys.stdout.write(html_report)
+            return 0
+        output_path: Path = Path(output_value).expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html_report, encoding="utf-8")
+        print(f"Wrote repository status report to {output_path}")
+        return 0
+    except (StatusReportError, OSError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/repository_status/repository_status.py
+++ b/repository_status/repository_status.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Report repository issue progress for humans or agents. §FS-repository-status-report"""
 
 from __future__ import annotations

--- a/repository_status/test_repository_status.py
+++ b/repository_status/test_repository_status.py
@@ -1,0 +1,222 @@
+"""Fixture tests for repository issue status. §FS-repository-status-report"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from repository_status.github_source import _run_issue_list
+from repository_status.measurements import build_report
+from repository_status.model import Issue, Policy, StatusReportError, issue_from_github, load_policy
+from repository_status.renderers import render_html, render_json
+
+
+POLICY_PATH: Path = Path(__file__).with_name("policy.json")
+GENERATED_AT: datetime = datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def github_issue(
+        number: int,
+        title: str,
+        state: str,
+        created_at: str,
+        updated_at: str,
+        labels: list[str],
+        project_status: str | None,
+        closed_at: str | None = None,
+) -> dict[str, Any]:
+    """Create a representative `gh issue list` record."""
+    project_items: list[dict[str, Any]] = []
+    if project_status is not None:
+        project_items.append(
+            {
+                "title": "GraalVM Reachability Metadata",
+                "status": {"name": project_status, "optionId": "fixture"},
+            }
+        )
+    return {
+        "number": number,
+        "title": title,
+        "url": f"https://github.com/oracle/graalvm-reachability-metadata/issues/{number}",
+        "state": state,
+        "createdAt": created_at,
+        "closedAt": closed_at,
+        "updatedAt": updated_at,
+        "labels": [{"name": label} for label in labels],
+        "projectItems": project_items,
+    }
+
+
+class RepositoryStatusTest(unittest.TestCase):
+    """Verify the shared measurements and both representations."""
+
+    def setUp(self) -> None:
+        self.policy: Policy = load_policy(POLICY_PATH)
+        open_payloads: list[dict[str, Any]] = [
+            github_issue(
+                101,
+                "High issue",
+                "OPEN",
+                "2026-07-20T12:00:00Z",
+                "2026-07-22T12:00:00Z",
+                ["priority", "high-priority"],
+                "Todo",
+            ),
+            github_issue(
+                102,
+                "Priority issue",
+                "OPEN",
+                "2026-06-23T12:00:00Z",
+                "2026-07-20T12:00:00Z",
+                ["priority"],
+                "In Progress",
+            ),
+            github_issue(
+                103,
+                "Normal issue",
+                "OPEN",
+                "2026-04-22T12:00:00Z",
+                "2026-07-01T12:00:00Z",
+                [],
+                "Done",
+            ),
+            github_issue(
+                104,
+                "Unsafe <script>alert(1)</script>",
+                "OPEN",
+                "2026-07-23T11:00:00Z",
+                "2026-07-23T11:00:00Z",
+                [],
+                None,
+            ),
+        ]
+        closed_payloads: list[dict[str, Any]] = [
+            github_issue(
+                105,
+                "Recently resolved priority",
+                "CLOSED",
+                "2026-07-01T12:00:00Z",
+                "2026-07-22T12:00:00Z",
+                ["priority"],
+                "Done",
+                "2026-07-22T12:00:00Z",
+            ),
+            github_issue(
+                106,
+                "Old resolution",
+                "CLOSED",
+                "2026-06-01T12:00:00Z",
+                "2026-06-10T12:00:00Z",
+                [],
+                "Done",
+                "2026-06-10T12:00:00Z",
+            ),
+        ]
+        self.open_issues: list[Issue] = [
+            issue_from_github(payload, self.policy.project_title) for payload in open_payloads
+        ]
+        self.closed_issues: list[Issue] = [
+            issue_from_github(payload, self.policy.project_title) for payload in closed_payloads
+        ]
+        self.report: dict[str, Any] = build_report(
+            policy=self.policy,
+            open_issues=self.open_issues,
+            recently_closed_issues=self.closed_issues,
+            generated_at=GENERATED_AT,
+            window_days=30,
+        )
+
+    def test_priority_backlog_age_debt_and_order(self) -> None:
+        """Priority remains label-derived while age contributes debt. §FS-repository-status-report.2"""
+        self.assertEqual(self.report["summary"]["weightedBacklog"], 17)
+        self.assertEqual(self.report["summary"]["weightedAgeDebt"], 272)
+        self.assertEqual(self.report["summary"]["priorityAgeDebt"], 180)
+        self.assertEqual(
+            self.report["ageDebtMeter"],
+            {"value": 180, "maximum": 20000, "fillPercent": 0.9},
+        )
+        self.assertEqual(self.report["tiers"]["priority"]["weight"], 5)
+        self.assertEqual(self.report["tiers"]["normal"]["oldestAgeDays"], 92)
+        self.assertEqual(
+            [item["number"] for item in self.report["attentionQueue"]],
+            [101, 102, 103, 104],
+        )
+
+    def test_age_bands_project_state_and_warnings(self) -> None:
+        """Age and inconsistent project data stay visible. §FS-repository-status-report.3"""
+        self.assertEqual(
+            self.report["ageBands"],
+            {"fresh": 2, "aging": 1, "old": 0, "stale": 1},
+        )
+        self.assertEqual(
+            self.report["project"],
+            {"todo": 1, "inProgress": 1, "done": 1, "unknown": 1},
+        )
+        self.assertEqual(
+            [warning["code"] for warning in self.report["warnings"]],
+            ["BOTH_PRIORITY_LABELS", "OPEN_ISSUE_DONE"],
+        )
+
+    def test_recent_weighted_flow(self) -> None:
+        """Recent flow separates progress from current state. §FS-repository-status-report.3"""
+        flow: dict[str, Any] = self.report["flow"]
+        self.assertEqual(flow["opened"], 4)
+        self.assertEqual(flow["resolved"], 1)
+        self.assertEqual(flow["weightedOpened"], 21)
+        self.assertEqual(flow["weightedResolved"], 5)
+        self.assertEqual(flow["weightedNetChange"], 16)
+        self.assertEqual(flow["weightedBurnRatio"], 0.2381)
+        self.assertEqual(flow["weightedBalancePercent"], 19.2)
+        self.assertEqual(flow["direction"], "growing")
+
+    def test_agent_json_is_round_trippable(self) -> None:
+        """Agent output remains one stable JSON document. §FS-repository-status-report.4"""
+        rendered: str = render_json(self.report)
+        parsed: dict[str, Any] = json.loads(rendered)
+        self.assertEqual(parsed["schemaVersion"], "1.0")
+        self.assertEqual(parsed["attentionQueue"][0]["priority"], "high")
+        self.assertTrue(rendered.endswith("\n"))
+
+    def test_human_html_is_self_contained_and_escaped(self) -> None:
+        """Human output is searchable HTML and escapes issue data. §FS-repository-status-report.4"""
+        rendered: str = render_html(self.report)
+        self.assertIn("<!doctype html>", rendered)
+        self.assertIn('id="issue-filter"', rendered)
+        self.assertIn('role="meter"', rendered)
+        self.assertIn('aria-valuenow="19.2"', rendered)
+        self.assertIn('aria-label="Priority age debt"', rendered)
+        self.assertIn('aria-valuemax="20000"', rendered)
+        self.assertLess(rendered.index("30-day flow"), rendered.index("Priority age debt"))
+        self.assertLess(rendered.index("Priority pressure"), rendered.index("30-day flow"))
+        self.assertNotIn("Unresolved issues", rendered)
+        self.assertNotIn("Age distribution", rendered)
+        self.assertNotIn("Project state", rendered)
+        self.assertIn("Unsafe &lt;script&gt;alert(1)&lt;/script&gt;", rendered)
+        self.assertNotIn("Unsafe <script>alert(1)</script>", rendered)
+
+    @patch("repository_status.github_source.subprocess.run")
+    def test_recent_flow_query_fails_at_github_search_cap(
+            self,
+            run_mock: MagicMock,
+    ) -> None:
+        """Recent flow cannot silently truncate at GitHub's search cap."""
+        run_mock.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps([{}] * 1_000),
+            stderr="",
+        )
+        with self.assertRaisesRegex(StatusReportError, "GitHub search limit of 1000"):
+            _run_issue_list("owner/repository", "closed", 10_000, "closed:>=2026-01-01")
+        command: list[str] = run_mock.call_args.args[0]
+        limit_index: int = command.index("--limit") + 1
+        self.assertEqual(command[limit_index], "1000")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/repository_status/test_repository_status.py
+++ b/repository_status/test_repository_status.py
@@ -1,3 +1,8 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Fixture tests for repository issue status. §FS-repository-status-report"""
 
 from __future__ import annotations

--- a/repository_status/test_repository_status.py
+++ b/repository_status/test_repository_status.py
@@ -183,8 +183,35 @@ class RepositoryStatusTest(unittest.TestCase):
         """Agent output remains one stable JSON document. §FS-repository-status-report.4"""
         rendered: str = render_json(self.report)
         parsed: dict[str, Any] = json.loads(rendered)
+        self.assertEqual(
+            list(parsed),
+            [
+                "schemaVersion",
+                "generatedAt",
+                "repository",
+                "calculationPolicy",
+                "tiers",
+                "flow",
+                "ageDebtMeter",
+                "project",
+                "warnings",
+                "attentionQueue",
+            ],
+        )
         self.assertEqual(parsed["schemaVersion"], "1.0")
-        self.assertEqual(parsed["attentionQueue"][0]["priority"], "high")
+        self.assertEqual(
+            parsed["ageDebtMeter"]["value"],
+            self.report["summary"]["priorityAgeDebt"],
+        )
+        self.assertNotIn("ageBands", parsed["calculationPolicy"])
+        self.assertNotIn("attentionOrder", parsed["calculationPolicy"])
+        self.assertEqual(parsed["flow"], self.report["flow"])
+        self.assertEqual(
+            [issue["number"] for issue in parsed["attentionQueue"]],
+            [101, 102, 103],
+        )
+        self.assertNotIn("summary", parsed)
+        self.assertNotIn("ageBands", parsed)
         self.assertTrue(rendered.endswith("\n"))
 
     def test_human_html_is_self_contained_and_escaped(self) -> None:


### PR DESCRIPTION
Closes #9095

## What this does

It was difficult to track the repository's unresolved issue backlog and, in particular, keep user-priority issues visible among the volume of open work. This adds a small standard-library tool, `repository_status/`, that fetches issues via the authenticated `gh` CLI, computes weighted measurements of backlog pressure and recent progress, and renders them as a self-contained HTML report and a schema-versioned JSON document. The behaviour is specified in `docs/repository-status.md` (§FS-repository-status-report).

## The metrics

All priorities are weighted (`high` 10, `priority` 5, `normal` 1), so a pile of trivial issues can't hide one serious one.

| Signal | Question it answers |
| --- | --- |
| Weighted backlog + per-tier cards | How much open work, by priority? |
| **Priority age debt** (`weight × age`, high + priority only) | How much high-value work has been neglected, and for how long? |
| 30-day flow (weighted opened vs. resolved, net backlog) | Is the backlog shrinking this window? |
| Age bands + data-quality warnings | What's stale or in an inconsistent state? |

Two deliberately independent signals: **flow** tracks recent movement; **priority age debt** tracks standing neglect. An old high-priority issue that saw no activity this month is invisible to flow but dominates age debt — which is the point. Age debt is rendered as a fixed `0 → 20000` fill meter (bound owned by `policy.json`) directly below the flow meter.

## One pipeline, two renderers

`--human` and `--agent` are mutually exclusive; both run the identical fetch → measure path and only diverge at the final renderer, so the HTML and JSON numbers are guaranteed to match.

```
gh issue list (open + recently-closed)
        │
   normalize → build_report()  ── one report model ──┐
        │                                            │
   --agent → render_json → stdout            --human → render_html → build/reports/…html
```

The JSON contract (stable `schemaVersion`, stdout is *only* the document, diagnostics to stderr, non-zero exit on failure) is what lets automation build on it without scraping HTML (§FS-repository-status-report.4).
