### PR TITLE
Close library requests whose artifact cannot be resolved

### DIFF
--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -241,8 +241,135 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
 
-      - name: "Mark issue eligible for dependency graph expansion"
+      # Closed-world search over the repositories the test builds configure: a miss proves
+      # absence from those repositories only, never that the artifact does not exist, so
+      # only a definite 404 from every one of them closes an issue. §CI-triage-new-issues
+      - name: "Check whether the artifact resolves from a configured repository"
         if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' && steps.support.outputs.not_for_native_image != 'true' }}
+        id: resolvable
+        env:
+          COORDS: ${{ steps.extract.outputs.coords }}
+        run: |
+          set -Eeuo pipefail
+
+          # Keep in sync with the repositories block in
+          # tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+          # (mavenLocal() is intentionally omitted; it is always empty on a CI runner).
+          REPOSITORIES=(
+            "https://repo.maven.apache.org/maven2"
+            "https://packages.confluent.io/maven"
+          )
+
+          GROUP="${COORDS%%:*}"
+          REST="${COORDS#*:}"
+          ARTIFACT="${REST%%:*}"
+          VERSION="${REST##*:}"
+          GROUP_PATH="${GROUP//.//}"
+
+          # Returns the HTTP status, or 000 when the request never completed.
+          probe() {
+            curl --silent --show-error --location \
+                 --head --fail-early \
+                 --max-time 20 --retry 2 --retry-connrefused \
+                 --output /dev/null --write-out '%{http_code}' \
+                 "$1" 2>/dev/null || true
+          }
+
+          version_found="false"
+          artifact_found="false"
+          indeterminate="false"
+
+          for BASE in "${REPOSITORIES[@]}"; do
+            POM_URL="${BASE}/${GROUP_PATH}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.pom"
+            METADATA_URL="${BASE}/${GROUP_PATH}/${ARTIFACT}/maven-metadata.xml"
+
+            POM_STATUS="$(probe "$POM_URL")"
+            echo "  ${POM_STATUS}  ${POM_URL}"
+            if [[ "$POM_STATUS" == "200" ]]; then
+              version_found="true"
+              break
+            fi
+            if [[ "$POM_STATUS" != "404" ]]; then
+              # 5xx, 401/403, timeout, DNS failure: absence is unproven.
+              indeterminate="true"
+            fi
+
+            METADATA_STATUS="$(probe "$METADATA_URL")"
+            echo "  ${METADATA_STATUS}  ${METADATA_URL}"
+            if [[ "$METADATA_STATUS" == "200" ]]; then
+              artifact_found="true"
+            elif [[ "$METADATA_STATUS" != "404" ]]; then
+              indeterminate="true"
+            fi
+          done
+
+          if [[ "$version_found" == "true" ]]; then
+            echo "Resolved $COORDS from a configured repository."
+            echo "outcome=resolvable" >> "$GITHUB_OUTPUT"
+          elif [[ "$indeterminate" == "true" ]]; then
+            echo "Could not prove absence of $COORDS; leaving the issue open for triage."
+            echo "outcome=indeterminate" >> "$GITHUB_OUTPUT"
+          elif [[ "$artifact_found" == "true" ]]; then
+            echo "$GROUP:$ARTIFACT exists but version $VERSION was not found."
+            echo "outcome=version-missing" >> "$GITHUB_OUTPUT"
+          else
+            echo "$COORDS was not found in any configured repository."
+            echo "outcome=unresolvable" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Close issue - artifact version not found in a configured repository"
+        if: ${{ steps.resolvable.outputs.outcome == 'version-missing' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          COORDS: ${{ steps.extract.outputs.coords }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const coords = process.env.COORDS || "";
+            const [group, artifact, version] = coords.split(":");
+            const body = [
+              `Automated triage: \`${group}:${artifact}\` was found, but version \`${version}\` is not published to any repository this project builds against (Maven Central, Confluent).`,
+              "",
+              "This usually means the version in the issue title has a typo, or it has not been released yet.",
+              "",
+              `Closing this issue. Please open a new request with a published version of \`${group}:${artifact}\` in the title.`,
+              "Note: Reopening will not re-run automation; maintainers will review manually."
+            ].join("\n");
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
+
+      - name: "Close issue - artifact is not available in any configured repository"
+        if: ${{ steps.resolvable.outputs.outcome == 'unresolvable' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          COORDS: ${{ steps.extract.outputs.coords }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const coords = process.env.COORDS || "";
+            const body = [
+              `Automated triage: \`${coords}\` could not be resolved from any repository this project builds against (Maven Central, Confluent).`,
+              "",
+              "Metadata in this repository is always shipped together with a test that resolves the library and runs in CI on every change. When we cannot download the artifact, we cannot build that test, and we cannot re-verify the metadata as new versions are released — so we are unable to support the coordinates as requested.",
+              "",
+              "**If this artifact is published to a public repository we do not yet configure**, please reply with the repository URL and we will consider adding it.",
+              "",
+              "**If this artifact is private or internal**, we cannot access it, but you can generate the metadata yourself: run your application with the tracing agent and place the generated configuration in your application's `META-INF/native-image` directory. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/",
+              "",
+              "**If your native image fails inside a public library** that this private artifact depends on, please open a request for that library's coordinates and include the error — we can act on that.",
+              "",
+              "Closing this issue.",
+              "Note: Reopening will not re-run automation; maintainers will review manually."
+            ].join("\n");
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
+
+      - name: "Mark issue eligible for dependency graph expansion"
+        if: ${{ steps.classify.outputs.should_triage == 'true' && steps.validate.outputs.invalid != 'true' && steps.duplicate.outputs.duplicate != 'true' && steps.support.outputs.supported != 'true' && steps.support.outputs.not_for_native_image != 'true' && steps.resolvable.outputs.outcome != 'unresolvable' && steps.resolvable.outputs.outcome != 'version-missing' }}
         id: expand
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/triage-new-issues.yml
+++ b/.github/workflows/triage-new-issues.yml
@@ -275,9 +275,12 @@ jobs:
                  "$1" 2>/dev/null || true
           }
 
-          version_found="false"
+          # Every outcome below rests on proof: a definite 404 from every repository to
+          # claim absence, a 200 to claim existence. A 5xx, a 401/403, or a transport
+          # failure proves neither, so the issue continues through triage uncommented.
+          version_absent="true"
+          artifact_absent="true"
           artifact_found="false"
-          indeterminate="false"
 
           for BASE in "${REPOSITORIES[@]}"; do
             POM_URL="${BASE}/${GROUP_PATH}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.pom"
@@ -285,13 +288,10 @@ jobs:
 
             POM_STATUS="$(probe "$POM_URL")"
             echo "  ${POM_STATUS}  ${POM_URL}"
-            if [[ "$POM_STATUS" == "200" ]]; then
-              version_found="true"
-              break
-            fi
             if [[ "$POM_STATUS" != "404" ]]; then
-              # 5xx, 401/403, timeout, DNS failure: absence is unproven.
-              indeterminate="true"
+              # Resolved, or unproven; either way there is nothing left to establish.
+              version_absent="false"
+              break
             fi
 
             METADATA_STATUS="$(probe "$METADATA_URL")"
@@ -299,22 +299,22 @@ jobs:
             if [[ "$METADATA_STATUS" == "200" ]]; then
               artifact_found="true"
             elif [[ "$METADATA_STATUS" != "404" ]]; then
-              indeterminate="true"
+              artifact_absent="false"
             fi
           done
 
-          if [[ "$version_found" == "true" ]]; then
-            echo "Resolved $COORDS from a configured repository."
-            echo "outcome=resolvable" >> "$GITHUB_OUTPUT"
-          elif [[ "$indeterminate" == "true" ]]; then
-            echo "Could not prove absence of $COORDS; leaving the issue open for triage."
-            echo "outcome=indeterminate" >> "$GITHUB_OUTPUT"
+          if [[ "$version_absent" != "true" ]]; then
+            echo "Nothing proven about $COORDS; continuing triage."
+            echo "outcome=none" >> "$GITHUB_OUTPUT"
           elif [[ "$artifact_found" == "true" ]]; then
             echo "$GROUP:$ARTIFACT exists but version $VERSION was not found."
             echo "outcome=version-missing" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ "$artifact_absent" == "true" ]]; then
             echo "$COORDS was not found in any configured repository."
             echo "outcome=unresolvable" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nothing proven about $GROUP:$ARTIFACT; continuing triage."
+            echo "outcome=none" >> "$GITHUB_OUTPUT"
           fi
 
       - name: "Close issue - artifact version not found in a configured repository"
@@ -334,8 +334,9 @@ jobs:
               "",
               "This usually means the version in the issue title has a typo, or it has not been released yet.",
               "",
-              `Closing this issue. Please open a new request with a published version of \`${group}:${artifact}\` in the title.`,
-              "Note: Reopening will not re-run automation; maintainers will review manually."
+              `Please open a new request with a published version of \`${group}:${artifact}\` in the title.`,
+              "",
+              "If these coordinates are valid and this triage is wrong, please reply here and we will take another look."
             ].join("\n");
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });
@@ -354,16 +355,13 @@ jobs:
             const body = [
               `Automated triage: \`${coords}\` could not be resolved from any repository this project builds against (Maven Central, Confluent).`,
               "",
-              "Metadata in this repository is always shipped together with a test that resolves the library and runs in CI on every change. When we cannot download the artifact, we cannot build that test, and we cannot re-verify the metadata as new versions are released — so we are unable to support the coordinates as requested.",
+              "Metadata in this repository is always shipped together with a test that resolves the library and runs in CI on every change. When we cannot download the artifact, we cannot build that test, and we cannot re-verify the metadata as new versions are released, so we are unable to support the coordinates as requested.",
               "",
               "**If this artifact is published to a public repository we do not yet configure**, please reply with the repository URL and we will consider adding it.",
               "",
               "**If this artifact is private or internal**, we cannot access it, but you can generate the metadata yourself: run your application with the tracing agent and place the generated configuration in your application's `META-INF/native-image` directory. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/",
               "",
-              "**If your native image fails inside a public library** that this private artifact depends on, please open a request for that library's coordinates and include the error — we can act on that.",
-              "",
-              "Closing this issue.",
-              "Note: Reopening will not re-run automation; maintainers will review manually."
+              "**If your native image fails inside a public library** that this private artifact depends on, please open a request for that library's coordinates and include the error, which we can act on."
             ].join("\n");
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
             await github.rest.issues.update({ owner, repo, issue_number, state: "closed" });

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -298,7 +298,15 @@ tracing agent when it is private. The check distinguishes an unknown
 whose requested version is missing, and reports each with its own message. Only a
 definite `404` from every configured repository closes an issue; transport
 failures and `5xx` responses leave the issue open for normal triage, so an
