### PR TITLE
Cover com.apollographql.federation:federation-graphql-java-support:6.1.0  schema resources

### DIFF
--- a/metadata/com.apollographql.federation/federation-graphql-java-support/6.1.0/reachability-metadata.json
+++ b/metadata/com.apollographql.federation/federation-graphql-java-support/6.1.0/reachability-metadata.json
@@ -16,6 +16,60 @@
       "condition" : {
         "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
       },
+      "glob" : "definitions_fed2_1.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_12.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_2.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_3.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_5.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_6.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_7.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_8.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
+      "glob" : "definitions_fed2_9.graphqls"
+    },
+    {
+      "condition" : {
+        "typeReached" : "com.apollographql.federation.graphqljava.FederationDirectives"
+      },
       "glob" : "i18n/Parsing.properties"
     },
     {

--- a/tests/src/com.apollographql.federation/federation-graphql-java-support/6.1.0/src/test/java/com_apollographql_federation/federation_graphql_java_support/FederationDirectivesTest.java
+++ b/tests/src/com.apollographql.federation/federation-graphql-java-support/6.1.0/src/test/java/com_apollographql_federation/federation_graphql_java_support/FederationDirectivesTest.java
@@ -14,25 +14,41 @@ import graphql.language.DirectiveDefinition;
 import graphql.language.InputValueDefinition;
 import graphql.language.SDLNamedDefinition;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class FederationDirectivesTest {
-    @Test
-    void loadsFederationTwoDefinitionsFromPackagedResource() {
-        List<SDLNamedDefinition> definitions = FederationDirectives.loadFederationSpecDefinitions(
-                Federation.FEDERATION_SPEC_V2_12);
+    private static final Map<String, String> FEDERATION_SPECIFICATION_RESOURCES = Map.ofEntries(
+            Map.entry(Federation.FEDERATION_SPEC_V2_0, "definitions_fed2_0.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_1, "definitions_fed2_1.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_2, "definitions_fed2_2.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_3, "definitions_fed2_3.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_5, "definitions_fed2_5.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_6, "definitions_fed2_6.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_7, "definitions_fed2_7.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_8, "definitions_fed2_8.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_9, "definitions_fed2_9.graphqls"),
+            Map.entry(Federation.FEDERATION_SPEC_V2_12, "definitions_fed2_12.graphqls"));
 
-        assertThat(definitions)
-                .extracting(SDLNamedDefinition::getName)
-                .contains("FieldSet", "Import", "Purpose", "cacheTag", "key", "link");
-        assertThat(definitions.stream()
-                .filter(DirectiveDefinition.class::isInstance)
-                .map(DirectiveDefinition.class::cast))
-                .anySatisfy(directive -> {
-                    assertThat(directive.getName()).isEqualTo("key");
-                    assertThat(directive.getInputValueDefinitions())
-                            .extracting(InputValueDefinition::getName)
-                            .contains("fields", "resolvable");
-                });
+    @Test
+    void loadsDefinitionsFromEveryPackagedFederationResource() {
+        // Each public specification version selects and parses its packaged resource.
+        FEDERATION_SPECIFICATION_RESOURCES.forEach((specification, resource) -> {
+            List<SDLNamedDefinition> definitions = FederationDirectives.loadFederationSpecDefinitions(specification);
+
+            assertThat(definitions)
+                    .as("definitions loaded from %s", resource)
+                    .extracting(SDLNamedDefinition::getName)
+                    .contains("FieldSet", "Import", "key", "link");
+            assertThat(definitions.stream()
+                    .filter(DirectiveDefinition.class::isInstance)
+                    .map(DirectiveDefinition.class::cast))
+                    .anySatisfy(directive -> {
+                        assertThat(directive.getName()).isEqualTo("key");
+                        assertThat(directive.getInputValueDefinitions())
+                                .extracting(InputValueDefinition::getName)
+                                .contains("fields", "resolvable");
+                    });
+        });
     }
 }

--- a/tests/src/com.apollographql.federation/federation-graphql-java-support/6.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/com.apollographql.federation/federation-graphql-java-support/6.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -29,12 +29,6 @@
         "typeReached" : "com_apollographql_federation.federation_graphql_java_support.FederationDirectivesTest"
       },
       "glob" : "META-INF/services/org.assertj.core.presentation.Representation"
-    },
-    {
-      "condition" : {
-        "typeReached" : "com_apollographql_federation.federation_graphql_java_support.FederationDirectivesTest"
-      },
-      "glob" : "definitions_fed2_12.graphqls"
     }
   ]
 }


### PR DESCRIPTION
Closes #9129

Load every packaged `com.apollographql.federation:federation-graphql-java-support:6.1.0` schema resource through its public API and register it in shipped metadata ([§TESTS-suite.2](https://github.com/oracle/graalvm-reachability-metadata/blob/master/docs/tests.md#2-what-a-good-test-must-do)).

This was done manually; stats are not updated because transitive dynamic-access calls are not tracked.