### PR TITLE
[GenAI] Add support for org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final using gpt-5.5

### DIFF
--- a/metadata/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/reachability-metadata.json
+++ b/metadata/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/reachability-metadata.json
@@ -1,0 +1,122 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.BeanDeserializerModifier[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.BeanSerializerModifier[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.deser.DataHandlerDeserializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "com.fasterxml.jackson.module.jakarta.xmlbind.ser.DataHandlerSerializer",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger"
+      },
+      "type" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger"
+      },
+      "type" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger"
+      },
+      "type" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger_$logger_en_US"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "glob" : "META-INF/services/com.fasterxml.jackson.databind.Module"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson._private.JacksonLogger_$logger"
+      },
+      "glob" : "META-INF/services/java.time.zone.ZoneRulesProvider"
+    }
+  ]
+}

--- a/metadata/org.jboss.resteasy/resteasy-jackson2-provider/index.json
+++ b/metadata/org.jboss.resteasy/resteasy-jackson2-provider/index.json
@@ -1,0 +1,14 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "6.2.15.Final",
+    "tested-versions" : [
+      "6.2.15.Final"
+    ],
+    "allowed-packages" : [
+      "org.jboss.resteasy.annotations.providers.jackson",
+      "org.jboss.resteasy.plugins.providers.jackson",
+      "org.jboss.resteasy.tracing.providers.jackson2"
+    ]
+  }
+]

--- a/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/execution-metrics.json
@@ -1,0 +1,86 @@
+{
+  "add_new_library_support:2026-08-07": {
+    "timestamp": "2026-08-07T13:37:26.331625Z",
+    "library": "org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final",
+    "starting_commit": "717db08a385838e17251722ec53450b6199a578b",
+    "ending_commit": "3cd3a5ba907b009539a38c1e869ca1a0288ef932",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.5",
+    "agent": "pi",
+    "model": "gpt-5.5",
+    "status": "success",
+    "stats": {
+      "version": "6.2.15.Final",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 536,
+          "missed": 1059,
+          "ratio": 0.33605,
+          "total": 1595
+        },
+        "line": {
+          "covered": 129,
+          "missed": 251,
+          "ratio": 0.339474,
+          "total": 380
+        },
+        "method": {
+          "covered": 34,
+          "missed": 51,
+          "ratio": 0.4,
+          "total": 85
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 3314,
+      "issue_label": "library-new-request",
+      "library": "org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final",
+      "summary": "The artifact brings RESTEasy core and Jackson dependencies needed to exercise the provider directly; meaningful JSON read/write coverage is reachable without extra Maven dependencies, Docker, or required properties.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Full HTTP server/client integration would require extra RESTEasy modules, but it is not necessary for meaningful provider coverage."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#3314 Support for org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final; label=library-new-request; body_chars=127"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.5",
+      "input_tokens_used": 59419,
+      "output_tokens_used": 4509,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final/library-preparation-preflight/pi-generation-2026-08-07T13-12-15-169604Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 88521,
+      "cached_input_tokens_used": 918016,
+      "output_tokens_used": 12674,
+      "iterations": 3,
+      "cost_usd": 1.2818,
+      "generated_loc": 204,
+      "tested_library_loc": 129,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 32,
+      "code_coverage_percent": 33.95
+    },
+    "artifacts": {
+      "metadata_file": "metadata/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/stats.json
+++ b/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "6.2.15.Final",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 536,
+        "missed" : 1059,
+        "ratio" : 0.33605,
+        "total" : 1595
+      },
+      "line" : {
+        "covered" : 129,
+        "missed" : 251,
+        "ratio" : 0.339474,
+        "total" : 380
+      },
+      "method" : {
+        "covered" : 34,
+        "missed" : 51,
+        "ratio" : 0.4,
+        "total" : 85
+      }
+    }
+  } ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/.gitignore
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/build.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.jboss.resteasy:resteasy-jackson2-provider:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/gradle.properties
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final
+library.version = 6.2.15.Final
+metadata.dir = org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/settings.gradle
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.jboss.resteasy.resteasy-jackson2-provider_tests'

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_jboss_resteasy.resteasy_jackson2_provider;
+
+import org.junit.jupiter.api.Test;
+
+class Resteasy_jackson2_providerTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
@@ -6,11 +6,161 @@
  */
 package org_jboss_resteasy.resteasy_jackson2_provider;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.resteasy.annotations.providers.jackson.Formatted;
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.junit.jupiter.api.Test;
 
