### PR TITLE
JNA: add reflection metadata for direct mapping (Native.register)

### DIFF
--- a/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
+++ b/metadata/net.java.dev.jna/jna/5.8.0/reachability-metadata.json
@@ -167,6 +167,18 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "type": "com.sun.jna.NativeLong",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "type": "com.sun.jna.NativeMapped",
       "jniAccessible": true,
       "methods": [
@@ -255,6 +267,32 @@
       "condition": {
         "typeReached": "com.sun.jna.Native"
       },
+      "type": "com.sun.jna.Structure$FFIType",
+      "fields": [
+        {
+          "name": "alignment"
+        },
+        {
+          "name": "elements"
+        },
+        {
+          "name": "size"
+        },
+        {
+          "name": "type"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
       "type": "com.sun.jna.Structure$FFIType$FFITypes",
       "jniAccessible": true,
       "fields": [
@@ -296,6 +334,18 @@
         },
         {
           "name": "ffi_type_void"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "com.sun.jna.Native"
+      },
+      "type": "com.sun.jna.Structure$FFIType$size_t",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },

--- a/stats/net.java.dev.jna/jna/5.8.0/stats.json
+++ b/stats/net.java.dev.jna/jna/5.8.0/stats.json
@@ -4,8 +4,8 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.093023,
-          "coveredCalls" : 4,
+          "coverageRatio" : 0.27907,
+          "coveredCalls" : 12,
           "totalCalls" : 43
         },
         "resources" : {
@@ -14,27 +14,27 @@
           "totalCalls" : 5
         }
       },
-      "coverageRatio" : 0.104167,
-      "coveredCalls" : 5,
+      "coverageRatio" : 0.270833,
+      "coveredCalls" : 13,
       "totalCalls" : 48
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 2528,
-        "missed" : 19382,
-        "ratio" : 0.115381,
+        "covered" : 4977,
+        "missed" : 16933,
+        "ratio" : 0.227157,
         "total" : 21910
       },
       "line" : {
-        "covered" : 586,
-        "missed" : 4098,
-        "ratio" : 0.125107,
+        "covered" : 1179,
+        "missed" : 3505,
+        "ratio" : 0.251708,
         "total" : 4684
       },
       "method" : {
-        "covered" : 105,
-        "missed" : 730,
-        "ratio" : 0.125749,
+        "covered" : 208,
+        "missed" : 627,
+        "ratio" : 0.249102,
         "total" : 835
       }
     }

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/DirectMappedCLibrary.java
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/DirectMappedCLibrary.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.NativeLong;
+
+/**
+ * Direct mapping: the native methods are bound with {@code Native.register}
+ * instead of being dispatched through an interface proxy created by
+ * {@code Native.load}.
+ */
+public final class DirectMappedCLibrary {
+
+    public static native int atol(String s);
+
+    /**
+     * Takes and returns a {@code NativeMapped} type, so registering it routes
+     * through {@code NativeMappedConverter}, which instantiates
+     * {@code NativeLong} reflectively.
+     */
+    public static native NativeLong labs(NativeLong i);
+
+    private DirectMappedCLibrary() {
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/DirectMappingTest.java
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/java/net_java_dev_jna/jna/DirectMappingTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package net_java_dev_jna.jna;
+
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises JNA direct mapping, which builds the libffi call descriptors in
+ * Java: {@code Native.register} resolves every parameter and return type
+ * through {@code Structure$FFIType.get}, running the static initializer that
+ * reflectively instantiates {@code Structure$FFIType} and reads its fields.
+ */
+class DirectMappingTest {
+
+    @Test
+    void registerAndCall() {
+        Native.register(DirectMappedCLibrary.class, "c");
+
+        assertThat(DirectMappedCLibrary.atol("42")).isEqualTo(42);
+        assertThat(DirectMappedCLibrary.labs(new NativeLong(-42)).longValue()).isEqualTo(42L);
+    }
+}

--- a/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/net.java.dev.jna/jna/5.8.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -6,6 +6,9 @@
           "net_java_dev_jna.jna.CLibrary"
         ]
       }
+    },
+    {
+      "type": "net_java_dev_jna.jna.DirectMappedCLibrary"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Adds the reflection metadata JNA needs for **direct mapping**
(`Native.register`), and a test that covers it. The entries come from
`./gradlew generateMetadata -Pcoordinates=net.java.dev.jna:jna:5.8.0`.

The existing metadata covers interface mapping (`Native.load`), where the
libffi call descriptors are built in native code. Direct mapping builds them in
Java and instantiates several types reflectively, none of them registered, so a
native image using it fails at run time:

```
java.lang.NoSuchMethodException: com.sun.jna.Structure$FFIType.<init>()
    at com.sun.jna.Klass.newInstance(Klass.java:48)
    at com.sun.jna.Structure.newInstance(Structure.java:1976)
    at com.sun.jna.Structure$FFIType.<clinit>(Structure.java:2077)
```

```
java.lang.NoSuchMethodException: com.sun.jna.NativeLong.<init>()
    at com.sun.jna.Klass.newInstance(Klass.java:48)
    at com.sun.jna.NativeMappedConverter.defaultValue(NativeMappedConverter.java:65)
    at com.sun.jna.Native.register(Native.java:1965)
```

The first is `Structure$FFIType`'s static initializer, which creates the
pre-defined libffi types through `Klass.newInstance()` and then reads their
fields — and the `size` field is itself a `Structure$FFIType$size_t` built the
same way. The second is `NativeMappedConverter`, which instantiates the
`NativeMapped` parameter type to derive its default value.

No existing test uses direct mapping, so this adds one that registers `atol`
and `labs` and calls them; `labs` takes and returns `NativeLong`, which is what
routes registration through `NativeMappedConverter`. Removing any of the three
metadata entries makes it fail.

Not a regression from a recent release — the reflective code is unchanged since
5.8.0, and the test fails on 5.8.0 too.

Two deliberate deviations from the raw agent output. The conditions are
normalised to `com.sun.jna.Native`, which the surrounding entries already use,
because the agent's computed condition is not stable across runs —
`Structure$FFIType$size_t` was recorded under `IntegerType` and
`NativeMappedConverter` in one run and under `Native` and `Structure` in the
next. And the agent's bare `Structure$FFIType` entry is dropped, since the
entry carrying the members registers the type as well.

Verified on GraalVM CE 25.0.2 (aarch64): `./gradlew test` passes for 5.8.0 and
5.18.1, plus `checkMetadataFiles` and `checkstyle`. Reverting only the metadata
change makes the new test fail while the existing one still passes. 5.19.1 also
passes, but I left `tested-versions` alone — that is a separate change, and
5.19.x still hits the unrelated `future-defaults-all` failure in #7741.

## Code sections where the PR accesses files, network, docker or some external service

- `tests/.../net_java_dev_jna/jna/DirectMappingTest.java` binds the system C
  library via `Native.register(DirectMappedCLibrary.class, "c")` and calls
  `atol` and `labs` — the same dependency the existing test already has through
  `Native.load("c")`. No network, Docker or filesystem access.
