### PR TITLE
Opt libraries into automated version compatibility updates

### DIFF
--- a/.github/workflows/verify-new-library-version-compatibility.yml
+++ b/.github/workflows/verify-new-library-version-compatibility.yml
@@ -1,11 +1,11 @@
-# Scheduled upstream-version tracker (every 6 hours): discovers newer versions, tests each across
-# the matrix, records passing ones via addTestedVersion (§TCK-test-harness.5) and files issues.
+# Daily upstream-version tracker: discovers opted-in libraries, tests the matrix, records passing
+# versions via addTestedVersion (§TCK-test-harness.5), and files issues.
 # §CI-verify-new-library-version-compatibility implements §FS-library-version-update-automation.
 name: "Verify compatibility with latest library versions"
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-all-libraries:
-    name: "📋 Get list of all supported libraries with newer versions"
+  get-opted-in-libraries:
+    name: "📋 Get opted-in libraries with newer versions"
     # Opens PRs, with labels and assignees. Works only on the main repo.
     if: github.repository == 'oracle/graalvm-reachability-metadata'
     runs-on: ubuntu-22.04
@@ -114,9 +114,9 @@ jobs:
 
   test-all-metadata:
     name: "🧪 ${{ matrix.name }} [${{ matrix.nativeImageMode }}] (GraalVM for JDK ${{ matrix.version }} @ ${{ matrix.os }})"
-    if: needs.get-all-libraries.outputs.none-found != 'true'
+    if: needs.get-opted-in-libraries.outputs.none-found != 'true'
     runs-on: ${{ matrix.os }}
-    needs: get-all-libraries
+    needs: get-opted-in-libraries
     permissions:
       contents: read
     env:
@@ -124,7 +124,7 @@ jobs:
       LOG_LINES: "300"
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.get-all-libraries.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.get-opted-in-libraries.outputs.matrix) }}
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -236,9 +236,9 @@ jobs:
       ISSUE_BODY_CHAR_LIMIT: "60000"
       LOG_LINES: "300"
     needs:
-      - get-all-libraries
+      - get-opted-in-libraries
       - test-all-metadata
-    if: needs.get-all-libraries.outputs.none-found != 'true'
+    if: needs.get-opted-in-libraries.outputs.none-found != 'true'
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -350,7 +350,7 @@ jobs:
       - name: "✔️ New library versions are supported (with locks, waiting and retries)"
         if: steps.aggregate.outputs.has-successful-updates == 'true'
         env:
-          BRANCH: ${{ needs.get-all-libraries.outputs.branch }}
+          BRANCH: ${{ needs.get-opted-in-libraries.outputs.branch }}
         run: |
           set -euo pipefail
           git config --local user.email "actions@github.com"
@@ -674,8 +674,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
         run: |
