### PR TITLE
Fix graphql-java Relay metadata packaging

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -229,6 +229,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 - **Coverage-backed support.** Every supported library version must have tests that exercise the library's reachable surface enough to fail when metadata is wrong or missing.
 - **Per-coordinate layout.** Tests live under `tests/src/<group>/<artifact>/<version>` unless an `index.json` entry sets `test-version` to share a suite across versions.
 - **Consumer-like exercise.** Tests must not pin to specific library versions or bypass the library's public API in ways that would mask metadata gaps. Scaffold-only tests are not acceptable.
+- **Separate test namespaces.** Tests and their helper types must use a package namespace that does not overlap the target library's allowed packages. This keeps test-only metadata separation from classifying library metadata as test-owned.
 - **Declared Docker images.** Tests that use Docker must declare every image they need in `required-docker-images.txt`. Each image must already appear in `tests/tck-build-logic/src/main/resources/allowed-docker-images/Dockerfile-<dockerImageName>`. Tests fail otherwise.
 - **Required lanes.** Tests must compile under JDK 25 and pass both `javaTest` and `nativeTest` lanes on every JDK/OS combination listed in `ci.json`.
 - **Recorded passing versions.** Newly added `tested-versions` entries are recorded in `index.json` only after they pass on **every** required environment (enforced by `verify-new-library-version-compatibility`).

