### PR TITLE
Apply 2026/08/03 layered tests results

### DIFF
--- a/.github/workflows/layered-tests.yml
+++ b/.github/workflows/layered-tests.yml
@@ -69,7 +69,7 @@ jobs:
               },
               {
                 selection: "Dedicated Layered Tests",
-                shards: 64,
+                shards: 128,
                 name: "Dedicated",
                 task: "testDedicatedLayer",
                 failureReport: "dedicated-layer-test-failures.txt",

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -116,7 +116,7 @@ Every Sunday at 00:30 UTC (`30 0 * * 0`) and on manual dispatch. The scheduled
 run checks every supported library on the default branch with GraalVM `latest-ea`
 and the `current-defaults` Native Image mode, using the cached shared base layer
 (§TCK-test-harness.3). An `all` selection uses 16 independent shared-layer
-shards and 64 independent dedicated-layer shards, allows up to 64 matrix jobs
+shards and 128 independent dedicated-layer shards, allows up to 64 matrix jobs
 to run in parallel, and permits six hours per shard. Manual dispatch defaults
 to both lanes, `master`, `all`, and `latest-ea`; it may instead run only the
 shared or dedicated lane and select a different ref, coordinate, JDK, or mode.

--- a/tests/tck-build-logic/src/main/resources/dedicated-layer-test-exclusions.txt
+++ b/tests/tck-build-logic/src/main/resources/dedicated-layer-test-exclusions.txt
@@ -251,6 +251,7 @@ io.smallrye.common:smallrye-common-function
 io.smallrye.common:smallrye-common-process
 io.smallrye:jandex
 io.smallrye:jandex-gizmo2
+io.sundr:sundr-model-repo
 io.suzaku:boopickle_2.13
 io.suzaku:boopickle_3
 io.swagger.core.v3:swagger-core-jakarta
@@ -395,6 +396,7 @@ org.hibernate.orm:hibernate-envers
 org.hibernate.reactive:hibernate-reactive-core
 org.hibernate.validator:hibernate-validator
 org.hibernate:hibernate-core
+org.hsqldb:hsqldb
 org.http4s:http4s-circe_3
 org.http4s:http4s-core_3
 org.http4s:http4s-dsl_3
@@ -429,6 +431,7 @@ org.jetbrains.kotlinx:kotlinx-coroutines-swing
 org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm
 org.jetbrains.kotlinx:kotlinx-io-bytestring-jvm
 org.jetbrains.kotlinx:kotlinx-serialization-core-jvm
+org.jetbrains.kotlinx:kotlinx-serialization-json-io-jvm
 org.jetbrains.kotlinx:kotlinx-serialization-properties-jvm
 org.jetbrains.kotlinx:kotlinx-serialization-protobuf-jvm
 org.jline:jline-console
@@ -579,6 +582,8 @@ org.wildfly.common:wildfly-common
 plexus:plexus-utils
 samples:docker
 software.amazon.awssdk:apache-client
+software.amazon.awssdk:auth
+software.amazon.awssdk:aws-core
 software.amazon.awssdk:aws-json-protocol
 software.amazon.awssdk:aws-query-protocol
 software.amazon.awssdk:cognitoidentity
@@ -586,6 +591,7 @@ software.amazon.awssdk:dynamodb
 software.amazon.awssdk:http-auth
 software.amazon.awssdk:http-auth-aws
 software.amazon.awssdk:http-auth-spi
+software.amazon.awssdk:iotdataplane
 software.amazon.awssdk:kms
 software.amazon.awssdk:lambda
 software.amazon.awssdk:metrics-spi
@@ -601,5 +607,6 @@ tools.jackson.datatype:jackson-datatype-joda
 tools.jackson.datatype:jackson-datatype-jsr310
 tools.jackson.jaxrs:jackson-jaxrs-json-provider
 tools.jackson.module:jackson-module-kotlin
+xerces:xercesImpl
 xml-apis:xml-apis
 xpp3:xpp3

--- a/tests/tck-build-logic/src/main/resources/shared-layered-test-exclusions.txt
+++ b/tests/tck-build-logic/src/main/resources/shared-layered-test-exclusions.txt
@@ -70,6 +70,7 @@ com.monovore:decline-effect_3
 com.monovore:decline_3
 com.nimbusds:nimbus-jose-jwt
 com.oracle.oci.sdk:oci-java-sdk-certificatesmanagement
+com.oracle.oci.sdk:oci-java-sdk-common
 com.querydsl:querydsl-jpa
 com.sksamuel.hoplite:hoplite-core
 com.softwaremill.magnolia1_3:magnolia_3
@@ -159,6 +160,7 @@ io.circe:circe-generic_3
 io.circe:circe-jawn_3
 io.circe:circe-numbers_3
 io.circe:circe-parser_3
+io.confluent:kafka-avro-serializer
 io.confluent:kafka-schema-registry-client
 io.dropwizard.metrics:metrics-jvm
 io.fabric8:kubernetes-model-certificates
@@ -297,6 +299,7 @@ org.hibernate.orm:hibernate-processor
 org.hibernate.reactive:hibernate-reactive-core
 org.hibernate.validator:hibernate-validator
 org.hibernate:hibernate-core
+org.hsqldb:hsqldb
 org.http4s:http4s-circe_3
 org.http4s:http4s-core_3
 org.http4s:http4s-dsl_3
@@ -412,6 +415,9 @@ org.snakeyaml:snakeyaml-engine
 org.sonatype.sisu:sisu-inject-bean
 org.specs2:specs2-core_3
 org.specs2:specs2-fp_3
+org.springframework.ai:spring-ai-client-chat
+org.springframework.ai:spring-ai-model
+org.springframework.boot:spring-boot-actuator-autoconfigure
 org.springframework.boot:spring-boot-configuration-processor
 org.springframework.boot:spring-boot-kafka
 org.springframework.boot:spring-boot-reactor-netty


### PR DESCRIPTION
This PR adds newly failing libraries to the layered exclude list and split the dedicated layered tests into 128 shards because it can currently still timeout.