-upstream outage cannot mass-close valid requests. It then — via
+upstream outage cannot mass-close valid requests.
+
+The repository list the gate probes is maintained by hand in the workflow and
+must be kept in sync with the `repositories` block in
+`org.graalvm.internal.tck.gradle`: `mavenCentral()` contributes no URL literal to
+extract, so the list cannot be derived from the build. Adding a repository to the
+build therefore requires adding it to the workflow in the same change. A workflow
+list that has fallen behind the build closes requests the build could in fact
+resolve. It then — via
 `open-dependency-issues-and-link-blockers.js`
 (§CI-shared-scripts) — generates a deps.dev dependency graph and opens or reuses
 `library-new-request` issues for unsupported transitive dependencies, linking

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -285,7 +285,20 @@ eligible. For automated native-build-tools issues with no labels and the standar
 validates the Maven coordinates, closes invalid/duplicate/already-supported
 requests, and also closes requests whose `groupId:artifactId` already has an
 `index.json` recorded as `not-for-native-image` even when that index carries no
-per-version `tested-versions`. It then — via
+per-version `tested-versions`.
+
+It then closes requests whose artifact cannot be resolved from any repository the
+test builds configure (Maven Central and Confluent, per
+`org.graalvm.internal.tck.gradle`). Resolution is a closed-world search: a miss
+proves only that the artifact is absent from the repositories we query, never
+that it does not exist, so the close comment asks the reporter for the repository
+URL when the artifact is published somewhere public and points them at the
+tracing agent when it is private. The check distinguishes an unknown
+`groupId:artifactId` (no `maven-metadata.xml` anywhere) from a known artifact
+whose requested version is missing, and reports each with its own message. Only a
+definite `404` from every configured repository closes an issue; transport
+failures and `5xx` responses leave the issue open for normal triage, so an
+upstream outage cannot mass-close valid requests. It then — via
 `open-dependency-issues-and-link-blockers.js`
 (§CI-shared-scripts) — generates a deps.dev dependency graph and opens or reuses
 `library-new-request` issues for unsupported transitive dependencies, linking


