### PR TITLE
Improve code coverage for org.apache.kafka:kafka-streams:3.6.2

### DIFF
--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsApiLoopCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsApiLoopCoverageTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.CogroupedKStream;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.Maybe;
+import org.apache.kafka.streams.state.internals.Murmur3;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaStreamsApiLoopCoverageTest {
+
+    @Test
+    void constructsKafkaStreamsWithAnExplicitClientSupplier() {
+        Topology topology = new Topology().addSource("source", "orders").addSink("sink", "processed-orders", "source");
+        java.util.Properties properties = new java.util.Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "explicit-supplier-coverage");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, System.getProperty("java.io.tmpdir") + "/explicit-supplier-coverage");
+
+        try (KafkaStreams streams = new KafkaStreams(topology, properties,
+                new org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier(),
+                org.apache.kafka.common.utils.Time.SYSTEM)) {
+            assertThat(streams.state()).isEqualTo(KafkaStreams.State.CREATED);
+            assertThat(streams.metrics()).isNotEmpty();
+        }
+    }
+
+    @Test
+    void buildsTableJoinAndValueTransformationTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> orders = builder.table("orders", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> customers = builder.table("customers", Consumed.with(Serdes.String(), Serdes.String()));
+
+        assertThat(orders.filter((key, value) -> value.startsWith("paid"))).isNotNull();
+        assertThat(orders.mapValues(String::length)).isNotNull();
+        assertThat(orders.join(customers, (order, customer) -> order + ":" + customer)).isNotNull();
+        assertThat(orders.leftJoin(customers, String::toUpperCase, (order, customer) -> order + ":" + customer,
+                TableJoined.as("customer-lookup"), Materialized.as("joined-orders"))).isNotNull();
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+        assertThat(topology.describe().toString()).contains("joined-orders");
+    }
+
+    @Test
+    void buildsStreamJoinRepartitionAndObservationTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> orders = builder.stream("orders", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> payments = builder.stream("payments", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> enriched = orders.leftJoin(payments, (order, payment) -> order + ":" + payment,
+                JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)),
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()));
+        enriched.peek((key, value) -> assertThat(value).contains(":"));
+        enriched.print(Printed.toSysOut());
+        assertThat(enriched.repartition().merge(orders)).isNotNull();
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+    }
+
+    @Test
+    void addsGlobalStoresUsingTimestampedAndDefaultSourceForms() {
+        org.apache.kafka.streams.processor.ProcessorSupplier<String, String> legacyProcessor =
+                () -> new org.apache.kafka.streams.processor.AbstractProcessor<>() {
+                    @Override
+                    public void process(String key, String value) {
+                        assertThat(key).isNotBlank();
+                        assertThat(value).isNotBlank();
+                    }
+                };
+        org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, Void, Void> apiProcessor =
+                () -> new org.apache.kafka.streams.processor.api.ContextualProcessor<>() {
+                    @Override
+                    public void process(org.apache.kafka.streams.processor.api.Record<String, String> record) {
+                        assertThat(record.key()).isNotBlank();
+                        assertThat(record.value()).isNotBlank();
+                    }
+                };
+        Topology topology = new Topology()
+                .addGlobalStore(Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore("legacy-global"),
+                        Serdes.String(), Serdes.String()).withLoggingDisabled(), "legacy-source", Serdes.String().deserializer(),
+                        Serdes.String().deserializer(), "legacy-topic", "legacy-processor", legacyProcessor)
+                .addGlobalStore(Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore("api-global"),
+                        Serdes.String(), Serdes.String()).withLoggingDisabled(), "api-source", (record, previous) -> record.timestamp(),
+                        Serdes.String().deserializer(), Serdes.String().deserializer(), "api-topic", "api-processor", apiProcessor);
+
+        assertThat(topology.describe().globalStores()).hasSize(2);
+        assertThat(topology.describe().toString()).contains("legacy-global").contains("api-global");
+    }
+
+    @Test
+    void buildsLegacyTransformForeignKeyAndWindowedCogroupOperators() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> orders = builder.stream("orders", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> payments = builder.stream("payments", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> orderTable = builder.table("order-table", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> customerTable = builder.table("customer-table", Consumed.with(Serdes.String(), Serdes.String()));
+
+        KStream<String, String> transformed = orders.transformValues(() -> valueTransformer("-checked"));
+        transformed.flatTransformValues(() -> valueTransformerList("-audit"));
+        orders.outerJoin(payments, (order, payment) -> order + ":" + payment,
+                JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)));
+        orders.process(() -> new org.apache.kafka.streams.processor.AbstractProcessor<String, String>() {
+            @Override
+            public void process(String key, String value) {
+                assertThat(key).isNotBlank();
+                assertThat(value).isNotBlank();
+            }
+        });
+
+        orderTable.join(customerTable, (order, customer) -> order + ":" + customer, Materialized.as("table-join"));
+        orderTable.transformValues(() -> keyedValueTransformer("-normalized"));
+        KGroupedStream<String, String> groupedOrders = orders.groupByKey();
+        CogroupedKStream<String, String> cogrouped = groupedOrders.cogroup((key, value, aggregate) -> aggregate + value);
+        cogrouped.aggregate(() -> "");
+        cogrouped.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).aggregate(() -> "");
+        cogrouped.windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(10))).aggregate(() -> "");
+        cogrouped.windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(10)))
+                .aggregate(() -> "", (key, left, right) -> left + right);
+        groupedOrders.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).reduce((left, right) -> left + right);
+        groupedOrders.windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(10))).count();
+        groupedOrders.windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(10))).reduce((left, right) -> left + right);
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+        assertThat(topology.describe().toString()).contains("table-join");
+    }
+
+    @Test
+    void exposesStoreSuppliersHashingAndQueryResultContracts() {
+        assertThat(Stores.lruMap("recent-orders", 25).name()).isEqualTo("recent-orders");
+        assertThat(Stores.persistentVersionedKeyValueStore("versions", Duration.ofHours(1)).name()).isEqualTo("versions");
+        assertThat(QueryableStoreTypes.sessionStore()).isNotNull();
+
+        byte[] orderId = "order-17".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        assertThat(Murmur3.hash32(orderId)).isEqualTo(Murmur3.hash32(orderId));
+        assertThat(Maybe.defined("paid").hashCode()).isEqualTo(Maybe.defined("paid").hashCode());
+        assertThat(Maybe.undefined().hashCode()).isEqualTo(Maybe.undefined().hashCode());
+
+        StateQueryResult<String> result = new StateQueryResult<>();
+        assertThat(result.getOnlyPartitionResult()).isNull();
+        assertThat(result.getPartitionResults()).isEmpty();
+    }
+
+    private ValueTransformer<String, String> valueTransformer(String suffix) {
+        return new ValueTransformer<>() {
+            @Override
+            public void init(org.apache.kafka.streams.processor.ProcessorContext context) {
+            }
+
+            @Override
+            public String transform(String value) {
+                return value + suffix;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    private ValueTransformer<String, Iterable<String>> valueTransformerList(String suffix) {
+        return new ValueTransformer<>() {
+            @Override
+            public void init(org.apache.kafka.streams.processor.ProcessorContext context) {
+            }
+
+            @Override
+            public Iterable<String> transform(String value) {
+                return java.util.List.of(value, value + suffix);
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+    private ValueTransformerWithKey<String, String, String> keyedValueTransformer(String suffix) {
+        return new ValueTransformerWithKey<>() {
+            @Override
+            public void init(org.apache.kafka.streams.processor.ProcessorContext context) {
+            }
+
+            @Override
+            public String transform(String key, String value) {
+                return key + ":" + value + suffix;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDeepWindowCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDeepWindowCoverageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.state.WindowStore;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaStreamsDeepWindowCoverageTest {
+
+    @Test
+    void buildsSessionAndSlidingWindowTopologiesThroughThePublicDsl() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> events = builder.stream("events", Consumed.with(Serdes.String(), Serdes.String()));
+        events.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5)))
+                .count(Materialized.as("session-store"))
+                .suppress(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded()))
+                .toStream()
+                .map((windowed, value) -> KeyValue.pair(windowed.key(), value.toString()))
+                .to("session-output");
+        events.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)))
+                .count(Materialized.<String, Long, WindowStore<org.apache.kafka.common.utils.Bytes, byte[]>>as("sliding-store"));
+        events.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(5)))
+                .reduce((left, right) -> right, Materialized.as("reduced-store"));
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+    }
+
+    @Test
+    void buildsForeignKeyTableJoinAndMaterializedViewsThroughThePublicDsl() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> orders = builder.table("orders", Consumed.with(Serdes.String(), Serdes.String()),
+                Materialized.as("orders-store"));
+        KTable<String, String> customers = builder.table("customers", Consumed.with(Serdes.String(), Serdes.String()),
+                Materialized.as("customers-store"));
+        orders.join(customers, value -> value, (order, customer) -> order + ":" + customer,
+                        Materialized.as("foreign-join-store"))
+                .toStream()
+                .to("foreign-join-output");
+        orders.groupBy((key, value) -> KeyValue.pair(value, key), Grouped.with(Serdes.String(), Serdes.String()))
+                .reduce((left, right) -> right, (left, right) -> left, Materialized.as("table-group-store"));
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDslAndProtocolCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDslAndProtocolCoverageTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndFailExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.test.NoOpProcessorContext;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaStreamsDslAndProtocolCoverageTest {
+
+    @Test
+    void configuresDslOptionsWithoutLosingTheirStreamSemantics() {
+        TimestampExtractor timestamps = (record, previousTimestamp) -> 42L;
+        Consumed<String, String> consumed = Consumed.<String, String>as("orders-source")
+                .withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String())
+                .withTimestampExtractor(timestamps)
+                .withOffsetResetPolicy(Topology.AutoOffsetReset.EARLIEST)
+                .withName("renamed-source");
+        StreamsBuilder sourceBuilder = new StreamsBuilder();
+        sourceBuilder.stream("orders", consumed);
+        assertThat(sourceBuilder.build().describe().subtopologies()).hasSize(1);
+        assertThat(Consumed.with(timestamps)).isNotNull();
+        assertThat(Consumed.with(Topology.AutoOffsetReset.LATEST)).isNotNull();
+
+        assertThat(Grouped.<String, Long>as("totals").withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.Long()).withName("daily-totals")).isNotNull();
+        assertThat(Grouped.keySerde(Serdes.String())).isNotNull();
+        assertThat(Grouped.valueSerde(Serdes.Long())).isNotNull();
+        assertThat(Grouped.with("named", Serdes.String(), Serdes.Long())).isNotNull();
+
+        assertThat(Branched.<String, String>as("valid").withName("accepted")).isNotNull();
+        assertThat(Branched.<String, String>withConsumer(stream -> { }).withName("audit")).isNotNull();
+        assertThat(Branched.<String, String>withConsumer(stream -> { }, "dead-letter")).isNotNull();
+        assertThat(Branched.<String, String>withFunction(stream -> stream, "normalized")).isNotNull();
+        assertThat(Branched.<String, String>withFunction(stream -> stream).withName("enriched")).isNotNull();
+        assertThat(EmitStrategy.onWindowClose()).isNotEqualTo(EmitStrategy.onWindowUpdate());
+        assertThat(JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5))
+                .before(Duration.ofSeconds(2)).after(Duration.ofSeconds(3)).size()).isEqualTo(5000L);
+    }
+
+    @Test
+    void describesTopologiesBuiltWithPublicSourceAndSinkForms() {
+        TimestampExtractor timestamps = (record, previousTimestamp) -> previousTimestamp + 1;
+        Topology.AutoOffsetReset reset = Topology.AutoOffsetReset.EARLIEST;
+
+        assertTopology(new Topology().addSource("pattern", Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource("serde", Serdes.String().deserializer(),
+                Serdes.String().deserializer(), "orders"));
+        assertTopology(new Topology().addSource("serde-pattern", Serdes.String().deserializer(),
+                Serdes.String().deserializer(), Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource(reset, "reset", "orders"));
+        assertTopology(new Topology().addSource(reset, "reset-pattern", Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource(reset, "reset-serde", Serdes.String().deserializer(),
+                Serdes.String().deserializer(), "orders"));
+        assertTopology(new Topology().addSource(reset, "reset-serde-pattern", Serdes.String().deserializer(),
+                Serdes.String().deserializer(), Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource(reset, "timestamped", timestamps,
+                Serdes.String().deserializer(), Serdes.String().deserializer(), "orders"));
+        assertTopology(new Topology().addSource(reset, "timestamped-pattern", timestamps,
+                Serdes.String().deserializer(), Serdes.String().deserializer(), Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource(reset, timestamps, "legacy-timestamp", "orders"));
+        assertTopology(new Topology().addSource(reset, timestamps, "legacy-timestamp-pattern",
+                Pattern.compile("orders-.*")));
+        assertTopology(new Topology().addSource(timestamps, "timestamp", "orders"));
+        assertTopology(new Topology().addSource(timestamps, "timestamp-pattern", Pattern.compile("orders-.*")));
+
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("sink-serde", "output", Serdes.String().serializer(), Serdes.String().serializer(), "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("sink-partition", "output", (topic, key, value, partitions) -> 0, "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("sink-both", "output", Serdes.String().serializer(), Serdes.String().serializer(),
+                        (topic, key, value, partitions) -> 0, "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("dynamic", (key, value, context) -> "output", "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("dynamic-partition", (key, value, context) -> "output",
+                        (topic, key, value, partitions) -> 0, "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("dynamic-serde", (key, value, context) -> "output", Serdes.String().serializer(),
+                        Serdes.String().serializer(), "source"));
+        assertTopology(new Topology().addSource("source", "orders")
+                .addSink("dynamic-all", (key, value, context) -> "output", Serdes.String().serializer(),
+                        Serdes.String().serializer(), (topic, key, value, partitions) -> 0, "source"));
+
+        Topology stateTopology = new Topology().addSource("source", "orders")
+                .addProcessor("counter", () -> new AbstractProcessor<String, String>() {
+                    @Override
+                    public void process(String key, String value) {
+                    }
+                }, "source")
+                .addStateStore(Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("counts"),
+                        Serdes.String(), Serdes.Long()), "counter")
+                .connectProcessorAndStateStores("counter", "counts");
+        assertThat(stateTopology.describe().subtopologies()).hasSize(1);
+    }
+
+    @Test
+    void preservesProtocolPayloadsAndHandlerOutcomes() {
+        SubscriptionInfoData.TaskId task = new SubscriptionInfoData.TaskId().setTopicGroupId(4).setPartition(2);
+        SubscriptionInfoData.PartitionToOffsetSum partition = new SubscriptionInfoData.PartitionToOffsetSum()
+                .setPartition(2).setOffsetSum(19L);
+        SubscriptionInfoData.TaskOffsetSum offset = new SubscriptionInfoData.TaskOffsetSum()
+                .setTopicGroupId(4).setPartition(2).setOffsetSum(19L).setNamedTopology("orders")
+                .setPartitionToOffsetSum(List.of(partition));
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag()
+                .setKey(new byte[] {1}).setValue(new byte[] {2, 3});
+        SubscriptionInfoData data = new SubscriptionInfoData().setPrevTasks(List.of(task)).setStandbyTasks(List.of(task));
+
+        assertThat(data.prevTasks()).containsExactly(task);
+        assertThat(data.standbyTasks()).containsExactly(task);
+        assertThat(data.duplicate()).isEqualTo(data);
+        assertThat(data.toString()).contains("SubscriptionInfoData");
+        assertThat(task.duplicate()).isEqualTo(task);
+        assertThat(partition.duplicate()).isEqualTo(partition);
+        assertThat(offset.duplicate()).isEqualTo(offset);
+        assertThat(offset.partitionToOffsetSum()).containsExactly(partition);
+        assertThat(tag.duplicate()).isEqualTo(tag);
+        assertThat(tag.key()).containsExactly(1);
+        assertThat(tag.value()).containsExactly(2, 3);
+
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("orders", 0, 0L, new byte[] {1}, new byte[] {2});
+        NoOpProcessorContext context = new NoOpProcessorContext();
+        assertThat(new LogAndContinueExceptionHandler().handle(context, record, new IllegalArgumentException()))
+                .isEqualTo(DeserializationExceptionHandler.DeserializationHandlerResponse.CONTINUE);
+        new LogAndContinueExceptionHandler().configure(Map.of());
+        assertThat(new LogAndFailExceptionHandler().handle(context, record, new IllegalArgumentException()))
+                .isEqualTo(DeserializationExceptionHandler.DeserializationHandlerResponse.FAIL);
+        assertThat(new DefaultProductionExceptionHandler().handle(new ProducerRecord<>("orders", new byte[] {1}, new byte[] {2}),
+                new IllegalStateException())).isEqualTo(ProductionExceptionHandler.ProductionExceptionHandlerResponse.FAIL);
+    }
+
+    private void assertTopology(Topology topology) {
+        assertThat(topology.describe().subtopologies()).hasSize(1);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDslOperationsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsDslOperationsCoverageTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaStreamsDslOperationsCoverageTest {
+
+    @Test
+    void buildsNamedStreamTransformationsAndAggregationTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> orders = builder.stream("orders", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> payments = builder.stream("payments");
+        GlobalKTable<String, String> customers = builder.globalTable("customers", Consumed.with(Serdes.String(), Serdes.String()),
+                Materialized.as("customers-store"));
+        KeyValueMapper<String, String, Iterable<KeyValue<String, String>>> duplicate =
+                (key, value) -> java.util.List.of(KeyValue.pair(key, value + value));
+        ValueJoiner<String, String, String> concatenate = (left, right) -> left + ":" + right;
+
+        orders.filterNot((key, value) -> value.isBlank());
+        orders.filterNot((key, value) -> key.isBlank(), Named.as("non-empty-key"));
+        orders.flatMap(duplicate);
+        orders.flatMap(duplicate, Named.as("duplicate-order"));
+        orders.flatMapValues(value -> java.util.List.of(value, value.toUpperCase()));
+        orders.flatMapValues(value -> java.util.List.of(value), Named.as("value-copy"));
+        orders.flatMapValues((key, value) -> java.util.List.of(key + value));
+        orders.flatMapValues((key, value) -> java.util.List.of(value), Named.as("keyed-value-copy"));
+        orders.foreach((key, value) -> { });
+        orders.foreach((key, value) -> { }, Named.as("audit-orders"));
+        orders.groupBy((key, value) -> key).count();
+        orders.groupBy((key, value) -> key, Grouped.with(Serdes.String(), Serdes.String())).count();
+        orders.groupByKey().count();
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String())).count();
+        Map<String, KStream<String, String>> branches = orders.split(Named.as("order-"))
+                .branch((key, value) -> value.startsWith("priority"), Branched.as("priority"))
+                .defaultBranch(Branched.as("standard"));
+        assertThat(branches).containsKeys("order-priority", "order-standard");
+
+        orders.join(customers, (key, value) -> key, concatenate);
+        orders.join(customers, (key, value) -> key, concatenate, Named.as("customer-join"));
+        orders.join(customers, (key, value) -> key, (key, left, right) -> key + left + right);
+        orders.join(customers, (key, value) -> key, (key, left, right) -> key + left + right, Named.as("keyed-customer-join"));
+        orders.join(payments, concatenate, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)));
+        orders.join(payments, concatenate, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)),
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()));
+
+        Topology topology = builder.build();
+        assertThat(topology.describe().subtopologies()).isNotEmpty();
+        assertThat(topology.describe().globalStores()).hasSize(1);
+    }
+
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsOptionsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsOptionsCoverageTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.BrokerNotFoundException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.InvalidStateStorePartitionException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.StreamsRebalancingException;
+import org.apache.kafka.streams.errors.StreamsStoppedException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaStreamsOptionsCoverageTest {
+
+    @Test
+    void configuresDslValueObjectsAndPreservesTheirOptions() {
+        org.apache.kafka.common.serialization.Serde<String> stringSerde = Serdes.String();
+        Joined<String, String, String> joined = Joined.with(stringSerde, stringSerde, stringSerde,
+                "orders", Duration.ofSeconds(2)).withKeySerde(stringSerde).withValueSerde(stringSerde)
+                .withOtherValueSerde(stringSerde).withName("renamed").withGracePeriod(Duration.ofSeconds(3));
+        assertThat(joined.keySerde()).isSameAs(stringSerde);
+        assertThat(joined.valueSerde()).isSameAs(stringSerde);
+        assertThat(joined.otherValueSerde()).isSameAs(stringSerde);
+        assertThat(joined.gracePeriod()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(Joined.<String, String, String>as("join")).isNotNull();
+
+        Produced<String, String> produced = Produced.<String, String>as("output").withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String()).withStreamPartitioner((topic, key, value, partitions) -> 0)
+                .withName("named-output");
+        assertThat(produced).isEqualTo(produced);
+        assertThat(produced.hashCode()).isEqualTo(produced.hashCode());
+        assertThat(Produced.<String, String>with(Serdes.String(), Serdes.String())
+                .withKeySerde(stringSerde).withValueSerde(stringSerde)
+                .withStreamPartitioner((topic, key, value, partitions) -> 0)).isNotNull();
+
+        Repartitioned<String, String> repartitioned = Repartitioned.with(Serdes.String(), Serdes.String())
+                .withName("repartitioned").withNumberOfPartitions(2).withKeySerde(Serdes.String())
+                .withValueSerde(Serdes.String()).withStreamPartitioner((topic, key, value, partitions) -> 0);
+        assertThat(repartitioned).isNotNull();
+        assertThat(Repartitioned.<String, String>as("named")).isNotNull();
+        assertThat(Repartitioned.<String, String>numberOfPartitions(3)).isNotNull();
+        assertThat(Repartitioned.<String, String>streamPartitioner((topic, key, value, partitions) -> 0)).isNotNull();
+
+        Materialized<String, String, org.apache.kafka.streams.processor.StateStore> materialized =
+                Materialized.<String, String, org.apache.kafka.streams.processor.StateStore>as("counts")
+                .withKeySerde(Serdes.String()).withValueSerde(Serdes.String()).withCachingEnabled()
+                .withCachingDisabled().withLoggingEnabled(Map.of("cleanup.policy", "compact"))
+                .withRetention(Duration.ofHours(1));
+        assertThat(materialized).isNotNull();
+        assertThat(Materialized.as(Stores.persistentKeyValueStore("other"))).isNotNull();
+
+        assertThat(Printed.<String, String>toSysOut().withLabel("orders").withName("printer")
+                .withKeyValueMapper((key, value) -> key + "=" + value)).isNotNull();
+        assertThat(Printed.<String, String>toFile(System.getProperty("java.io.tmpdir") + "/orders.txt")).isNotNull();
+
+        JoinWindows windows = JoinWindows.of(Duration.ofSeconds(5)).grace(Duration.ofSeconds(1));
+        assertThat(windows.gracePeriodMs()).isEqualTo(1000L);
+        assertThatThrownBy(() -> windows.windowsFor(10L)).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(windows).isEqualTo(JoinWindows.of(Duration.ofSeconds(5)).grace(Duration.ofSeconds(1)));
+        assertThat(windows.toString()).contains("JoinWindows");
+
+        SessionWindows sessions = SessionWindows.with(Duration.ofSeconds(4)).grace(Duration.ofSeconds(1));
+        assertThat(sessions.inactivityGap()).isEqualTo(4000L);
+        assertThat(sessions.gracePeriodMs()).isEqualTo(1000L);
+        assertThat(sessions).isEqualTo(SessionWindows.with(Duration.ofSeconds(4)).grace(Duration.ofSeconds(1)));
+        assertThat(SessionWindows.ofInactivityGapAndGrace(Duration.ofSeconds(4), Duration.ofSeconds(1))).isNotNull();
+        assertThat(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(4)).toString()).contains("SessionWindows");
+
+        SlidingWindows sliding = SlidingWindows.ofTimeDifferenceAndGrace(Duration.ofSeconds(4), Duration.ofSeconds(1));
+        assertThat(sliding.timeDifferenceMs()).isEqualTo(4000L);
+        assertThat(sliding.gracePeriodMs()).isEqualTo(1000L);
+        assertThat(sliding).isEqualTo(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(4), Duration.ofSeconds(1)));
+        assertThat(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(4)).toString()).contains("SlidingWindows");
+    }
+
+    @Test
+    void roundTripsSessionWindowedKeysAndBuildsStatefulTopologies() {
+        Windowed<String> key = new Windowed<>("customer", new SessionWindow(10L, 20L));
+        SessionWindowedSerializer<String> serializer = new SessionWindowedSerializer<>(Serdes.String().serializer());
+        SessionWindowedDeserializer<String> deserializer = new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+        serializer.configure(Map.of(), true);
+        deserializer.configure(Map.of(), true);
+        byte[] bytes = serializer.serialize("sessions", key);
+        assertThat(serializer.serializeBaseKey("sessions", key)).isNotEmpty();
+        assertThat(deserializer.deserialize("sessions", bytes)).isEqualTo(key);
+        serializer.close();
+        deserializer.close();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.addStateStore(Stores.keyValueStoreBuilder(Stores.persistentKeyValueStore("counts"),
+                Serdes.String(), Serdes.Long()));
+        builder.table("orders", Materialized.as("orders-store"));
+        builder.globalTable("catalog", Materialized.as("catalog-store"));
+        assertThat(builder.build().describe().globalStores()).hasSize(1);
+
+        StreamJoined<String, String, String> streamJoined = StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
+                .withKeySerde(Serdes.String()).withValueSerde(Serdes.String()).withOtherValueSerde(Serdes.String())
+                .withName("stream-join").withStoreName("join-store").withLoggingDisabled()
+                .withLoggingEnabled(Map.of("cleanup.policy", "compact"));
+        assertThat(streamJoined.toString()).contains("join-store");
+        assertThat(StreamJoined.<String, String, String>as("named-join")).isNotNull();
+        assertThat(StreamJoined.<String, String, String>with(
+                Stores.persistentWindowStore("left", Duration.ofHours(1), Duration.ofMinutes(1), false),
+                Stores.persistentWindowStore("right", Duration.ofHours(1), Duration.ofMinutes(1), false))
+                .withThisStoreSupplier(Stores.persistentWindowStore("left-replacement", Duration.ofHours(1), Duration.ofMinutes(1), false))
+                .withOtherStoreSupplier(Stores.persistentWindowStore("right-replacement", Duration.ofHours(1), Duration.ofMinutes(1), false)))
+                .isNotNull();
+    }
+
+    @Test
+    void reportsConfigurationErrorsAndLifecycleRulesWithContext() {
+        RuntimeException cause = new RuntimeException("lost");
+        assertThat(new BrokerNotFoundException("broker")).hasMessage("broker");
+        assertThat(new InvalidStateStoreException(cause)).hasCause(cause);
+        assertThat(new InvalidStateStorePartitionException("partition")).hasMessage("partition");
+        assertThat(new LockException("lock")).hasMessage("lock");
+        assertThat(new LockException(cause)).hasCause(cause);
+        assertThat(new ProcessorStateException("processor")).hasMessage("processor");
+        assertThat(new ProcessorStateException(cause)).hasCause(cause);
+        assertThat(new StateStoreMigratedException("migrated")).hasMessage("migrated");
+        assertThat(new StateStoreNotAvailableException("unavailable")).hasMessage("unavailable");
+        assertThat(new StreamsRebalancingException("rebalancing")).hasMessage("rebalancing");
+        assertThat(new StreamsStoppedException("stopped")).hasMessage("stopped");
+        assertThat(new TaskAssignmentException("assignment")).hasMessage("assignment");
+        assertThat(new TaskAssignmentException(cause)).hasCause(cause);
+        assertThat(new TaskIdFormatException("task")).hasMessageContaining("task");
+        assertThat(new TaskIdFormatException(cause)).hasCause(cause);
+        assertThat(new TaskMigratedException("migrated")).hasMessageContaining("migrated");
+        assertThat(new TopologyException("topology")).hasMessageContaining("topology");
+        assertThat(new TopologyException(cause)).hasCause(cause);
+        assertThat(new UnknownStateStoreException("store")).hasMessage("store");
+
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "coverage-options");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, System.getProperty("java.io.tmpdir") + "/coverage-options");
+        Topology topology = new Topology().addSource("source", "input").addSink("sink", "output", "source");
+        try (KafkaStreams streams = new KafkaStreams(topology, properties, Time.SYSTEM)) {
+            streams.setUncaughtExceptionHandler((Thread.UncaughtExceptionHandler) (thread, exception) -> { });
+            streams.setUncaughtExceptionHandler(exception -> org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler
+                    .StreamThreadExceptionResponse.SHUTDOWN_CLIENT);
+            streams.setGlobalStateRestoreListener(new org.apache.kafka.streams.processor.StateRestoreListener() {
+                @Override
+                public void onRestoreStart(org.apache.kafka.common.TopicPartition partition, String store,
+                                           long startOffset, long endOffset) {
+                }
+
+                @Override
+                public void onBatchRestored(org.apache.kafka.common.TopicPartition partition, String store,
+                                            long batchEndOffset, long numRestored) {
+                }
+
+                @Override
+                public void onRestoreEnd(org.apache.kafka.common.TopicPartition partition, String store,
+                                         long totalRestored) {
+                }
+            });
+            assertThat(streams.addStreamThread()).isEmpty();
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsPublicApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsPublicApiCoverageTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.errors.BrokerNotFoundException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.InvalidStateStorePartitionException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.MissingSourceTopicException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.StreamsNotStartedException;
+import org.apache.kafka.streams.errors.StreamsRebalancingException;
+import org.apache.kafka.streams.errors.StreamsStoppedException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
+import org.apache.kafka.streams.errors.UnknownTopologyException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaStreamsPublicApiCoverageTest {
+
+    @Test
+    void exposesValueObjectsAndStoreQueryOptions() {
+        KeyValue<String, Integer> pair = KeyValue.pair("region", 3);
+        assertThat(pair).isEqualTo(new KeyValue<>("region", 3));
+        assertThat(pair.hashCode()).isEqualTo(new KeyValue<>("region", 3).hashCode());
+        assertThat(pair.toString()).contains("region").contains("3");
+
+        HostInfo active = new HostInfo("active", 9092);
+        HostInfo standby = new HostInfo("standby", 9093);
+        KeyQueryMetadata metadata = new KeyQueryMetadata(active, Set.of(standby), 4);
+        assertThat(metadata.activeHost()).isEqualTo(active);
+        assertThat(metadata.getActiveHost()).isEqualTo(active);
+        assertThat(metadata.partition()).isEqualTo(4);
+        assertThat(metadata.getPartition()).isEqualTo(4);
+        assertThat(metadata.standbyHosts()).containsExactly(standby);
+        assertThat(metadata.getStandbyHosts()).containsExactly(standby);
+        assertThat(metadata).isEqualTo(new KeyQueryMetadata(active, Set.of(standby), 4));
+        assertThat(metadata.hashCode()).isEqualTo(new KeyQueryMetadata(active, Set.of(standby), 4).hashCode());
+        assertThat(metadata.toString()).contains("active").contains("4");
+
+        StoreQueryParameters<?> query = StoreQueryParameters
+                .fromNameAndType("counts", QueryableStoreTypes.keyValueStore())
+                .withPartition(2)
+                .enableStaleStores();
+        assertThat(query.storeName()).isEqualTo("counts");
+        assertThat(query.queryableStoreType()).isInstanceOf(QueryableStoreTypes.keyValueStore().getClass());
+        assertThat(query.partition()).isEqualTo(2);
+        assertThat(query.staleStoresEnabled()).isTrue();
+        assertThat(query).isEqualTo(query);
+        assertThat(query.hashCode()).isEqualTo(query.hashCode());
+        assertThat(query.toString()).contains("counts").contains("2");
+    }
+
+    @Test
+    void configuresTopologyAndStreamsLifecycleBeforeStartup() {
+        Properties properties = streamProperties();
+        StreamsConfig config = new StreamsConfig(properties);
+        assertThat(StreamsConfig.consumerPrefix("client")).isEqualTo("consumer.client");
+        assertThat(StreamsConfig.mainConsumerPrefix("client")).isEqualTo("main.consumer.client");
+        assertThat(StreamsConfig.restoreConsumerPrefix("client")).isEqualTo("restore.consumer.client");
+        assertThat(StreamsConfig.globalConsumerPrefix("client")).isEqualTo("global.consumer.client");
+        assertThat(StreamsConfig.producerPrefix("client")).isEqualTo("producer.client");
+        assertThat(StreamsConfig.adminClientPrefix("client")).isEqualTo("admin.client");
+        assertThat(StreamsConfig.clientTagPrefix("client")).isEqualTo("client.tag.client");
+        assertThat(StreamsConfig.configDef().names()).contains(StreamsConfig.APPLICATION_ID_CONFIG);
+        assertThat(config.getGlobalConsumerConfigs("global")).containsEntry("client.id", "global-global-consumer");
+        assertThat(config.defaultTimestampExtractor()).isNotNull();
+        assertThat(config.defaultDeserializationExceptionHandler()).isNotNull();
+
+        TopologyConfig topologyConfig = new TopologyConfig(config);
+        assertThat(topologyConfig.isNamedTopology()).isFalse();
+        assertThat(topologyConfig.parseStoreType()).isNotNull();
+        Topology topology = new Topology(topologyConfig).addSource("source", "input").addSink("sink", "output", "source");
+        assertThat(topology.describe().subtopologies()).hasSize(1);
+
+        StreamsBuilder builder = new StreamsBuilder(topologyConfig);
+        builder.stream(java.util.regex.Pattern.compile("input-.*"));
+        builder.stream(java.util.regex.Pattern.compile("events-.*"), org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        builder.globalTable("global-topic");
+        builder.globalTable("global-topic-2", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        assertThat(builder.build().describe().globalStores()).hasSize(2);
+
+        try (KafkaStreams streams = new KafkaStreams(topology, properties, Time.SYSTEM)) {
+            assertThat(streams.state()).isEqualTo(KafkaStreams.State.CREATED);
+            assertThat(streams.isPaused()).isFalse();
+            streams.pause();
+            assertThat(streams.isPaused()).isTrue();
+            streams.resume();
+            assertThat(streams.isPaused()).isFalse();
+            assertThatThrownBy(streams::allMetadata).isInstanceOf(StreamsNotStartedException.class);
+            assertThatThrownBy(() -> streams.allMetadataForStore("missing")).isInstanceOf(StreamsNotStartedException.class);
+            assertThatThrownBy(() -> streams.streamsMetadataForStore("missing")).isInstanceOf(StreamsNotStartedException.class);
+            assertThat(streams.localThreadsMetadata()).hasSize(1);
+            assertThat(streams.metadataForLocalThreads()).hasSize(1);
+            assertThatThrownBy(streams::metadataForAllStreamsClients).isInstanceOf(StreamsNotStartedException.class);
+            assertThat(streams.metrics()).isNotEmpty();
+            assertThat(streams.allLocalStorePartitionLags()).isEmpty();
+            assertThatThrownBy(() -> streams.queryMetadataForKey("missing", "key", Serdes.String().serializer()))
+                    .isInstanceOf(StreamsNotStartedException.class);
+            assertThat(streams.removeStreamThread()).isEmpty();
+            assertThat(streams.removeStreamThread(Duration.ofMillis(1))).isEmpty();
+            assertThat(streams.close(new KafkaStreams.CloseOptions().timeout(Duration.ofMillis(1)).leaveGroup(true))).isFalse();
+        }
+        assertThat(KafkaStreams.State.RUNNING.isRunningOrRebalancing()).isTrue();
+        assertThat(KafkaStreams.State.PENDING_SHUTDOWN.hasStartedOrFinishedShuttingDown()).isTrue();
+    }
+
+    @Test
+    void preservesExceptionMessagesCausesAndTaskContext() {
+        RuntimeException cause = new RuntimeException("connection lost");
+        TaskId task = new TaskId(2, 7);
+        assertThat(new BrokerNotFoundException("broker", cause)).hasMessage("broker").hasCause(cause);
+        assertThat(new BrokerNotFoundException(cause)).hasCause(cause);
+        assertThat(new InvalidStateStoreException("store", cause)).hasCause(cause);
+        assertThat(new InvalidStateStorePartitionException("partition", cause)).hasCause(cause);
+        assertThat(new LockException("lock", cause)).hasCause(cause);
+        assertThat(new ProcessorStateException("processor", cause)).hasCause(cause);
+        assertThat(new StateStoreMigratedException("migrated", cause)).hasCause(cause);
+        assertThat(new StateStoreNotAvailableException("unavailable", cause)).hasCause(cause);
+        assertThat(new StreamsNotStartedException("not started", cause)).hasCause(cause);
+        assertThat(new StreamsRebalancingException("rebalancing", cause)).hasCause(cause);
+        assertThat(new StreamsStoppedException("stopped", cause)).hasCause(cause);
+        assertThat(new TaskAssignmentException("assignment", cause)).hasCause(cause);
+        assertThat(new TaskIdFormatException("task", cause)).hasCause(cause);
+        assertThat(new TaskMigratedException("migrated", cause)).hasCause(cause);
+        assertThat(new TopologyException("topology", cause)).hasCause(cause);
+        assertThat(new UnknownStateStoreException("store", cause)).hasCause(cause);
+        assertThat(new UnknownTopologyException("topology", cause, "named")).hasCause(cause);
+        assertThat(new MissingSourceTopicException("topic")).hasMessage("topic");
+        assertThat(new StreamsException("task failed", cause, task).taskId()).contains(task);
+        StreamsException exception = new StreamsException(cause);
+        exception.setTaskId(task);
+        assertThat(exception.taskId()).contains(task);
+        assertThat(new TaskCorruptedException(Set.of(task)).corruptedTasks()).containsExactly(task);
+    }
+
+    private Properties streamProperties() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "coverage-app");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, System.getProperty("java.io.tmpdir") + "/kafka-coverage-state");
+        return properties;
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsRuntimeCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsRuntimeCoverageTest.java
@@ -1,0 +1,530 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.TestUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KafkaStreamsRuntimeCoverageTest {
+
+    private static final String KAFKA_SERVER = "localhost:9093";
+
+    private EmbeddedZookeeper zookeeper;
+
+    private KafkaServer kafkaServer;
+
+    @BeforeAll
+    void startBroker() {
+        zookeeper = new EmbeddedZookeeper();
+        Properties brokerProperties = new Properties();
+        brokerProperties.setProperty("zookeeper.connect", "localhost:" + zookeeper.port());
+        brokerProperties.setProperty("log.dirs", TestUtils.tempDir().getPath());
+        brokerProperties.setProperty("listeners", "PLAINTEXT://" + KAFKA_SERVER);
+        brokerProperties.setProperty("offsets.topic.replication.factor", "1");
+        brokerProperties.setProperty("transaction.state.log.replication.factor", "1");
+        brokerProperties.setProperty("transaction.state.log.min.isr", "1");
+        kafkaServer = TestUtils.createServer(new KafkaConfig(brokerProperties), Time.SYSTEM);
+    }
+
+    @AfterAll
+    void stopBroker() {
+        if (kafkaServer != null) {
+            kafkaServer.shutdown();
+        }
+        if (zookeeper != null) {
+            zookeeper.shutdown();
+        }
+    }
+
+    @Test
+    void processesJoinsAggregatesWindowsAndStateStoresThroughKafkaStreams() throws Exception {
+        createTopics("orders", "payments", "discounts", "order-count-output", "joined-output", "table-joined-output",
+                "window-output", "transformed-output", "selected-count-output", "self-join-output", "rates",
+                "filtered-discount-output", "inner-table-join-output", "left-table-join-output", "outer-table-join-output",
+                "discount-passthrough-output", "discount-transform-output", "global-customers", "global-joined-output");
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.addStateStore(Stores.timestampedKeyValueStoreBuilder(
+                Stores.persistentTimestampedKeyValueStore("timestamped-key-values"), Serdes.String(), Serdes.String()));
+        builder.addStateStore(Stores.timestampedWindowStoreBuilder(
+                Stores.persistentTimestampedWindowStore("timestamped-windows", Duration.ofHours(1),
+                        Duration.ofMinutes(1), false), Serdes.String(), Serdes.String()));
+        builder.addStateStore(Stores.windowStoreBuilder(
+                Stores.inMemoryWindowStore("in-memory-windows", Duration.ofSeconds(10), Duration.ofSeconds(1), false),
+                Serdes.String(), Serdes.String()));
+        KStream<String, String> orders = builder.stream("orders", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> payments = builder.stream("payments", Consumed.with(Serdes.String(), Serdes.String()));
+
+        orders.process(() -> new TimestampedKeyValueWriter(), "timestamped-key-values");
+        orders.process(() -> new TimestampedWindowWriter(), "timestamped-windows");
+        orders.process(() -> new InMemoryWindowWriter(), "in-memory-windows");
+        orders.filter((key, value) -> value.startsWith("paid"))
+                .mapValues(value -> value + "-normalized")
+                .flatMapValues(value -> List.of(value, value + "-audit"))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .count(Materialized.as("order-counts"))
+                .toStream()
+                .to("order-count-output", Produced.with(Serdes.String(), Serdes.Long()));
+        orders.leftJoin(payments, (order, payment) -> order + ":" + payment,
+                        org.apache.kafka.streams.kstream.JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(10)))
+                .to("joined-output", Produced.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> discounts = builder.table("discounts", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> rates = builder.table("rates", Consumed.with(Serdes.String(), Serdes.String()));
+        GlobalKTable<String, String> customers = builder.globalTable("global-customers",
+                Consumed.with(Serdes.String(), Serdes.String()), Materialized.as("global-customers-store"));
+        orders.peek((key, value) -> { })
+                .to("transformed-output", Produced.with(Serdes.String(), Serdes.String()));
+        // Drive the public print processor with records rather than constructing its internal action directly.
+        orders.print(Printed.<String, String>toSysOut().withLabel("runtime-coverage"));
+        orders.leftJoin(discounts, (order, discount) -> order + ":" + discount)
+                .to("table-joined-output", Produced.with(Serdes.String(), Serdes.String()));
+        orders.join(customers, (key, value) -> key, (order, customer) -> order + ":" + customer)
+                .to("global-joined-output", Produced.with(Serdes.String(), Serdes.String()));
+        discounts.filter((key, value) -> value.startsWith("g"))
+                .mapValues(value -> value + "-filtered")
+                .toStream()
+                .to("filtered-discount-output", Produced.with(Serdes.String(), Serdes.String()));
+        // Execute KTable pass-through and transform processors through the public KTable DSL.
+        discounts.toStream().to("discount-passthrough-output", Produced.with(Serdes.String(), Serdes.String()));
+        discounts.transformValues(() -> new ValueTransformerWithKey<String, String, String>() {
+            @Override
+            public void init(org.apache.kafka.streams.processor.ProcessorContext context) {
+            }
+
+            @Override
+            public String transform(String key, String value) {
+                return key + ":" + value;
+            }
+
+            @Override
+            public void close() {
+            }
+        }).toStream().to("discount-transform-output", Produced.with(Serdes.String(), Serdes.String()));
+        discounts.join(rates, (discount, rate) -> discount + ":" + rate)
+                .toStream()
+                .to("inner-table-join-output", Produced.with(Serdes.String(), Serdes.String()));
+        discounts.leftJoin(rates, (discount, rate) -> discount + ":" + rate)
+                .toStream()
+                .to("left-table-join-output", Produced.with(Serdes.String(), Serdes.String()));
+        discounts.outerJoin(rates, (discount, rate) -> String.valueOf(discount) + ":" + rate)
+                .toStream()
+                .to("outer-table-join-output", Produced.with(Serdes.String(), Serdes.String()));
+        orders.selectKey((key, value) -> value.substring(0, 1))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .count(Materialized.as("selected-counts"))
+                .toStream()
+                .to("selected-count-output", Produced.with(Serdes.String(), Serdes.Long()));
+        discounts.groupBy((key, value) -> org.apache.kafka.streams.KeyValue.pair(value.substring(0, 1), value))
+                .reduce((left, right) -> left + right, (left, right) -> right,
+                        Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("discount-groups"));
+        orders.join(orders, (left, right) -> left + ":" + right,
+                        org.apache.kafka.streams.kstream.JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(10)))
+                .to("self-join-output", Produced.with(Serdes.String(), Serdes.String()));
+        orders.map((key, value) -> org.apache.kafka.streams.KeyValue.pair(key + "-mapped", value))
+                .flatMap((key, value) -> List.of(org.apache.kafka.streams.KeyValue.pair(key, value),
+                        org.apache.kafka.streams.KeyValue.pair(key + "-copy", value + "-copy")))
+                .split()
+                .branch((key, value) -> key.endsWith("-mapped"))
+                .defaultBranch()
+                .values()
+                .forEach(stream -> stream.to("transformed-output", Produced.with(Serdes.String(), Serdes.String())));
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMinutes(1)))
+                .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("window-counts").withCachingEnabled())
+                .suppress(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded()))
+                .toStream()
+                .to("window-output");
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMinutes(1)))
+                .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("queryable-window-counts")
+                        .withCachingEnabled());
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5)))
+                .count(Materialized.as("session-counts"));
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5)))
+                .count(Materialized.as(Stores.inMemorySessionStore("in-memory-sessions", Duration.ofSeconds(10))));
+        orders.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)))
+                .count(Materialized.as("sliding-counts"));
+
+        Properties properties = streamProperties();
+        try (KafkaStreams streams = new KafkaStreams(builder.build(), properties);
+             KafkaProducer<String, String> producer = new KafkaProducer<>(producerProperties());
+             KafkaConsumer<String, Long> counts = new KafkaConsumer<>(countConsumerProperties());
+             KafkaConsumer<String, String> transforms = new KafkaConsumer<>(stringConsumerProperties("transforms"));
+             KafkaConsumer<String, String> joins = new KafkaConsumer<>(stringConsumerProperties());
+             KafkaConsumer<String, String> tableJoins = new KafkaConsumer<>(stringConsumerProperties("table-joins"))) {
+            streams.start();
+            assertThat(streams.addStreamThread()).isPresent();
+            counts.subscribe(List.of("order-count-output"));
+            transforms.subscribe(List.of("transformed-output"));
+            joins.subscribe(List.of("joined-output"));
+            tableJoins.subscribe(List.of("table-joined-output"));
+
+            producer.send(new ProducerRecord<>("payments", "customer-1", "card")).get();
+            producer.send(new ProducerRecord<>("discounts", "customer-1", "gold")).get();
+            producer.send(new ProducerRecord<>("rates", "customer-1", "standard")).get();
+            producer.send(new ProducerRecord<>("global-customers", "customer-1", "preferred")).get();
+            long recordTime = System.currentTimeMillis();
+            producer.send(new ProducerRecord<>("orders", null, recordTime, "customer-1", "paid-order")).get();
+            producer.send(new ProducerRecord<>("orders", null, recordTime + 1L, "customer-1", "paid-order")).get();
+            producer.send(new ProducerRecord<>("orders", null, recordTime + 4_000L,
+                    "customer-3", "ignored-order")).get();
+            producer.send(new ProducerRecord<>("orders", null, recordTime + 2_000L,
+                    "customer-3", "ignored-order")).get();
+            producer.send(new ProducerRecord<>("orders", null, recordTime + Duration.ofSeconds(30).toMillis(),
+                    "customer-2", "ignored-order")).get();
+
+            assertThat(readValues(counts, 2)).contains(4L);
+            assertThat(readValues(transforms, 4)).contains("paid-order", "paid-order-copy");
+            assertThat(readValues(joins, 2)).contains("paid-order:card");
+            assertThat(readValues(tableJoins, 1)).contains("paid-order:gold");
+            assertThat(streams.allMetadata()).isNotNull();
+            assertThat(streams.allMetadataForStore("order-counts")).isNotNull();
+            assertThat(streams.streamsMetadataForStore("order-counts")).isNotNull();
+            assertThat(streams.queryMetadataForKey("order-counts", "customer-1", Serdes.String().serializer())).isNotNull();
+            assertThat(streams.queryMetadataForKey("order-counts", "customer-1",
+                    (topic, key, value, partitions) -> 0)).isNotNull();
+
+            ReadOnlyKeyValueStore<String, Long> stateStore = streams.store(StoreQueryParameters
+                    .fromNameAndType("order-counts", QueryableStoreTypes.keyValueStore()));
+            assertThat(stateStore.get("customer-1")).isEqualTo(4L);
+            try (KeyValueIterator<String, Long> entries = stateStore.all()) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<String, Long> entries = stateStore.range("customer-0", "customer-z")) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.peekNextKey()).isEqualTo("customer-1");
+                assertThat(entries.next().value).isEqualTo(4L);
+            }
+            try (KeyValueIterator<String, Long> entries = stateStore.reverseRange("customer-0", "customer-z")) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.peekNextKey()).isEqualTo("customer-1");
+                assertThat(entries.next().value).isEqualTo(4L);
+            }
+            try (KeyValueIterator<String, Long> entries = stateStore.reverseAll()) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<String, Long> entries = stateStore.prefixScan("customer", Serdes.String().serializer())) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().value).isEqualTo(4L);
+            }
+            ReadOnlyKeyValueStore<String, Long> selectedStore = streams.store(StoreQueryParameters
+                    .fromNameAndType("selected-counts", QueryableStoreTypes.keyValueStore()));
+            assertThat(selectedStore.get("p")).isEqualTo(2L);
+            try (KeyValueIterator<String, Long> entries = selectedStore.all()) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.peekNextKey()).isEqualTo("i");
+            }
+            ReadOnlyKeyValueStore<String, String> discountGroups = streams.store(StoreQueryParameters
+                    .fromNameAndType("discount-groups", QueryableStoreTypes.keyValueStore()));
+            assertThat(discountGroups.get("g")).isEqualTo("gold");
+            ReadOnlyKeyValueStore<String, ValueAndTimestamp<String>> timestampedValues = streams.store(StoreQueryParameters
+                    .fromNameAndType("timestamped-key-values", QueryableStoreTypes.timestampedKeyValueStore()));
+            assertThat(timestampedValues.get("customer-1").value()).isEqualTo("paid-order");
+            try (KeyValueIterator<String, ValueAndTimestamp<String>> entries = timestampedValues.reverseRange("customer-0",
+                    "customer-z")) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+            try (KeyValueIterator<String, ValueAndTimestamp<String>> entries = timestampedValues.prefixScan("customer",
+                    Serdes.String().serializer())) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().value.value()).isEqualTo("paid-order");
+            }
+            ReadOnlyWindowStore<String, ValueAndTimestamp<String>> timestampedWindows = streams.store(StoreQueryParameters
+                    .fromNameAndType("timestamped-windows", QueryableStoreTypes.timestampedWindowStore()));
+            try (WindowStoreIterator<ValueAndTimestamp<String>> entries = timestampedWindows.backwardFetch("customer-1",
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().value.value()).isEqualTo("paid-order");
+            }
+            try (KeyValueIterator<Windowed<String>, ValueAndTimestamp<String>> entries = timestampedWindows.all()) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<Windowed<String>, ValueAndTimestamp<String>> entries = timestampedWindows.backwardAll()) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+            try (KeyValueIterator<Windowed<String>, ValueAndTimestamp<String>> entries = timestampedWindows.fetchAll(
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<Windowed<String>, ValueAndTimestamp<String>> entries = timestampedWindows.backwardFetchAll(
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            ReadOnlyWindowStore<String, String> inMemoryWindows = streams.store(StoreQueryParameters
+                    .fromNameAndType("in-memory-windows", QueryableStoreTypes.windowStore()));
+            try (WindowStoreIterator<String> entries = inMemoryWindows.fetch("customer-1",
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                entries.hasNext();
+            }
+            try (WindowStoreIterator<String> entries = inMemoryWindows.backwardFetch("customer-1",
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, String> entries = inMemoryWindows.fetchAll(
+                    Instant.ofEpochMilli(recordTime + Duration.ofSeconds(29).toMillis()),
+                    Instant.ofEpochMilli(recordTime + Duration.ofSeconds(31).toMillis()))) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().value).isEqualTo("ignored-order");
+            }
+            try (KeyValueIterator<Windowed<String>, String> entries = inMemoryWindows.backwardAll()) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+            ReadOnlySessionStore<String, Long> inMemorySessions = streams.store(StoreQueryParameters
+                    .fromNameAndType("in-memory-sessions", QueryableStoreTypes.sessionStore()));
+            try (KeyValueIterator<Windowed<String>, Long> entries = inMemorySessions.fetch("customer-1")) {
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = inMemorySessions.backwardFetch(
+                    "customer-0", "customer-z")) {
+                entries.hasNext();
+            }
+            ReadOnlySessionStore<String, Long> sessionCounts = streams.store(StoreQueryParameters
+                    .fromNameAndType("session-counts", QueryableStoreTypes.sessionStore()));
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.fetch("customer-1")) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.peekNextKey().key()).isEqualTo("customer-1");
+                assertThat(entries.next().value).isEqualTo(2L);
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.backwardFetch("customer-1")) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.fetch("customer-0", "customer-z")) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.backwardFetch("customer-0", "customer-z")) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.findSessions("customer-1",
+                    recordTime - 1_000L, recordTime + 1_000L)) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().value).isEqualTo(2L);
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = sessionCounts.backwardFindSessions("customer-0",
+                    "customer-z", recordTime - 1_000L, recordTime + 1_000L)) {
+                assertThat(entries.hasNext()).isTrue();
+                assertThat(entries.next().key.key()).isEqualTo("customer-1");
+            }
+            assertThat(sessionCounts.fetchSession("customer-1", recordTime, recordTime + 1L)).isEqualTo(2L);
+            ReadOnlyWindowStore<String, Long> windowCounts = streams.store(StoreQueryParameters
+                    .fromNameAndType("queryable-window-counts", QueryableStoreTypes.windowStore()));
+            try (WindowStoreIterator<Long> entries = windowCounts.fetch("customer-1", Instant.ofEpochMilli(recordTime - 1_000L),
+                    Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            try (WindowStoreIterator<Long> entries = windowCounts.backwardFetch("customer-1",
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = windowCounts.fetchAll(
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = windowCounts.backwardFetchAll(
+                    Instant.ofEpochMilli(recordTime - 1_000L), Instant.ofEpochMilli(recordTime + 1_000L))) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = windowCounts.all()) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            try (KeyValueIterator<Windowed<String>, Long> entries = windowCounts.backwardAll()) {
+                assertThat(entries).isNotNull();
+                entries.hasNext();
+            }
+            ReadOnlyWindowStore<String, Long> slidingCounts = streams.store(StoreQueryParameters
+                    .fromNameAndType("sliding-counts", QueryableStoreTypes.windowStore()));
+            try (WindowStoreIterator<Long> entries = slidingCounts.fetch("customer-3",
+                    Instant.ofEpochMilli(recordTime), Instant.ofEpochMilli(recordTime + 5_000L))) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+            try (WindowStoreIterator<Long> entries = slidingCounts.backwardFetch("customer-3",
+                    Instant.ofEpochMilli(recordTime), Instant.ofEpochMilli(recordTime + 5_000L))) {
+                assertThat(entries.hasNext()).isTrue();
+                entries.peekNextKey();
+                entries.next();
+            }
+
+        }
+    }
+
+    private static final class InMemoryWindowWriter extends ContextualProcessor<String, String, Void, Void> {
+        @Override
+        public void process(Record<String, String> record) {
+            WindowStore<String, String> store = context().getStateStore("in-memory-windows");
+            store.put(record.key(), record.value(), record.timestamp());
+        }
+    }
+
+    private static final class TimestampedKeyValueWriter extends ContextualProcessor<String, String, Void, Void> {
+        @Override
+        public void process(Record<String, String> record) {
+            TimestampedKeyValueStore<String, String> store = context().getStateStore("timestamped-key-values");
+            store.put(record.key(), ValueAndTimestamp.make(record.value(), record.timestamp()));
+        }
+    }
+
+    private static final class TimestampedWindowWriter extends ContextualProcessor<String, String, Void, Void> {
+        @Override
+        public void process(Record<String, String> record) {
+            TimestampedWindowStore<String, String> store = context().getStateStore("timestamped-windows");
+            store.put(record.key(), ValueAndTimestamp.make(record.value(), record.timestamp()), record.timestamp());
+        }
+    }
+
+    private void createTopics(String... topicNames) throws Exception {
+        Properties properties = new Properties();
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        try (Admin admin = Admin.create(properties)) {
+            admin.createTopics(java.util.Arrays.stream(topicNames)
+                    .map(topic -> new NewTopic(topic, 1, (short) 1)).toList()).all().get();
+        }
+    }
+
+    private <T> List<T> readValues(KafkaConsumer<String, T> consumer, int expected) {
+        java.util.ArrayList<T> values = new java.util.ArrayList<>();
+        long deadline = System.currentTimeMillis() + 10_000L;
+        while (values.size() < expected && System.currentTimeMillis() < deadline) {
+            for (ConsumerRecord<String, T> record : consumer.poll(Duration.ofMillis(100))) {
+                values.add(record.value());
+            }
+        }
+        return values;
+    }
+
+    private Properties streamProperties() {
+        Properties properties = new Properties();
+        String runId = UUID.randomUUID().toString();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "runtime-coverage-" + runId);
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER);
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, System.getProperty("java.io.tmpdir") + "/runtime-coverage-" + runId);
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        // Public EOS configuration drives transaction initialization and the producer-config validation path.
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        properties.put(StreamsConfig.producerPrefix(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION), 1);
+        return properties;
+    }
+
+    private Map<String, Object> producerProperties() {
+        return Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    }
+
+    private Map<String, Object> countConsumerProperties() {
+        return consumerProperties(LongDeserializer.class);
+    }
+
+    private Map<String, Object> stringConsumerProperties() {
+        return stringConsumerProperties("joins");
+    }
+
+    private Map<String, Object> stringConsumerProperties(String groupSuffix) {
+        return consumerProperties(StringDeserializer.class, groupSuffix);
+    }
+
+    private Map<String, Object> consumerProperties(Class<?> valueDeserializer) {
+        return consumerProperties(valueDeserializer, valueDeserializer.getSimpleName());
+    }
+
+    private Map<String, Object> consumerProperties(Class<?> valueDeserializer, String groupSuffix) {
+        return Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_SERVER,
+                ConsumerConfig.GROUP_ID_CONFIG, "runtime-coverage-" + groupSuffix,
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsWindowAndGeneratedApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsWindowAndGeneratedApiCoverageTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageSizeAccumulator;
+import org.apache.kafka.common.protocol.MessageUtil;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaStreamsWindowAndGeneratedApiCoverageTest {
+
+    @Test
+    void roundTripsTimeWindowedKeysAndExposesWindowDefinitions() {
+        Windowed<String> order = new Windowed<>("order-7", new TimeWindow(100L, 200L));
+        TimeWindowedSerializer<String> serializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        TimeWindowedDeserializer<String> deserializer = new TimeWindowedDeserializer<>(Serdes.String().deserializer(), 100L);
+        serializer.configure(Map.of(), true);
+        deserializer.configure(Map.of(), true);
+
+        byte[] encoded = serializer.serialize("orders", order);
+        assertThat(serializer.serializeBaseKey("orders", order)).isNotEmpty();
+        assertThat(deserializer.deserialize("orders", encoded)).isEqualTo(order);
+        assertThat(deserializer.getWindowSize()).isEqualTo(100L);
+        assertThat(order.hashCode()).isEqualTo(new Windowed<>("order-7", new TimeWindow(100L, 200L)).hashCode());
+        assertThat(order.toString()).contains("order-7").contains("100");
+        serializer.close();
+        deserializer.close();
+        TimeWindowedSerializer<String> defaultSerializer = new TimeWindowedSerializer<>();
+        TimeWindowedDeserializer<String> defaultDeserializer = new TimeWindowedDeserializer<>();
+        defaultDeserializer.setIsChangelogTopic(true);
+        assertThat(defaultSerializer).isNotNull();
+        assertThat(defaultDeserializer).isNotNull();
+
+        TimeWindows windows = TimeWindows.ofSizeAndGrace(Duration.ofSeconds(10), Duration.ofSeconds(2))
+                .advanceBy(Duration.ofSeconds(5));
+        assertThat(windows.size()).isEqualTo(10_000L);
+        assertThat(windows.gracePeriodMs()).isEqualTo(2_000L);
+        assertThat(windows.windowsFor(12_000L)).hasSize(2);
+        assertThat(windows).isEqualTo(TimeWindows.ofSizeAndGrace(Duration.ofSeconds(10), Duration.ofSeconds(2))
+                .advanceBy(Duration.ofSeconds(5)));
+        assertThat(windows.toString()).contains("TimeWindows");
+        assertThat(TimeWindows.of(Duration.ofSeconds(10)).grace(Duration.ofSeconds(1))).isNotNull();
+        assertThat(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).isNotNull();
+
+        UnlimitedWindows unlimited = UnlimitedWindows.of().startOn(Instant.ofEpochMilli(50L));
+        assertThat(unlimited.windowsFor(100L)).hasSize(1);
+        assertThat(unlimited.size()).isEqualTo(Long.MAX_VALUE);
+        assertThat(unlimited.gracePeriodMs()).isEqualTo(0L);
+        assertThat(unlimited).isEqualTo(UnlimitedWindows.of().startOn(Instant.ofEpochMilli(50L)));
+        assertThat(unlimited.toString()).contains("UnlimitedWindows");
+
+        assertThat(order.window().startTime()).isEqualTo(Instant.ofEpochMilli(100L));
+        assertThat(order.window().endTime()).isEqualTo(Instant.ofEpochMilli(200L));
+        assertThat(order.window().toString()).contains("startMs=100");
+        assertThat(new WindowedSerdes()).isNotNull();
+        Serde<Windowed<String>> windowedSerde = WindowedSerdes.timeWindowedSerdeFrom(String.class, 100L);
+        assertThat(windowedSerde.deserializer().deserialize("orders", windowedSerde.serializer().serialize("orders", order)))
+                .isEqualTo(order);
+        assertThat(WindowedSerdes.timeWindowedSerdeFrom(String.class)).isNotNull();
+        assertThat(WindowedSerdes.sessionWindowedSerdeFrom(String.class)).isNotNull();
+    }
+
+    @Test
+    void preservesGeneratedSubscriptionPayloadFieldsAndProtocolCapabilities() {
+        SubscriptionInfoData.TaskId task = new SubscriptionInfoData.TaskId().setTopicGroupId(3).setPartition(9);
+        SubscriptionInfoData.PartitionToOffsetSum partition = new SubscriptionInfoData.PartitionToOffsetSum()
+                .setPartition(9).setOffsetSum(44L);
+        SubscriptionInfoData.TaskOffsetSum offset = new SubscriptionInfoData.TaskOffsetSum().setTopicGroupId(3)
+                .setPartition(9).setOffsetSum(44L).setNamedTopology("payments")
+                .setPartitionToOffsetSum(List.of(partition));
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag().setKey(new byte[] {7})
+                .setValue(new byte[] {8, 9});
+        SubscriptionInfoData data = new SubscriptionInfoData().setVersion(1).setLatestSupportedVersion(11)
+                .setUniqueField((byte) 2).setPrevTasks(List.of(task)).setStandbyTasks(List.of(task))
+                .setTaskOffsetSums(List.of(offset)).setClientTags(List.of(tag));
+
+        assertThat(data.apiKey()).isNotZero();
+        assertThat(data.lowestSupportedVersion()).isLessThanOrEqualTo(data.highestSupportedVersion());
+        assertThat(data.uniqueField()).isEqualTo((byte) 2);
+        assertThat(data.unknownTaggedFields()).isEmpty();
+        assertThat(data.hashCode()).isEqualTo(data.duplicate().hashCode());
+        assertThat(task.topicGroupId()).isEqualTo(3);
+        assertThat(task.partition()).isEqualTo(9);
+        assertThat(task.lowestSupportedVersion()).isLessThanOrEqualTo(task.highestSupportedVersion());
+        assertThat(task.unknownTaggedFields()).isEmpty();
+        assertThat(task.hashCode()).isEqualTo(task.duplicate().hashCode());
+        assertThat(offset.topicGroupId()).isEqualTo(3);
+        assertThat(offset.partition()).isEqualTo(9);
+        assertThat(offset.offsetSum()).isEqualTo(44L);
+        assertThat(offset.namedTopology()).isEqualTo("payments");
+        assertThat(offset.unknownTaggedFields()).isEmpty();
+        assertThat(offset.hashCode()).isEqualTo(offset.duplicate().hashCode());
+        assertThat(partition.partition()).isEqualTo(9);
+        assertThat(partition.offsetSum()).isEqualTo(44L);
+        assertThat(partition.unknownTaggedFields()).isEmpty();
+        assertThat(partition.hashCode()).isEqualTo(partition.duplicate().hashCode());
+        assertThat(tag.unknownTaggedFields()).isEmpty();
+        assertThat(tag.hashCode()).isEqualTo(tag.duplicate().hashCode());
+        assertThat(tag.toString()).contains("ClientTag");
+    }
+
+    @Test
+    void serializesGeneratedProtocolRecordsThroughTheirPublicMessageContract() {
+        SubscriptionInfoData.TaskId task = new SubscriptionInfoData.TaskId().setTopicGroupId(3).setPartition(9);
+        SubscriptionInfoData.PartitionToOffsetSum partition = new SubscriptionInfoData.PartitionToOffsetSum()
+                .setPartition(9).setOffsetSum(44L);
+        SubscriptionInfoData.TaskOffsetSum offset = new SubscriptionInfoData.TaskOffsetSum().setTopicGroupId(3)
+                .setPartition(9).setOffsetSum(44L).setNamedTopology("payments");
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag().setKey(new byte[] {7}).setValue(new byte[] {8, 9});
+
+        assertThat(roundTripTask(task)).isEqualTo(task);
+        assertThat(roundTripPartition(partition)).isEqualTo(partition);
+        assertThat(roundTripOffset(offset)).isEqualTo(offset);
+        assertThat(roundTripTag(tag)).isEqualTo(tag);
+    }
+
+    private SubscriptionInfoData.TaskId roundTripTask(SubscriptionInfoData.TaskId value) {
+        short version = 6;
+        MessageSizeAccumulator size = new MessageSizeAccumulator();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        value.addSize(size, cache, version);
+        ByteBufferAccessor writable = new ByteBufferAccessor(java.nio.ByteBuffer.allocate(size.totalSize()));
+        value.write(writable, cache, version);
+        SubscriptionInfoData.TaskId restored = new SubscriptionInfoData.TaskId(
+                new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        restored.read(new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        assertThat(restored.lowestSupportedVersion()).isLessThanOrEqualTo(restored.highestSupportedVersion());
+        return restored;
+    }
+
+    private SubscriptionInfoData.PartitionToOffsetSum roundTripPartition(SubscriptionInfoData.PartitionToOffsetSum value) {
+        short version = 9;
+        MessageSizeAccumulator size = new MessageSizeAccumulator();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        value.addSize(size, cache, version);
+        ByteBufferAccessor writable = new ByteBufferAccessor(java.nio.ByteBuffer.allocate(size.totalSize()));
+        value.write(writable, cache, version);
+        SubscriptionInfoData.PartitionToOffsetSum restored = new SubscriptionInfoData.PartitionToOffsetSum(
+                new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        restored.read(new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        assertThat(restored.toString()).contains("PartitionToOffsetSum");
+        return restored;
+    }
+
+    private SubscriptionInfoData.TaskOffsetSum roundTripOffset(SubscriptionInfoData.TaskOffsetSum value) {
+        short version = 11;
+        MessageSizeAccumulator size = new MessageSizeAccumulator();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        value.addSize(size, cache, version);
+        ByteBufferAccessor writable = new ByteBufferAccessor(java.nio.ByteBuffer.allocate(size.totalSize()));
+        value.write(writable, cache, version);
+        SubscriptionInfoData.TaskOffsetSum restored = new SubscriptionInfoData.TaskOffsetSum(
+                new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        restored.read(new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        assertThat(restored.toString()).contains("TaskOffsetSum");
+        return restored;
+    }
+
+    private SubscriptionInfoData.ClientTag roundTripTag(SubscriptionInfoData.ClientTag value) {
+        short version = 11;
+        MessageSizeAccumulator size = new MessageSizeAccumulator();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        value.addSize(size, cache, version);
+        ByteBufferAccessor writable = new ByteBufferAccessor(java.nio.ByteBuffer.allocate(size.totalSize()));
+        value.write(writable, cache, version);
+        SubscriptionInfoData.ClientTag restored = new SubscriptionInfoData.ClientTag(
+                new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        restored.read(new ByteBufferAccessor(MessageUtil.toByteBuffer(value, version)), version);
+        assertThat(restored.lowestSupportedVersion()).isLessThanOrEqualTo(restored.highestSupportedVersion());
+        return restored;
+    }
+
+    @Test
+    void buildsSuppressionAndJoinOptionsForStatefulOperators() {
+        assertThat(Suppressed.untilTimeLimit(Duration.ofSeconds(1), Suppressed.BufferConfig.maxRecords(10))
+                .withName("bounded")).isNotNull();
+        assertThat(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded()).withName("final-results")).isNotNull();
+        assertThat(Materialized.as(Materialized.StoreType.IN_MEMORY)).isNotNull();
+        assertThat(Materialized.as(Stores.persistentWindowStore("joined", Duration.ofHours(1), Duration.ofMinutes(5), false)))
+                .isNotNull();
+        assertThat(Named.as("first").withName("second")).isNotNull();
+        assertThat(TableJoined.with((topic, key, value, partitions) -> 0, (topic, key, value, partitions) -> 0)
+                .withName("table-join")).isNotNull();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+    "coordinates": "org.apache.kafka:kafka-streams:3.6.2"
+}


### PR DESCRIPTION
# Improve code coverage for org.apache.kafka:kafka-streams:3.6.2

## Code coverage improvement

- Pull request: https://github.com/oracle/graalvm-reachability-metadata/pull/9138
- Source issue: [#9055](https://github.com/oracle/graalvm-reachability-metadata/issues/9055)
- Coordinate: `org.apache.kafka:kafka-streams:3.6.2`
- Coverage suite path: `tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement`
- Needs human intervention: no

## JaCoCo coverage

### Public API guidance phase

- Baseline: 1825/3923 (46.52%)
- Final: 1980/3923 (50.47%)
- Delta: +155 covered methods, +3.95pp

### Deep-method guidance phase

- Baseline: 1516/15413 (9.84%)
- Final: 1740/15413 (11.29%)
- Delta: +224 covered methods, +1.45pp

## Sampled PGO guidance evidence

Sampled PGO is navigation evidence only; sample counts do not measure coverage, and sample absence does not prove non-execution.

- Baseline: 9,628 contexts, 6,904 sampled methods, 40,436 samples
- Final: 11,440 contexts, 7,518 sampled methods, 297,185 samples

## Target outcomes

- Completed: 389
- Skipped: 0
- Exhausted: 0
- Failed: 0

## Validation commands

```console
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-9055-kafka-streams/gradlew checkstyle -Pcoordinates=org.apache.kafka:kafka-streams:3.6.2 --stacktrace
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-9055-kafka-streams/gradlew javaTest -Pcoordinates=org.apache.kafka:kafka-streams:3.6.2 --stacktrace
/home/mihailo/git/graalvm-reachability-metadata/.agents/worktrees/issue-8380-coverage/.agents/worktrees/issue-9055-kafka-streams/gradlew codeCoverageTest -Pcoordinates=org.apache.kafka:kafka-streams:3.6.2 --stacktrace
```

This PR improves the dedicated coverage suite but does not auto-close the continuing coverage-improvement issue. Refs #9055.