-          git fetch origin "${{ needs.get-all-libraries.outputs.branch }}"
-          git checkout "${{ needs.get-all-libraries.outputs.branch }}"
+          git fetch origin "${{ needs.get-opted-in-libraries.outputs.branch }}"
+          git checkout "${{ needs.get-opted-in-libraries.outputs.branch }}"
           if git rev-parse --verify HEAD >/dev/null 2>&1 && ! git diff --quiet "origin/master...HEAD"; then
             PR_BODY_FILE="$(mktemp)"
             {

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -102,6 +102,7 @@ Each artifact directory **must** include an `index.json` file (at `metadata/<gro
 
 **Optional Keys:**
 * `latest`: Boolean. If `true`, this is the default metadata version for the artifact.
+* `auto-update`: Opt-in marker whose only valid value is `true`. It may appear only on the unique `latest: true` entry and allows the daily compatibility workflow to discover and test newer upstream versions automatically. Omit it to keep the artifact out of that automation.
 * `requires`: An array of `groupId:artifactId` coordinates for libraries this metadata depends on.
 * `default-for`: A Java-format regex used to match library versions if no exact match exists in `tested-versions` (e.g., `"0\\.0\\..*"`).
 * `test-version`: Defines the subdirectory in `tests/src` containing the test code. Use this to share a single test suite across multiple metadata versions.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -283,7 +283,9 @@ Example:
 
 These tasks support the scheduled workflow that checks newer upstream library versions and updates our metadata accordingly.
 
-1. List supported libraries that have newer upstream versions
+1. List opted-in libraries that have newer upstream versions. A library opts in
+   by setting `"auto-update": true` on its unique `"latest": true`
+   `metadata/<group>/<artifact>/index.json` entry.
     ```console
     ./gradlew fetchExistingLibrariesWithNewerVersions --quiet
     ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -141,10 +141,11 @@ not gate the scheduled release (§CI-create-scheduled-release).
 
 ### CI-verify-new-library-version-compatibility: Verify new library version compatibility
 
-Every six hours (`0 */6 * * *`) and on manual dispatch. Owns the upstream-version
+Every day (`0 0 * * *`) and on manual dispatch. Owns the upstream-version
 tracking loop fully specified in §FS-repository-functional-spec.9
 (§GOAL-broad-version-coverage, §GOAL-fresh-metadata): it discovers newer versions
-with `fetchExistingLibrariesWithNewerVersions`, builds a matrix with
+only for libraries whose latest index entry sets `auto-update: true`, using
+`fetchExistingLibrariesWithNewerVersions`, and builds a matrix with
 `generateNewLibraryVersionCompatibilityMatrix` (capped per
 §FS-repository-functional-spec.5.3), tests every candidate across the matrix
 using `run-consecutive-tests.sh` (§CI-shared-scripts), records versions that pass

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -42,7 +42,7 @@ These constraints apply uniformly to human-authored PRs and to Forge output, and
 ### 4.1 Metadata distribution
 
 - A directory hierarchy under `metadata/<groupId>/<artifactId>/<metadata-version>/` containing JSON files in the format described by GraalVM's [Native Image Manual Configuration](https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/#manual-configuration) reference.
-- An artifact-level `metadata/<groupId>/<artifactId>/index.json` that records, per metadata version: tested library versions, allowed packages, source/test/documentation URLs, optional `requires`, `default-for`, `skipped-versions`, and `override` flags.
+- An artifact-level `metadata/<groupId>/<artifactId>/index.json` that records, per metadata version: tested library versions, allowed packages, source/test/documentation URLs, optional `requires`, `default-for`, `skipped-versions`, `override`, and compatibility-automation opt-in flags.
 - A repository-level `metadata/library-and-framework-list.json` enumerating every supported library, with `test_level` ∈ `{untested, community-tested, fully-tested}`.
 - A `stats/<groupId>/<artifactId>/<metadata-version>/` mirror of per-version metrics — `stats.json` (dynamic-access call sites, coverage, lines of code, dependency information) produced by the harness, alongside the schema-validated `execution-metrics.json` each Forge run records.
 
@@ -65,7 +65,7 @@ The harness uses a single coordinates filter `-Pcoordinates=` accepting `all`, `
 
 GitHub Actions, configured by [`ci.json`](../ci.json) as the single source of truth for OS/JDK matrix, run the workflows enumerated in [ci.md](ci.md):
 - PR-scoped: changed-metadata, changed-infrastructure, new-library-version, Spring AOT smoke, library-stats validation, library-and-framework-list validation, checkstyle.
-- Schedule-driven: full metadata sweep every three days to prevent incomplete or breaking metadata from shipping in releases, new-library-version compatibility (every six hours), Docker image vulnerability scans, scheduled release every Monday, scheduled coverage publication.
+- Schedule-driven: full metadata sweep every three days to prevent incomplete or breaking metadata from shipping in releases, opted-in new-library-version compatibility (daily), Docker image vulnerability scans, scheduled release every Monday, scheduled coverage publication.
 - Event-driven snapshot publication: every push to `master` may refresh the floating `SNAPSHOT` release when metadata changed since the previous `SNAPSHOT` tag.
 
 CI must pass before any merge, and is the authoritative gate — local runs are best-effort.
@@ -174,11 +174,11 @@ schemas/                                                 # vendored JSON schemas
 
 Plugin-relevant content is `<groupId>/<artifactId>/index.json` and the per-version `reachability-metadata.json` files; the plugin discovers libraries by directory walk. `library-and-framework-list.json` and `schemas/` are present for downstream tooling (the libraries-and-frameworks page and offline validators) and are not consumed by native-build-tools at native-image time.
 
-**2. `<groupId>/<artifactId>/index.json`** — one per supported artifact, schema [metadata-library-index-schema-v2.1.0.json](../metadata/schemas/metadata-library-index-schema-v2.1.0.json). It is a JSON **array** of entries. Metadata entries require `metadata-version`, `tested-versions`, and `allowed-packages`, with optional `default-for` (Java regex), `latest: true`, `override: true`, `requires: ["<group>:<artifact>", …]`, `test-version`, `skipped-versions`, `language`, and the four URL fields. Plugin-relevant fields are the first six.
+**2. `<groupId>/<artifactId>/index.json`** — one per supported artifact, schema [metadata-library-index-schema-v2.2.0.json](../metadata/schemas/metadata-library-index-schema-v2.2.0.json). It is a JSON **array** of entries. Metadata entries require `metadata-version`, `tested-versions`, and `allowed-packages`, with optional `default-for` (Java regex), `latest: true`, `override: true`, `requires: ["<group>:<artifact>", …]`, `test-version`, `skipped-versions`, `language`, `auto-update: true`, and the four URL fields. `auto-update` is a repository-automation opt-in allowed only on the unique `latest: true` entry; omission disables automated upstream-version compatibility checks for the artifact. Plugin-relevant fields are the first six.
 
 Alternatively, the array can hold a single `not-for-native-image: true` entry with a required `reason` and an optional `replacement`, and no other fields. This marks an artifact that is intentionally not a native-image metadata target — a Scala.js artifact, a pure test framework, or a coordinate superseded by another — so the absence of any `metadata-version` directory is a recorded decision rather than missing support. native-build-tools loads no metadata for such a coordinate; the `reason`/`replacement` are surfaced to humans and the libraries-and-frameworks page.
 
-The schema follows semver. **Minor- and patch-version bumps** (e.g., `v2.1.0` → `v2.1.1` or `v2.1.x` → `v2.2.0`) are guaranteed backward-compatible with native-build-tools: minor bumps add new optional fields or non-plugin index formats used by the website, the test harness, or future tooling (`requires`, `test-version`, `skipped-versions`, `language`, `source-code-url`, `test-code-url`, `documentation-url`, `repository-url`, `not-for-native-image`); patch bumps refine validation of those same auxiliary fields and formats. The plugin reads only the six fields enumerated above, so an older native-build-tools release continues to resolve metadata correctly against any newer minor or patch version of the schema. A **major-version bump** (e.g., `v2.x` → `v3.0.0`) is reserved for changes that native-build-tools itself must adopt; it is shipped in lockstep with a plugin release rather than absorbed silently by older plugins.
+The schema follows semver. **Minor- and patch-version bumps** (e.g., `v2.1.0` → `v2.1.1` or `v2.1.x` → `v2.2.0`) are guaranteed backward-compatible with native-build-tools: minor bumps add new optional fields or non-plugin index formats used by the website, the test harness, or future tooling (`requires`, `test-version`, `skipped-versions`, `language`, `source-code-url`, `test-code-url`, `documentation-url`, `repository-url`, `not-for-native-image`, `auto-update`); patch bumps refine validation of those same auxiliary fields and formats. The plugin reads only the six fields enumerated above, so an older native-build-tools release continues to resolve metadata correctly against any newer minor or patch version of the schema. A **major-version bump** (e.g., `v2.x` → `v3.0.0`) is reserved for changes that native-build-tools itself must adopt; it is shipped in lockstep with a plugin release rather than absorbed silently by older plugins.
 
 **3. `<groupId>/<artifactId>/<metadata-version>/reachability-metadata.json`** — the only file the plugin loads at native-image time. Schema [reachability-metadata-schema-v1.2.0.json](../metadata/schemas/reachability-metadata-schema-v1.2.0.json) (a vendored copy of the upstream GraalVM schema), with top-level keys `reflection`, `jni`, `resources`, `bundles`, `serialization`, and `foreignCalls`. Every entry's `condition` carries exactly one key, `typeReached`, so the plugin can rely on conditional registration; `typeReached` is the schema's only condition form. The legacy split-config layout (`reflect-config.json`, `jni-config.json`, …) is no longer present.
 
@@ -362,7 +362,7 @@ in §5.3.
 The repository must keep its tested-version coverage current as upstream
 libraries release new versions, without a human watching Maven Central. The
 [`verify-new-library-version-compatibility`](../.github/workflows/verify-new-library-version-compatibility.yml)
-GitHub Actions workflow owns this loop. It runs on a schedule (every six hours)
+GitHub Actions workflow owns this loop. It runs on a schedule (daily)
 and on manual `workflow_dispatch`, and performs its mutating steps only on the
 canonical `oracle/graalvm-reachability-metadata` repository. Each run discovers
 newer upstream versions, tests every candidate across the supported environment
@@ -379,11 +379,13 @@ label it applies is defined in the
 #### 1. Discovery of newer versions
 
 `./gradlew fetchExistingLibrariesWithNewerVersions` lists every already-supported
-library whose newest upstream release is ahead of its highest tested version,
-emitting candidate versions newest-first. Before a candidate enters the run it
+library whose unique `latest: true` index entry opts in with `auto-update: true`
+and whose newest upstream release is ahead of its highest tested version,
+emitting candidate versions newest-first. Libraries without the marker are
+discarded before Maven Central is queried. Before a candidate enters the run it
 is de-duplicated against open issues: a library whose newest candidate version
 already has an open `[Automation] … fails for <group:artifact:version>` issue is
-skipped, so a known-failing version is not re-tested every six hours.
+skipped, so a known-failing version is not re-tested every day.
 `generateNewLibraryVersionCompatibilityMatrix` turns the surviving candidates
 into the CI test matrix, bounded by the per-run library budget and the
 ≤ 30-newer-versions-per-library cap (§FS-repository-functional-spec.5.3). When

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -17,7 +17,10 @@ would otherwise miss, and must never change how a consumer's code runs
   JSON array recording, per metadata version, the `tested-versions`,
   `allowed-packages`, the source/test/documentation/repository URLs, and optional
   `default-for`, `latest`, `override`, `requires`, `test-version`,
-  `skipped-versions`, and `language`. This is how native-build-tools selects a
+  `skipped-versions`, `language`, and `auto-update`. The automation-only
+  `auto-update: true` marker may appear on the unique latest entry to opt the
+  artifact into daily upstream-version compatibility checks; native-build-tools
+  ignores it. The remaining fields define how native-build-tools selects a
   metadata version for a dependency (§FS-repository-functional-spec.4).
 - `metadata/<groupId>/<artifactId>/<metadata-version>/reachability-metadata.json`
   — the only file `native-image` loads. It carries `reflection`, `jni`,

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -174,7 +174,7 @@ These emit the GitHub Actions matrices the workflows consume, all driven by
 | `generateChangedCoordinatesMatrix`, `generateChangedMetadataTestMatrix`, `generateChangedCoordinatesOnlyMatrix`, `generateChangedIndexFileCoordinatesList` | PR-scoped matrices for changed metadata and index files. |
 | `generateInfrastructureChangedCoordinatesMatrix` | Matrix for build-logic changes; also selects the coordinate for §E2E-infrastructure-tests. |
 | `generateAffectedSpringTestMatrix` | Impacted Spring AOT projects. |
-| `fetchExistingLibrariesWithNewerVersions`, `generateNewLibraryVersionCompatibilityMatrix` | Discover newer upstream versions and build the compatibility matrix (§GOAL-broad-version-coverage). |
+| `fetchExistingLibrariesWithNewerVersions`, `generateNewLibraryVersionCompatibilityMatrix` | Discover newer upstream versions for `auto-update` libraries and build the compatibility matrix (§FS-library-version-update-automation.1). |
 
 ## 8. Reporting, stats, coverage, and packaging
 

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -2903,7 +2903,7 @@ class PullRequestReviewTests(unittest.TestCase):
                 "get_pull_request_changed_files",
                 return_value=[
                     "metadata/org.example/demo/index.json",
-                    "metadata/schemas/metadata-library-index-schema-v2.1.0.json",
+                    "metadata/schemas/metadata-library-index-schema-v2.2.0.json",
                     "tests/src/org.example/demo/1.0.0/build.gradle",
                     "metadata/org.example/demo/1.0.0/reachability-metadata.json",
                 ],

--- a/metadata/antlr/antlr/index.json
+++ b/metadata/antlr/antlr/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.7.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/antlr/antlr/$version$/antlr-$version$-sources.jar",
     "repository-url" : "https://www.antlr2.org",

--- a/metadata/aopalliance/aopalliance/index.json
+++ b/metadata/aopalliance/aopalliance/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/aopalliance/aopalliance/$version$/aopalliance-$version$-sources.jar",
     "repository-url" : "https://sourceforge.net/p/aopalliance/code/",

--- a/metadata/at.yawk.lz4/lz4-java/index.json
+++ b/metadata/at.yawk.lz4/lz4-java/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10.4",
     "source-code-url" : "https://repo1.maven.org/maven2/at/yawk/lz4/lz4-java/$version$/lz4-java-$version$-sources.jar",
     "repository-url" : "https://github.com/yawkat/lz4-java/tree/v1.10.4",

--- a/metadata/berkeleydb/je/index.json
+++ b/metadata/berkeleydb/je/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages" : [
       "com.sleepycat"
     ],

--- a/metadata/biz.aQute.bnd/biz.aQute.bnd.annotation/index.json
+++ b/metadata/biz.aQute.bnd/biz.aQute.bnd.annotation/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.4.1",
     "source-code-url" : "https://repo1.maven.org/maven2/biz/aQute/bnd/biz.aQute.bnd.annotation/$version$/biz.aQute.bnd.annotation-$version$-sources.jar",
     "repository-url" : "https://github.com/bndtools/bnd",

--- a/metadata/ch.qos.logback.contrib/logback-jackson/index.json
+++ b/metadata/ch.qos.logback.contrib/logback-jackson/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "ch.qos.logback"
     ],

--- a/metadata/ch.qos.logback.contrib/logback-json-classic/index.json
+++ b/metadata/ch.qos.logback.contrib/logback-json-classic/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "ch.qos.logback"
     ],

--- a/metadata/ch.qos.logback/logback-classic/index.json
+++ b/metadata/ch.qos.logback/logback-classic/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.29",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/$version$/logback-classic-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",

--- a/metadata/ch.qos.logback/logback-core/index.json
+++ b/metadata/ch.qos.logback/logback-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.33",
     "source-code-url" : "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/$version$/logback-core-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/logback",

--- a/metadata/com.atomikos/transactions/index.json
+++ b/metadata/com.atomikos/transactions/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/atomikos/transactions/$version$/transactions-$version$-sources.jar",
     "repository-url" : "https://atomikos.repositoryhosting.com/hg/atomikos/development",

--- a/metadata/com.datastax.oss/native-protocol/index.json
+++ b/metadata/com.datastax.oss/native-protocol/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/datastax/oss/native-protocol/$version$/native-protocol-$version$-sources.jar",
     "repository-url" : "https://github.com/datastax/native-protocol",

--- a/metadata/com.ecwid.consul/consul-api/index.json
+++ b/metadata/com.ecwid.consul/consul-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "com.ecwid"
     ],

--- a/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-annotations/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/$version$/jackson-annotations-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-annotations",

--- a/metadata/com.fasterxml.jackson.core/jackson-core/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/$version$/jackson-core-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-core",

--- a/metadata/com.fasterxml.jackson.core/jackson-databind/index.json
+++ b/metadata/com.fasterxml.jackson.core/jackson-databind/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.15.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/$version$/jackson-databind-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-databind",

--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/index.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.13.5",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/$version$/jackson-datatype-jdk8-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-modules-java8",

--- a/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/index.json
+++ b/metadata/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.22.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/$version$/jackson-datatype-jsr310-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-modules-java8",

--- a/metadata/com.fasterxml.jackson.module/jackson-module-kotlin/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-kotlin/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.17.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-kotlin/$version$/jackson-module-kotlin-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-module-kotlin",

--- a/metadata/com.fasterxml.jackson.module/jackson-module-parameter-names/index.json
+++ b/metadata/com.fasterxml.jackson.module/jackson-module-parameter-names/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.22.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/jackson/module/jackson-module-parameter-names/$version$/jackson-module-parameter-names-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-modules-java8",

--- a/metadata/com.fasterxml/classmate/index.json
+++ b/metadata/com.fasterxml/classmate/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/fasterxml/classmate/$version$/classmate-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/java-classmate",

--- a/metadata/com.github.ben-manes.caffeine/caffeine/index.json
+++ b/metadata/com.github.ben-manes.caffeine/caffeine/index.json
@@ -20,6 +20,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.8",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/ben-manes/caffeine/caffeine/$version$/caffeine-$version$-sources.jar",
     "repository-url" : "https://github.com/ben-manes/caffeine/tree/v3.1.8",

--- a/metadata/com.github.jnr/jnr-a64asm/index.json
+++ b/metadata/com.github.jnr/jnr-a64asm/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/jnr/jnr-a64asm/$version$/jnr-a64asm-$version$-sources.jar",
     "repository-url" : "https://github.com/jnr/jnr-a64asm",

--- a/metadata/com.github.jnr/jnr-x86asm/index.json
+++ b/metadata/com.github.jnr/jnr-x86asm/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/github/jnr/jnr-x86asm/$version$/jnr-x86asm-$version$-sources.jar",
     "repository-url" : "https://github.com/jnr/jnr-x86asm",

--- a/metadata/com.github.luben/zstd-jni/index.json
+++ b/metadata/com.github.luben/zstd-jni/index.json
@@ -58,6 +58,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.7-2",
     "test-version" : "1.5.2-5",
     "tested-versions" : [

--- a/metadata/com.google.auth/google-auth-library-credentials/index.json
+++ b/metadata/com.google.auth/google-auth-library-credentials/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/auth/google-auth-library-credentials/$version$/google-auth-library-credentials-$version$-sources.jar",
     "repository-url" : "https://github.com/googleapis/google-auth-library-java",

--- a/metadata/com.google.code.findbugs/jsr305/index.json
+++ b/metadata/com.google.code.findbugs/jsr305/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.1",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/$version$/jsr305-$version$-sources.jar",
     "repository-url" : "https://code.google.com/p/jsr-305/",

--- a/metadata/com.google.code.gson/gson/index.json
+++ b/metadata/com.google.code.gson/gson/index.json
@@ -39,6 +39,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.14.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/code/gson/gson/$version$/gson-$version$-sources.jar",
     "repository-url" : "https://github.com/google/gson",

--- a/metadata/com.google.errorprone/error_prone_annotations/index.json
+++ b/metadata/com.google.errorprone/error_prone_annotations/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.6.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/$version$/error_prone_annotations-$version$-sources.jar",
     "repository-url" : "https://github.com/google/error-prone",

--- a/metadata/com.google.guava/failureaccess/index.json
+++ b/metadata/com.google.guava/failureaccess/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/$version$/failureaccess-$version$-sources.jar",
     "repository-url" : "https://github.com/google/guava",

--- a/metadata/com.google.guava/guava/index.json
+++ b/metadata/com.google.guava/guava/index.json
@@ -18,6 +18,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "33.6.0-jre",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/google/guava/guava/$version$/guava-$version$-sources.jar",
     "repository-url" : "https://github.com/google/guava",

--- a/metadata/com.google.guava/listenablefuture/index.json
+++ b/metadata/com.google.guava/listenablefuture/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [ "com.google.guava" ],
     "metadata-version": "9999.0-empty-to-avoid-conflict-with-guava",
     "source-code-url": "https://github.com/google/guava/tree/v27.0/futures/listenablefuture9999",

--- a/metadata/com.google.j2objc/j2objc-annotations/index.json
+++ b/metadata/com.google.j2objc/j2objc-annotations/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/$version$/j2objc-annotations-$version$-sources.jar",
     "repository-url" : "https://github.com/google/j2objc",

--- a/metadata/com.google.protobuf/protobuf-java-util/index.json
+++ b/metadata/com.google.protobuf/protobuf-java-util/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.25.9",
     "source-code-url" : "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java-util/$version$/protobuf-java-util-$version$-sources.jar",
     "repository-url" : "https://github.com/protocolbuffers/protobuf",

--- a/metadata/com.googlecode.javaewah/JavaEWAH/index.json
+++ b/metadata/com.googlecode.javaewah/JavaEWAH/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.13",
     "source-code-url" : "https://repo1.maven.org/maven2/com/googlecode/javaewah/JavaEWAH/$version$/JavaEWAH-$version$-sources.jar",
     "repository-url" : "https://github.com/lemire/javaewah",

--- a/metadata/com.graphql-java/graphql-java-extended-validation/index.json
+++ b/metadata/com.graphql-java/graphql-java-extended-validation/index.json
@@ -22,6 +22,7 @@
       "graphql"
     ],
     "latest": true,
+    "auto-update": true,
     "metadata-version": "19.2",
     "tested-versions": [
       "19.2"

--- a/metadata/com.graphql-java/graphql-java/index.json
+++ b/metadata/com.graphql-java/graphql-java/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "19.7",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/graphql-java/$version$/graphql-java-$version$-sources.jar",
     "repository-url" : "https://github.com/graphql-java/graphql-java",

--- a/metadata/com.graphql-java/java-dataloader/index.json
+++ b/metadata/com.graphql-java/java-dataloader/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2021-03-30T02-06-56-9a47743",
     "source-code-url" : "https://repo1.maven.org/maven2/com/graphql-java/java-dataloader/2021-03-30T02-06-56-9a47743/java-dataloader-2021-03-30T02-06-56-9a47743-sources.jar",
     "repository-url" : "https://github.com/graphql-java/java-dataloader",

--- a/metadata/com.h2database/h2/index.json
+++ b/metadata/com.h2database/h2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1.210",
     "source-code-url" : "https://repo1.maven.org/maven2/com/h2database/h2/$version$/h2-$version$-sources.jar",
     "repository-url" : "https://github.com/h2database/h2database",

--- a/metadata/com.hazelcast/hazelcast/index.json
+++ b/metadata/com.hazelcast/hazelcast/index.json
@@ -19,6 +19,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.5.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/hazelcast/hazelcast/$version$/hazelcast-$version$-sources.jar",
     "repository-url" : "https://github.com/hazelcast/hazelcast",

--- a/metadata/com.itextpdf/forms/index.json
+++ b/metadata/com.itextpdf/forms/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/itextpdf/forms/$version$/forms-$version$-sources.jar",
     "repository-url" : "https://github.com/itext/itext-java",

--- a/metadata/com.itextpdf/io/index.json
+++ b/metadata/com.itextpdf/io/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/itextpdf/io/$version$/io-$version$-sources.jar",
     "repository-url" : "https://github.com/itext/itext-java",

--- a/metadata/com.itextpdf/kernel/index.json
+++ b/metadata/com.itextpdf/kernel/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/itextpdf/kernel/$version$/kernel-$version$-sources.jar",
     "repository-url" : "https://github.com/itext/itext-java",

--- a/metadata/com.itextpdf/layout/index.json
+++ b/metadata/com.itextpdf/layout/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/itextpdf/layout/$version$/layout-$version$-sources.jar",
     "repository-url" : "https://github.com/itext/itext-java",

--- a/metadata/com.itextpdf/svg/index.json
+++ b/metadata/com.itextpdf/svg/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/com/itextpdf/svg/$version$/svg-$version$-sources.jar",
     "repository-url" : "https://github.com/itext/itext-java",

--- a/metadata/com.microsoft.sqlserver/mssql-jdbc/index.json
+++ b/metadata/com.microsoft.sqlserver/mssql-jdbc/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.2.0.jre11",
     "source-code-url" : "https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/$version$/mssql-jdbc-$version$-sources.jar",
     "repository-url" : "https://github.com/microsoft/mssql-jdbc",

--- a/metadata/com.mysql/mysql-connector-j/index.json
+++ b/metadata/com.mysql/mysql-connector-j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "8.0.31",
     "source-code-url" : "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/$version$/mysql-connector-j-$version$-sources.jar",
     "repository-url" : "https://github.com/mysql/mysql-connector-j",

--- a/metadata/com.nimbusds/nimbus-jose-jwt/index.json
+++ b/metadata/com.nimbusds/nimbus-jose-jwt/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.10",
     "source-code-url" : "https://repo1.maven.org/maven2/com/nimbusds/nimbus-jose-jwt/$version$/nimbus-jose-jwt-$version$-sources.jar",
     "repository-url" : "https://bitbucket.org/connect2id/nimbus-jose-jwt",

--- a/metadata/com.opencsv/opencsv/index.json
+++ b/metadata/com.opencsv/opencsv/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/opencsv/opencsv/$version$/opencsv-$version$-sources.jar",
     "repository-url" : "https://sourceforge.net/p/opencsv/source/",

--- a/metadata/com.rabbitmq/amqp-client/index.json
+++ b/metadata/com.rabbitmq/amqp-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.12.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/$version$/amqp-client-$version$-sources.jar",
     "repository-url" : "https://github.com/rabbitmq/rabbitmq-java-client",

--- a/metadata/com.squareup.okhttp3/mockwebserver/index.json
+++ b/metadata/com.squareup.okhttp3/mockwebserver/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.12.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/okhttp3/mockwebserver/$version$/mockwebserver-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okhttp",

--- a/metadata/com.squareup.okhttp3/okhttp/index.json
+++ b/metadata/com.squareup.okhttp3/okhttp/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.8.0",
     "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/$version$/okhttp-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okhttp",

--- a/metadata/com.squareup.okio/okio-jvm/index.json
+++ b/metadata/com.squareup.okio/okio-jvm/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/squareup/okio/okio-jvm/$version$/okio-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okio",

--- a/metadata/com.squareup.okio/okio/index.json
+++ b/metadata/com.squareup.okio/okio/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.17.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/squareup/okio/okio/$version$/okio-$version$-sources.jar",
     "repository-url" : "https://github.com/square/okio",

--- a/metadata/com.sun.istack/istack-commons-runtime/index.json
+++ b/metadata/com.sun.istack/istack-commons-runtime/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/sun/istack/istack-commons-runtime/$version$/istack-commons-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jaxb-istack-commons",

--- a/metadata/com.sun.mail/jakarta.mail/index.json
+++ b/metadata/com.sun.mail/jakarta.mail/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "com.sun.mail",
       "jakarta"

--- a/metadata/com.typesafe/config/index.json
+++ b/metadata/com.typesafe/config/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.4.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/typesafe/config/1.4.2/config-1.4.2-sources.jar",
     "repository-url" : "https://github.com/lightbend/config",

--- a/metadata/com.vaadin.external.google/android-json/index.json
+++ b/metadata/com.vaadin.external.google/android-json/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "0.0.20131108.vaadin1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/com/vaadin/external/google/android-json/$version$/android-json-$version$-sources.jar",
     "repository-url" : "http://developer.android.com/sdk/",

--- a/metadata/com.zaxxer/HikariCP/index.json
+++ b/metadata/com.zaxxer/HikariCP/index.json
@@ -52,6 +52,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/com/zaxxer/HikariCP/$version$/HikariCP-$version$-sources.jar",
     "repository-url" : "https://github.com/brettwooldridge/HikariCP",

--- a/metadata/commons-cli/commons-cli/index.json
+++ b/metadata/commons-cli/commons-cli/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/$version$/commons-cli-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-cli",

--- a/metadata/commons-codec/commons-codec/index.json
+++ b/metadata/commons-codec/commons-codec/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/$version$/commons-codec-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-codec",

--- a/metadata/commons-fileupload/commons-fileupload/index.json
+++ b/metadata/commons-fileupload/commons-fileupload/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/commons-fileupload/commons-fileupload/$version$/commons-fileupload-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-fileupload",

--- a/metadata/commons-io/commons-io/index.json
+++ b/metadata/commons-io/commons-io/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.17.0",
     "source-code-url" : "https://repo1.maven.org/maven2/commons-io/commons-io/$version$/commons-io-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-io",

--- a/metadata/commons-logging/commons-logging/index.json
+++ b/metadata/commons-logging/commons-logging/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2",
     "source-code-url" : "https://repo1.maven.org/maven2/commons-logging/commons-logging/$version$/commons-logging-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-logging",

--- a/metadata/dev.langchain4j/langchain4j/index.json
+++ b/metadata/dev.langchain4j/langchain4j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.16.0",
     "source-code-url" : "https://repo1.maven.org/maven2/dev/langchain4j/langchain4j/$version$/langchain4j-$version$-sources.jar",
     "repository-url" : "https://github.com/langchain4j/langchain4j",

--- a/metadata/io.dropwizard.metrics/metrics-core/index.json
+++ b/metadata/io.dropwizard.metrics/metrics-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.12.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-core/$version$/metrics-core-$version$-sources.jar",
     "repository-url" : "https://github.com/dropwizard/metrics",

--- a/metadata/io.github.java-diff-utils/java-diff-utils/index.json
+++ b/metadata/io.github.java-diff-utils/java-diff-utils/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.12",
     "source-code-url" : "https://repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/$version$/java-diff-utils-$version$-sources.jar",
     "repository-url" : "https://github.com/java-diff-utils/java-diff-utils",

--- a/metadata/io.github.x-stream/mxparser/index.json
+++ b/metadata/io.github.x-stream/mxparser/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2.2",
     "source-code-url" : "https://repo1.maven.org/maven2/io/github/x-stream/mxparser/$version$/mxparser-$version$-sources.jar",
     "repository-url" : "https://github.com/x-stream/mxparser",

--- a/metadata/io.grpc/grpc-context/index.json
+++ b/metadata/io.grpc/grpc-context/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.57.0",
     "source-code-url" : "https://github.com/grpc/grpc-java/tree/v$version$/api/src/context/java",
     "repository-url" : "https://github.com/grpc/grpc-java",

--- a/metadata/io.grpc/grpc-core/index.json
+++ b/metadata/io.grpc/grpc-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "override" : true,
     "metadata-version" : "1.69.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-core/$version$/grpc-core-$version$-sources.jar",

--- a/metadata/io.grpc/grpc-netty/index.json
+++ b/metadata/io.grpc/grpc-netty/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "override" : true,
     "metadata-version" : "1.51.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/grpc/grpc-netty/$version$/grpc-netty-$version$-sources.jar",

--- a/metadata/io.jsonwebtoken/jjwt-gson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-gson/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "0.12.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-gson/$version$/jjwt-gson-$version$-sources.jar",
     "repository-url" : "https://github.com/jwtk/jjwt",

--- a/metadata/io.jsonwebtoken/jjwt-jackson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-jackson/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "0.12.7",
     "test-version" : "0.12.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/jsonwebtoken/jjwt-jackson/$version$/jjwt-jackson-$version$-sources.jar",

--- a/metadata/io.jsonwebtoken/jjwt-orgjson/index.json
+++ b/metadata/io.jsonwebtoken/jjwt-orgjson/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "io.jsonwebtoken"
     ],

--- a/metadata/io.lettuce/lettuce-core/index.json
+++ b/metadata/io.lettuce/lettuce-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.1.10.RELEASE",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/lettuce/lettuce-core/$version$/lettuce-core-$version$-sources.jar",
     "repository-url" : "https://github.com/redis/lettuce",

--- a/metadata/io.micrometer/context-propagation/index.json
+++ b/metadata/io.micrometer/context-propagation/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/micrometer/context-propagation/$version$/context-propagation-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/context-propagation",

--- a/metadata/io.micrometer/micrometer-commons/index.json
+++ b/metadata/io.micrometer/micrometer-commons/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.16.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/micrometer/micrometer-commons/$version$/micrometer-commons-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/micrometer",

--- a/metadata/io.micrometer/micrometer-jakarta9/index.json
+++ b/metadata/io.micrometer/micrometer-jakarta9/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.16.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/micrometer/micrometer-jakarta9/$version$/micrometer-jakarta9-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/micrometer",

--- a/metadata/io.micrometer/micrometer-observation/index.json
+++ b/metadata/io.micrometer/micrometer-observation/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.16.4",
     "source-code-url" : "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/$version$/micrometer-observation-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/micrometer",

--- a/metadata/io.micrometer/micrometer-registry-prometheus/index.json
+++ b/metadata/io.micrometer/micrometer-registry-prometheus/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.16.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/micrometer/micrometer-registry-prometheus/$version$/micrometer-registry-prometheus-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/micrometer",

--- a/metadata/io.micrometer/micrometer-tracing/index.json
+++ b/metadata/io.micrometer/micrometer-tracing/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/micrometer/micrometer-tracing/$version$/micrometer-tracing-$version$-sources.jar",
     "repository-url" : "https://github.com/micrometer-metrics/tracing",

--- a/metadata/io.nats/jnats/index.json
+++ b/metadata/io.nats/jnats/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.16.11",
     "source-code-url" : "https://repo1.maven.org/maven2/io/nats/jnats/$version$/jnats-$version$-sources.jar",
     "repository-url" : "https://github.com/nats-io/nats.java",

--- a/metadata/io.netty/netty-buffer/index.json
+++ b/metadata/io.netty/netty-buffer/index.json
@@ -1,7 +1,6 @@
 [
   {
     "latest": true,
-    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-buffer/index.json
+++ b/metadata/io.netty/netty-buffer/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-codec-dns/index.json
+++ b/metadata/io.netty/netty-codec-dns/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.79.Final",
     "test-version" : "4.1.74.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec-dns/$version$/netty-codec-dns-$version$-sources.jar",

--- a/metadata/io.netty/netty-codec-http/index.json
+++ b/metadata/io.netty/netty-codec-http/index.json
@@ -1,7 +1,6 @@
 [
   {
     "latest": true,
-    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-codec-http/index.json
+++ b/metadata/io.netty/netty-codec-http/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-codec-http2/index.json
+++ b/metadata/io.netty/netty-codec-http2/index.json
@@ -1,7 +1,6 @@
 [
   {
     "latest": true,
-    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-codec-http2/index.json
+++ b/metadata/io.netty/netty-codec-http2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-codec-socks/index.json
+++ b/metadata/io.netty/netty-codec-socks/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.79.Final",
     "test-version" : "4.1.60.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/io/netty/netty-codec-socks/4.1.79.Final/netty-codec-socks-4.1.79.Final-sources.jar",

--- a/metadata/io.netty/netty-codec/index.json
+++ b/metadata/io.netty/netty-codec/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.42.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-codec/$version$/netty-codec-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-common/index.json
+++ b/metadata/io.netty/netty-common/index.json
@@ -31,6 +31,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "override" : true,
     "metadata-version" : "4.1.115.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-common/$version$/netty-common-$version$-sources.jar",

--- a/metadata/io.netty/netty-handler-proxy/index.json
+++ b/metadata/io.netty/netty-handler-proxy/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.60.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-handler-proxy/4.1.60.Final/netty-handler-proxy-4.1.60.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-handler/index.json
+++ b/metadata/io.netty/netty-handler/index.json
@@ -1,7 +1,6 @@
 [
   {
     "latest": true,
-    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-handler/index.json
+++ b/metadata/io.netty/netty-handler/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-resolver-dns-classes-macos/index.json
+++ b/metadata/io.netty/netty-resolver-dns-classes-macos/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.74.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver-dns-classes-macos/4.1.74.Final/netty-resolver-dns-classes-macos-4.1.74.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-resolver-dns/index.json
+++ b/metadata/io.netty/netty-resolver-dns/index.json
@@ -1,7 +1,6 @@
 [
   {
     "latest": true,
-    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-resolver-dns/index.json
+++ b/metadata/io.netty/netty-resolver-dns/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "override": true,
     "metadata-version": "4.1.80.Final",
     "tested-versions": [

--- a/metadata/io.netty/netty-resolver/index.json
+++ b/metadata/io.netty/netty-resolver/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.0.Alpha2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-resolver/$version$/netty-resolver-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-tcnative-classes/index.json
+++ b/metadata/io.netty/netty-tcnative-classes/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.48.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-tcnative-classes/$version$/netty-tcnative-classes-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty-tcnative",

--- a/metadata/io.netty/netty-transport-classes-epoll/index.json
+++ b/metadata/io.netty/netty-transport-classes-epoll/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.99.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-classes-epoll/$version$/netty-transport-classes-epoll-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-transport-native-epoll/index.json
+++ b/metadata/io.netty/netty-transport-native-epoll/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.42.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-epoll/4.1.42.Final/netty-transport-native-epoll-4.1.42.Final-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-transport-native-unix-common/index.json
+++ b/metadata/io.netty/netty-transport-native-unix-common/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.57.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport-native-unix-common/$version$/netty-transport-native-unix-common-$version$-sources.jar",
     "repository-url" : "https://github.com/netty/netty",

--- a/metadata/io.netty/netty-transport/index.json
+++ b/metadata/io.netty/netty-transport/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "override" : true,
     "metadata-version" : "4.1.115.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/netty/netty-transport/$version$/netty-transport-$version$-sources.jar",

--- a/metadata/io.opentelemetry/opentelemetry-api-incubator/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-api-incubator/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.56.0-alpha",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-api-incubator/$version$/opentelemetry-api-incubator-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-api/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.19.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-api/$version$/opentelemetry-api-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-common/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-common/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.56.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-common/$version$/opentelemetry-common-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-context/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-context/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.19.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-context/$version$/opentelemetry-context-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-jaeger/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.20.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-jaeger/$version$/opentelemetry-exporter-jaeger-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-logging/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.20.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/opentelemetry/opentelemetry-exporter-logging/$version$/opentelemetry-exporter-logging-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-otlp/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "override" : true,
     "metadata-version" : "1.19.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-otlp/$version$/opentelemetry-exporter-otlp-$version$-sources.jar",

--- a/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-exporter-zipkin/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.20.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-exporter-zipkin/$version$/opentelemetry-exporter-zipkin-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-metrics/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.59.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-metrics/$version$/opentelemetry-sdk-metrics-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
+++ b/metadata/io.opentelemetry/opentelemetry-sdk-trace/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.55.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-sdk-trace/$version$/opentelemetry-sdk-trace-$version$-sources.jar",
     "repository-url" : "https://github.com/open-telemetry/opentelemetry-java",

--- a/metadata/io.projectreactor.netty/reactor-netty-core/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/netty/reactor-netty-core/$version$/reactor-netty-core-$version$-sources.jar",
     "repository-url" : "https://github.com/reactor/reactor-netty",

--- a/metadata/io.projectreactor.netty/reactor-netty-http/index.json
+++ b/metadata/io.projectreactor.netty/reactor-netty-http/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.39",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/netty/reactor-netty-http/$version$/reactor-netty-http-$version$-sources.jar",
     "repository-url" : "https://github.com/reactor/reactor-netty",

--- a/metadata/io.projectreactor/reactor-core/index.json
+++ b/metadata/io.projectreactor/reactor-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.5.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/io/projectreactor/reactor-core/$version$/reactor-core-$version$-sources.jar",
     "repository-url" : "https://github.com/reactor/reactor-core",

--- a/metadata/io.r2dbc/r2dbc-spi/index.json
+++ b/metadata/io.r2dbc/r2dbc-spi/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0.RELEASE",
     "source-code-url" : "https://repo1.maven.org/maven2/io/r2dbc/r2dbc-spi/$version$/r2dbc-spi-$version$-sources.jar",
     "repository-url" : "https://github.com/r2dbc/r2dbc-spi",

--- a/metadata/io.undertow/undertow-core/index.json
+++ b/metadata/io.undertow/undertow-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.4.0.Final",
     "tested-versions" : [
       "2.4.0.Final",

--- a/metadata/io.zipkin.reporter2/zipkin-reporter/index.json
+++ b/metadata/io.zipkin.reporter2/zipkin-reporter/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.4.0",
     "source-code-url" : "https://repo1.maven.org/maven2/io/zipkin/reporter2/zipkin-reporter/$version$/zipkin-reporter-$version$-sources.jar",
     "repository-url" : "https://github.com/openzipkin/zipkin-reporter-java",

--- a/metadata/jakarta.activation/jakarta.activation-api/index.json
+++ b/metadata/jakarta.activation/jakarta.activation-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/activation/jakarta.activation-api/$version$/jakarta.activation-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/jaf-api",

--- a/metadata/jakarta.annotation/jakarta.annotation-api/index.json
+++ b/metadata/jakarta.annotation/jakarta.annotation-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/$version$/jakarta.annotation-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/common-annotations-api",

--- a/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.cdi-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.cdi-api/$version$/jakarta.enterprise.cdi-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/cdi",

--- a/metadata/jakarta.enterprise/jakarta.enterprise.lang-model/index.json
+++ b/metadata/jakarta.enterprise/jakarta.enterprise.lang-model/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.0.Alpha1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/enterprise/jakarta.enterprise.lang-model/$version$/jakarta.enterprise.lang-model-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/cdi",

--- a/metadata/jakarta.inject/jakarta.inject-api/index.json
+++ b/metadata/jakarta.inject/jakarta.inject-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/inject/jakarta.inject-api/$version$/jakarta.inject-api-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/injection-api",

--- a/metadata/jakarta.interceptor/jakarta.interceptor-api/index.json
+++ b/metadata/jakarta.interceptor/jakarta.interceptor-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/interceptor/jakarta.interceptor-api/$version$/jakarta.interceptor-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/interceptors",

--- a/metadata/jakarta.mail/jakarta.mail-api/index.json
+++ b/metadata/jakarta.mail/jakarta.mail-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/mail/jakarta.mail-api/$version$/jakarta.mail-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/mail-api",

--- a/metadata/jakarta.persistence/jakarta.persistence-api/index.json
+++ b/metadata/jakarta.persistence/jakarta.persistence-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.0-M3",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/persistence/jakarta.persistence-api/$version$/jakarta.persistence-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/persistence",

--- a/metadata/jakarta.servlet/jakarta.servlet-api/index.json
+++ b/metadata/jakarta.servlet/jakarta.servlet-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.2.0-M1",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/$version$/jakarta.servlet-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/servlet",

--- a/metadata/jakarta.transaction/jakarta.transaction-api/index.json
+++ b/metadata/jakarta.transaction/jakarta.transaction-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.3.1",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/transaction/jakarta.transaction-api/$version$/jakarta.transaction-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/transactions",

--- a/metadata/jakarta.validation/jakarta.validation-api/index.json
+++ b/metadata/jakarta.validation/jakarta.validation-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/jakarta/validation/jakarta.validation-api/$version$/jakarta.validation-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/validation",

--- a/metadata/jakarta.websocket/jakarta.websocket-api/index.json
+++ b/metadata/jakarta.websocket/jakarta.websocket-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-api/$version$/jakarta.websocket-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/websocket",

--- a/metadata/jakarta.websocket/jakarta.websocket-client-api/index.json
+++ b/metadata/jakarta.websocket/jakarta.websocket-client-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/websocket/jakarta.websocket-client-api/$version$/jakarta.websocket-client-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/websocket",

--- a/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
+++ b/metadata/jakarta.ws.rs/jakarta.ws.rs-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/ws/rs/jakarta.ws.rs-api/$version$/jakarta.ws.rs-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/rest",

--- a/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
+++ b/metadata/jakarta.xml.bind/jakarta.xml.bind-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.0-M1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/jakarta/xml/bind/jakarta.xml.bind-api/$version$/jakarta.xml.bind-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jakartaee/jaxb-api",

--- a/metadata/javax.annotation/javax.annotation-api/index.json
+++ b/metadata/javax.annotation/javax.annotation-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2",
     "source-code-url" : "https://repo1.maven.org/maven2/javax/annotation/javax.annotation-api/$version$/javax.annotation-api-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/javax.annotation",

--- a/metadata/javax.cache/cache-api/index.json
+++ b/metadata/javax.cache/cache-api/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.1",
     "source-code-url" : "https://repo1.maven.org/maven2/javax/cache/cache-api/$version$/cache-api-$version$-sources.jar",
     "repository-url" : "https://github.com/jsr107/jsr107spec",

--- a/metadata/joda-time/joda-time/index.json
+++ b/metadata/joda-time/joda-time/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.9.9",
     "source-code-url" : "https://repo1.maven.org/maven2/joda-time/joda-time/$version$/joda-time-$version$-sources.jar",
     "repository-url" : "https://github.com/JodaOrg/joda-time",

--- a/metadata/junit/junit/index.json
+++ b/metadata/junit/junit/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.13.2",
     "source-code-url" : "https://repo1.maven.org/maven2/junit/junit/$version$/junit-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit4",

--- a/metadata/log4j/log4j/index.json
+++ b/metadata/log4j/log4j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.apache.log4j"
     ],

--- a/metadata/mysql/mysql-connector-java/index.json
+++ b/metadata/mysql/mysql-connector-java/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "mysql"
     ],

--- a/metadata/net.bytebuddy/byte-buddy-agent/index.json
+++ b/metadata/net.bytebuddy/byte-buddy-agent/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.11.17",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-agent/$version$/byte-buddy-agent-$version$-sources.jar",
     "repository-url" : "https://github.com/raphw/byte-buddy",

--- a/metadata/net.java.dev.jna/jna/index.json
+++ b/metadata/net.java.dev.jna/jna/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "com.sun.jna"
     ],

--- a/metadata/net.minidev/accessors-smart/index.json
+++ b/metadata/net.minidev/accessors-smart/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2",
     "source-code-url" : "https://repo1.maven.org/maven2/net/minidev/accessors-smart/$version$/accessors-smart-$version$-sources.jar",
     "repository-url" : "https://github.com/netplex/json-smart-v2",

--- a/metadata/net.minidev/json-smart/index.json
+++ b/metadata/net.minidev/json-smart/index.json
@@ -16,6 +16,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/net/minidev/json-smart/$version$/json-smart-$version$-sources.jar",
     "repository-url" : "https://github.com/netplex/json-smart-v2",

--- a/metadata/org.antlr/antlr-runtime/index.json
+++ b/metadata/org.antlr/antlr-runtime/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.5.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/antlr/antlr-runtime/$version$/antlr-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/antlr/antlr3",

--- a/metadata/org.antlr/antlr4-runtime/index.json
+++ b/metadata/org.antlr/antlr4-runtime/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.10",
     "source-code-url" : "https://repo1.maven.org/maven2/org/antlr/antlr4-runtime/$version$/antlr4-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/antlr/antlr4",

--- a/metadata/org.apache.activemq/activemq-broker/index.json
+++ b/metadata/org.apache.activemq/activemq-broker/index.json
@@ -23,6 +23,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-broker/$version$/activemq-broker-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/activemq",

--- a/metadata/org.apache.activemq/activemq-client/index.json
+++ b/metadata/org.apache.activemq/activemq-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/activemq-client/$version$/activemq-client-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/activemq",

--- a/metadata/org.apache.activemq/artemis-jms-client/index.json
+++ b/metadata/org.apache.activemq/artemis-jms-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.36.0",
     "test-version" : "2.28.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/activemq/artemis-jms-client/$version$/artemis-jms-client-$version$-sources.jar",

--- a/metadata/org.apache.avro/avro/index.json
+++ b/metadata/org.apache.avro/avro/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.12.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/avro/avro/$version$/avro-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/avro",

--- a/metadata/org.apache.commons/commons-collections4/index.json
+++ b/metadata/org.apache.commons/commons-collections4/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-collections4/$version$/commons-collections4-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-collections",

--- a/metadata/org.apache.commons/commons-compress/index.json
+++ b/metadata/org.apache.commons/commons-compress/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.23.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/$version$/commons-compress-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-compress",

--- a/metadata/org.apache.commons/commons-dbcp2/index.json
+++ b/metadata/org.apache.commons/commons-dbcp2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.apache.commons"
     ],

--- a/metadata/org.apache.commons/commons-lang3/index.json
+++ b/metadata/org.apache.commons/commons-lang3/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.19.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/$version$/commons-lang3-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-lang",

--- a/metadata/org.apache.commons/commons-math/index.json
+++ b/metadata/org.apache.commons/commons-math/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-math/$version$/commons-math-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/commons-math",

--- a/metadata/org.apache.commons/commons-pool2/index.json
+++ b/metadata/org.apache.commons/commons-pool2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.apache.commons"
     ],

--- a/metadata/org.apache.commons/commons-text/index.json
+++ b/metadata/org.apache.commons/commons-text/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.9",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/commons/commons-text/$version$/commons-text-$version$-sources.jar",
     "repository-url" : "https://gitbox.apache.org/repos/asf?p=commons-text.git",

--- a/metadata/org.apache.curator/curator-client/index.json
+++ b/metadata/org.apache.curator/curator-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.7.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/curator/curator-client/$version$/curator-client-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/curator",

--- a/metadata/org.apache.curator/curator-recipes/index.json
+++ b/metadata/org.apache.curator/curator-recipes/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.6.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/curator/curator-recipes/$version$/curator-recipes-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/curator",

--- a/metadata/org.apache.httpcomponents.client5/httpclient5/index.json
+++ b/metadata/org.apache.httpcomponents.client5/httpclient5/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/$version$/httpclient5-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-client",

--- a/metadata/org.apache.httpcomponents.core5/httpcore5-h2/index.json
+++ b/metadata/org.apache.httpcomponents.core5/httpcore5-h2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/$version$/httpcore5-h2-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/metadata/org.apache.httpcomponents.core5/httpcore5/index.json
+++ b/metadata/org.apache.httpcomponents.core5/httpcore5/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/$version$/httpcore5-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/metadata/org.apache.httpcomponents/httpclient/index.json
+++ b/metadata/org.apache.httpcomponents/httpclient/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.5.14",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/$version$/httpclient-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-client",

--- a/metadata/org.apache.httpcomponents/httpcore/index.json
+++ b/metadata/org.apache.httpcomponents/httpcore/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.4.16",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpcore/$version$/httpcore-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/httpcomponents-core",

--- a/metadata/org.apache.kafka/kafka-clients/index.json
+++ b/metadata/org.apache.kafka/kafka-clients/index.json
@@ -30,6 +30,7 @@
   },
   {
     "latest": true,
+    "auto-update": true,
     "metadata-version": "4.2.1",
     "source-code-url": "https://repo.maven.apache.org/maven2/org/apache/kafka/kafka-clients/$version$/kafka-clients-$version$-sources.jar",
     "repository-url": "https://github.com/apache/kafka",

--- a/metadata/org.apache.kafka/kafka-streams/index.json
+++ b/metadata/org.apache.kafka/kafka-streams/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.6.0",
     "tested-versions" : [
       "3.6.0",

--- a/metadata/org.apache.logging.log4j/log4j-slf4j2-impl/index.json
+++ b/metadata/org.apache.logging.log4j/log4j-slf4j2-impl/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.24.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j2-impl/$version$/log4j-slf4j2-impl-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/logging-log4j2",

--- a/metadata/org.apache.pulsar/bouncy-castle-bc/index.json
+++ b/metadata/org.apache.pulsar/bouncy-castle-bc/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pulsar/bouncy-castle-bc/$version$/bouncy-castle-bc-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/pulsar",

--- a/metadata/org.apache.pulsar/pulsar-client-api/index.json
+++ b/metadata/org.apache.pulsar/pulsar-client-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/pulsar/pulsar-client-api/$version$/pulsar-client-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/pulsar",

--- a/metadata/org.apache.santuario/xmlsec/index.json
+++ b/metadata/org.apache.santuario/xmlsec/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages" : [
       "org.apache"
     ],

--- a/metadata/org.apache.tomcat.embed/tomcat-embed-core/index.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-core/index.json
@@ -101,6 +101,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "11.0.18",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/$version$/tomcat-embed-core-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/tomcat",

--- a/metadata/org.apache.tomcat.embed/tomcat-embed-el/index.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-el/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.0.83",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/$version$/tomcat-embed-el-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/tomcat",

--- a/metadata/org.apache.tomcat.embed/tomcat-embed-websocket/index.json
+++ b/metadata/org.apache.tomcat.embed/tomcat-embed-websocket/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.0.83",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-websocket/$version$/tomcat-embed-websocket-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/tomcat",

--- a/metadata/org.apache.tomcat/tomcat-jdbc/index.json
+++ b/metadata/org.apache.tomcat/tomcat-jdbc/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "10.1.14",
     "tested-versions" : [
       "10.1.14",

--- a/metadata/org.apache.yetus/audience-annotations/index.json
+++ b/metadata/org.apache.yetus/audience-annotations/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "0.14.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apache/yetus/audience-annotations/$version$/audience-annotations-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/yetus",

--- a/metadata/org.apache.zookeeper/zookeeper-jute/index.json
+++ b/metadata/org.apache.zookeeper/zookeeper-jute/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.8.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/$version$/zookeeper-jute-$version$-sources.jar",
     "repository-url" : "https://gitbox.apache.org/repos/asf/zookeeper.git",

--- a/metadata/org.apache.zookeeper/zookeeper/index.json
+++ b/metadata/org.apache.zookeeper/zookeeper/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.8.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/$version$/zookeeper-$version$-sources.jar",
     "repository-url" : "https://github.com/apache/zookeeper",

--- a/metadata/org.apiguardian/apiguardian-api/index.json
+++ b/metadata/org.apiguardian/apiguardian-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/apiguardian/apiguardian-api/$version$/apiguardian-api-$version$-sources.jar",
     "repository-url" : "https://github.com/apiguardian-team/apiguardian",

--- a/metadata/org.aspectj/aspectjweaver/index.json
+++ b/metadata/org.aspectj/aspectjweaver/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.9.7",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7-sources.jar",
     "repository-url" : "https://github.com/eclipse-aspectj/aspectj",

--- a/metadata/org.attoparser/attoparser/index.json
+++ b/metadata/org.attoparser/attoparser/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.8.RELEASE",
     "source-code-url" : "https://repo1.maven.org/maven2/org/attoparser/attoparser/$version$/attoparser-$version$-sources.jar",
     "repository-url" : "https://github.com/attoparser/attoparser",

--- a/metadata/org.awaitility/awaitility/index.json
+++ b/metadata/org.awaitility/awaitility/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.2.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/awaitility/awaitility/$version$/awaitility-$version$-sources.jar",
     "repository-url" : "https://github.com/awaitility/awaitility",

--- a/metadata/org.bouncycastle/bcpkix-jdk15on/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk15on/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.bouncycastle"
     ],

--- a/metadata/org.bouncycastle/bcpkix-jdk15to18/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk15to18/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.77",
     "source-code-url" : "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk15to18/$version$/bcpkix-jdk15to18-$version$-sources.jar",
     "repository-url" : "https://github.com/bcgit/bc-java",

--- a/metadata/org.bouncycastle/bcpkix-jdk18on/index.json
+++ b/metadata/org.bouncycastle/bcpkix-jdk18on/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.77",
     "source-code-url" : "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/$version$/bcpkix-jdk18on-$version$-sources.jar",
     "repository-url" : "https://github.com/bcgit/bc-java",

--- a/metadata/org.checkerframework/checker-compat-qual/index.json
+++ b/metadata/org.checkerframework/checker-compat-qual/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.5.5",
     "source-code-url" : "https://repo1.maven.org/maven2/org/checkerframework/checker-compat-qual/$version$/checker-compat-qual-$version$-sources.jar",
     "repository-url" : "https://github.com/typetools/checker-framework",

--- a/metadata/org.checkerframework/checker-qual/index.json
+++ b/metadata/org.checkerframework/checker-qual/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.12.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/checkerframework/checker-qual/$version$/checker-qual-$version$-sources.jar",
     "repository-url" : "https://github.com/typetools/checker-framework",

--- a/metadata/org.codehaus.jettison/jettison/index.json
+++ b/metadata/org.codehaus.jettison/jettison/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/codehaus/jettison/jettison/$version$/jettison-$version$-sources.jar",
     "repository-url" : "https://github.com/jettison-json/jettison",

--- a/metadata/org.codehaus.woodstox/stax2-api/index.json
+++ b/metadata/org.codehaus.woodstox/stax2-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.2.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/codehaus/woodstox/stax2-api/$version$/stax2-api-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/stax2-api",

--- a/metadata/org.eclipse.angus/angus-activation/index.json
+++ b/metadata/org.eclipse.angus/angus-activation/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/angus/angus-activation/$version$/angus-activation-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/angus-activation",

--- a/metadata/org.eclipse.angus/angus-mail/index.json
+++ b/metadata/org.eclipse.angus/angus-mail/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/angus/angus-mail/$version$/angus-mail-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/angus-mail",

--- a/metadata/org.eclipse.angus/jakarta.mail/index.json
+++ b/metadata/org.eclipse.angus/jakarta.mail/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "jakarta"
     ],

--- a/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-alpn-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.1.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-alpn-client/$version$/jetty-alpn-client-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-client/index.json
+++ b/metadata/org.eclipse.jetty/jetty-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.1.5",
     "test-version" : "12.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/$version$/jetty-client-$version$-sources.jar",

--- a/metadata/org.eclipse.jetty/jetty-http/index.json
+++ b/metadata/org.eclipse.jetty/jetty-http/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.4.1.v20170120",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/$version$/jetty-http-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-io/index.json
+++ b/metadata/org.eclipse.jetty/jetty-io/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.4.0.RC0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-io/$version$/jetty-io-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-security/index.json
+++ b/metadata/org.eclipse.jetty/jetty-security/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.3.19.v20170502",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-security/$version$/jetty-security-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-server/index.json
+++ b/metadata/org.eclipse.jetty/jetty-server/index.json
@@ -66,6 +66,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.1.10",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/$version$/jetty-server-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-session/index.json
+++ b/metadata/org.eclipse.jetty/jetty-session/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.0.10",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-session/$version$/jetty-session-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jetty/jetty-util/index.json
+++ b/metadata/org.eclipse.jetty/jetty-util/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.0.9",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/$version$/jetty-util-$version$-sources.jar",
     "repository-url" : "https://github.com/jetty/jetty.project",

--- a/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
+++ b/metadata/org.eclipse.jgit/org.eclipse.jgit/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.4.0.202509020913-r",
     "source-code-url" : "https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/$version$/org.eclipse.jgit-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-jgit/jgit",

--- a/metadata/org.eclipse.paho/org.eclipse.paho.client.mqttv3/index.json
+++ b/metadata/org.eclipse.paho/org.eclipse.paho.client.mqttv3/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.eclipse.paho.client.mqttv3"
     ],

--- a/metadata/org.eclipse.paho/org.eclipse.paho.mqttv5.client/index.json
+++ b/metadata/org.eclipse.paho/org.eclipse.paho.mqttv5.client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.eclipse.paho.mqttv5"
     ],

--- a/metadata/org.ehcache/ehcache/index.json
+++ b/metadata/org.ehcache/ehcache/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.ehcache"
     ],

--- a/metadata/org.flywaydb/flyway-core/index.json
+++ b/metadata/org.flywaydb/flyway-core/index.json
@@ -173,6 +173,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.5.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-core/$version$/flyway-core-$version$-sources.jar",
     "repository-url" : "https://github.com/flyway/flyway",

--- a/metadata/org.flywaydb/flyway-database-postgresql/index.json
+++ b/metadata/org.flywaydb/flyway-database-postgresql/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "10.19.0",
     "test-version" : "10.10.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-postgresql/$version$/flyway-database-postgresql-$version$-sources.jar",

--- a/metadata/org.flywaydb/flyway-sqlserver/index.json
+++ b/metadata/org.flywaydb/flyway-sqlserver/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "12.3.0",
     "test-version" : "11.8.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-sqlserver/$version$/flyway-sqlserver-$version$-sources.jar",

--- a/metadata/org.freemarker/freemarker/index.json
+++ b/metadata/org.freemarker/freemarker/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.freemarker",
       "freemarker"

--- a/metadata/org.glassfish.jaxb/jaxb-core/index.json
+++ b/metadata/org.glassfish.jaxb/jaxb-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-core/$version$/jaxb-core-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jaxb-ri",

--- a/metadata/org.glassfish.jaxb/jaxb-runtime/index.json
+++ b/metadata/org.glassfish.jaxb/jaxb-runtime/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/$version$/jaxb-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/eclipse-ee4j/jaxb-ri",

--- a/metadata/org.glassfish.jaxb/txw2/index.json
+++ b/metadata/org.glassfish.jaxb/txw2/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/glassfish/jaxb/txw2/$version$/txw2-$version$-sources.jar",
     "repository-url" : "https://github.com/javaee/jaxb-v2",

--- a/metadata/org.hamcrest/hamcrest-core/index.json
+++ b/metadata/org.hamcrest/hamcrest-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/$version$/hamcrest-core-$version$-sources.jar",
     "repository-url" : "https://github.com/hamcrest/JavaHamcrest",

--- a/metadata/org.hamcrest/hamcrest/index.json
+++ b/metadata/org.hamcrest/hamcrest/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest/$version$/hamcrest-$version$-sources.jar",
     "repository-url" : "https://github.com/hamcrest/JavaHamcrest",

--- a/metadata/org.hdrhistogram/HdrHistogram/index.json
+++ b/metadata/org.hdrhistogram/HdrHistogram/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.HdrHistogram"
     ],

--- a/metadata/org.hibernate.models/hibernate-models/index.json
+++ b/metadata/org.hibernate.models/hibernate-models/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/hibernate/models/hibernate-models/$version$/hibernate-models-$version$-sources.jar",
     "repository-url" : "https://github.com/hibernate/hibernate-models",

--- a/metadata/org.hibernate.orm/hibernate-core/index.json
+++ b/metadata/org.hibernate.orm/hibernate-core/index.json
@@ -12,6 +12,7 @@
       "org.postgresql.Driver"
     ],
     "latest": true,
+    "auto-update": true,
     "metadata-version": "8.0.0.Alpha1",
     "test-version": "7.1.0.Final",
     "tested-versions": [

--- a/metadata/org.hibernate.orm/hibernate-envers/index.json
+++ b/metadata/org.hibernate.orm/hibernate-envers/index.json
@@ -20,6 +20,7 @@
     "documentation-url": "https://repo.maven.apache.org/maven2/org/hibernate/orm/hibernate-envers/$version$/hibernate-envers-$version$-javadoc.jar",
     "description": "Hibernate Envers adds auditing and history tracking to Hibernate ORM entities by recording entity revisions and changes over time. It lets applications query historical versions of audited data and inspect which properties changed in each revision.",
     "latest": true,
+    "auto-update": true,
     "requires": [
       "org.hibernate.orm:hibernate-core"
     ]

--- a/metadata/org.hibernate.reactive/hibernate-reactive-core/index.json
+++ b/metadata/org.hibernate.reactive/hibernate-reactive-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.hibernate.reactive"
     ],

--- a/metadata/org.hibernate.validator/hibernate-validator/index.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/index.json
@@ -25,6 +25,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.1.0.Final",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/hibernate/validator/hibernate-validator/$version$/hibernate-validator-$version$-sources.jar",
     "repository-url" : "https://github.com/hibernate/hibernate-validator",

--- a/metadata/org.hibernate/hibernate-core/index.json
+++ b/metadata/org.hibernate/hibernate-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.1.0.Final",
     "source-code-url" : "https://repo1.maven.org/maven2/org/hibernate/orm/hibernate-core/$version$/hibernate-core-$version$-sources.jar",
     "repository-url" : "https://github.com/hibernate/hibernate-orm",

--- a/metadata/org.hibernate/hibernate-spatial/index.json
+++ b/metadata/org.hibernate/hibernate-spatial/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.hibernate"
     ],

--- a/metadata/org.jboss.logging/jboss-logging/index.json
+++ b/metadata/org.jboss.logging/jboss-logging/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.5.0.Final",
     "tested-versions" : [
       "3.5.0.Final",

--- a/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
+++ b/metadata/org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.jboss",
       "javax.servlet"

--- a/metadata/org.jctools/jctools-core/index.json
+++ b/metadata/org.jctools/jctools-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.jctools"
     ],

--- a/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-daemon-embeddable/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.20",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/$version$/kotlin-daemon-embeddable-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-reflect/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.10",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-reflect/$version$/kotlin-reflect-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-script-runtime/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-script-runtime/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.20",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/$version$/kotlin-script-runtime-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-scripting-common/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-scripting-common/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.21",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/$version$/kotlin-scripting-common-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-scripting-compiler-embeddable/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.21",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/$version$/kotlin-scripting-compiler-embeddable-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-scripting-jvm/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-scripting-jvm/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.3.21",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-jvm/$version$/kotlin-scripting-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib-common/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib-common/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.31",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/$version$/kotlin-stdlib-common-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib-jdk7/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib-jdk7/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.31",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/$version$/kotlin-stdlib-jdk7-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib-jdk8/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib-jdk8/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.31",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/$version$/kotlin-stdlib-jdk8-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
+++ b/metadata/org.jetbrains.kotlin/kotlin-stdlib/index.json
@@ -19,6 +19,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.10",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/$version$/kotlin-stdlib-$version$-sources.jar",
     "repository-url" : "https://github.com/JetBrains/kotlin",

--- a/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-reactive/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/$version$/kotlinx-coroutines-reactive-$version$-sources.jar",
     "repository-url" : "https://github.com/Kotlin/kotlinx.coroutines",

--- a/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-coroutines-reactor/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/$version$/kotlinx-coroutines-reactor-$version$-sources.jar",
     "repository-url" : "https://github.com/Kotlin/kotlinx.coroutines",

--- a/metadata/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/index.json
+++ b/metadata/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.9.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/$version$/kotlinx-serialization-core-jvm-$version$-sources.jar",
     "repository-url" : "https://github.com/Kotlin/kotlinx.serialization",

--- a/metadata/org.jetbrains/annotations/index.json
+++ b/metadata/org.jetbrains/annotations/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [ "org.jetbrains" ],
     "metadata-version": "13.0",
     "source-code-url": "https://repo1.maven.org/maven2/org/jetbrains/annotations/$version$/annotations-$version$-sources.jar",

--- a/metadata/org.jline/jline-console/index.json
+++ b/metadata/org.jline/jline-console/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.28.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/jline/jline-console/$version$/jline-console-$version$-sources.jar",
     "repository-url" : "https://github.com/jline/jline3",

--- a/metadata/org.jline/jline-terminal/index.json
+++ b/metadata/org.jline/jline-terminal/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.jline",
       "org.fusesource"

--- a/metadata/org.jline/jline/index.json
+++ b/metadata/org.jline/jline/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.fusesource",
       "org.jline"

--- a/metadata/org.jooq/jooq/index.json
+++ b/metadata/org.jooq/jooq/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.20.0",
     "test-version" : "3.18.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jooq/jooq/$version$/jooq-$version$-sources.jar",

--- a/metadata/org.json/json/index.json
+++ b/metadata/org.json/json/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "20220320",
     "source-code-url" : "https://repo1.maven.org/maven2/org/json/json/$version$/json-$version$-sources.jar",
     "repository-url" : "https://github.com/stleary/JSON-java",

--- a/metadata/org.jspecify/jspecify/index.json
+++ b/metadata/org.jspecify/jspecify/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/jspecify/jspecify/$version$/jspecify-$version$-sources.jar",
     "repository-url" : "https://github.com/jspecify/jspecify",

--- a/metadata/org.junit.jupiter/junit-jupiter-api/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-api/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/$version$/junit-jupiter-api-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/metadata/org.junit.jupiter/junit-jupiter-engine/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-engine/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/$version$/junit-jupiter-engine-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/metadata/org.junit.jupiter/junit-jupiter-params/index.json
+++ b/metadata/org.junit.jupiter/junit-jupiter-params/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.9.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/$version$/junit-jupiter-params-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit5",

--- a/metadata/org.junit.platform/junit-platform-commons/index.json
+++ b/metadata/org.junit.platform/junit-platform-commons/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.8.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/$version$/junit-platform-commons-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit5",

--- a/metadata/org.junit.platform/junit-platform-engine/index.json
+++ b/metadata/org.junit.platform/junit-platform-engine/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.10.4",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/$version$/junit-platform-engine-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/metadata/org.junit.platform/junit-platform-launcher/index.json
+++ b/metadata/org.junit.platform/junit-platform-launcher/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.9.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-launcher/$version$/junit-platform-launcher-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/metadata/org.junit.platform/junit-platform-reporting/index.json
+++ b/metadata/org.junit.platform/junit-platform-reporting/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.9.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-reporting/$version$/junit-platform-reporting-$version$-sources.jar",
     "repository-url" : "https://github.com/junit-team/junit-framework",

--- a/metadata/org.liquibase/liquibase-core/index.json
+++ b/metadata/org.liquibase/liquibase-core/index.json
@@ -92,6 +92,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/liquibase/liquibase-core/$version$/liquibase-core-$version$-sources.jar",
     "repository-url" : "https://github.com/liquibase/liquibase",

--- a/metadata/org.mariadb.jdbc/mariadb-java-client/index.json
+++ b/metadata/org.mariadb.jdbc/mariadb-java-client/index.json
@@ -36,6 +36,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.5.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/$version$/mariadb-java-client-$version$-sources.jar",
     "repository-url" : "https://github.com/mariadb-corporation/mariadb-connector-j",

--- a/metadata/org.mariadb/r2dbc-mariadb/index.json
+++ b/metadata/org.mariadb/r2dbc-mariadb/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/mariadb/r2dbc-mariadb/$version$/r2dbc-mariadb-$version$-sources.jar",
     "repository-url" : "https://github.com/mariadb-corporation/mariadb-connector-r2dbc",

--- a/metadata/org.mockito/mockito-core/index.json
+++ b/metadata/org.mockito/mockito-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.mockito"
     ],

--- a/metadata/org.mockito/mockito-junit-jupiter/index.json
+++ b/metadata/org.mockito/mockito-junit-jupiter/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.5.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mockito/mockito-junit-jupiter/$version$/mockito-junit-jupiter-$version$-sources.jar",
     "repository-url" : "https://github.com/mockito/mockito",

--- a/metadata/org.mongodb/bson/index.json
+++ b/metadata/org.mongodb/bson/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.11.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/bson/$version$/bson-$version$-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/metadata/org.mongodb/mongodb-driver-core/index.json
+++ b/metadata/org.mongodb/mongodb-driver-core/index.json
@@ -19,6 +19,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/mongodb/mongodb-driver-core/$version$/mongodb-driver-core-$version$-sources.jar",
     "repository-url" : "https://github.com/mongodb/mongo-java-driver",

--- a/metadata/org.neo4j.bolt/neo4j-bolt-connection-netty/index.json
+++ b/metadata/org.neo4j.bolt/neo4j-bolt-connection-netty/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/neo4j/bolt/neo4j-bolt-connection-netty/$version$/neo4j-bolt-connection-netty-$version$-sources.jar",
     "repository-url" : "https://github.com/neo4j/bolt-connection-java",

--- a/metadata/org.neo4j.bolt/neo4j-bolt-connection-pooled/index.json
+++ b/metadata/org.neo4j.bolt/neo4j-bolt-connection-pooled/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/neo4j/bolt/neo4j-bolt-connection-pooled/$version$/neo4j-bolt-connection-pooled-$version$-sources.jar",
     "repository-url" : "https://github.com/neo4j/bolt-connection-java",

--- a/metadata/org.neo4j.bolt/neo4j-bolt-connection-routed/index.json
+++ b/metadata/org.neo4j.bolt/neo4j-bolt-connection-routed/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/neo4j/bolt/neo4j-bolt-connection-routed/$version$/neo4j-bolt-connection-routed-$version$-sources.jar",
     "repository-url" : "https://github.com/neo4j/bolt-connection-java",

--- a/metadata/org.neo4j.bolt/neo4j-bolt-connection/index.json
+++ b/metadata/org.neo4j.bolt/neo4j-bolt-connection/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/neo4j/bolt/neo4j-bolt-connection/$version$/neo4j-bolt-connection-$version$-sources.jar",
     "repository-url" : "https://github.com/neo4j/bolt-connection-java",

--- a/metadata/org.neo4j.driver/neo4j-java-driver/index.json
+++ b/metadata/org.neo4j.driver/neo4j-java-driver/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.28.5",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/neo4j/driver/neo4j-java-driver/$version$/neo4j-java-driver-$version$-sources.jar",
     "repository-url" : "https://github.com/neo4j/neo4j-java-driver",

--- a/metadata/org.objenesis/objenesis/index.json
+++ b/metadata/org.objenesis/objenesis/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/objenesis/objenesis/$version$/objenesis-$version$-sources.jar",
     "repository-url" : "https://github.com/easymock/objenesis",

--- a/metadata/org.opengauss/opengauss-jdbc/index.json
+++ b/metadata/org.opengauss/opengauss-jdbc/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.opengauss"
     ],

--- a/metadata/org.opentest4j/opentest4j/index.json
+++ b/metadata/org.opentest4j/opentest4j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.2.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/opentest4j/opentest4j/$version$/opentest4j-$version$-sources.jar",
     "repository-url" : "https://github.com/ota4j-team/opentest4j",

--- a/metadata/org.osgi/org.osgi.annotation.bundle/index.json
+++ b/metadata/org.osgi/org.osgi.annotation.bundle/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.bundle/$version$/org.osgi.annotation.bundle-$version$-sources.jar",
     "repository-url" : "https://github.com/osgi/osgi",

--- a/metadata/org.osgi/org.osgi.annotation.versioning/index.json
+++ b/metadata/org.osgi/org.osgi.annotation.versioning/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/osgi/org.osgi.annotation.versioning/$version$/org.osgi.annotation.versioning-$version$-sources.jar",
     "repository-url" : "https://github.com/osgi/osgi",

--- a/metadata/org.osgi/org.osgi.resource/index.json
+++ b/metadata/org.osgi/org.osgi.resource/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/osgi/org.osgi.resource/$version$/org.osgi.resource-$version$-sources.jar",
     "repository-url" : "https://github.com/osgi/osgi",

--- a/metadata/org.osgi/org.osgi.service.serviceloader/index.json
+++ b/metadata/org.osgi/org.osgi.service.serviceloader/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/osgi/org.osgi.service.serviceloader/$version$/org.osgi.service.serviceloader-$version$-sources.jar",
     "repository-url" : "https://github.com/osgi/osgi",

--- a/metadata/org.ow2.asm/asm-analysis/index.json
+++ b/metadata/org.ow2.asm/asm-analysis/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.7.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/$version$/asm-analysis-$version$-sources.jar",
     "repository-url" : "https://gitlab.ow2.org/asm/asm",

--- a/metadata/org.ow2.asm/asm-commons/index.json
+++ b/metadata/org.ow2.asm/asm-commons/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/$version$/asm-commons-$version$-sources.jar",
     "repository-url" : "https://gitlab.ow2.org/asm/asm",

--- a/metadata/org.ow2.asm/asm-tree/index.json
+++ b/metadata/org.ow2.asm/asm-tree/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.7.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/$version$/asm-tree-$version$-sources.jar",
     "repository-url" : "https://gitlab.ow2.org/asm/asm/",

--- a/metadata/org.ow2.asm/asm-util/index.json
+++ b/metadata/org.ow2.asm/asm-util/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.7.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/$version$/asm-util-$version$-sources.jar",
     "repository-url" : "https://gitlab.ow2.org/asm/asm",

--- a/metadata/org.ow2.asm/asm/index.json
+++ b/metadata/org.ow2.asm/asm/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "9.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/$version$/asm-$version$-sources.jar",
     "repository-url" : "https://gitlab.ow2.org/asm/asm",

--- a/metadata/org.postgresql/postgresql/index.json
+++ b/metadata/org.postgresql/postgresql/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "42.7.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/postgresql/postgresql/$version$/postgresql-$version$-sources.jar",
     "repository-url" : "https://github.com/pgjdbc/pgjdbc",

--- a/metadata/org.quartz-scheduler/quartz/index.json
+++ b/metadata/org.quartz-scheduler/quartz/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [
       "org.quartz"
     ],

--- a/metadata/org.reactivestreams/reactive-streams/index.json
+++ b/metadata/org.reactivestreams/reactive-streams/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/$version$/reactive-streams-$version$-sources.jar",
     "repository-url" : "https://github.com/reactive-streams/reactive-streams-jvm",

--- a/metadata/org.rocksdb/rocksdbjni/index.json
+++ b/metadata/org.rocksdb/rocksdbjni/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "10.4.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/rocksdb/rocksdbjni/$version$/rocksdbjni-$version$-sources.jar",
     "repository-url" : "https://github.com/facebook/rocksdb",

--- a/metadata/org.skyscreamer/jsonassert/index.json
+++ b/metadata/org.skyscreamer/jsonassert/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.5.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/skyscreamer/jsonassert/$version$/jsonassert-$version$-sources.jar",
     "repository-url" : "https://github.com/skyscreamer/JSONassert",

--- a/metadata/org.slf4j/jcl-over-slf4j/index.json
+++ b/metadata/org.slf4j/jcl-over-slf4j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/$version$/jcl-over-slf4j-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/metadata/org.slf4j/jul-to-slf4j/index.json
+++ b/metadata/org.slf4j/jul-to-slf4j/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.30",
     "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/$version$/jul-to-slf4j-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/metadata/org.slf4j/slf4j-api/index.json
+++ b/metadata/org.slf4j/slf4j-api/index.json
@@ -15,6 +15,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.7.36",
     "source-code-url" : "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/$version$/slf4j-api-$version$-sources.jar",
     "repository-url" : "https://github.com/qos-ch/slf4j",

--- a/metadata/org.snakeyaml/snakeyaml-engine/index.json
+++ b/metadata/org.snakeyaml/snakeyaml-engine/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/snakeyaml/snakeyaml-engine/$version$/snakeyaml-engine-$version$-sources.jar",
     "repository-url" : "https://bitbucket.org/snakeyaml/snakeyaml-engine",

--- a/metadata/org.springframework.amqp/spring-amqp/index.json
+++ b/metadata/org.springframework.amqp/spring-amqp/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/amqp/spring-amqp/$version$/spring-amqp-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-amqp",

--- a/metadata/org.springframework.amqp/spring-rabbit/index.json
+++ b/metadata/org.springframework.amqp/spring-rabbit/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/amqp/spring-rabbit/$version$/spring-rabbit-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-amqp",

--- a/metadata/org.springframework.amqp/spring-rabbitmq-client/index.json
+++ b/metadata/org.springframework.amqp/spring-rabbitmq-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/amqp/spring-rabbitmq-client/$version$/spring-rabbitmq-client-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-amqp",

--- a/metadata/org.springframework.boot/spring-boot-actuator-autoconfigure/index.json
+++ b/metadata/org.springframework.boot/spring-boot-actuator-autoconfigure/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.6.3",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-actuator-autoconfigure/$version$/spring-boot-actuator-autoconfigure-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-actuator/index.json
+++ b/metadata/org.springframework.boot/spring-boot-actuator/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.6.3",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-actuator/$version$/spring-boot-actuator-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-amqp/index.json
+++ b/metadata/org.springframework.boot/spring-boot-amqp/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-amqp/$version$/spring-boot-amqp-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-health/index.json
+++ b/metadata/org.springframework.boot/spring-boot-health/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-health/$version$/spring-boot-health-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-http-client/index.json
+++ b/metadata/org.springframework.boot/spring-boot-http-client/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-http-client/$version$/spring-boot-http-client-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-jdbc/index.json
+++ b/metadata/org.springframework.boot/spring-boot-jdbc/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-jdbc/$version$/spring-boot-jdbc-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-kafka/index.json
+++ b/metadata/org.springframework.boot/spring-boot-kafka/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.1.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-kafka/$version$/spring-boot-kafka-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
+++ b/metadata/org.springframework.boot/spring-boot-micrometer-metrics/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-micrometer-metrics/$version$/spring-boot-micrometer-metrics-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-netty/index.json
+++ b/metadata/org.springframework.boot/spring-boot-netty/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-netty/$version$/spring-boot-netty-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-reactor-netty/index.json
+++ b/metadata/org.springframework.boot/spring-boot-reactor-netty/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-reactor-netty/$version$/spring-boot-reactor-netty-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-reactor/index.json
+++ b/metadata/org.springframework.boot/spring-boot-reactor/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-reactor/$version$/spring-boot-reactor-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-restclient/index.json
+++ b/metadata/org.springframework.boot/spring-boot-restclient/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-restclient/$version$/spring-boot-restclient-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-servlet/index.json
+++ b/metadata/org.springframework.boot/spring-boot-servlet/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-servlet/$version$/spring-boot-servlet-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-transaction/index.json
+++ b/metadata/org.springframework.boot/spring-boot-transaction/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-transaction/$version$/spring-boot-transaction-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-validation/index.json
+++ b/metadata/org.springframework.boot/spring-boot-validation/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.6",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-validation/$version$/spring-boot-validation-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-web-server/index.json
+++ b/metadata/org.springframework.boot/spring-boot-web-server/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/$version$/spring-boot-web-server-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.boot/spring-boot-webflux/index.json
+++ b/metadata/org.springframework.boot/spring-boot-webflux/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "4.0.2",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webflux/$version$/spring-boot-webflux-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-boot",

--- a/metadata/org.springframework.cloud/spring-cloud-context/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-context/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-context/$version$/spring-cloud-context-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-commons",

--- a/metadata/org.springframework.cloud/spring-cloud-function-context/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-function-context/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-function-context/$version$/spring-cloud-function-context-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-function",

--- a/metadata/org.springframework.cloud/spring-cloud-function-core/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-function-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-function-core/$version$/spring-cloud-function-core-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-function",

--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit-core/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-stream-binder-rabbit-core/$version$/spring-cloud-stream-binder-rabbit-core-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-stream",

--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-rabbit/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-stream-binder-rabbit/$version$/spring-cloud-stream-binder-rabbit-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-stream",

--- a/metadata/org.springframework.cloud/spring-cloud-stream/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.0.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-stream/$version$/spring-cloud-stream-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-cloud/spring-cloud-stream",

--- a/metadata/org.springframework.integration/spring-integration-amqp/index.json
+++ b/metadata/org.springframework.integration/spring-integration-amqp/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/integration/spring-integration-amqp/$version$/spring-integration-amqp-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-integration",

--- a/metadata/org.springframework.integration/spring-integration-core/index.json
+++ b/metadata/org.springframework.integration/spring-integration-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/integration/spring-integration-core/$version$/spring-integration-core-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-integration",

--- a/metadata/org.springframework.integration/spring-integration-jmx/index.json
+++ b/metadata/org.springframework.integration/spring-integration-jmx/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/integration/spring-integration-jmx/$version$/spring-integration-jmx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-integration",

--- a/metadata/org.springframework.integration/spring-integration-kafka/index.json
+++ b/metadata/org.springframework.integration/spring-integration-kafka/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "7.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/integration/spring-integration-kafka/$version$/spring-integration-kafka-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-integration",

--- a/metadata/org.springframework.security/spring-security-crypto/index.json
+++ b/metadata/org.springframework.security/spring-security-crypto/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.4.0",
     "tested-versions" : [
       "6.4.0",

--- a/metadata/org.springframework/spring-aop/index.json
+++ b/metadata/org.springframework/spring-aop/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aop/$version$/spring-aop-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-aspects/index.json
+++ b/metadata/org.springframework/spring-aspects/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.3.31",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-aspects/$version$/spring-aspects-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-context-support/index.json
+++ b/metadata/org.springframework/spring-context-support/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.3.18",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-context-support/$version$/spring-context-support-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-context/index.json
+++ b/metadata/org.springframework/spring-context/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.3.15",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-context/$version$/spring-context-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-expression/index.json
+++ b/metadata/org.springframework/spring-expression/index.json
@@ -88,6 +88,7 @@
   },
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.2.7",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-expression/$version$/spring-expression-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-test/index.json
+++ b/metadata/org.springframework/spring-test/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.0.0",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-test/$version$/spring-test-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-tx/index.json
+++ b/metadata/org.springframework/spring-tx/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "6.0.2",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/spring-tx/$version$/spring-tx-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-web/index.json
+++ b/metadata/org.springframework/spring-web/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.3.18",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-web/$version$/spring-web-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.springframework/spring-webflux/index.json
+++ b/metadata/org.springframework/spring-webflux/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "5.3.31",
     "source-code-url" : "https://repo1.maven.org/maven2/org/springframework/spring-webflux/$version$/spring-webflux-$version$-sources.jar",
     "repository-url" : "https://github.com/spring-projects/spring-framework",

--- a/metadata/org.testcontainers/testcontainers/index.json
+++ b/metadata/org.testcontainers/testcontainers/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.19.8",
     "source-code-url" : "https://repo1.maven.org/maven2/org/testcontainers/testcontainers/$version$/testcontainers-$version$-sources.jar",
     "repository-url" : "https://github.com/testcontainers/testcontainers-java",

--- a/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
+++ b/metadata/org.thymeleaf.extras/thymeleaf-extras-springsecurity6/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.0.RELEASE",
     "source-code-url" : "https://repo1.maven.org/maven2/org/thymeleaf/extras/thymeleaf-extras-springsecurity6/$version$/thymeleaf-extras-springsecurity6-$version$-sources.jar",
     "repository-url" : "https://github.com/thymeleaf/thymeleaf",

--- a/metadata/org.thymeleaf/thymeleaf-spring6/index.json
+++ b/metadata/org.thymeleaf/thymeleaf-spring6/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.0.RELEASE",
     "source-code-url" : "https://repo1.maven.org/maven2/org/thymeleaf/thymeleaf-spring6/$version$/thymeleaf-spring6-$version$-sources.jar",
     "repository-url" : "https://github.com/thymeleaf/thymeleaf",

--- a/metadata/org.thymeleaf/thymeleaf/index.json
+++ b/metadata/org.thymeleaf/thymeleaf/index.json
@@ -46,6 +46,7 @@
   },
   {
     "latest": true,
+    "auto-update": true,
     "metadata-version": "3.1.5.RELEASE",
     "source-code-url": "https://repo1.maven.org/maven2/org/thymeleaf/thymeleaf/$version$/thymeleaf-$version$-sources.jar",
     "repository-url": "https://github.com/thymeleaf/thymeleaf",

--- a/metadata/org.unbescape/unbescape/index.json
+++ b/metadata/org.unbescape/unbescape/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest": true,
+    "auto-update": true,
     "allowed-packages": [ "org.unbescape" ],
     "metadata-version": "1.1.6.RELEASE",
     "source-code-url": "https://repo.maven.apache.org/maven2/org/unbescape/unbescape/$version$/unbescape-$version$-sources.jar",

--- a/metadata/org.xerial.snappy/snappy-java/index.json
+++ b/metadata/org.xerial.snappy/snappy-java/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.0.4.1",
     "source-code-url" : "https://repo.maven.apache.org/maven2/org/xerial/snappy/snappy-java/$version$/snappy-java-$version$-sources.jar",
     "repository-url" : "https://github.com/xerial/snappy-java",

--- a/metadata/org.xmlunit/xmlunit-core/index.json
+++ b/metadata/org.xmlunit/xmlunit-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.9.1",
     "source-code-url" : "https://repo1.maven.org/maven2/org/xmlunit/xmlunit-core/$version$/xmlunit-core-$version$-sources.jar",
     "repository-url" : "https://github.com/xmlunit/xmlunit",

--- a/metadata/org.yaml/snakeyaml/index.json
+++ b/metadata/org.yaml/snakeyaml/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.0",
     "source-code-url" : "https://repo1.maven.org/maven2/org/yaml/snakeyaml/$version$/snakeyaml-$version$-sources.jar",
     "repository-url" : "https://bitbucket.org/snakeyaml/snakeyaml",

--- a/metadata/schemas/metadata-library-index-schema-v2.2.0.json
+++ b/metadata/schemas/metadata-library-index-schema-v2.2.0.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/metadata/schemas/metadata-library-index-schema-v2.1.0.json",
+  "$id": "https://raw.githubusercontent.com/oracle/graalvm-reachability-metadata/master/metadata/schemas/metadata-library-index-schema-v2.2.0.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Schema for metadata/<groupId>/<artifactId>/index.json. Each file either describes Native Image metadata bundles for a range of library versions, or marks the artifact as not applicable to Native Image.",
   "type": "array",
@@ -79,6 +79,11 @@
         "latest": {
           "type": "boolean",
           "description": "Marks this entry as the latest/default metadata for currently supported versions."
+        },
+        "auto-update": {
+          "type": "boolean",
+          "const": true,
+          "description": "Opts the artifact into automated upstream-version compatibility checks. This marker is allowed only on the entry with 'latest: true'."
         },
         "default-for": {
           "type": "string",
@@ -230,6 +235,7 @@
       },
       {
         "latest": true,
+        "auto-update": true,
         "metadata-version": "1.0.0",
         "tested-versions": [ "1.0.0", "1.1.0" , "1.2.0"],
         "allowed-packages": [ "org.example.library" ]

--- a/metadata/software.amazon.awssdk/s3/index.json
+++ b/metadata/software.amazon.awssdk/s3/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "2.30.0",
     "source-code-url" : "https://repo1.maven.org/maven2/software/amazon/awssdk/s3/$version$/s3-$version$-sources.jar",
     "repository-url" : "https://github.com/aws/aws-sdk-java-v2",

--- a/metadata/tools.jackson.core/jackson-core/index.json
+++ b/metadata/tools.jackson.core/jackson-core/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/$version$/jackson-core-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-core",

--- a/metadata/tools.jackson.core/jackson-databind/index.json
+++ b/metadata/tools.jackson.core/jackson-databind/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.0",
     "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/$version$/jackson-databind-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-databind",

--- a/metadata/tools.jackson.dataformat/jackson-dataformat-cbor/index.json
+++ b/metadata/tools.jackson.dataformat/jackson-dataformat-cbor/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/dataformat/jackson-dataformat-cbor/$version$/jackson-dataformat-cbor-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-dataformats-binary",

--- a/metadata/tools.jackson.dataformat/jackson-dataformat-yaml/index.json
+++ b/metadata/tools.jackson.dataformat/jackson-dataformat-yaml/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.1.0",
     "source-code-url" : "https://repo1.maven.org/maven2/tools/jackson/dataformat/jackson-dataformat-yaml/$version$/jackson-dataformat-yaml-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-dataformats-text",

--- a/metadata/tools.jackson.datatype/jackson-datatype-joda/index.json
+++ b/metadata/tools.jackson.datatype/jackson-datatype-joda/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "3.0.4",
     "source-code-url" : "https://repo.maven.apache.org/maven2/tools/jackson/datatype/jackson-datatype-joda/$version$/jackson-datatype-joda-$version$-sources.jar",
     "repository-url" : "https://github.com/FasterXML/jackson-datatype-joda",

--- a/metadata/xmlpull/xmlpull/index.json
+++ b/metadata/xmlpull/xmlpull/index.json
@@ -1,6 +1,7 @@
 [
   {
     "latest" : true,
+    "auto-update" : true,
     "metadata-version" : "1.1.3.1",
     "source-code-url" : "N/A",
     "repository-url" : "https://github.com/xmlpull-org/xmlpull-api-v1",

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTask.java
@@ -169,6 +169,7 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
                 if (METADATA_PATTERN.matcher(filePath).matches()) {
                     checkLibraryIndexTestedVersions(json, filePath, failures);
                     checkLibraryIndexUrlTemplates(json, filePath, failures);
+                    checkLibraryIndexAutoUpdate(json, filePath, failures);
                 }
 
                 // Print success only if no new failures were added by schema or semantic checks
@@ -183,6 +184,31 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
         if (!failures.isEmpty()) {
             failures.forEach(f -> getLogger().error(f));
             throw new GradleException("Validation failed for " + failures.size() + " file(s).");
+        }
+    }
+
+    /**
+     * Enforces the artifact-level automation marker placement from
+     * §FS-library-version-update-automation.1.
+     */
+    static void checkLibraryIndexAutoUpdate(JsonNode json, String filePath, List<String> failures) {
+        if (json == null || !json.isArray()) {
+            return;
+        }
+
+        int autoUpdateEntries = 0;
+        for (JsonNode entry : json) {
+            if (!entry.path("auto-update").asBoolean(false)) {
+                continue;
+            }
+            autoUpdateEntries++;
+            if (!entry.path("latest").asBoolean(false)) {
+                failures.add("❌ " + filePath
+                        + ": auto-update is allowed only on the entry with latest: true");
+            }
+        }
+        if (autoUpdateEntries > 1) {
+            failures.add("❌ " + filePath + ": auto-update may appear on at most one entry");
         }
     }
 
@@ -390,7 +416,7 @@ public abstract class ValidateIndexFilesTask extends CoordinatesAwareTask {
 
     public static String mapToSchemaPath(String filePath) {
         if (METADATA_PATTERN.matcher(filePath).matches()) {
-            return "metadata/schemas/metadata-library-index-schema-v2.1.0.json";
+            return "metadata/schemas/metadata-library-index-schema-v2.2.0.json";
         }
         return "";
     }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/ScaffoldTask.java
@@ -230,10 +230,16 @@ class ScaffoldTask extends DefaultTask {
         writeIndexFile(metadataIndex.toPath(), entries);
     }
 
-    private void setLatest(List<MetadataVersionsIndexEntry> list, int index, Boolean newValue) {
+    private void setLatest(
+            List<MetadataVersionsIndexEntry> list,
+            int index,
+            Boolean latest,
+            Boolean autoUpdate
+    ) {
         MetadataVersionsIndexEntry oldEntry = list.get(index);
         list.set(index, new MetadataVersionsIndexEntry(
-                newValue,
+                latest,
+                autoUpdate,
                 oldEntry.override(),
                 oldEntry.defaultFor(),
                 oldEntry.metadataVersion(),
@@ -257,6 +263,7 @@ class ScaffoldTask extends DefaultTask {
     private void updateLatestEntry(List<MetadataVersionsIndexEntry> entries) {
         int latestIndex = 0;
         VersionNumber latestVersion = VersionNumber.parse(entries.get(0).metadataVersion());
+        boolean autoUpdate = entries.stream().anyMatch(entry -> Boolean.TRUE.equals(entry.autoUpdate()));
         for (int i = 1; i < entries.size(); i++) {
             VersionNumber nextVersion = VersionNumber.parse(entries.get(i).metadataVersion());
             if (latestVersion.compareTo(nextVersion) < 0) {
@@ -266,7 +273,13 @@ class ScaffoldTask extends DefaultTask {
         }
 
         for (int i = 0; i < entries.size(); i++) {
-            setLatest(entries, i, i == latestIndex ? true : null);
+            boolean latest = i == latestIndex;
+            setLatest(
+                    entries,
+                    i,
+                    latest ? Boolean.TRUE : null,
+                    latest && autoUpdate ? Boolean.TRUE : null
+            );
         }
     }
 
@@ -332,6 +345,7 @@ class ScaffoldTask extends DefaultTask {
     private MetadataVersionsIndexEntry createIndexEntry(Coordinates coordinates, List<String> packageRoots, DiscoveredArtifactMetadata discoveredMetadata, LibraryLanguage language, boolean latest) {
         return new MetadataVersionsIndexEntry(
                 latest ? Boolean.TRUE : null,
+                null, // auto-update
                 null, // override
                 null, // default-for
                 coordinates.version(), // metadata-version

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/TestedVersionUpdaterTask.java
@@ -200,6 +200,7 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                 updateDependentTestVersions(oldMetadata, newVersion, entries);
                 return new MetadataVersionsIndexEntry(
                         entry.latest(),
+                        entry.autoUpdate(),
                         entry.override(),
                         entry.defaultFor(),
                         newVersion,
@@ -558,6 +559,7 @@ public abstract class TestedVersionUpdaterTask extends DefaultTask {
                 // Create a new entry with the updated test-version
                 MetadataVersionsIndexEntry updatedEntry = new MetadataVersionsIndexEntry(
                         entry.latest(),
+                        entry.autoUpdate(),
                         entry.override(),
                         entry.defaultFor(),
                         entry.metadataVersion(),

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTask.java
@@ -68,15 +68,23 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
             }
         }
 
+        List<String> eligibleLibraries = libraries.stream()
+                .filter(library -> INFRASTRUCTURE_TESTS.stream().noneMatch(library::startsWith))
+                .filter(FetchExistingLibrariesWithNewerVersionsTask::isAutoUpdateEnabled)
+                .toList();
+        getLogger().quiet(
+                "Supported libraries: {}; opted into automatic updates: {}",
+                libraries.size(),
+                eligibleLibraries.size()
+        );
+
         List<String> newerVersions = new ArrayList<>();
-        for (String libraryName : libraries) {
-            if (INFRASTRUCTURE_TESTS.stream().noneMatch(libraryName::startsWith)) {
-                List<String> versions = getNewerVersionsFor(libraryName, getLatestLibraryVersion(libraryName));
-                List<String> skipped = getSkippedVersions(libraryName);
-                versions.removeAll(skipped);
-                for (String v : versions) {
-                    newerVersions.add(libraryName + ":" + v);
-                }
+        for (String libraryName : eligibleLibraries) {
+            List<String> versions = getNewerVersionsFor(libraryName, getLatestLibraryVersion(libraryName));
+            List<String> skipped = getSkippedVersions(libraryName);
+            versions.removeAll(skipped);
+            for (String v : versions) {
+                newerVersions.add(libraryName + ":" + v);
             }
         }
 
@@ -99,6 +107,41 @@ public abstract class FetchExistingLibrariesWithNewerVersionsTask extends Defaul
             ObjectMapper om = new ObjectMapper()
                     .setSerializationInclusion(JsonInclude.Include.NON_NULL);
             System.out.println(om.writeValueAsString(pairs));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Implements the artifact opt-in from §FS-library-version-update-automation.1.
+     */
+    static boolean isAutoUpdateEnabled(String libraryModule) {
+        String[] coordinates = libraryModule.split(":");
+        if (coordinates.length != 2) {
+            return false;
+        }
+
+        File indexFile = new File("metadata/" + coordinates[0] + "/" + coordinates[1] + "/index.json");
+        return isAutoUpdateEnabled(indexFile);
+    }
+
+    static boolean isAutoUpdateEnabled(File indexFile) {
+        if (!indexFile.exists()) {
+            return false;
+        }
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper()
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            List<MetadataVersionsIndexEntry> entries = objectMapper.readValue(
+                    indexFile,
+                    new TypeReference<List<MetadataVersionsIndexEntry>>() {}
+            );
+            return entries.stream().anyMatch(entry ->
+                    entry != null
+                            && Boolean.TRUE.equals(entry.latest())
+                            && Boolean.TRUE.equals(entry.autoUpdate())
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/MetadataVersionsIndexEntry.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/model/MetadataVersionsIndexEntry.java
@@ -17,6 +17,8 @@ import java.util.List;
  */
 public record MetadataVersionsIndexEntry(
         Boolean latest,
+        @JsonProperty("auto-update")
+        Boolean autoUpdate,
         Boolean override,
         @JsonProperty("default-for")
         String defaultFor,

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataGenerationUtils.java
@@ -647,6 +647,7 @@ public final class MetadataGenerationUtils {
         List<String> latestAllowedPackages = null;
         List<String> latestRequires = null;
         LibraryLanguage latestLanguage = null;
+        Boolean latestAutoUpdate = null;
         // Copy default metadata properties from the current latest entry.
         for (int i = 0; i < entries.size(); i++) {
             MetadataVersionsIndexEntry entry = entries.get(i);
@@ -654,8 +655,9 @@ public final class MetadataGenerationUtils {
                 latestAllowedPackages = entry.allowedPackages();
                 latestRequires = entry.requires();
                 latestLanguage = entry.language();
+                latestAutoUpdate = entry.autoUpdate();
                 if (markAsLatest) {
-                    entries.set(i, copyWithLatest(entry, null));
+                    entries.set(i, copyWithLatest(entry, null, null));
                 }
             }
         }
@@ -665,6 +667,7 @@ public final class MetadataGenerationUtils {
         List<String> testedVersions = moveTestedVersionsCoveredByNewMetadata(entries, newCoords.version());
         MetadataVersionsIndexEntry newEntry = new MetadataVersionsIndexEntry(
                 markAsLatest ? Boolean.TRUE : null, // latest
+                markAsLatest ? latestAutoUpdate : null, // auto-update
                 null, // override
                 null, // default-for
                 newCoords.version(), // metadata-version
@@ -783,6 +786,7 @@ public final class MetadataGenerationUtils {
     private static MetadataVersionsIndexEntry copyWithTestedVersions(MetadataVersionsIndexEntry entry, List<String> testedVersions) {
         return new MetadataVersionsIndexEntry(
                 entry.latest(),
+                entry.autoUpdate(),
                 entry.override(),
                 entry.defaultFor(),
                 entry.metadataVersion(),
@@ -803,9 +807,14 @@ public final class MetadataGenerationUtils {
         );
     }
 
-    private static MetadataVersionsIndexEntry copyWithLatest(MetadataVersionsIndexEntry entry, Boolean latest) {
+    private static MetadataVersionsIndexEntry copyWithLatest(
+            MetadataVersionsIndexEntry entry,
+            Boolean latest,
+            Boolean autoUpdate
+    ) {
         return new MetadataVersionsIndexEntry(
                 latest,
+                autoUpdate,
                 entry.override(),
                 entry.defaultFor(),
                 entry.metadataVersion(),

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/ScaffoldTaskTests.java
@@ -469,6 +469,15 @@ class ScaffoldTaskTests {
 
         ScaffoldTask initialTask = registerScaffoldTask(project, "scaffoldInitial", initialCoordinates);
         initialTask.run();
+        Path indexFile = tempDir.resolve("metadata/org.postgresql/postgresql/index.json");
+        List<Map<String, Object>> initialEntries = OBJECT_MAPPER.readValue(
+                indexFile.toFile(),
+                new TypeReference<>() {}
+        );
+        initialEntries.stream()
+                .filter(entry -> Boolean.TRUE.equals(entry.get("latest")))
+                .forEach(entry -> entry.put("auto-update", true));
+        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(indexFile.toFile(), initialEntries);
 
         ScaffoldTask secondTask = registerScaffoldTask(project, "scaffoldSecond", secondCoordinates);
         secondTask.run();
@@ -481,11 +490,12 @@ class ScaffoldTaskTests {
         assertThat(indexEntries.get(0)).containsEntry("metadata-version", "42.7.2")
                 .containsEntry("tested-versions", List.of("42.7.2"))
                 .containsEntry("allowed-packages", List.of("org.postgresql"))
-                .doesNotContainKey("latest");
+                .doesNotContainKeys("latest", "auto-update");
         assertThat(indexEntries.get(1)).containsEntry("metadata-version", "42.7.3")
                 .containsEntry("tested-versions", List.of("42.7.3"))
                 .containsEntry("allowed-packages", List.of("org.postgresql"))
-                .containsEntry("latest", true);
+                .containsEntry("latest", true)
+                .containsEntry("auto-update", true);
         assertThat(tempDir.resolve("tests/src/org.postgresql/postgresql/42.7.3/build.gradle")).exists();
         assertThat(tempDir.resolve("metadata/org.postgresql/postgresql/42.7.3/reachability-metadata.json")).exists();
         assertThat(Files.readString(tempDir.resolve("metadata/org.postgresql/postgresql/index.json"), StandardCharsets.UTF_8))

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/TestedVersionUpdaterTaskTests.java
@@ -172,6 +172,7 @@ class TestedVersionUpdaterTaskTests {
         );
         assertThat(indexEntries).hasSize(2);
         assertThat(indexEntries.get(0)).containsEntry("metadata-version", "1.0.0")
+                .containsEntry("auto-update", true)
                 .containsEntry("tested-versions", List.of("1.0.0"));
         assertThat(indexEntries.get(1)).containsEntry("test-version", "1.0.0");
     }
@@ -379,6 +380,7 @@ class TestedVersionUpdaterTaskTests {
 
         List<Map<String, Object>> indexEntries = readIndex(group, artifact);
         assertThat(indexEntries.get(0)).containsEntry("tested-versions", List.of(oldVersion, newVersion));
+        assertThat(indexEntries.get(0)).containsEntry("auto-update", true);
         assertThat(Files.readString(indexFile)).isEqualTo(indexAfterFirstRun);
     }
 
@@ -403,6 +405,7 @@ class TestedVersionUpdaterTaskTests {
                 [
                   {
                     "latest": true,
+                    "auto-update": true,
                     "allowed-packages": [
                       "com.example"
                     ],

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/FetchExistingLibrariesWithNewerVersionsTaskTests.java
@@ -109,6 +109,57 @@ class FetchExistingLibrariesWithNewerVersionsTaskTests {
         assertThat(newerVersions).containsExactly("1.1.0", "1.2.0");
     }
 
+    @Test
+    void autoUpdateRequiresTheMarkerOnTheLatestEntry() throws IOException {
+        Path disabledIndex = tempDir.resolve("disabled-index.json");
+        Files.writeString(disabledIndex, """
+                [
+                  {
+                    "latest": true,
+                    "metadata-version": "1.0.0",
+                    "tested-versions": ["1.0.0"],
+                    "allowed-packages": ["com.example"]
+                  }
+                ]
+                """);
+        Path staleMarkerIndex = tempDir.resolve("stale-marker-index.json");
+        Files.writeString(staleMarkerIndex, """
+                [
+                  {
+                    "auto-update": true,
+                    "metadata-version": "1.0.0",
+                    "tested-versions": ["1.0.0"],
+                    "allowed-packages": ["com.example"]
+                  },
+                  {
+                    "latest": true,
+                    "metadata-version": "2.0.0",
+                    "tested-versions": ["2.0.0"],
+                    "allowed-packages": ["com.example"]
+                  }
+                ]
+                """);
+        Path enabledIndex = tempDir.resolve("enabled-index.json");
+        Files.writeString(enabledIndex, """
+                [
+                  {
+                    "latest": true,
+                    "auto-update": true,
+                    "metadata-version": "2.0.0",
+                    "tested-versions": ["2.0.0"],
+                    "allowed-packages": ["com.example"]
+                  }
+                ]
+                """);
+
+        assertThat(FetchExistingLibrariesWithNewerVersionsTask.isAutoUpdateEnabled(disabledIndex.toFile()))
+                .isFalse();
+        assertThat(FetchExistingLibrariesWithNewerVersionsTask.isAutoUpdateEnabled(staleMarkerIndex.toFile()))
+                .isFalse();
+        assertThat(FetchExistingLibrariesWithNewerVersionsTask.isAutoUpdateEnabled(enabledIndex.toFile()))
+                .isTrue();
+    }
+
     private HttpServer startServer(ThrowingExchangeHandler handler) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/", exchange -> {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/ValidateIndexFilesTaskTests.java
@@ -78,4 +78,62 @@ class ValidateIndexFilesTaskTests {
 
         assertThat(failures).isEmpty();
     }
+
+    @Test
+    void allowsAutoUpdateOnTheLatestEntry() throws IOException {
+        JsonNode index = OBJECT_MAPPER.readTree("""
+                [
+                  {
+                    "latest": true,
+                    "auto-update": true,
+                    "metadata-version": "1.0.0",
+                    "tested-versions": ["1.0.0"],
+                    "allowed-packages": ["com.example"]
+                  }
+                ]
+                """);
+        List<String> failures = new ArrayList<>();
+
+        ValidateIndexFilesTask.checkLibraryIndexAutoUpdate(
+                index,
+                "metadata/com.example/demo/index.json",
+                failures
+        );
+
+        assertThat(failures).isEmpty();
+    }
+
+    @Test
+    void rejectsAutoUpdateOnNonLatestOrMultipleEntries() throws IOException {
+        JsonNode index = OBJECT_MAPPER.readTree("""
+                [
+                  {
+                    "auto-update": true,
+                    "metadata-version": "1.0.0",
+                    "tested-versions": ["1.0.0"],
+                    "allowed-packages": ["com.example"]
+                  },
+                  {
+                    "latest": true,
+                    "auto-update": true,
+                    "metadata-version": "2.0.0",
+                    "tested-versions": ["2.0.0"],
+                    "allowed-packages": ["com.example"]
+                  }
+                ]
+                """);
+        List<String> failures = new ArrayList<>();
+
+        ValidateIndexFilesTask.checkLibraryIndexAutoUpdate(
+                index,
+                "metadata/com.example/demo/index.json",
+                failures
+        );
+
+        assertThat(failures)
+                .anySatisfy(failure -> assertThat(failure)
+                        .contains("only on the entry with latest: true"))
+                .anySatisfy(failure -> assertThat(failure)
+                        .contains("at most one entry"));
+    }
 }

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/MetadataGenerationUtilsTests.java
@@ -41,6 +41,7 @@ class MetadataGenerationUtilsTests {
                 [
                   {
                     "latest" : true,
+                    "auto-update" : true,
                     "metadata-version" : "2021-03-30T02-06-56-9a47743",
                     "tested-versions" : [
                       "2021-03-30T02-06-56-9a47743"
@@ -72,6 +73,7 @@ class MetadataGenerationUtilsTests {
         List<Map<String, Object>> entries = readIndex(group, artifact);
         assertThat(entries.get(0))
                 .containsEntry("latest", true)
+                .containsEntry("auto-update", true)
                 .containsEntry("metadata-version", newVersion)
                 .containsEntry("tested-versions", List.of(
                         newVersion,
@@ -79,6 +81,8 @@ class MetadataGenerationUtilsTests {
                 ));
         assertThat(findEntry(entries, "2021-07-17T01-39-28-682c652"))
                 .containsEntry("tested-versions", List.of("2021-07-17T01-39-28-682c652"));
+        assertThat(findEntry(entries, "2021-03-30T02-06-56-9a47743"))
+                .doesNotContainKeys("latest", "auto-update");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Restrict the scheduled new-library-version compatibility workflow to libraries that explicitly opt in through their artifact-level `index.json`.

This change:

- adds the optional `auto-update: true` marker to metadata library index schema v2.2.0
- requires the marker to live on the unique `latest: true` metadata entry
- filters non-opted-in libraries before any Maven Central requests are made
- preserves or transfers the marker when index authoring tools rewrite entries or move `latest`
- changes the workflow schedule from every six hours to daily at `00:00 UTC`
- updates workflow terminology from all supported libraries to opted-in libraries
- opts in:
  - `org.hibernate.orm:hibernate-core`
  - `org.hibernate.validator:hibernate-validator`
- updates the grounded functional specification and contributor, developer, CI, metadata, and TCK documentation

A real discovery run on this branch reports 1,637 supported libraries, exactly two opted into automatic updates, and currently discovers `org.hibernate.orm:hibernate-core:8.0.0.Beta1` as the only newer candidate.

## Index contract

```json
{
  "latest": true,
  "auto-update": true,
  "metadata-version": "1.2.3",
  "tested-versions": [
    "1.2.3"
  ],
  "allowed-packages": [
    "com.example"
  ]
}
```

Omission means disabled. The schema accepts only `true`, and semantic validation rejects the marker on a non-latest entry or on multiple entries.

## Testing

Passed:

- full `tests/tck-build-logic` unit test task
- focused discovery, index validation, updater, scaffold, and metadata-generation tests
- `validateIndexFiles -Pcoordinates=all` for all 1,637 index files
- `validateIndexFiles` for both opted-in Hibernate libraries
- `checkMetadataFiles` for `hibernate-core`
- `checkMetadataFiles` for `hibernate-validator`
- live `fetchExistingLibrariesWithNewerVersions --quiet` discovery
- workflow YAML parsing
- JSON parsing for the schema and opted-in indexes
- `git diff --check`

Known unrelated local validation limitations:

- the included-build `check` runs all tests successfully, then existing Gradle plugin validation fails on `AbstractLibraryStatsTask.getStatsFile()` being annotated with `@Internal`
- `grund check` reports only the existing outdated grund init blocks in the root and Forge `AGENTS.md` files
- the focused Forge Python test cannot import locally because the environment is missing the `attrs` dependency
- repository-wide Spotless scans were CPU-active for more than ten minutes without completing; the change-specific Java compilation and tests pass

Fixes #9135