### PR DESCRIPTION
Closes #9139

## What this does

Requests for artifacts that no configured repository serves currently flow all the way into the agent workflows, which discover the problem the expensive way. #7767, #7768 and #7769 each burned three agent runs across three different bots before landing in `human-intervention`, every one of them rediscovering the same `404` from Maven Central for `oracle.spectra.bundles:*`. This adds a resolvability gate to issue triage that catches it in one HTTP request.

The gate deliberately does **only** the deterministic check. Two richer designs were considered and dropped:

- **Adding more repositories to the build config.** Tallying groupIds across all 53 `human-intervention` requests shows the "public library on a repository we don't configure" case is close to empty: 18 `org.springframework.boot`, 8 `io.opentelemetry.instrumentation`, 6 `org.springframework.ai` and the rest are on Maven Central already and stuck for unrelated reasons. The only non-Central coordinates are the Oracle-internal ones this issue is about. Extra repositories would also be consulted for every resolution in the whole suite, which costs latency and widens the dependency-confusion surface.
- **An agent lookup for "where is this published?"** GitHub Models turns out to be retiring, both `models.github.ai/catalog/models` and the inference endpoint return `410 github_models_retirement_brownout`, and every remaining option needs a model API secret in the triage path. Not worth it for a case the data says barely occurs.

