### PR TITLE
Stage dependent metadata for iteration commits

### DIFF
--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -548,10 +548,6 @@ class WorkflowStrategy(ABC):
             self.context.get("test_version")
             or resolve_test_version(self.reachability_repo_path, self.group, self.artifact, self.version)
         )
-        metadata_version = str(
-            self.context.get("metadata_version")
-            or resolve_metadata_version(self.reachability_repo_path, self.group, self.artifact, self.version)
-        )
         stage_paths = [
             os.path.join(
                 self.reachability_repo_path,
@@ -561,20 +557,10 @@ class WorkflowStrategy(ABC):
                 self.artifact,
                 test_version,
             ),
-            os.path.join(
-                self.reachability_repo_path,
-                "metadata",
-                self.group,
-                self.artifact,
-                "index.json",
-            ),
-            os.path.join(
-                self.reachability_repo_path,
-                "metadata",
-                self.group,
-                self.artifact,
-                metadata_version,
-            ),
+            # Whole `metadata/` tree, not the target artifact's directory: generation traces
+            # through transitive dependencies and can produce entries owned by another
+            # artifact, which artifact-scoped staging would drop (§WF-forge-workflow-drivers.3).
+            os.path.join(self.reachability_repo_path, "metadata"),
             stats_artifact_dir(self.reachability_repo_path, self.group, self.artifact),
         ]
         existing_paths = [path for path in stage_paths if os.path.exists(path)]

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -242,6 +242,14 @@ finalization succeeds, otherwise the finalization status becomes the run
 status. Drivers must not call the private finalization internals and must not
 re-implement the status merge at their call sites.
 
+The iteration commit stages the whole `metadata/` tree, not just the target
+coordinate's `metadata/<group>/<artifact>/<metadata-version>` directory and
+`index.json`. Metadata generation traces through the target's transitive
+dependencies, so a run can produce entries that belong to a dependency's
+artifact; staging the artifact-scoped paths alone would drop them, and the next
+checkpoint reset would delete them. Test sources and stats stay scoped to the
+target coordinate.
+
 Per-coordinate finalization repairs missing `allowed-packages`
 deterministically. If `checkMetadataFiles` still fails, Forge runs up to three
 Codex metadata fix and validation attempts before failing the run. Each Codex


### PR DESCRIPTION
Closes #9140

## What this does

Metadata generation can produce entries owned by transitive dependencies. The iteration commit previously staged only the target artifact metadata, so a checkpoint reset discarded those dependency entries. The workflow contract now requires staging the whole [`metadata/` tree](forge/docs/workflows/workflow-drivers.md#3-shared-run-finalization-and-metrics-publication) (§WF-forge-workflow-drivers.3).

## Preserving generated dependency metadata

- Stages `metadata/` as one unit, including dependency-owned entries and their indexes.
- Keeps generated test sources and library stats scoped to the target coordinate.