### PR TITLE
JNA: add missing Structure FFIType reflection metadata for JNA 5.13+

### DIFF
--- a/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
@@ -255,6 +255,32 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "type": "com.sun.jna.Structure$FFIType",
+      "fields": [
+        {
+          "name": "alignment"
+        },
+        {
+          "name": "elements"
+        },
+        {
+          "name": "size"
+        },
+        {
+          "name": "type"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "type": "com.sun.jna.Structure$FFIType$FFITypes",
       "jniAccessible": true,
       "fields": [
@@ -296,6 +322,18 @@
         },
         {
           "name": "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Structure$FFIType$size_t",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/JnaTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/JnaTest.java
@@ -16,4 +16,14 @@ class JnaTest {
         int number = CLibrary.INSTANCE.atol("42");
         assertThat(number).isEqualTo(42);
     }
+
+    @Test
+    void testStructure() {
+        PointStructure point = new PointStructure();
+        point.x = 42;
+        point.y = 43;
+        point.write();
+        assertThat(point.x).isEqualTo(42);
+        assertThat(point.y).isEqualTo(43);
+    }
 }

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/PointStructure.java
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/PointStructure.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Structure;
+
+import java.util.List;
+
+public class PointStructure extends Structure {
+    public int x;
+    public int y;
+
+    @Override
+    protected List<String> getFieldOrder() {
+        return List.of("x", "y");
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -6,6 +6,13 @@
           "net_java_dev_jna.jna.CLibrary"
         ]
       }
+    },
+    {
+      "type": "net_java_dev_jna.jna.PointStructure",
+      "fields": [
+        { "name": "x" },
+        { "name": "y" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
JNA 5.13+ reflectively instantiates `Structure$FFIType` and
`Structure$FFIType$size_t` via their no-arg constructors when a
`Structure` subclass derives its layout. The existing metadata (for
5.8.0) lacks these entries, so native-image builds using newer JNA
versions — including those listed as `tested-versions` up to 5.18.1 —
crash at runtime with:

```
NoSuchMethodException: com.sun.jna.Structure$FFIType.<init>()
```

This was caught by a `--self-test` smoke test in a downstream project
(drifty, a Java CLI tool) that exercises the real libsodium/JNA path in
the production native image: `NativeExecutableIT.selfTest()`.

**Changes:**
1. Add reflection entries for `com.sun.jna.Structure$FFIType` with its
   no-arg constructor and fields (`alignment`, `elements`, `size`,
   `type`).
2. Add reflection entry for `com.sun.jna.Structure$FFIType$size_t` with
   its no-arg constructor.
3. Add a `PointStructure` test that creates a `Structure` subclass,
   writes to it, and reads back — exercising the FFIType path that
   triggers this reflective lookup.

**Verification:**
- `./gradlew -p tests/src/net.java.dev.jna/jna/5.8.0 nativeTest` passes
  with both the original `test()` and the new `testStructure()` test
  succeeding in the native image.

Related: https://github.com/oracle/graalvm-reachability-metadata/issues/7741