### PR TITLE
[GenAI] Add support for junit:junit:3.7 using gpt-5.5 (chunked dynamic-access)

### DIFF
--- a/metadata/junit/junit/3.7/reachability-metadata.json
+++ b/metadata/junit/junit/3.7/reachability-metadata.json
@@ -1,85 +1,59 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.io.File",
-      "serializable": true,
-      "fields": [
+      "type" : "java.io.File",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "path"
+          "name" : "path"
         },
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      "condition" : {
+        "typeReached" : "junit.runner.BaseTestRunner"
       },
-      "type": "java.io.File",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
-      },
-      "type": "java.io.File",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.io.File",
-      "methods": [
+      "type" : "java.io.FileNotFoundException",
+      "jniAccessible" : true,
+      "methods" : [
         {
-          "name": "toPath",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.runner.BaseTestRunner"
-      },
-      "type": "java.io.FileNotFoundException",
-      "jniAccessible": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String",
             "java.lang.String"
           ]
@@ -87,1100 +61,397 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Class[]"
+      "type" : "java.lang.Class[]"
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Deprecated"
+      "type" : "java.lang.Deprecated"
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Long",
-      "serializable": true,
-      "fields": [
+      "type" : "java.lang.Long",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         },
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Long",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
-      },
-      "type": "java.lang.Long",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Number",
-      "serializable": true,
-      "fields": [
+      "type" : "java.lang.Number",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Number",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
-      },
-      "type": "java.lang.Number",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Object",
-      "methods": [
+      "type" : "java.lang.Object",
+      "methods" : [
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Object"
+      "type" : "java.lang.StackTraceElement[]"
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.String",
-      "serializable": true,
-      "fields": [
+      "type" : "java.lang.String",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "serialPersistentFields"
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "serialVersionUID"
+          "name" : "serialVersionUID"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
-      },
-      "type": "java.lang.String",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.annotation.Annotation[][]"
-    },
-    {
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
         {
-          "name": "getRuntimeMXBean",
-          "parameterTypes": []
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "getThreadMXBean",
-          "parameterTypes": []
+          "name" : "getThreadMXBean",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
-      },
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
         {
-          "name": "getRuntimeMXBean",
-          "parameterTypes": []
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
-      },
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
+      "type" : "java.lang.management.ThreadMXBean",
+      "methods" : [
         {
-          "name": "getThreadMXBean",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "java.lang.management.RuntimeMXBean",
-      "methods": [
-        {
-          "name": "getInputArguments",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
-      },
-      "type": "java.lang.management.RuntimeMXBean",
-      "methods": [
-        {
-          "name": "getInputArguments",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "java.lang.management.ThreadMXBean",
-      "methods": [
-        {
-          "name": "getThreadCpuTime",
-          "parameterTypes": [
+          "name" : "getThreadCpuTime",
+          "parameterTypes" : [
             "long"
           ]
         },
         {
-          "name": "isThreadCpuTimeSupported",
-          "parameterTypes": []
+          "name" : "isThreadCpuTimeSupported",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.management.ThreadMXBean",
-      "methods": [
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
+      },
+      "type" : "java.util.AbstractMap",
+      "methods" : [
         {
-          "name": "getThreadCpuTime",
-          "parameterTypes": [
-            "long"
-          ]
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "isThreadCpuTimeSupported",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.nio.file.Files",
-      "methods": [
+      "type" : "java.util.HashMap",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "createTempDirectory",
-          "parameterTypes": [
-            "java.lang.String",
-            "java.nio.file.attribute.FileAttribute[]"
-          ]
+          "name" : "loadFactor"
         },
         {
-          "name": "createTempDirectory",
-          "parameterTypes": [
-            "java.nio.file.Path",
-            "java.lang.String",
-            "java.nio.file.attribute.FileAttribute[]"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.nio.file.Path",
-      "methods": [
-        {
-          "name": "toFile",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.nio.file.attribute.FileAttribute"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.nio.file.attribute.FileAttribute[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.util.AbstractMap",
-      "methods": [
-        {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.util.HashMap",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "loadFactor"
+          "name" : "serialVersionUID"
         },
         {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        },
-        {
-          "name": "threshold"
+          "name" : "threshold"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "java.util.HashMap",
-      "serializable": true
+      "type" : "junit.framework.TestCase"
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
-      },
-      "type": "java.util.HashMap",
-      "serializable": true
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "junit.framework.TestCase"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BaseTestRunnerTest$SuiteProvider"
-      },
-      "type": "junit.framework.TestCase"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
-      },
-      "type": "junit.framework.TestSuite$1"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.AnnotatedBuilderTest"
-      },
-      "type": "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
-      "methods": [
+      "type" : "org.junit.experimental.max.MaxHistory",
+      "serializable" : true,
+      "fields" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
+          "name" : "fDurations"
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class",
-            "org.junit.runners.model.RunnerBuilder"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.AnnotatedBuilderTest"
-      },
-      "type": "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.runner.BaseTestRunner"
-      },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteProvider",
-      "methods": [
-        {
-          "name": "suite",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
-      },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
-      "methods": [
-        {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "fFailureTimestamps"
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
+          "name" : "fHistoryStore"
         },
         {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BaseTestRunnerTest$SuiteProvider"
-      },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
+          "name" : "serialPersistentFields"
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
-        },
-        {
-          "name": "recordsConstructorParameter",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
-      "fields": [
-        {
-          "name": "value"
+          "name" : "serialVersionUID"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "parameters",
-          "parameterTypes": []
-        },
-        {
-          "name": "recordsFieldParameter",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
-      },
-      "type": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest$MalformedJUnit3TestCase"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "afterClass",
-          "parameterTypes": []
-        },
-        {
-          "name": "beforeClass",
-          "parameterTypes": []
-        },
-        {
-          "name": "testMethod",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest$LegacyMethodFixture",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "after",
-          "parameterTypes": []
-        },
-        {
-          "name": "before",
-          "parameterTypes": []
-        },
-        {
-          "name": "testMethod",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitRunnerFilterFactoriesTest"
-      },
-      "type": "junit.junit.OrgJunitRunnerFilterFactoriesTest$TestNameFilterFactory",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitRunnerManipulationOrderingTest"
-      },
-      "type": "junit.junit.OrgJunitRunnerManipulationOrderingTest$ReversingOrderingFactory",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
-      },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
-        {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TestSuiteTest"
-      },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
-      },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
-        {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TestSuiteTest"
-      },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        },
-        {
-          "name": "testRuns",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "junit.junit.TheoriesTest$SingleValueSupplier",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "junit.junit.TheoriesTest$TheoryFixture",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        },
-        {
-          "name": "acceptsSuppliedValue",
-          "parameterTypes": [
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "org.junit.experimental.max.MaxHistory",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "fDurations"
-        },
-        {
-          "name": "fFailureTimestamps"
-        },
-        {
-          "name": "fHistoryStore"
-        },
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
+          "name" : "readObject",
+          "parameterTypes" : [
             "java.io.ObjectInputStream"
           ]
         },
         {
-          "name": "readObjectNoData",
-          "parameterTypes": []
+          "name" : "readObjectNoData",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "readResolve",
-          "parameterTypes": []
+          "name" : "readResolve",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "writeObject",
-          "parameterTypes": [
+          "name" : "writeObject",
+          "parameterTypes" : [
             "java.io.ObjectOutputStream"
           ]
         },
         {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "writeReplace",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "org.junit.experimental.theories.Theories",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "org.junit.internal.runners.JUnit4ClassRunner",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "org.junit.internal.runners.JUnit4ClassRunner",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "org.junit.runners.Parameterized",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.Class"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "sun.management.VMManagementImpl",
-      "jniAccessible": true,
-      "fields": [
-        {
-          "name": "compTimeMonitoringSupport"
-        },
-        {
-          "name": "currentThreadCpuTimeSupport"
-        },
-        {
-          "name": "objectMonitorUsageSupport"
-        },
-        {
-          "name": "otherThreadCpuTimeSupport"
-        },
-        {
-          "name": "remoteDiagnosticCommandsSupport"
-        },
-        {
-          "name": "synchronizerUsageSupport"
-        },
-        {
-          "name": "threadAllocatedMemorySupport"
-        },
-        {
-          "name": "threadContentionMonitoringSupport"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
-      },
-      "type": "sun.management.VMManagementImpl",
-      "jniAccessible": true,
-      "fields": [
-        {
-          "name": "compTimeMonitoringSupport"
-        },
-        {
-          "name": "currentThreadCpuTimeSupport"
-        },
-        {
-          "name": "objectMonitorUsageSupport"
-        },
-        {
-          "name": "otherThreadCpuTimeSupport"
-        },
-        {
-          "name": "remoteDiagnosticCommandsSupport"
-        },
-        {
-          "name": "synchronizerUsageSupport"
-        },
-        {
-          "name": "threadAllocatedMemorySupport"
-        },
-        {
-          "name": "threadContentionMonitoringSupport"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.Deprecated"
         ]
       },
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.reflect.InvocationHandler"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "java.lang.annotation.Retention"
         ]
       },
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.reflect.InvocationHandler"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": {
-        "proxy": [
-          "org.junit.experimental.theories.ParametersSuppliedBy"
-        ]
-      },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.reflect.InvocationHandler"
           ]
         }

--- a/metadata/junit/junit/3.7/reachability-metadata.json
+++ b/metadata/junit/junit/3.7/reachability-metadata.json
@@ -46,6 +46,20 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "java.io.File",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type": "java.io.File",
+      "serializable": true
+    },
+    {
+      "condition": {
         "typeReached": "junit.junit.TemporaryFolderTest"
       },
       "type": "java.io.File",
@@ -71,24 +85,6 @@
           ]
         }
       ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
     },
     {
       "condition": {
@@ -148,6 +144,20 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "java.lang.Long",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type": "java.lang.Long",
+      "serializable": true
+    },
+    {
+      "condition": {
         "typeReached": "junit.framework.TestSuite"
       },
       "type": "java.lang.Number",
@@ -189,9 +199,17 @@
     },
     {
       "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
       },
-      "type": "java.lang.Object"
+      "type": "java.lang.Number",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type": "java.lang.Number",
+      "serializable": true
     },
     {
       "condition": {
@@ -208,6 +226,12 @@
           "parameterTypes": []
         }
       ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.Object"
     },
     {
       "condition": {
@@ -276,6 +300,13 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "condition": {
         "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
       "type": "java.lang.annotation.Annotation[]"
@@ -310,10 +341,29 @@
         {
           "name": "getRuntimeMXBean",
           "parameterTypes": []
+        },
+        {
+          "name": "getThreadMXBean",
+          "parameterTypes": []
         }
       ]
     },
     {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
+      },
       "type": "java.lang.management.ManagementFactory",
       "methods": [
         {
@@ -332,6 +382,36 @@
       ]
     },
     {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.ThreadMXBean",
+      "methods": [
+        {
+          "name": "getThreadCpuTime",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "isThreadCpuTimeSupported",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
+      },
       "type": "java.lang.management.ThreadMXBean",
       "methods": [
         {
@@ -360,25 +440,19 @@
     },
     {
       "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
         "typeReached": "junit.junit.TheoriesTest"
       },
       "type": "java.lang.reflect.Constructor[]"
     },
     {
       "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+        "typeReached": "junit.framework.TestSuite"
       },
       "type": "java.lang.reflect.Field[]"
     },
     {
       "condition": {
-        "typeReached": "junit.framework.TestSuite"
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
       "type": "java.lang.reflect.Field[]"
     },
@@ -397,24 +471,6 @@
     {
       "condition": {
         "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
       },
       "type": "java.lang.reflect.Method[]"
     },
@@ -548,9 +604,35 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true
+    },
+    {
+      "condition": {
         "typeReached": "junit.framework.TestSuite"
       },
       "type": "junit.framework.TestCase"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BaseTestRunnerTest$SuiteProvider"
+      },
+      "type": "junit.framework.TestCase"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "junit.framework.TestSuite$1"
     },
     {
       "condition": {
@@ -635,6 +717,12 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.BaseTestRunnerTest$SuiteProvider"
+      },
+      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase"
+    },
+    {
+      "condition": {
         "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
       "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
@@ -682,6 +770,12 @@
     },
     {
       "condition": {
+        "typeReached": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type": "junit.junit.OrgJunitExperimentalMaxMaxCoreTest$MalformedJUnit3TestCase"
+    },
+    {
+      "condition": {
         "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
       },
       "type": "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
@@ -724,6 +818,30 @@
         },
         {
           "name": "testMethod",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitRunnerFilterFactoriesTest"
+      },
+      "type": "junit.junit.OrgJunitRunnerFilterFactoriesTest$TestNameFilterFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitRunnerManipulationOrderingTest"
+      },
+      "type": "junit.junit.OrgJunitRunnerManipulationOrderingTest$ReversingOrderingFactory",
+      "methods": [
+        {
+          "name": "<init>",
           "parameterTypes": []
         }
       ]
@@ -952,6 +1070,39 @@
       ]
     },
     {
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
       "type": "sun.management.VMManagementImpl",
       "jniAccessible": true,
       "fields": [

--- a/metadata/junit/junit/3.7/reachability-metadata.json
+++ b/metadata/junit/junit/3.7/reachability-metadata.json
@@ -1,10 +1,1039 @@
 {
-  "reflection" : [
+  "reflection": [
     {
-      "condition" : {
-        "typeReached" : "junit.framework.TestSuite"
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
       },
-      "type" : "junit.framework.TestCase"
+      "type": "java.io.File",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "path"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.io.File",
+      "methods": [
+        {
+          "name": "toPath",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.runner.BaseTestRunner"
+      },
+      "type": "java.io.FileNotFoundException",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Deprecated"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Long",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Number",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.String",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getThreadMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.ThreadMXBean",
+      "methods": [
+        {
+          "name": "getThreadCpuTime",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "isThreadCpuTimeSupported",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.nio.file.Files",
+      "methods": [
+        {
+          "name": "createTempDirectory",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.nio.file.attribute.FileAttribute[]"
+          ]
+        },
+        {
+          "name": "createTempDirectory",
+          "parameterTypes": [
+            "java.nio.file.Path",
+            "java.lang.String",
+            "java.nio.file.attribute.FileAttribute[]"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.nio.file.Path",
+      "methods": [
+        {
+          "name": "toFile",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.nio.file.attribute.FileAttribute"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.nio.file.attribute.FileAttribute[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.util.AbstractMap",
+      "methods": [
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "loadFactor"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "threshold"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.framework.TestCase"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.AnnotatedBuilderTest"
+      },
+      "type": "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class",
+            "org.junit.runners.model.RunnerBuilder"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.AnnotatedBuilderTest"
+      },
+      "type": "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.runner.BaseTestRunner"
+      },
+      "type": "junit.junit.BaseTestRunnerTest$SuiteProvider",
+      "methods": [
+        {
+          "name": "suite",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
+      },
+      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods": [
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "parameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "recordsConstructorParameter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "parameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "recordsFieldParameter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "afterClass",
+          "parameterTypes": []
+        },
+        {
+          "name": "beforeClass",
+          "parameterTypes": []
+        },
+        {
+          "name": "testMethod",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest$LegacyMethodFixture",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "after",
+          "parameterTypes": []
+        },
+        {
+          "name": "before",
+          "parameterTypes": []
+        },
+        {
+          "name": "testMethod",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TestSuiteTest"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TestSuiteTest"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "junit.junit.TheoriesTest$SingleValueSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "junit.junit.TheoriesTest$TheoryFixture",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "acceptsSuppliedValue",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.junit.experimental.max.MaxHistory",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "fDurations"
+        },
+        {
+          "name": "fFailureTimestamps"
+        },
+        {
+          "name": "fHistoryStore"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "org.junit.experimental.theories.Theories",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "org.junit.runners.Parameterized",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.Deprecated"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": {
+        "proxy": [
+          "org.junit.experimental.theories.ParametersSuppliedBy"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/stats/junit/junit/3.7/execution-metrics.json
+++ b/stats/junit/junit/3.7/execution-metrics.json
@@ -88,5 +88,96 @@
     "artifacts": {
       "metadata_file": "metadata/junit/junit/3.7/reachability-metadata.json"
     }
+  },
+  "add_new_library_support:2026-08-07": {
+    "timestamp": "2026-08-07T11:39:47.904350Z",
+    "library": "junit:junit:3.7",
+    "starting_commit": "883ded077dd238d8500de5222c9ed1eb4e60d418",
+    "ending_commit": "4effce240b6af595c289efcf0c5c07541d1867d0",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "gpt-5.5",
+    "status": "chunk_ready",
+    "stats": {
+      "version": "3.7",
+      "dynamicAccess": {
+        "breakdown": {
+          "reflection": {
+            "coverageRatio": 0.871429,
+            "coveredCalls": 61,
+            "totalCalls": 70
+          }
+        },
+        "coverageRatio": 0.871429,
+        "coveredCalls": 61,
+        "totalCalls": 70
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 6999,
+          "missed": 14497,
+          "ratio": 0.325595,
+          "total": 21496
+        },
+        "line": {
+          "covered": 1653,
+          "missed": 3238,
+          "ratio": 0.337968,
+          "total": 4891
+        },
+        "method": {
+          "covered": 623,
+          "missed": 1007,
+          "ratio": 0.382209,
+          "total": 1630
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "advisory_preparation",
+      "issue_number": 995,
+      "issue_label": "library-new-request",
+      "library": "junit:junit:3.7",
+      "summary": "JUnit 3.7 itself has no external service or extra library dependency, but the normal TCK scaffold can upgrade it to JUnit 4.13.2 via JUnit Vintage, making coverage non-meaningful for 3.7.",
+      "deterministic_setup": [],
+      "agent_guidance": "Ensure the test runtime actually resolves `junit:junit:3.7`; the default scaffold's `org.junit.vintage:junit-vintage-engine` dependency pulls `junit:junit:4.13.2` and Gradle conflict resolution upgrades 3.7. Exclude/disable that upgrade or enforce the 3.7 artifact before judging coverage. Write coverage tests against JUnit 3 APIs such as `junit.framework.*`, `junit.runner.*`, and text UI runner classes; avoid JUnit 4-only APIs.",
+      "risks": [
+        "If dependency resolution is not corrected, generated tests may pass while covering JUnit 4.13.2 instead of the requested 3.7 artifact.",
+        "Forcing JUnit 3.7 while leaving JUnit Vintage active may break JUnit Platform discovery because Vintage expects JUnit 4 classes."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#995 Support for junit:junit:3.7; label=library-new-request; body_chars=453"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "13 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.5",
+      "input_tokens_used": 28230,
+      "output_tokens_used": 3055,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/junit:junit:3.7/library-preparation-preflight/pi-generation-2026-08-07T10-30-10-608929Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 364612,
+      "cached_input_tokens_used": 2867712,
+      "output_tokens_used": 29826,
+      "iterations": 11,
+      "cost_usd": 4.1518,
+      "generated_loc": 708,
+      "tested_library_loc": 1653,
+      "metadata_entries": 99,
+      "test_only_metadata_entries": 133,
+      "code_coverage_percent": 33.8
+    },
+    "artifacts": {
+      "metadata_file": "metadata/junit/junit/3.7/reachability-metadata.json"
+    }
   }
 }

--- a/stats/junit/junit/3.7/stats.json
+++ b/stats/junit/junit/3.7/stats.json
@@ -4,32 +4,32 @@
     "dynamicAccess" : {
       "breakdown" : {
         "reflection" : {
-          "coverageRatio" : 0.542857,
-          "coveredCalls" : 38,
+          "coverageRatio" : 0.871429,
+          "coveredCalls" : 61,
           "totalCalls" : 70
         }
       },
-      "coverageRatio" : 0.542857,
-      "coveredCalls" : 38,
+      "coverageRatio" : 0.871429,
+      "coveredCalls" : 61,
       "totalCalls" : 70
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 5339,
-        "missed" : 16157,
-        "ratio" : 0.248372,
+        "covered" : 6999,
+        "missed" : 14497,
+        "ratio" : 0.325595,
         "total" : 21496
       },
       "line" : {
-        "covered" : 1240,
-        "missed" : 3651,
-        "ratio" : 0.253527,
+        "covered" : 1653,
+        "missed" : 3238,
+        "ratio" : 0.337968,
         "total" : 4891
       },
       "method" : {
-        "covered" : 469,
-        "missed" : 1161,
-        "ratio" : 0.28773,
+        "covered" : 623,
+        "missed" : 1007,
+        "ratio" : 0.382209,
         "total" : 1630
       }
     }

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -26,7 +26,8 @@
     "org.junit.internal.runners.JUnit4ClassRunner",
     "org.junit.internal.runners.TestClass",
     "org.junit.internal.runners.TestMethod",
-    "org.junit.internal.runners.ClassRoadie"
+    "org.junit.internal.runners.ClassRoadie",
+    "org.junit.internal.runners.MethodRoadie"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -27,7 +27,8 @@
     "org.junit.internal.runners.TestClass",
     "org.junit.internal.runners.TestMethod",
     "org.junit.internal.runners.ClassRoadie",
-    "org.junit.internal.runners.MethodRoadie"
+    "org.junit.internal.runners.MethodRoadie",
+    "org.junit.runner.FilterFactories"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -28,7 +28,8 @@
     "org.junit.internal.runners.TestMethod",
     "org.junit.internal.runners.ClassRoadie",
     "org.junit.internal.runners.MethodRoadie",
-    "org.junit.runner.FilterFactories"
+    "org.junit.runner.FilterFactories",
+    "org.junit.runner.manipulation.Ordering"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -20,7 +20,8 @@
     "org.junit.internal.Classes",
     "org.junit.internal.management.ReflectiveRuntimeMXBean",
     "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder",
-    "org.junit.internal.management.ManagementFactory$FactoryHolder"
+    "org.junit.internal.management.ManagementFactory$FactoryHolder",
+    "org.junit.internal.management.ReflectiveThreadMXBean$Holder"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -18,7 +18,8 @@
     "org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters",
     "org.junit.experimental.max.MaxHistory",
     "org.junit.internal.Classes",
-    "org.junit.internal.management.ReflectiveRuntimeMXBean"
+    "org.junit.internal.management.ReflectiveRuntimeMXBean",
+    "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -16,7 +16,8 @@
     "org.junit.runners.model.TestClass",
     "org.junit.experimental.theories.Theories",
     "org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters",
-    "org.junit.experimental.max.MaxHistory"
+    "org.junit.experimental.max.MaxHistory",
+    "org.junit.internal.Classes"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -15,7 +15,8 @@
     "org.junit.runners.model.FrameworkMethod$1",
     "org.junit.runners.model.TestClass",
     "org.junit.experimental.theories.Theories",
-    "org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters"
+    "org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters",
+    "org.junit.experimental.max.MaxHistory"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -22,7 +22,8 @@
     "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder",
     "org.junit.internal.management.ManagementFactory$FactoryHolder",
     "org.junit.internal.management.ReflectiveThreadMXBean$Holder",
-    "org.junit.internal.management.ReflectiveThreadMXBean"
+    "org.junit.internal.management.ReflectiveThreadMXBean",
+    "org.junit.internal.runners.JUnit4ClassRunner"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -24,7 +24,8 @@
     "org.junit.internal.management.ReflectiveThreadMXBean$Holder",
     "org.junit.internal.management.ReflectiveThreadMXBean",
     "org.junit.internal.runners.JUnit4ClassRunner",
-    "org.junit.internal.runners.TestClass"
+    "org.junit.internal.runners.TestClass",
+    "org.junit.internal.runners.TestMethod"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -23,7 +23,8 @@
     "org.junit.internal.management.ManagementFactory$FactoryHolder",
     "org.junit.internal.management.ReflectiveThreadMXBean$Holder",
     "org.junit.internal.management.ReflectiveThreadMXBean",
-    "org.junit.internal.runners.JUnit4ClassRunner"
+    "org.junit.internal.runners.JUnit4ClassRunner",
+    "org.junit.internal.runners.TestClass"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -21,7 +21,8 @@
     "org.junit.internal.management.ReflectiveRuntimeMXBean",
     "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder",
     "org.junit.internal.management.ManagementFactory$FactoryHolder",
-    "org.junit.internal.management.ReflectiveThreadMXBean$Holder"
+    "org.junit.internal.management.ReflectiveThreadMXBean$Holder",
+    "org.junit.internal.management.ReflectiveThreadMXBean"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -29,7 +29,8 @@
     "org.junit.internal.runners.ClassRoadie",
     "org.junit.internal.runners.MethodRoadie",
     "org.junit.runner.FilterFactories",
-    "org.junit.runner.manipulation.Ordering"
+    "org.junit.runner.manipulation.Ordering",
+    "org.junit.experimental.max.MaxCore"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -25,7 +25,8 @@
     "org.junit.internal.management.ReflectiveThreadMXBean",
     "org.junit.internal.runners.JUnit4ClassRunner",
     "org.junit.internal.runners.TestClass",
-    "org.junit.internal.runners.TestMethod"
+    "org.junit.internal.runners.TestMethod",
+    "org.junit.internal.runners.ClassRoadie"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -19,7 +19,8 @@
     "org.junit.experimental.max.MaxHistory",
     "org.junit.internal.Classes",
     "org.junit.internal.management.ReflectiveRuntimeMXBean",
-    "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder"
+    "org.junit.internal.management.ReflectiveRuntimeMXBean$Holder",
+    "org.junit.internal.management.ManagementFactory$FactoryHolder"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -17,7 +17,8 @@
     "org.junit.experimental.theories.Theories",
     "org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters",
     "org.junit.experimental.max.MaxHistory",
-    "org.junit.internal.Classes"
+    "org.junit.internal.Classes",
+    "org.junit.internal.management.ReflectiveRuntimeMXBean"
   ],
   "coordinate": "junit:junit:3.7",
   "currentChunkClassCount": 15,

--- a/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
+++ b/tests/src/junit/junit/3.7/dynamic-access-exhaust-report.json
@@ -37,7 +37,7 @@
   "exhaustedClasses": [],
   "failedClasses": [],
   "issueNumber": 995,
-  "latestChunkCommit": "8c6e9c9519478d87be8500de217e55ab63317596",
-  "latestChunkPullRequest": 9127,
+  "latestChunkCommit": "6eda67cf34882035f36fb5ec91f4640756932231",
+  "latestChunkPullRequest": 9260,
   "skippedClasses": []
 }

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitExperimentalMaxMaxCoreTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitExperimentalMaxMaxCoreTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import java.nio.file.Path;
+
+import junit.framework.TestCase;
+import org.junit.experimental.max.MaxCore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.runner.Result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitExperimentalMaxMaxCoreTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void reportsMalformedJUnit3TestClassThroughMaxCore() {
+        MaxCore maxCore = MaxCore.storedLocally(temporaryDirectory.resolve("max-history.ser").toFile());
+
+        Result result = maxCore.run(MalformedJUnit3TestCase.class);
+
+        assertThat(result.getRunCount()).isEqualTo(1);
+        assertThat(result.getFailureCount()).isEqualTo(1);
+        assertThat(result.getFailures().get(0).getDescription().toString())
+                .isEqualTo("warning(junit.framework.TestSuite$1)");
+    }
+
+    private static class MalformedJUnit3TestCase extends TestCase {
+        private MalformedJUnit3TestCase(String name) {
+            super(name);
+        }
+
+        public void testCannotBeConstructedByJUnit3Suite() {
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitExperimentalMaxMaxHistoryTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitExperimentalMaxMaxHistoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import org.junit.experimental.max.MaxHistory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitExperimentalMaxMaxHistoryTest {
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void persistsAndReadsRememberedRunHistory() throws Exception {
+        File historyFile = temporaryDirectory.resolve("max-history.ser").toFile();
+        Description completedTest = Description.createTestDescription(SampleTestCase.class, "testSample");
+        Description newTest = Description.createTestDescription(SampleTestCase.class, "testOther");
+
+        MaxHistory history = MaxHistory.forFolder(historyFile);
+        RunListener listener = history.listener();
+        listener.testStarted(completedTest);
+        listener.testFinished(completedTest);
+        listener.testRunFinished(new Result());
+
+        MaxHistory reloadedHistory = MaxHistory.forFolder(historyFile);
+        Comparator<Description> comparator = reloadedHistory.testComparator();
+
+        assertThat(historyFile).isFile();
+        assertThat(historyFile.length()).isPositive();
+        assertThat(comparator.compare(newTest, completedTest)).isLessThan(0);
+    }
+
+    public static class SampleTestCase {
+        public void testSample() {
+        }
+
+        public void testOther() {
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest {
+    @Test
+    void disableOnDebugReadsRuntimeArgumentsThroughManagementFactoryWrapper() throws Throwable {
+        RecordingRule rule = new RecordingRule();
+        DisableOnDebug disableOnDebug = new DisableOnDebug(rule);
+
+        Statement statement = disableOnDebug.apply(new Statement() {
+            @Override
+            public void evaluate() {
+            }
+        }, Description.createTestDescription(getClass(), "sample"));
+        statement.evaluate();
+
+        assertThat(disableOnDebug.isDebugging()).isEqualTo(hasDebugArgument(ManagementFactory.getRuntimeMXBean()
+                .getInputArguments()));
+        assertThat(rule.applied).isEqualTo(!disableOnDebug.isDebugging());
+    }
+
+    private static boolean hasDebugArgument(List<String> arguments) {
+        for (String argument : arguments) {
+            if ("-Xdebug".equals(argument) || argument.startsWith("-agentlib:jdwp")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final class RecordingRule implements TestRule {
+        private boolean applied;
+
+        @Override
+        public Statement apply(Statement base, Description description) {
+            applied = true;
+            return base;
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalManagementReflectiveThreadMXBeanTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalManagementReflectiveThreadMXBeanTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import org.junit.internal.management.ManagementFactory;
+import org.junit.internal.management.ThreadMXBean;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class OrgJunitInternalManagementReflectiveThreadMXBeanTest {
+    @Test
+    void managementFactoryThreadBeanQueriesCpuTimeForCurrentThread() {
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        boolean supported = threadBean.isThreadCpuTimeSupported();
+
+        if (supported) {
+            assertThat(threadBean.getThreadCpuTime(Thread.currentThread().getId())).isGreaterThanOrEqualTo(-1L);
+        } else {
+            assertThatThrownBy(() -> threadBean.getThreadCpuTime(Thread.currentThread().getId()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalRunnersClassRoadieTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalRunnersClassRoadieTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitInternalRunnersClassRoadieTest {
+    @Test
+    void invokesClassLevelBeforeAndAfterMethodsWithLegacyRunner() {
+        LegacyClassFixture.beforeClassCalls = 0;
+        LegacyClassFixture.afterClassCalls = 0;
+        LegacyClassFixture.testCalls = 0;
+        LegacyClassFixture.beforeRanBeforeTest = false;
+        LegacyClassFixture.afterRanAfterTest = false;
+
+        Result result = JUnitCore.runClasses(LegacyClassFixture.class);
+
+        assertThat(result.getFailureCount()).isZero();
+        assertThat(result.getRunCount()).isEqualTo(1);
+        assertThat(LegacyClassFixture.beforeClassCalls).isEqualTo(1);
+        assertThat(LegacyClassFixture.afterClassCalls).isEqualTo(1);
+        assertThat(LegacyClassFixture.testCalls).isEqualTo(1);
+        assertThat(LegacyClassFixture.beforeRanBeforeTest).isTrue();
+        assertThat(LegacyClassFixture.afterRanAfterTest).isTrue();
+    }
+
+    @RunWith(JUnit4ClassRunner.class)
+    public static class LegacyClassFixture {
+        private static int beforeClassCalls;
+        private static int afterClassCalls;
+        private static int testCalls;
+        private static boolean beforeRanBeforeTest;
+        private static boolean afterRanAfterTest;
+
+        @BeforeClass
+        public static void beforeClass() {
+            beforeClassCalls++;
+        }
+
+        @org.junit.Test
+        public void testMethod() {
+            testCalls++;
+            beforeRanBeforeTest = beforeClassCalls == 1;
+        }
+
+        @AfterClass
+        public static void afterClass() {
+            afterClassCalls++;
+            afterRanAfterTest = testCalls == 1;
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalRunnersMethodRoadieTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitInternalRunnersMethodRoadieTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitInternalRunnersMethodRoadieTest {
+    @Test
+    void invokesMethodLevelBeforeAndAfterMethodsWithLegacyRunner() {
+        LegacyMethodFixture.events = new StringBuilder();
+
+        Result result = JUnitCore.runClasses(LegacyMethodFixture.class);
+
+        assertThat(result.getFailureCount()).isZero();
+        assertThat(result.getRunCount()).isEqualTo(1);
+        assertThat(LegacyMethodFixture.events.toString()).isEqualTo("before,test,after,");
+    }
+
+    @RunWith(JUnit4ClassRunner.class)
+    public static class LegacyMethodFixture {
+        private static StringBuilder events = new StringBuilder();
+
+        @Before
+        public void before() {
+            events.append("before,");
+        }
+
+        @org.junit.Test
+        public void testMethod() {
+            events.append("test,");
+        }
+
+        @After
+        public void after() {
+            events.append("after,");
+        }
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitRunnerFilterFactoriesTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitRunnerFilterFactoriesTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runner.FilterFactory;
+import org.junit.runner.FilterFactoryParams;
+import org.junit.runner.manipulation.Filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitRunnerFilterFactoriesTest {
+    @Test
+    void createsFilterFactoryWithPublicNoArgumentConstructor() throws Exception {
+        Description description = Description.createSuiteDescription("suite");
+        FilterFactoryParams params = new FilterFactoryParams(description, "keep");
+
+        Filter filter = createFilter(TestNameFilterFactory.class, params);
+
+        assertThat(filter.shouldRun(Description.createTestDescription(SampleTestCase.class, "keep"))).isTrue();
+        assertThat(filter.shouldRun(Description.createTestDescription(SampleTestCase.class, "skip"))).isFalse();
+        assertThat(filter.describe()).isEqualTo("method named keep");
+        assertThat(TestNameFilterFactory.createdWith.getTopLevelDescription()).isSameAs(description);
+        assertThat(TestNameFilterFactory.createdWith.getArgs()).isEqualTo("keep");
+    }
+
+    private static Filter createFilter(Class<? extends FilterFactory> factoryClass, FilterFactoryParams params)
+            throws Exception {
+        Class<?> filterFactoriesClass = Class.forName("org.junit.runner.FilterFactories");
+        Method createFilter = filterFactoriesClass.getDeclaredMethod(
+                "createFilter", Class.class, FilterFactoryParams.class);
+        createFilter.setAccessible(true);
+        try {
+            return (Filter) createFilter.invoke(null, factoryClass, params);
+        } catch (InvocationTargetException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw exception;
+        }
+    }
+
+    public static class TestNameFilterFactory implements FilterFactory {
+        private static FilterFactoryParams createdWith;
+
+        public TestNameFilterFactory() {
+        }
+
+        @Override
+        public Filter createFilter(FilterFactoryParams params) {
+            createdWith = params;
+            return new Filter() {
+                @Override
+                public boolean shouldRun(Description description) {
+                    return params.getArgs().equals(description.getMethodName());
+                }
+
+                @Override
+                public String describe() {
+                    return "method named " + params.getArgs();
+                }
+            };
+        }
+    }
+
+    public static class SampleTestCase {
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitRunnerManipulationOrderingTest.java
+++ b/tests/src/junit/junit/3.7/src/test/java/junit/junit/OrgJunitRunnerManipulationOrderingTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package junit.junit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.InvalidOrderingException;
+import org.junit.runner.manipulation.Orderable;
+import org.junit.runner.manipulation.Orderer;
+import org.junit.runner.manipulation.Ordering;
+import org.junit.runner.manipulation.Sorter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrgJunitRunnerManipulationOrderingTest {
+    @Test
+    void createsOrderingFromPublicFactoryClass() throws InvalidOrderingException {
+        Description target = Description.createSuiteDescription("ordered-suite");
+        ReversingOrderingFactory.lastTarget = null;
+
+        Ordering ordering = Ordering.definedBy(ReversingOrderingFactory.class, target);
+        RecordingOrderable orderable = new RecordingOrderable(
+                Description.createTestDescription(FirstTestCase.class, "first"),
+                Description.createTestDescription(SecondTestCase.class, "second"));
+
+        ordering.apply(orderable);
+
+        assertThat(ReversingOrderingFactory.lastTarget).isSameAs(target);
+        assertThat(orderable.orderedDescriptions)
+                .extracting(Description::getMethodName)
+                .containsExactly("second", "first");
+    }
+
+    public static class ReversingOrderingFactory implements Ordering.Factory {
+        private static Description lastTarget;
+
+        public ReversingOrderingFactory() {
+        }
+
+        @Override
+        public Ordering create(Ordering.Context context) {
+            lastTarget = context.getTarget();
+            return new Ordering() {
+                @Override
+                protected List<Description> orderItems(Collection<Description> descriptions) {
+                    List<Description> ordered = new ArrayList<>(descriptions);
+                    Collections.reverse(ordered);
+                    return ordered;
+                }
+            };
+        }
+    }
+
+    private static class RecordingOrderable implements Orderable {
+        private final List<Description> descriptions;
+        private List<Description> orderedDescriptions;
+
+        RecordingOrderable(Description first, Description second) {
+            descriptions = new ArrayList<>();
+            descriptions.add(first);
+            descriptions.add(second);
+        }
+
+        @Override
+        public void order(Orderer orderer) throws InvalidOrderingException {
+            orderedDescriptions = orderer.order(descriptions);
+        }
+
+        @Override
+        public void sort(Sorter sorter) {
+            descriptions.sort((left, right) -> sorter.compare(left, right));
+        }
+    }
+
+    public static class FirstTestCase {
+    }
+
+    public static class SecondTestCase {
+    }
+}

--- a/tests/src/junit/junit/3.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/junit/junit/3.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,45 +1,457 @@
 {
-  "reflection" : [
+  "reflection": [
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
       },
-      "type" : "java.io.File",
-      "methods" : [
+      "type": "java.io.File",
+      "serializable": true,
+      "fields": [
         {
-          "name" : "toPath",
-          "parameterTypes" : [ ]
+          "name": "path"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
       },
-      "type" : "java.lang.Object"
-    },
-    {
-      "condition" : {
-        "typeReached" : "junit.junit.TheoriesTest"
-      },
-      "type" : "java.lang.Object"
-    },
-    {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
-      },
-      "type" : "java.nio.file.Files",
-      "methods" : [
+      "type": "java.io.File",
+      "methods": [
         {
-          "name" : "createTempDirectory",
-          "parameterTypes" : [
+          "name": "toPath",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.runner.BaseTestRunner"
+      },
+      "type": "java.io.FileNotFoundException",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Class[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Deprecated"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Long",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "value"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Number",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.StackTraceElement[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.String",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getRuntimeMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.ManagementFactory",
+      "methods": [
+        {
+          "name": "getThreadMXBean",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.RuntimeMXBean",
+      "methods": [
+        {
+          "name": "getInputArguments",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.management.ThreadMXBean",
+      "methods": [
+        {
+          "name": "getThreadCpuTime",
+          "parameterTypes": [
+            "long"
+          ]
+        },
+        {
+          "name": "isThreadCpuTimeSupported",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Field[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "java.lang.reflect.Method[]"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
+      },
+      "type": "java.nio.file.Files",
+      "methods": [
+        {
+          "name": "createTempDirectory",
+          "parameterTypes": [
             "java.lang.String",
             "java.nio.file.attribute.FileAttribute[]"
           ]
         },
         {
-          "name" : "createTempDirectory",
-          "parameterTypes" : [
+          "name": "createTempDirectory",
+          "parameterTypes": [
             "java.nio.file.Path",
             "java.lang.String",
             "java.nio.file.attribute.FileAttribute[]"
@@ -48,38 +460,113 @@
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
       },
-      "type" : "java.nio.file.Path",
-      "methods" : [
+      "type": "java.nio.file.Path",
+      "methods": [
         {
-          "name" : "toFile",
-          "parameterTypes" : [ ]
+          "name": "toFile",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
       },
-      "type" : "java.nio.file.attribute.FileAttribute"
+      "type": "java.nio.file.attribute.FileAttribute"
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
+      "condition": {
+        "typeReached": "junit.junit.TemporaryFolderTest"
       },
-      "type" : "java.nio.file.attribute.FileAttribute[]"
+      "type": "java.nio.file.attribute.FileAttribute[]"
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.AnnotatedBuilderTest"
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
       },
-      "type" : "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
-      "methods" : [
+      "type": "java.util.AbstractMap",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "java.util.HashMap",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "loadFactor"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        },
+        {
+          "name": "threshold"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.framework.TestCase"
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.AnnotatedBuilderTest"
+      },
+      "type": "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
             "java.lang.Class",
             "org.junit.runners.model.RunnerBuilder"
           ]
@@ -87,181 +574,464 @@
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.AnnotatedBuilderTest"
+      "condition": {
+        "typeReached": "junit.junit.AnnotatedBuilderTest"
       },
-      "type" : "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
-      "methods" : [
+      "type": "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [
+          "name": "<init>",
+          "parameterTypes": [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.runner.BaseTestRunner"
+      "condition": {
+        "typeReached": "junit.runner.BaseTestRunner"
       },
-      "type" : "junit.junit.BaseTestRunnerTest$SuiteProvider",
-      "methods" : [
+      "type": "junit.junit.BaseTestRunnerTest$SuiteProvider",
+      "methods": [
         {
-          "name" : "suite",
-          "parameterTypes" : [ ]
+          "name": "suite",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.framework.TestSuite"
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
       },
-      "type" : "junit.junit.BaseTestRunnerTest$SuiteTestCase",
-      "methods" : [
+      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
         },
         {
-          "name" : "testRuns",
-          "parameterTypes" : [ ]
-        }
-      ]
-    },
-    {
-      "condition" : {
-        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
-      "methods" : [
-        {
-          "name" : "<init>",
-          "parameterTypes" : [
+          "name": "<init>",
+          "parameterTypes": [
             "java.lang.String"
           ]
         },
         {
-          "name" : "parameters",
-          "parameterTypes" : [ ]
-        },
-        {
-          "name" : "recordsConstructorParameter",
-          "parameterTypes" : [ ]
+          "name": "testRuns",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
-      "type" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
-      "fields" : [
+      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
+      "methods": [
         {
-          "name" : "value"
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "parameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "recordsConstructorParameter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
+      "fields": [
+        {
+          "name": "value"
         }
       ],
-      "methods" : [
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         },
         {
-          "name" : "parameters",
-          "parameterTypes" : [ ]
+          "name": "parameters",
+          "parameterTypes": []
         },
         {
-          "name" : "recordsFieldParameter",
-          "parameterTypes" : [ ]
+          "name": "recordsFieldParameter",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TestSuiteTest"
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
       },
-      "type" : "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods" : [
+      "type": "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         },
         {
-          "name" : "testRuns",
-          "parameterTypes" : [ ]
+          "name": "afterClass",
+          "parameterTypes": []
+        },
+        {
+          "name": "beforeClass",
+          "parameterTypes": []
+        },
+        {
+          "name": "testMethod",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TestSuiteTest"
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
       },
-      "type" : "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods" : [
+      "type": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest$LegacyMethodFixture",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "after",
+          "parameterTypes": []
+        },
+        {
+          "name": "before",
+          "parameterTypes": []
+        },
+        {
+          "name": "testMethod",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TestSuiteTest"
+      },
+      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestCase"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "testRuns",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TestSuiteTest"
+      },
+      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
             "java.lang.String"
           ]
         },
         {
-          "name" : "testRuns",
-          "parameterTypes" : [ ]
+          "name": "testRuns",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TheoriesTest"
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
       },
-      "type" : "junit.junit.TheoriesTest$SingleValueSupplier",
-      "methods" : [
+      "type": "junit.junit.TheoriesTest$SingleValueSupplier",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TheoriesTest"
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
       },
-      "type" : "junit.junit.TheoriesTest$TheoryFixture",
-      "methods" : [
+      "type": "junit.junit.TheoriesTest$TheoryFixture",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": []
         },
         {
-          "name" : "acceptsSuppliedValue",
-          "parameterTypes" : [
+          "name": "acceptsSuppliedValue",
+          "parameterTypes": [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
-      },
-      "type" : "sun.security.provider.NativePRNG",
-      "methods" : [
+      "type": "org.junit.experimental.max.MaxHistory",
+      "serializable": true,
+      "fields": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [
-            "java.security.SecureRandomParameters"
+          "name": "fDurations"
+        },
+        {
+          "name": "fFailureTimestamps"
+        },
+        {
+          "name": "fHistoryStore"
+        },
+        {
+          "name": "serialPersistentFields"
+        },
+        {
+          "name": "serialVersionUID"
+        }
+      ],
+      "methods": [
+        {
+          "name": "readObject",
+          "parameterTypes": [
+            "java.io.ObjectInputStream"
+          ]
+        },
+        {
+          "name": "readObjectNoData",
+          "parameterTypes": []
+        },
+        {
+          "name": "readResolve",
+          "parameterTypes": []
+        },
+        {
+          "name": "writeObject",
+          "parameterTypes": [
+            "java.io.ObjectOutputStream"
+          ]
+        },
+        {
+          "name": "writeReplace",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": "org.junit.experimental.theories.Theories",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition" : {
-        "typeReached" : "junit.junit.TemporaryFolderTest"
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
       },
-      "type" : "sun.security.provider.SHA",
-      "methods" : [
+      "type": "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods": [
         {
-          "name" : "<init>",
-          "parameterTypes" : [ ]
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type": "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type": "org.junit.runners.Parameterized",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.management.VMManagementImpl",
+      "jniAccessible": true,
+      "fields": [
+        {
+          "name": "compTimeMonitoringSupport"
+        },
+        {
+          "name": "currentThreadCpuTimeSupport"
+        },
+        {
+          "name": "objectMonitorUsageSupport"
+        },
+        {
+          "name": "otherThreadCpuTimeSupport"
+        },
+        {
+          "name": "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name": "synchronizerUsageSupport"
+        },
+        {
+          "name": "threadAllocatedMemorySupport"
+        },
+        {
+          "name": "threadContentionMonitoringSupport"
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.Deprecated"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.framework.TestSuite"
+      },
+      "type": {
+        "proxy": [
+          "java.lang.annotation.Retention"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "junit.junit.TheoriesTest"
+      },
+      "type": {
+        "proxy": [
+          "org.junit.experimental.theories.ParametersSuppliedBy"
+        ]
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.reflect.InvocationHandler"
+          ]
         }
       ]
     }

--- a/tests/src/junit/junit/3.7/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/junit/junit/3.7/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,457 +1,135 @@
 {
-  "reflection": [
+  "reflection" : [
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.junit.TemporaryFolderTest"
       },
-      "type": "java.io.File",
-      "serializable": true,
-      "fields": [
+      "type" : "java.io.File",
+      "methods" : [
         {
-          "name": "path"
-        },
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
+          "name" : "toPath",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
-      "type": "java.io.File",
-      "methods": [
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.Object"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.annotation.Annotation[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.annotation.Annotation[][]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.reflect.Constructor[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.reflect.Field[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
+      },
+      "type" : "java.lang.reflect.Method[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.TemporaryFolderTest"
+      },
+      "type" : "java.nio.file.Files",
+      "methods" : [
         {
-          "name": "toPath",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.runner.BaseTestRunner"
-      },
-      "type": "java.io.FileNotFoundException",
-      "jniAccessible": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.String",
-            "java.lang.String"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Class[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Deprecated"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Long",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        },
-        {
-          "name": "value"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Number",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.Object",
-      "methods": [
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.Object"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.StackTraceElement[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.String",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.annotation.Annotation[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.annotation.Annotation[][]"
-    },
-    {
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
-        {
-          "name": "getRuntimeMXBean",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "java.lang.management.ManagementFactory",
-      "methods": [
-        {
-          "name": "getThreadMXBean",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "java.lang.management.RuntimeMXBean",
-      "methods": [
-        {
-          "name": "getInputArguments",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "java.lang.management.ThreadMXBean",
-      "methods": [
-        {
-          "name": "getThreadCpuTime",
-          "parameterTypes": [
-            "long"
-          ]
-        },
-        {
-          "name": "isThreadCpuTimeSupported",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Constructor[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Field[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": "java.lang.reflect.Method[]"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
-      },
-      "type": "java.nio.file.Files",
-      "methods": [
-        {
-          "name": "createTempDirectory",
-          "parameterTypes": [
+          "name" : "createTempDirectory",
+          "parameterTypes" : [
             "java.lang.String",
             "java.nio.file.attribute.FileAttribute[]"
           ]
         },
         {
-          "name": "createTempDirectory",
-          "parameterTypes": [
+          "name" : "createTempDirectory",
+          "parameterTypes" : [
             "java.nio.file.Path",
             "java.lang.String",
             "java.nio.file.attribute.FileAttribute[]"
@@ -460,113 +138,44 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TemporaryFolderTest"
       },
-      "type": "java.nio.file.Path",
-      "methods": [
+      "type" : "java.nio.file.Path",
+      "methods" : [
         {
-          "name": "toFile",
-          "parameterTypes": []
+          "name" : "toFile",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TemporaryFolderTest"
       },
-      "type": "java.nio.file.attribute.FileAttribute"
+      "type" : "java.nio.file.attribute.FileAttribute"
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TemporaryFolderTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TemporaryFolderTest"
       },
-      "type": "java.nio.file.attribute.FileAttribute[]"
+      "type" : "java.nio.file.attribute.FileAttribute[]"
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.junit.AnnotatedBuilderTest"
       },
-      "type": "java.util.AbstractMap",
-      "methods": [
+      "type" : "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
+      "methods" : [
         {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "java.util.HashMap",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "loadFactor"
-        },
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        },
-        {
-          "name": "threshold"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": "junit.framework.TestCase"
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.AnnotatedBuilderTest"
-      },
-      "type": "junit.junit.AnnotatedBuilderTest$BuilderAwareRunner",
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class",
             "org.junit.runners.model.RunnerBuilder"
           ]
@@ -574,464 +183,549 @@
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.AnnotatedBuilderTest"
+      "condition" : {
+        "typeReached" : "junit.junit.AnnotatedBuilderTest"
       },
-      "type": "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
-      "methods": [
+      "type" : "junit.junit.AnnotatedBuilderTest$ClassOnlyRunner",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.runner.BaseTestRunner"
+      "condition" : {
+        "typeReached" : "junit.runner.BaseTestRunner"
       },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteProvider",
-      "methods": [
+      "type" : "junit.junit.BaseTestRunnerTest$SuiteProvider",
+      "methods" : [
         {
-          "name": "suite",
-          "parameterTypes": []
+          "name" : "suite",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
+      "condition" : {
+        "typeReached" : "junit.framework.TestCase"
       },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
-      "methods": [
+      "type" : "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods" : [
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "junit.junit.BaseTestRunnerTest$SuiteTestCase",
-      "methods": [
+      "type" : "junit.junit.BaseTestRunnerTest$SuiteTestCase",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
-      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
-      "methods": [
+      "type" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$ConstructorInjectedFixture",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "recordsConstructorParameter",
-          "parameterTypes": []
+          "name" : "recordsConstructorParameter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
-      "type": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
-      "fields": [
+      "type" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest$FieldInjectedFixture",
+      "fields" : [
         {
-          "name": "value"
+          "name" : "value"
         }
       ],
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "parameters",
-          "parameterTypes": []
+          "name" : "parameters",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "recordsFieldParameter",
-          "parameterTypes": []
+          "name" : "recordsFieldParameter",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
       },
-      "type": "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
-      "methods": [
+      "type" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest$LegacyClassFixture",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "afterClass",
-          "parameterTypes": []
+          "name" : "afterClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "beforeClass",
-          "parameterTypes": []
+          "name" : "beforeClass",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "testMethod",
-          "parameterTypes": []
+          "name" : "testMethod",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
       },
-      "type": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest$LegacyMethodFixture",
-      "methods": [
+      "type" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest$LegacyMethodFixture",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "after",
-          "parameterTypes": []
+          "name" : "after",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "before",
-          "parameterTypes": []
+          "name" : "before",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "testMethod",
-          "parameterTypes": []
+          "name" : "testMethod",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
+      "condition" : {
+        "typeReached" : "junit.framework.TestCase"
       },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods" : [
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TestSuiteTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TestSuiteTest"
       },
-      "type": "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$DefaultConstructorTestCase",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestCase"
+      "condition" : {
+        "typeReached" : "junit.framework.TestCase"
       },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods" : [
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.framework.TestSuite"
       },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TestSuiteTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TestSuiteTest"
       },
-      "type": "junit.junit.TestSuiteTest$StringConstructorTestCase",
-      "methods": [
+      "type" : "junit.junit.TestSuiteTest$StringConstructorTestCase",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         },
         {
-          "name": "testRuns",
-          "parameterTypes": []
+          "name" : "testRuns",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
       },
-      "type": "junit.junit.TheoriesTest$SingleValueSupplier",
-      "methods": [
+      "type" : "junit.junit.TheoriesTest$SingleValueSupplier",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
       },
-      "type": "junit.junit.TheoriesTest$TheoryFixture",
-      "methods": [
+      "type" : "junit.junit.TheoriesTest$TheoryFixture",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": []
+          "name" : "<init>",
+          "parameterTypes" : [ ]
         },
         {
-          "name": "acceptsSuppliedValue",
-          "parameterTypes": [
+          "name" : "acceptsSuppliedValue",
+          "parameterTypes" : [
             "java.lang.String"
           ]
         }
       ]
     },
     {
-      "type": "org.junit.experimental.max.MaxHistory",
-      "serializable": true,
-      "fields": [
-        {
-          "name": "fDurations"
-        },
-        {
-          "name": "fFailureTimestamps"
-        },
-        {
-          "name": "fHistoryStore"
-        },
-        {
-          "name": "serialPersistentFields"
-        },
-        {
-          "name": "serialVersionUID"
-        }
-      ],
-      "methods": [
-        {
-          "name": "readObject",
-          "parameterTypes": [
-            "java.io.ObjectInputStream"
-          ]
-        },
-        {
-          "name": "readObjectNoData",
-          "parameterTypes": []
-        },
-        {
-          "name": "readResolve",
-          "parameterTypes": []
-        },
-        {
-          "name": "writeObject",
-          "parameterTypes": [
-            "java.io.ObjectOutputStream"
-          ]
-        },
-        {
-          "name": "writeReplace",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
       },
-      "type": "org.junit.experimental.theories.Theories",
-      "methods": [
+      "type" : "org.junit.experimental.theories.Theories",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersClassRoadieTest"
       },
-      "type": "org.junit.internal.runners.JUnit4ClassRunner",
-      "methods": [
+      "type" : "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalRunnersMethodRoadieTest"
       },
-      "type": "org.junit.internal.runners.JUnit4ClassRunner",
-      "methods": [
+      "type" : "org.junit.internal.runners.JUnit4ClassRunner",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "condition": {
-        "typeReached": "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
+      "condition" : {
+        "typeReached" : "junit.junit.BlockJUnit4ClassRunnerWithParametersTest"
       },
-      "type": "org.junit.runners.Parameterized",
-      "methods": [
+      "type" : "org.junit.runners.Parameterized",
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.Class"
           ]
         }
       ]
     },
     {
-      "type": "sun.management.VMManagementImpl",
-      "jniAccessible": true,
-      "fields": [
-        {
-          "name": "compTimeMonitoringSupport"
-        },
-        {
-          "name": "currentThreadCpuTimeSupport"
-        },
-        {
-          "name": "objectMonitorUsageSupport"
-        },
-        {
-          "name": "otherThreadCpuTimeSupport"
-        },
-        {
-          "name": "remoteDiagnosticCommandsSupport"
-        },
-        {
-          "name": "synchronizerUsageSupport"
-        },
-        {
-          "name": "threadAllocatedMemorySupport"
-        },
-        {
-          "name": "threadContentionMonitoringSupport"
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
+      "condition" : {
+        "typeReached" : "junit.junit.TheoriesTest"
       },
-      "type": {
-        "proxy": [
-          "java.lang.Deprecated"
-        ]
-      },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.reflect.InvocationHandler"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.framework.TestSuite"
-      },
-      "type": {
-        "proxy": [
-          "java.lang.annotation.Retention"
-        ]
-      },
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "java.lang.reflect.InvocationHandler"
-          ]
-        }
-      ]
-    },
-    {
-      "condition": {
-        "typeReached": "junit.junit.TheoriesTest"
-      },
-      "type": {
-        "proxy": [
+      "type" : {
+        "proxy" : [
           "org.junit.experimental.theories.ParametersSuppliedBy"
         ]
       },
-      "methods": [
+      "methods" : [
         {
-          "name": "<init>",
-          "parameterTypes": [
+          "name" : "<init>",
+          "parameterTypes" : [
             "java.lang.reflect.InvocationHandler"
           ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "java.io.File",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type" : "java.io.File",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "java.lang.Long",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type" : "java.lang.Long",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type" : "java.lang.Number",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "java.lang.String",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getRuntimeMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
+      },
+      "type" : "java.lang.management.ManagementFactory",
+      "methods" : [
+        {
+          "name" : "getThreadMXBean",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
+      "type" : "java.lang.management.RuntimeMXBean",
+      "methods" : [
+        {
+          "name" : "getInputArguments",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalManagementReflectiveThreadMXBeanTest"
+      },
+      "type" : "java.lang.management.ThreadMXBean",
+      "methods" : [
+        {
+          "name" : "getThreadCpuTime",
+          "parameterTypes" : [
+            "long"
+          ]
+        },
+        {
+          "name" : "isThreadCpuTimeSupported",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxHistoryTest"
+      },
+      "type" : "java.util.HashMap",
+      "serializable" : true
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BaseTestRunnerTest$SuiteProvider"
+      },
+      "type" : "junit.framework.TestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "junit.framework.TestSuite$1"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.BaseTestRunnerTest$SuiteProvider"
+      },
+      "type" : "junit.junit.BaseTestRunnerTest$SuiteTestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest"
+      },
+      "type" : "junit.junit.OrgJunitExperimentalMaxMaxCoreTest$MalformedJUnit3TestCase"
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitRunnerFilterFactoriesTest"
+      },
+      "type" : "junit.junit.OrgJunitRunnerFilterFactoriesTest$TestNameFilterFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitRunnerManipulationOrderingTest"
+      },
+      "type" : "junit.junit.OrgJunitRunnerManipulationOrderingTest$ReversingOrderingFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "junit.junit.OrgJunitInternalManagementManagementFactoryInnerFactoryHolderTest"
+      },
+      "type" : "sun.management.VMManagementImpl",
+      "jniAccessible" : true,
+      "fields" : [
+        {
+          "name" : "compTimeMonitoringSupport"
+        },
+        {
+          "name" : "currentThreadCpuTimeSupport"
+        },
+        {
+          "name" : "objectMonitorUsageSupport"
+        },
+        {
+          "name" : "otherThreadCpuTimeSupport"
+        },
+        {
+          "name" : "remoteDiagnosticCommandsSupport"
+        },
+        {
+          "name" : "synchronizerUsageSupport"
+        },
+        {
+          "name" : "threadAllocatedMemorySupport"
+        },
+        {
+          "name" : "threadContentionMonitoringSupport"
         }
       ]
     }


### PR DESCRIPTION

## What does this PR do?

Refs: #995

This PR introduces tests and metadata for junit:junit:3.7, enabling support for this library.

Summary:
- Chunked dynamic-access: yes
- Chunk class threshold: 15
- Current chunk class count: 15
- Processed dynamic-access classes: completed=30, skipped=0, exhausted=0, failed=0
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 364612
- Cached input tokens: 2867712
- Output tokens: 29826
- Metadata entries: 99
- Test-only metadata entries: 133
- Iterations: 11
- Library coverage percentage: 33.8
- Generated lines of code: 708
- Tested library lines of code: 1653

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `883ded077dd238d8500de5222c9ed1eb4e60d418`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 61/70 covered calls (87.14%)
- Reflection: 61/70 covered calls (87.14%)

Library coverage:
- Instruction: 6999/21496 (32.56%)
- Line: 1653/4891 (33.80%)
- Method: 623/1630 (38.22%)

### Local CI Verification

- Status: `success`
- Commands run: 0
- Fixup attempts: 0
