### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-oauth2-resource-server as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-oauth2-resource-server/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-oauth2-resource-server/index.json
@@ -1,0 +1,6 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "Artifact JAR contains no JVM class files, so there is no library code for native-image metadata."
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #9228

This PR records `org.springframework.boot:spring-boot-starter-oauth2-resource-server` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- Artifact JAR contains no JVM class files, so there is no library code for native-image metadata.

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `883ded077dd238d8500de5222c9ed1eb4e60d418`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