--- a/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
+++ b/metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json
@@ -1,4 +1,76 @@
 {
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnection",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultConnectionCursor",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultEdge",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.relay.Connection"
+      },
+      "type" : "graphql.relay.DefaultPageInfo",
+      "allDeclaredMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLArgument",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLDirective",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLEnumValueDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLFieldDefinition",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLInputObjectField",
+      "allPublicMethods" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "graphql.GraphQL"
+      },
+      "type" : "graphql.schema.GraphQLOutputType",
+      "allPublicMethods" : true
+    }
+  ],
   "resources" : [
     {
       "bundle" : "i18n.General"

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphQlTests.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/GraphQlTests.java
@@ -4,13 +4,17 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package graphql;
+package com_graphql_java.graphql_java;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com_graphql_java.graphql_java.starwars.Droid;
+import com_graphql_java.graphql_java.starwars.Human;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
 import graphql.introspection.IntrospectionQuery;
 import graphql.relay.Connection;
 import graphql.relay.DefaultConnection;
@@ -26,15 +30,11 @@ import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import graphql.starwars.Droid;
-import graphql.starwars.Human;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Brian Clozel
- */
+/** Exercises graphql-java through its public API in an isolated test namespace. */
 public class GraphQlTests {
 
 
@@ -77,7 +77,7 @@ public class GraphQlTests {
   }
 
   private GraphQLSchema parseSchema(String schemaFileName, Consumer<RuntimeWiring.Builder> consumer) throws IOException {
-    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream(schemaFileName + ".graphqls")) {
+    try (InputStream inputStream = GraphQlTests.class.getResourceAsStream("/graphql/" + schemaFileName + ".graphqls")) {
       TypeDefinitionRegistry registry = new SchemaParser().parse(inputStream);
       RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
       consumer.accept(runtimeWiringBuilder);

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Character.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Character.java
@@ -4,13 +4,21 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package graphql.starwars;
+package com_graphql_java.graphql_java.starwars;
+
+import java.util.List;
 
 /**
  * @author Brian Clozel
  */
-public enum Episode {
-  NEWHOPE,
-  EMPIRE,
-  JEDI
+public interface Character {
+
+  Long getId();
+
+  String getName();
+
+  Character getFriends();
+
+  List<Episode> getAppearsIn();
+
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Droid.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Droid.java
@@ -4,23 +4,23 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package graphql.starwars;
+package com_graphql_java.graphql_java.starwars;
 
 import java.util.List;
 
 /**
  * @author Brian Clozel
  */
-public class Human implements Character {
+public class Droid implements Character {
 
   @Override
   public Long getId() {
-    return 42L;
+    return null;
   }
 
   @Override
   public String getName() {
-    return "GraalVM";
+    return null;
   }
 
   @Override
@@ -33,7 +33,7 @@ public class Human implements Character {
     return null;
   }
 
-  public String getHomePlanet() {
+  public String getPrimaryFunction() {
     return null;
   }
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Episode.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Episode.java
@@ -4,21 +4,13 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package graphql.starwars;
-
-import java.util.List;
+package com_graphql_java.graphql_java.starwars;
 
 /**
  * @author Brian Clozel
  */
-public interface Character {
-
-  Long getId();
-
-  String getName();
-
-  Character getFriends();
-
-  List<Episode> getAppearsIn();
-
+public enum Episode {
+  NEWHOPE,
+  EMPIRE,
+  JEDI
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Human.java
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/java/com_graphql_java/graphql_java/starwars/Human.java
@@ -4,23 +4,23 @@
  * You should have received a copy of the CC0 legalcode along with this
  * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
-package graphql.starwars;
+package com_graphql_java.graphql_java.starwars;
 
 import java.util.List;
 
 /**
  * @author Brian Clozel
  */
-public class Droid implements Character {
+public class Human implements Character {
 
   @Override
   public Long getId() {
-    return null;
+    return 42L;
   }
 
   @Override
   public String getName() {
-    return null;
+    return "GraalVM";
   }
 
   @Override
@@ -33,7 +33,7 @@ public class Droid implements Character {
     return null;
   }
 
-  public String getPrimaryFunction() {
+  public String getHomePlanet() {
     return null;
   }
 }

--- a/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.graphql-java/graphql-java/19.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,104 +1,22 @@
 {
   "reflection" : [
     {
-      "condition" : {
-        "typeReached" : "graphql.relay.Connection"
-      },
-      "type" : "graphql.relay.DefaultConnection",
-      "allDeclaredMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.relay.Connection"
-      },
-      "type" : "graphql.relay.DefaultConnectionCursor",
-      "allDeclaredMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.relay.Connection"
-      },
-      "type" : "graphql.relay.DefaultEdge",
-      "allDeclaredMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.relay.Connection"
-      },
-      "type" : "graphql.relay.DefaultPageInfo",
-      "allDeclaredMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLArgument",
-      "allPublicMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLDirective",
-      "allPublicMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLEnumValueDefinition",
-      "allPublicMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLFieldDefinition",
-      "allPublicMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLInputObjectField",
-      "allPublicMethods" : true
-    },
-    {
-      "condition" : {
-        "typeReached" : "graphql.GraphQL"
-      },
-      "type" : "graphql.schema.GraphQLOutputType",
-      "allPublicMethods" : true
-    },
-    {
-      "type" : "graphql.starwars.Human",
+      "type" : "com_graphql_java.graphql_java.starwars.Human",
       "allPublicMethods" : true
     }
   ],
   "resources" : [
     {
       "condition" : {
-        "typeReached" : "graphql.GraphQlTests"
+        "typeReached" : "com_graphql_java.graphql_java.GraphQlTests"
       },
       "glob" : "graphql/greeting.graphqls"
     },
     {
       "condition" : {
-        "typeReached" : "graphql.GraphQlTests"
+        "typeReached" : "com_graphql_java.graphql_java.GraphQlTests"
       },
       "glob" : "graphql/starwars.graphqls"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/javax.xml.stream.XMLOutputFactory"
-    },
-    {
-      "condition" : {
-        "typeReached" : "org.junit.platform.reporting.legacy.xml.XmlReportWriter"
-      },
-      "glob" : "META-INF/services/java.net.spi.InetAddressResolverProvider"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #9107.

`graphql-java` Relay connection results fail in consumer native images because the reflection metadata for `DefaultConnection`, `DefaultConnectionCursor`, `DefaultEdge`, and `DefaultPageInfo` was not shipped.

## Root cause

The `graphql-java:19.7` suite was generated with its test and Star Wars helper classes in the library namespace (`graphql` and `graphql.starwars`). The `splitTestOnlyMetadata` authoring step identifies test-only metadata by package ownership. Because the test package overlapped the library allowed package, it treated the library-owned Relay and GraphQL schema reflection entries as test-only and moved them to `src/test/resources/META-INF/native-image/reachability-metadata.json`.

The TCK native image still loaded that test resource, so `GraphQlTests.paginatedQuery()` passed. Consumer images do not package test resources, and therefore lacked the registrations. The `19.7` metadata version is also used for graphql-java 19.7 through 26.0, including the issue reproducer's graphql-java 25.0.

## Fix

- Restore the conditional Relay and GraphQL schema reflection entries to shipped `metadata/com.graphql-java/graphql-java/19.7/reachability-metadata.json`.
- Move the test and all its helper types to the generated `com_graphql_java.graphql_java` namespace.
- Retain only the isolated test fixture metadata in the test resource.
- Specify that test namespaces must not overlap library allowed packages, preventing this packaging error.

## Validation

- `./gradlew checkMetadataFiles -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`
- `./gradlew compileTestJava -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`
- `./gradlew javaTest -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`
- `./gradlew nativeTest -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`
- `./gradlew checkstyle -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`
- `./gradlew splitTestOnlyMetadata -Pcoordinates=com.graphql-java:graphql-java:19.7 --stacktrace`

`grund check` remains blocked by pre-existing root and Forge `AGENTS.md` v2-to-v3 initialization notices.