-class Resteasy_jackson2_providerTest {
+public class Resteasy_jackson2_providerTest {
+    private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void providerAcceptsStandardAndStructuredJsonMediaTypes() {
+        ResteasyJackson2Provider provider = new ResteasyJackson2Provider();
+        MediaType vendorJson = MediaType.valueOf("application/vnd.acme.person+json");
+
+        assertThat(provider.isReadable(Person.class, Person.class, NO_ANNOTATIONS, MediaType.APPLICATION_JSON_TYPE))
+                .isTrue();
+        assertThat(provider.isWriteable(Person.class, Person.class, NO_ANNOTATIONS, MediaType.APPLICATION_JSON_TYPE))
+                .isTrue();
+        assertThat(provider.isReadable(Person.class, Person.class, NO_ANNOTATIONS, vendorJson)).isTrue();
+        assertThat(provider.isWriteable(Person.class, Person.class, NO_ANNOTATIONS, vendorJson)).isTrue();
+    }
+
+    @Test
+    void writesPojoToJsonAndReadsItBack() throws Exception {
+        ResteasyJackson2Provider provider = new ResteasyJackson2Provider();
+        Person person = new Person("Ada", 37, new Address("London", "NW1"));
+        ByteArrayOutputStream entityStream = new ByteArrayOutputStream();
+        MultivaluedMap<String, Object> writeHeaders = new MultivaluedHashMap<>();
+
+        provider.writeTo(
+                person,
+                Person.class,
+                Person.class,
+                NO_ANNOTATIONS,
+                MediaType.APPLICATION_JSON_TYPE,
+                writeHeaders,
+                entityStream);
+
+        String json = entityStream.toString(StandardCharsets.UTF_8);
+        assertThat(json).contains("\"name\":\"Ada\"");
+        assertThat(json).contains("\"city\":\"London\"");
+
+        Person roundTripped = (Person) provider.readFrom(
+                objectClass(Person.class),
+                Person.class,
+                NO_ANNOTATIONS,
+                MediaType.APPLICATION_JSON_TYPE,
+                new MultivaluedHashMap<>(),
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(roundTripped.name).isEqualTo("Ada");
+        assertThat(roundTripped.age).isEqualTo(37);
+        assertThat(roundTripped.address.city).isEqualTo("London");
+        assertThat(roundTripped.address.postalCode).isEqualTo("NW1");
+    }
+
+    @Test
+    void readsGenericCollectionsUsingTheSuppliedGenericType() throws Exception {
+        ResteasyJackson2Provider provider = new ResteasyJackson2Provider();
+        Type peopleType = new GenericType<List<Person>>() {
+        }.getType();
+        String json = """
+                [
+                  {"name":"Grace","age":40,"address":{"city":"Arlington","postalCode":"22207"}},
+                  {"name":"Katherine","age":45,"address":{"city":"Hampton","postalCode":"23666"}}
+                ]
+                """;
+
+        @SuppressWarnings("unchecked")
+        List<Person> people = (List<Person>) provider.readFrom(
+                objectClass(List.class),
+                peopleType,
+                NO_ANNOTATIONS,
+                MediaType.APPLICATION_JSON_TYPE,
+                new MultivaluedHashMap<>(),
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(people).hasSize(2);
+        assertThat(people.get(0).name).isEqualTo("Grace");
+        assertThat(people.get(0).address.city).isEqualTo("Arlington");
+        assertThat(people.get(1).name).isEqualTo("Katherine");
+        assertThat(people.get(1).address.postalCode).isEqualTo("23666");
+    }
+
+    @Test
+    void formattedAnnotationEnablesIndentedJsonOutput() throws Exception {
+        ResteasyJackson2Provider provider = new ResteasyJackson2Provider();
+        Person person = new Person("Dorothy", 31, new Address("Washington", "20001"));
+        ByteArrayOutputStream entityStream = new ByteArrayOutputStream();
+        Annotation[] annotations = new Annotation[] {new FormattedLiteral()};
+
+        provider.writeTo(
+                person,
+                Person.class,
+                Person.class,
+                annotations,
+                MediaType.APPLICATION_JSON_TYPE,
+                new MultivaluedHashMap<>(),
+                entityStream);
+
+        String json = entityStream.toString(StandardCharsets.UTF_8);
+        assertThat(json).contains("\n");
+        assertThat(json).contains("  \"name\" : \"Dorothy\"");
+        assertThat(json).contains("  \"address\" : {");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<Object> objectClass(Class<T> type) {
+        return (Class<Object>) type;
+    }
+
+    public static class Person {
+        public String name;
+        public int age;
+        public Address address;
+
+        public Person() {
+        }
+
+        public Person(String name, int age, Address address) {
+            this.name = name;
+            this.age = age;
+            this.address = address;
+        }
+    }
+
+    public static class Address {
+        public String city;
+        public String postalCode;
+
+        public Address() {
+        }
+
+        public Address(String city, String postalCode) {
+            this.city = city;
+            this.postalCode = postalCode;
+        }
+    }
+
+    private static final class FormattedLiteral implements Formatted {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Formatted.class;
+        }
     }
 }

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
@@ -19,9 +19,14 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.annotations.providers.jackson.Formatted;
+import org.jboss.resteasy.plugins.providers.jackson.JsonProcessingExceptionMapper;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.jupiter.api.Test;
 
 public class Resteasy_jackson2_providerTest {
@@ -122,6 +127,18 @@ public class Resteasy_jackson2_providerTest {
         assertThat(json).contains("\n");
         assertThat(json).contains("  \"name\" : \"Dorothy\"");
         assertThat(json).contains("  \"address\" : {");
+    }
+
+    @Test
+    void jsonProcessingExceptionMapperReturnsBadRequestResponse() {
+        JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper();
+        JsonParseException exception = new JsonParseException("Unexpected JSON token", JsonLocation.NA);
+
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+            assertThat(response.getEntity()).isInstanceOf(String.class);
+            assertThat((String) response.getEntity()).contains("deserialize data");
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/java/org_jboss_resteasy/resteasy_jackson2_provider/Resteasy_jackson2_providerTest.java
@@ -25,6 +25,7 @@ import org.jboss.resteasy.annotations.providers.jackson.Formatted;
 import org.jboss.resteasy.plugins.providers.jackson.JsonProcessingExceptionMapper;
 import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import org.junit.jupiter.api.Test;
@@ -130,6 +131,28 @@ public class Resteasy_jackson2_providerTest {
     }
 
     @Test
+    void jsonViewAnnotationLimitsSerializedProperties() throws Exception {
+        ResteasyJackson2Provider provider = new ResteasyJackson2Provider();
+        Account account = new Account("apollo", "launch-code");
+        ByteArrayOutputStream entityStream = new ByteArrayOutputStream();
+        Annotation[] annotations = new Annotation[] {new JsonViewLiteral(PublicView.class)};
+
+        provider.writeTo(
+                account,
+                Account.class,
+                Account.class,
+                annotations,
+                MediaType.APPLICATION_JSON_TYPE,
+                new MultivaluedHashMap<>(),
+                entityStream);
+
+        String json = entityStream.toString(StandardCharsets.UTF_8);
+        assertThat(json).contains("\"username\":\"apollo\"");
+        assertThat(json).doesNotContain("secret");
+        assertThat(json).doesNotContain("launch-code");
+    }
+
+    @Test
     void jsonProcessingExceptionMapperReturnsBadRequestResponse() {
         JsonProcessingExceptionMapper mapper = new JsonProcessingExceptionMapper();
         JsonParseException exception = new JsonParseException("Unexpected JSON token", JsonLocation.NA);
@@ -174,10 +197,50 @@ public class Resteasy_jackson2_providerTest {
         }
     }
 
+    public interface PublicView {
+    }
+
+    public interface InternalView extends PublicView {
+    }
+
+    public static class Account {
+        @JsonView(PublicView.class)
+        public String username;
+
+        @JsonView(InternalView.class)
+        public String secret;
+
+        public Account() {
+        }
+
+        public Account(String username, String secret) {
+            this.username = username;
+            this.secret = secret;
+        }
+    }
+
     private static final class FormattedLiteral implements Formatted {
         @Override
         public Class<? extends Annotation> annotationType() {
             return Formatted.class;
+        }
+    }
+
+    private static final class JsonViewLiteral implements JsonView {
+        private final Class<?>[] views;
+
+        JsonViewLiteral(Class<?>... views) {
+            this.views = views.clone();
+        }
+
+        @Override
+        public Class<?>[] value() {
+            return views.clone();
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return JsonView.class;
         }
     }
 }

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,177 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "ch.qos.logback.classic.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.apache.log4j.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.apache.logging.log4j.Logger"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.jboss.logmanager.LogManager"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.jboss.logging.Logger"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org.jboss.resteasy.resteasy_jaxrs.i18n.LogMessages_$logger_en_US"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest$Account",
+      "fields" : [
+        {
+          "name" : "username"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        },
+        {
+          "name" : "postalCode"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest$Address",
+      "fields" : [
+        {
+          "name" : "city"
+        },
+        {
+          "name" : "postalCode"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider"
+      },
+      "type" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest$Person",
+      "fields" : [
+        {
+          "name" : "address"
+        },
+        {
+          "name" : "age"
+        },
+        {
+          "name" : "name"
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "type" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest$Person",
+      "fields" : [
+        {
+          "name" : "address"
+        },
+        {
+          "name" : "age"
+        },
+        {
+          "name" : "name"
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "glob" : "META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "glob" : "META-INF/services/org.jboss.logging.LoggerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_jboss_resteasy.resteasy_jackson2_provider.Resteasy_jackson2_providerTest"
+      },
+      "glob" : "META-INF/services/org.jboss.resteasy.spi.config.ConfigurationFactory"
+    }
+  ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/user-code-filter.json
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/user-code-filter.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.jboss.resteasy.annotations.providers.jackson.**"
+    },
+    {
+      "includeClasses": "org.jboss.resteasy.plugins.providers.jackson.**"
+    },
+    {
+      "includeClasses": "org.jboss.resteasy.tracing.providers.jackson2.**"
+    }
+  ]
+}

--- a/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/user-code-filter.json
+++ b/tests/src/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/user-code-filter.json
@@ -1,16 +1,19 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.jboss.resteasy.annotations.providers.jackson.**"
+      "includeClasses" : "org.jboss.resteasy.annotations.providers.jackson.**"
     },
     {
-      "includeClasses": "org.jboss.resteasy.plugins.providers.jackson.**"
+      "includeClasses" : "org.jboss.resteasy.plugins.providers.jackson.**"
     },
     {
-      "includeClasses": "org.jboss.resteasy.tracing.providers.jackson2.**"
+      "includeClasses" : "org.jboss.resteasy.tracing.providers.jackson2.**"
+    },
+    {
+      "includeClasses" : "org_jboss_resteasy.resteasy_jackson2_provider.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #3314

This PR introduces tests and metadata for org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.5
- Agent: pi
- Model: gpt-5.5
- Input tokens: 88521
- Cached input tokens: 918016
- Output tokens: 12674
- Metadata entries: 19
- Test-only metadata entries: 32
- Iterations: 3
- Library coverage percentage: 33.95
- Generated lines of code: 204
- Tested library lines of code: 129

### Forge

- Forge monitored branch: `origin/master`
- Forge branch: `master`
- Forge commit hash: `883ded077dd238d8500de5222c9ed1eb4e60d418`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 536/1595 (33.61%)
- Line: 129/380 (33.95%)
- Method: 34/85 (40.00%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