## How the check decides

Resolution is a **closed-world search**: Gradle only ever asks the repositories declared in `org.graalvm.internal.tck.gradle`, so a miss proves absence from those repositories, never that the artifact does not exist. The gate is built around that limit. It probes the POM, and on a miss `maven-metadata.xml`, across Maven Central and Confluent, and acts only on a result it can prove:

| Probe result | What it proves | Action |
|---|---|---|
| POM `200` anywhere | artifact resolves | triage continues, no comment |
| anything other than a definite `404` | nothing | triage continues, no comment |
| POMs all `404`, metadata `200` | version absent, artifact exists | close as `version-missing` |
| everything `404` | artifact absent | close as `unresolvable` |

A `404` is the server stating it looked and the file is not there. A `5xx`, a `401`, or a timeout is not an answer at all, so it can never close an issue. This matters because triage runs unattended on `issues: [opened]`: without that rule a Maven Central outage would auto-close and comment on every request opened during it.

Verified against real coordinates:

```
oracle.spectra.bundles:helidon-mp:2607.0.8  => unresolvable    (the reported case)
org.postgresql:postgresql:42.7.3            => no comment      (resolves on Central)
org.postgresql:postgresql:99.99.99          => version-missing
io.confluent:kafka-avro-serializer:8.2.1    => no comment      (resolves on Confluent)
a repository did not answer                 => no comment
```

The Confluent case is why the probe covers both repositories: a Central-only check would have closed a library the repository already supports.

## Comment examples

Only the two closing outcomes comment. Because absence is unprovable, both messages ask rather than simply reject.

`version-missing`, for `org.postgresql:postgresql:99.99.99`:

> Automated triage: `org.postgresql:postgresql` was found, but version `99.99.99` is not published to any repository this project builds against (Maven Central, Confluent).
>
> This usually means the version in the issue title has a typo, or it has not been released yet.
>
> Please open a new request with a published version of `org.postgresql:postgresql` in the title.
>
> If these coordinates are valid and this triage is wrong, please reply here and we will take another look.

`unresolvable`, for `oracle.spectra.bundles:helidon-mp:2607.0.8`:

> Automated triage: `oracle.spectra.bundles:helidon-mp:2607.0.8` could not be resolved from any repository this project builds against (Maven Central, Confluent).
>
> Metadata in this repository is always shipped together with a test that resolves the library and runs in CI on every change. When we cannot download the artifact, we cannot build that test, and we cannot re-verify the metadata as new versions are released, so we are unable to support the coordinates as requested.
>
> **If this artifact is published to a public repository we do not yet configure**, please reply with the repository URL and we will consider adding it.
>
> **If this artifact is private or internal**, we cannot access it, but you can generate the metadata yourself: run your application with the tracing agent and place the generated configuration in your application's `META-INF/native-image` directory. See https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/
>
> **If your native image fails inside a public library** that this private artifact depends on, please open a request for that library's coordinates and include the error, which we can act on.

Behavior is specified in [§CI-triage-new-issues](docs/ci.md); the dependency-graph expansion gate now also excludes both closing outcomes, so a closed issue never fans out into transitive dependency issues.

## Open questions

1. **The three motivating issues stay open.** The workflow triggers on `issues: [opened]`, so it will not retroactively touch #7767-#7769. I'd close them by hand with the same explanation.
2. **Already-labeled issues can still reach the agents** before triage ever sees them. A matching preflight in `add_new_library_support.py` would close that path; I left it out to keep this change to triage.
3. **The repository list is duplicated** between the workflow and `org.graalvm.internal.tck.gradle`, now stated as a requirement in the spec because `mavenCentral()` has no URL literal to extract. A Gradle task printing resolved repository URLs would remove the drift risk if that seems worth it.
