### PR TITLE
[GenAI] Add support for org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1 using gpt-5.5

### DIFF
--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/reachability-metadata.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/reachability-metadata.json
@@ -1,0 +1,608 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "boolean[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "ch.qos.logback.classic.BasicConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "ch.qos.logback.classic.spi.LogbackServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "int[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties"
+      },
+      "type": "jakarta.inject.Provider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.io.Serializable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.Comparable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.Object"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.Object[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "java.lang.String"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.String[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.constant.Constable[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "java.lang.constant.ConstantDesc[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "javax.money.MonetaryAmount"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "kotlin.Metadata"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "kotlin.coroutines.Continuation"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "kotlin.jvm.JvmInline"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "kotlinx.serialization.Serializable"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "long[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.commons.logging.impl.Slf4jLogFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner"
+      },
+      "type": "org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.logging.log4j.util.EnvironmentPropertySource"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.logging.log4j.util.SystemPropertiesPropertySource"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.eclipse.core.runtime.FileLocator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.osgi.framework.FrameworkUtil"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.slf4j.helpers.Log4jLoggerFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.boot.logging.log4j2.SpringBootPropertySource"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.boot.logging.logback.RootLogLevelConfigurator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.AbstractExtendedBindingProperties",
+      "methods": [
+        {
+          "name": "setBindings",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBindingProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConsumer",
+          "parameterTypes": []
+        },
+        {
+          "name": "getProducer",
+          "parameterTypes": []
+        },
+        {
+          "name": "setConsumer",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties"
+          ]
+        },
+        {
+          "name": "setProducer",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties",
+      "methods": [
+        {
+          "name": "getTopic",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAckMode",
+          "parameterTypes": [
+            "org.springframework.kafka.listener.ContainerProperties$AckMode"
+          ]
+        },
+        {
+          "name": "setDlqName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setDlqPartitions",
+          "parameterTypes": [
+            "java.lang.Integer"
+          ]
+        },
+        {
+          "name": "setEnableDlq",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setStandardHeaders",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties$StandardHeaders"
+          ]
+        },
+        {
+          "name": "setStartOffset",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties$StartOffset"
+          ]
+        },
+        {
+          "name": "setTopic",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaTopicProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties$StandardHeadersEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties$StartOffsetEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getBindings",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties",
+      "methods": [
+        {
+          "name": "getTopic",
+          "parameterTypes": []
+        },
+        {
+          "name": "setCloseTimeout",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "setCompressionType",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties$CompressionType"
+          ]
+        },
+        {
+          "name": "setHeaderPatterns",
+          "parameterTypes": [
+            "java.lang.String[]"
+          ]
+        },
+        {
+          "name": "setSync",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setTopic",
+          "parameterTypes": [
+            "org.springframework.cloud.stream.binder.kafka.properties.KafkaTopicProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties$CompressionTypeEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.cloud.stream.binder.kafka.properties.KafkaTopicProperties",
+      "methods": [
+        {
+          "name": "getProperties",
+          "parameterTypes": []
+        },
+        {
+          "name": "setProperties",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "setReplicationFactor",
+          "parameterTypes": [
+            "java.lang.Short"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.kafka.listener.ContainerProperties$AckModeEditor"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner"
+      },
+      "type": "org.springframework.kafka.config.KafkaStreamsCustomizer"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "org.springframework.messaging.support.GenericMessage",
+      "methods": [
+        {
+          "name": "getHeaders",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPayload",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.messaging.support.GenericMessage",
+      "methods": [
+        {
+          "name": "getHeaders",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor"
+      },
+      "type": "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "META-INF/services/ch.qos.logback.classic.spi.Configurator"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "META-INF/services/org.apache.logging.log4j.util.PropertySource"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "commons-logging.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "log4j2.StatusLogger.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "log4j2.component.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "log4j2.system.properties"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "logback-test.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "logback.xml"
+    },
+    {
+      "condition": {
+        "typeReached": "org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties"
+      },
+      "glob": "spring.properties"
+    }
+  ]
+}

--- a/metadata/org.springframework.cloud/spring-cloud-stream-binder-kafka/index.json
+++ b/metadata/org.springframework.cloud/spring-cloud-stream-binder-kafka/index.json
@@ -1,0 +1,12 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "5.0.1",
+    "tested-versions" : [
+      "5.0.1"
+    ],
+    "allowed-packages" : [
+      "org.springframework.cloud.stream.binder.kafka"
+    ]
+  }
+]

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/execution-metrics.json
@@ -1,0 +1,85 @@
+{
+  "add_new_library_support:2026-08-07": {
+    "timestamp": "2026-08-07T13:08:34.750969Z",
+    "library": "org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1",
+    "starting_commit": "52c312316477b1f4732b56b7247a66b83c80a3d0",
+    "ending_commit": "b65492a211c41d179dc6732bd0a143008e6a8dc3",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "5.0.1",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 162,
+          "missed": 4212,
+          "ratio": 0.037037,
+          "total": 4374
+        },
+        "line": {
+          "covered": 40,
+          "missed": 1006,
+          "ratio": 0.038241,
+          "total": 1046
+        },
+        "method": {
+          "covered": 15,
+          "missed": 161,
+          "ratio": 0.085227,
+          "total": 176
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 7031,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1",
+      "summary": "No extra setup is required: the artifact brings Spring Cloud Stream/Spring Kafka dependencies, and meaningful coverage can be reached through binder configuration, properties, runtime hints, converters, and provisioning paths without a live Kafka broker.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "True end-to-end send/receive coverage would require a Kafka broker, but it is not necessary for initial meaningful reachability coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7031 Support for org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1; label=library-new-request; body_chars=133"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.5",
+      "input_tokens_used": 51032,
+      "output_tokens_used": 5000,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1/library-preparation-preflight/pi-generation-2026-08-07T12-15-35-898624Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 198081,
+      "cached_input_tokens_used": 1823232,
+      "output_tokens_used": 16095,
+      "iterations": 4,
+      "cost_usd": 2.3849,
+      "generated_loc": 272,
+      "tested_library_loc": 40,
+      "metadata_entries": 101,
+      "code_coverage_percent": 3.82
+    },
+    "artifacts": {
+      "metadata_file": "metadata/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/stats.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "5.0.1",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 162,
+        "missed" : 4212,
+        "ratio" : 0.037037,
+        "total" : 4374
+      },
+      "line" : {
+        "covered" : 40,
+        "missed" : 1006,
+        "ratio" : 0.038241,
+        "total" : 1046
+      },
+      "method" : {
+        "covered" : 15,
+        "missed" : 161,
+        "ratio" : 0.085227,
+        "total" : 176
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/.gitignore
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/build.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.cloud:spring-cloud-stream-binder-kafka:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/gradle.properties
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1
+library.version = 5.0.1
+metadata.dir = org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/settings.gradle
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.cloud.spring-cloud-stream-binder-kafka_tests'

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_cloud.spring_cloud_stream_binder_kafka;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_cloud_stream_binder_kafkaTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
@@ -7,6 +7,7 @@
 package org_springframework_cloud.spring_cloud_stream_binder_kafka;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,7 @@ import org.springframework.cloud.stream.binder.kafka.KafkaBindingRebalanceListen
 import org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor;
 import org.springframework.cloud.stream.binder.kafka.KafkaNullConverter;
 import org.springframework.cloud.stream.binder.kafka.aot.KafkaBinderRuntimeHints;
+import org.springframework.cloud.stream.binder.kafka.config.DefaultMessageConverterHelper;
 import org.springframework.cloud.stream.binder.kafka.properties.JaasLoginModuleConfiguration;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.properties.KafkaBindingProperties;
@@ -236,6 +238,29 @@ public class Spring_cloud_stream_binder_kafkaTest {
 
         assertThat(converter.fromMessage(kafkaNullMessage, Object.class)).isSameAs(KafkaNull.INSTANCE);
         assertThat(converter.fromMessage(regularMessage, Object.class)).isNull();
+    }
+
+    @Test
+    void defaultMessageConverterHelperRemovesFailedRecordFromKafkaBatchHeaders() {
+        DefaultMessageConverterHelper helper = new DefaultMessageConverterHelper();
+        ArrayList<String> receivedTopics = new ArrayList<>(List.of("orders.created", "orders.updated"));
+        ArrayList<Integer> receivedPartitions = new ArrayList<>(List.of(0, 1));
+        List<Long> offsets = List.of(11L, 12L);
+        ArrayList<String> applicationValues = new ArrayList<>(List.of("first", "second"));
+        Message<List<String>> batchMessage = MessageBuilder.withPayload(List.of("created", "updated"))
+                .setHeader("kafka_receivedTopic", receivedTopics)
+                .setHeader("kafka_receivedPartitionId", receivedPartitions)
+                .setHeader("kafka_offsets", offsets)
+                .setHeader("applicationValues", applicationValues)
+                .build();
+
+        helper.postProcessBatchMessageOnFailure(batchMessage, 0);
+
+        assertThat(helper.shouldFailIfCantConvert(batchMessage)).isFalse();
+        assertThat(receivedTopics).containsExactly("orders.updated");
+        assertThat(receivedPartitions).containsExactly(1);
+        assertThat(offsets).containsExactly(11L, 12L);
+        assertThat(applicationValues).containsExactly("first", "second");
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
@@ -6,11 +6,255 @@
  */
 package org_springframework_cloud.spring_cloud_stream_binder_kafka;
 
-import org.junit.jupiter.api.Test;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 
-class Spring_cloud_stream_binder_kafkaTest {
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.boot.kafka.autoconfigure.KafkaConnectionDetails;
+import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.kafka.KafkaBindingRebalanceListener;
+import org.springframework.cloud.stream.binder.kafka.KafkaNullConverter;
+import org.springframework.cloud.stream.binder.kafka.aot.KafkaBinderRuntimeHints;
+import org.springframework.cloud.stream.binder.kafka.properties.JaasLoginModuleConfiguration;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaBindingProperties;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaConsumerProperties;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaExtendedBindingProperties;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaProducerProperties;
+import org.springframework.cloud.stream.binder.kafka.properties.KafkaTopicProperties;
+import org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.security.jaas.KafkaJaasLoginModuleInitializer;
+import org.springframework.kafka.support.KafkaNull;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_cloud_stream_binder_kafkaTest {
+    private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void binderConfigurationMergesBootKafkaBinderAndClientSpecificProperties() {
+        KafkaProperties kafkaProperties = new KafkaProperties();
+        kafkaProperties.setBootstrapServers(List.of("boot-broker:9092"));
+        kafkaProperties.setClientId("boot-client");
+        kafkaProperties.getConsumer().setGroupId("orders-group");
+        kafkaProperties.getConsumer().getProperties().put("max.partition.fetch.bytes", "2048");
+        kafkaProperties.getProducer().setAcks("all");
+        kafkaProperties.getProducer().getProperties().put("delivery.timeout.ms", "120000");
+
+        KafkaBinderConfigurationProperties binderProperties = binderConfiguration(kafkaProperties);
+        binderProperties.setBrokers("binder-one", "binder-two:19092");
+        binderProperties.setDefaultBrokerPort("29092");
+        binderProperties.setRequiredAcks("1");
+        binderProperties.setHeaders("traceId", "spanId");
+        binderProperties.setHealthTimeout(11);
+        binderProperties.setAuthorizationExceptionRetryInterval(Duration.ofSeconds(12));
+        binderProperties.setConfiguration(Map.of(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG, "use_all_dns_ips"));
+        binderProperties.setConsumerProperties(Map.of(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "64"));
+        binderProperties.setProducerProperties(Map.of(ProducerConfig.LINGER_MS_CONFIG, "5"));
+
+        assertThat(binderProperties.getKafkaConnectionString()).isEqualTo("binder-one:29092,binder-two:19092");
+        assertThat(binderProperties.getHeaders()).containsExactly("traceId", "spanId");
+        assertThat(binderProperties.getHealthTimeout()).isEqualTo(11);
+        assertThat(binderProperties.getRequiredAcks()).isEqualTo("1");
+        assertThat(binderProperties.getAuthorizationExceptionRetryInterval()).isEqualTo(Duration.ofSeconds(12));
+
+        assertThat(binderProperties.mergedConsumerConfiguration())
+                .containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "binder-one:29092,binder-two:19092")
+                .doesNotContainKey(ConsumerConfig.GROUP_ID_CONFIG)
+                .containsEntry(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "64")
+                .containsEntry(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG, "use_all_dns_ips");
+        assertThat(binderProperties.mergedProducerConfiguration())
+                .containsEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "binder-one:29092,binder-two:19092")
+                .containsEntry(ProducerConfig.ACKS_CONFIG, "all")
+                .containsEntry(ProducerConfig.LINGER_MS_CONFIG, "5")
+                .containsEntry(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG, "use_all_dns_ips");
+    }
+
+    @Test
+    void bindingPropertiesBindNestedConsumerProducerTopicAndMapSettings() {
+        Map<String, Object> source = Map.ofEntries(
+                Map.entry("kafka.bindings.orders-in.consumer.enable-dlq", "true"),
+                Map.entry("kafka.bindings.orders-in.consumer.dlq-name", "orders.dlq"),
+                Map.entry("kafka.bindings.orders-in.consumer.dlq-partitions", "3"),
+                Map.entry("kafka.bindings.orders-in.consumer.start-offset", "earliest"),
+                Map.entry("kafka.bindings.orders-in.consumer.ack-mode", "manual"),
+                Map.entry("kafka.bindings.orders-in.consumer.standard-headers", "both"),
+                Map.entry("kafka.bindings.orders-in.consumer.topic.properties[retention.ms]", "60000"),
+                Map.entry("kafka.bindings.orders-out.producer.compression-type", "gzip"),
+                Map.entry("kafka.bindings.orders-out.producer.sync", "true"),
+                Map.entry("kafka.bindings.orders-out.producer.close-timeout", "13"),
+                Map.entry("kafka.bindings.orders-out.producer.header-patterns[0]", "!id"),
+                Map.entry("kafka.bindings.orders-out.producer.header-patterns[1]", "trace-*"),
+                Map.entry("kafka.bindings.orders-out.producer.topic.replication-factor", "2"),
+                Map.entry("kafka.bindings.orders-out.producer.topic.properties[cleanup.policy]", "compact"));
+        Binder binder = new Binder(new MapConfigurationPropertySource(source));
+
+        KafkaExtendedBindingProperties bindings = binder.bindOrCreate("kafka", KafkaExtendedBindingProperties.class);
+        KafkaConsumerProperties consumer = bindings.getExtendedConsumerProperties("orders-in");
+        KafkaProducerProperties producer = bindings.getExtendedProducerProperties("orders-out");
+
+        assertThat(bindings.getDefaultsPrefix()).isEqualTo("spring.cloud.stream.kafka.default");
+        assertThat(bindings.getExtendedPropertiesEntryClass()).isEqualTo(KafkaBindingProperties.class);
+        assertThat(consumer.isEnableDlq()).isTrue();
+        assertThat(consumer.getDlqName()).isEqualTo("orders.dlq");
+        assertThat(consumer.getDlqPartitions()).isEqualTo(3);
+        assertThat(consumer.getStartOffset()).isEqualTo(KafkaConsumerProperties.StartOffset.earliest);
+        assertThat(consumer.getAckMode()).isEqualTo(ContainerProperties.AckMode.MANUAL);
+        assertThat(consumer.getStandardHeaders()).isEqualTo(KafkaConsumerProperties.StandardHeaders.both);
+        assertThat(consumer.getTopic().getProperties()).containsEntry("retention.ms", "60000");
+        assertThat(producer.getCompressionType()).isEqualTo(KafkaProducerProperties.CompressionType.gzip);
+        assertThat(producer.isSync()).isTrue();
+        assertThat(producer.getCloseTimeout()).isEqualTo(13);
+        assertThat(producer.getHeaderPatterns()).containsExactly("!id", "trace-*");
+        assertThat(producer.getTopic().getReplicationFactor()).isEqualTo((short) 2);
+        assertThat(producer.getTopic().getProperties()).containsEntry("cleanup.policy", "compact");
+    }
+
+    @Test
+    void producerConsumerTopicTransactionAndJaasPropertiesRetainConfiguredValues() {
+        KafkaTopicProperties topic = new KafkaTopicProperties();
+        topic.setReplicationFactor((short) 2);
+        topic.setReplicasAssignments(Map.of(0, List.of(1, 2), 1, List.of(2, 3)));
+        topic.setProperties(Map.of("min.insync.replicas", "2"));
+
+        KafkaProducerProperties producer = new KafkaProducerProperties();
+        Expression messageKeyExpression = PARSER.parseExpression("headers['partitionKey']");
+        producer.setMessageKeyExpression(messageKeyExpression);
+        producer.setSendTimeoutExpression(PARSER.parseExpression("10000"));
+        producer.setTopic(topic);
+        producer.setUseTopicHeader(true);
+        producer.setRecordMetadataChannel("metadataChannel");
+        producer.setTransactionManager("txManager");
+        producer.setAllowNonTransactional(true);
+
+        KafkaConsumerProperties consumer = new KafkaConsumerProperties();
+        consumer.setTopic(topic);
+        consumer.setTrustedPackages(new String[] {"example.orders", "example.shared"});
+        consumer.setConfiguration(Map.of(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "10"));
+        consumer.setPollTimeout(10_000L);
+        consumer.setIdleEventInterval(10_000L);
+        consumer.setCommonErrorHandlerBeanName("errorHandler");
+        consumer.setDlqProducerProperties(producer);
+
+        KafkaProperties kafkaProperties = new KafkaProperties();
+        KafkaBinderConfigurationProperties binderProperties = binderConfiguration(kafkaProperties);
+        binderProperties.getTransaction().setTransactionIdPrefix("tx-orders-");
+        binderProperties.getTransaction().getProducer().setPartitionCount(4);
+        binderProperties.getTransaction().getProducer().setMessageKeyExpression(messageKeyExpression);
+        binderProperties.getMetrics().setDefaultOffsetLagMetricsEnabled(false);
+        binderProperties.getMetrics().setOffsetLagMetricsInterval(Duration.ofSeconds(30));
+        JaasLoginModuleConfiguration jaas = new JaasLoginModuleConfiguration();
+        jaas.setLoginModule("com.sun.security.auth.module.Krb5LoginModule");
+        jaas.setControlFlag("required");
+        jaas.setOptions(Map.of("useKeyTab", "true"));
+        binderProperties.setJaas(jaas);
+
+        Message<String> message = MessageBuilder.withPayload("payload").setHeader("partitionKey", "order-42").build();
+        assertThat(producer.getMessageKeyExpression().getValue(message)).isEqualTo("order-42");
+        assertThat(producer.getTheMessageKeyExpression()).contains("partitionKey");
+        assertThat(producer.getSendTimeoutExpression().getValue()).isEqualTo(10_000);
+        assertThat(producer.getTopic().getReplicasAssignments()).containsEntry(0, List.of(1, 2));
+        assertThat(consumer.getTrustedPackages()).containsExactly("example.orders", "example.shared");
+        assertThat(consumer.getConfiguration()).containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "10");
+        assertThat(consumer.getDlqProducerProperties()).isSameAs(producer);
+        assertThat(binderProperties.getTransaction().getTransactionIdPrefix()).isEqualTo("tx-orders-");
+        assertThat(binderProperties.getTransaction().getProducer().getPartitionCount()).isEqualTo(4);
+        assertThat(binderProperties.getMetrics().isDefaultOffsetLagMetricsEnabled()).isFalse();
+        assertThat(binderProperties.getMetrics().getOffsetLagMetricsInterval()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(binderProperties.getJaas().getControlFlag())
+                .isEqualTo(KafkaJaasLoginModuleInitializer.ControlFlag.REQUIRED);
+        assertThat(binderProperties.getJaas().getOptions()).containsEntry("useKeyTab", "true");
+    }
+
+    @Test
+    void provisionerUsesBinderConfigurationAndCanReturnDestinationsWithoutBrokerWhenAutoCreateIsDisabled() {
+        KafkaProperties kafkaProperties = new KafkaProperties();
+        kafkaProperties.getAdmin().getProperties().put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10000");
+        KafkaBinderConfigurationProperties binderProperties = binderConfiguration(kafkaProperties);
+        binderProperties.setBrokers("admin-broker:9092");
+        binderProperties.setAutoCreateTopics(false);
+        binderProperties.setConfiguration(Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT"));
+        KafkaTopicProvisioner provisioner = new KafkaTopicProvisioner(binderProperties, kafkaProperties,
+                adminProperties -> adminProperties.put("custom.admin.flag", "enabled"));
+        provisioner.afterPropertiesSet();
+
+        ExtendedProducerProperties<KafkaProducerProperties> producerProperties =
+                new ExtendedProducerProperties<>(new KafkaProducerProperties());
+        producerProperties.setPartitionCount(5);
+        ProducerDestination producerDestination =
+                provisioner.provisionProducerDestination("orders.created", producerProperties);
+
+        KafkaConsumerProperties kafkaConsumerProperties = new KafkaConsumerProperties();
+        kafkaConsumerProperties.setDestinationIsPattern(true);
+        ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties =
+                new ExtendedConsumerProperties<>(kafkaConsumerProperties);
+        ConsumerDestination consumerDestination =
+                provisioner.provisionConsumerDestination("orders\\..*", "orders-service", consumerProperties);
+
+        assertThat(provisioner.getAdminClientProperties())
+                .containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "admin-broker:9092")
+                .containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "PLAINTEXT")
+                .containsEntry("custom.admin.flag", "enabled");
+        assertThat(producerDestination.getName()).isEqualTo("orders.created");
+        assertThat(producerDestination.getNameForPartition(3)).isEqualTo("orders.created");
+        assertThat(producerDestination.toString()).contains("orders.created");
+        assertThat(consumerDestination.getName()).isEqualTo("orders\\..*");
+        assertThat(consumerDestination.toString()).contains("orders\\..*");
+    }
+
+    @Test
+    void kafkaNullConverterAndRebalanceListenerExerciseMessagingCallbacks() {
+        KafkaNullConverter converter = new KafkaNullConverter();
+        Message<KafkaNull> kafkaNullMessage = MessageBuilder.withPayload(KafkaNull.INSTANCE).build();
+        Message<String> regularMessage = MessageBuilder.withPayload("value").build();
+        KafkaBindingRebalanceListener listener = new KafkaBindingRebalanceListener() {
+        };
+
+        listener.onPartitionsRevokedBeforeCommit("orders-in", null, List.of());
+        listener.onPartitionsRevokedAfterCommit("orders-in", null, List.of());
+        listener.onPartitionsAssigned("orders-in", null, List.of(), true);
+
+        assertThat(converter.fromMessage(kafkaNullMessage, Object.class)).isSameAs(KafkaNull.INSTANCE);
+        assertThat(converter.fromMessage(regularMessage, Object.class)).isNull();
+    }
+
+    @Test
+    void runtimeHintsRegisterKafkaBindingPropertyTypes() {
+        RuntimeHints hints = new RuntimeHints();
+        new KafkaBinderRuntimeHints().registerHints(hints,
+                Spring_cloud_stream_binder_kafkaTest.class.getClassLoader());
+
+        assertThat(hints.reflection().getTypeHint(KafkaConsumerProperties.class)).isNotNull();
+        assertThat(hints.reflection().getTypeHint(KafkaProducerProperties.class)).isNotNull();
+        assertThat(hints.reflection().getTypeHint(KafkaExtendedBindingProperties.class)).isNotNull();
+        assertThat(hints.reflection().getTypeHint(KafkaBindingProperties.class)).isNotNull();
+    }
+
+    private static KafkaBinderConfigurationProperties binderConfiguration(KafkaProperties kafkaProperties) {
+        ObjectProvider<KafkaConnectionDetails> connectionDetails = new ObjectProvider<>() {
+            @Override
+            public KafkaConnectionDetails getIfAvailable() {
+                return null;
+            }
+        };
+        return new KafkaBinderConfigurationProperties(kafkaProperties, connectionDetails);
     }
 }

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/src/test/java/org_springframework_cloud/spring_cloud_stream_binder_kafka/Spring_cloud_stream_binder_kafkaTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.kafka.KafkaBindingRebalanceListener;
+import org.springframework.cloud.stream.binder.kafka.KafkaExpressionEvaluatingInterceptor;
 import org.springframework.cloud.stream.binder.kafka.KafkaNullConverter;
 import org.springframework.cloud.stream.binder.kafka.aot.KafkaBinderRuntimeHints;
 import org.springframework.cloud.stream.binder.kafka.properties.JaasLoginModuleConfiguration;
@@ -38,6 +39,7 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.security.jaas.KafkaJaasLoginModuleInitializer;
 import org.springframework.kafka.support.KafkaNull;
@@ -234,6 +236,23 @@ public class Spring_cloud_stream_binder_kafkaTest {
 
         assertThat(converter.fromMessage(kafkaNullMessage, Object.class)).isSameAs(KafkaNull.INSTANCE);
         assertThat(converter.fromMessage(regularMessage, Object.class)).isNull();
+    }
+
+    @Test
+    void expressionEvaluatingInterceptorAddsComputedMessageKeyHeader() {
+        KafkaExpressionEvaluatingInterceptor interceptor = new KafkaExpressionEvaluatingInterceptor(
+                PARSER.parseExpression("headers['tenant'] + ':' + payload"), new StandardEvaluationContext());
+        Message<String> message = MessageBuilder.withPayload("order-42")
+                .setHeader("tenant", "acme")
+                .build();
+
+        Message<?> intercepted = interceptor.preSend(message, null);
+
+        assertThat(intercepted.getPayload()).isEqualTo("order-42");
+        assertThat(intercepted.getHeaders()).containsEntry("tenant", "acme");
+        assertThat(intercepted.getHeaders())
+                .containsEntry(KafkaExpressionEvaluatingInterceptor.MESSAGE_KEY_HEADER, "acme:order-42");
+        assertThat(message.getHeaders()).doesNotContainKey(KafkaExpressionEvaluatingInterceptor.MESSAGE_KEY_HEADER);
     }
 
     @Test

--- a/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/user-code-filter.json
+++ b/tests/src/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.cloud.stream.binder.kafka.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7031

This PR introduces tests and metadata for org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 198081
- Cached input tokens: 1823232
- Output tokens: 16095
- Metadata entries: 101
- Iterations: 4
- Library coverage percentage: 3.82
- Generated lines of code: 272
- Tested library lines of code: 40

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `883ded077dd238d8500de5222c9ed1eb4e60d418`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 162/4374 (3.70%)
- Line: 40/1046 (3.82%)
- Method: 15/176 (8.52%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
