### PR TITLE
[GenAI] Add support for io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha using gpt-5.6-terra

### DIFF
--- a/metadata/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/reachability-metadata.json
+++ b/metadata/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/reachability-metadata.json
@@ -1,0 +1,38 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.proto.metrics.v1.Exemplar"
+      },
+      "type" : "com.google.protobuf.ExtensionRegistry",
+      "methods" : [
+        {
+          "name" : "getEmptyRegistry",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest"
+      },
+      "type" : "java.nio.Buffer",
+      "fields" : [
+        {
+          "name" : "address"
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest"
+      },
+      "type" : "sun.misc.Unsafe",
+      "fields" : [
+        {
+          "name" : "theUnsafe"
+        }
+      ]
+    }
+  ]
+}

--- a/metadata/io.opentelemetry.proto/opentelemetry-proto/index.json
+++ b/metadata/io.opentelemetry.proto/opentelemetry-proto/index.json
@@ -1,0 +1,26 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "1.10.0-alpha",
+    "source-code-url" : "https://repo1.maven.org/maven2/io/opentelemetry/proto/opentelemetry-proto/$version$/opentelemetry-proto-$version$-sources.jar",
+    "repository-url" : "https://github.com/open-telemetry/opentelemetry-proto-java",
+    "test-code-url" : "https://github.com/open-telemetry/opentelemetry-proto-java/tree/v1.10.0/src/test/java/io/opentelemetry/proto",
+    "documentation-url" : "https://repo1.maven.org/maven2/io/opentelemetry/proto/opentelemetry-proto/$version$/opentelemetry-proto-$version$-javadoc.jar",
+    "description" : "OpenTelemetry Proto provides generated Java bindings for the OpenTelemetry Protocol (OTLP) Protobuf messages. It enables JVM applications and OpenTelemetry test suites to serialize and deserialize OTLP telemetry data such as traces, metrics, logs, and profiles.",
+    "tested-versions" : [
+      "1.10.0-alpha"
+    ],
+    "allowed-packages" : [
+      "io.opentelemetry.proto.collector.logs.v1",
+      "io.opentelemetry.proto.collector.metrics.v1",
+      "io.opentelemetry.proto.collector.profiles.v1development",
+      "io.opentelemetry.proto.collector.trace.v1",
+      "io.opentelemetry.proto.common.v1",
+      "io.opentelemetry.proto.logs.v1",
+      "io.opentelemetry.proto.metrics.v1",
+      "io.opentelemetry.proto.profiles.v1development",
+      "io.opentelemetry.proto.resource.v1",
+      "io.opentelemetry.proto.trace.v1"
+    ]
+  }
+]

--- a/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/execution-metrics.json
@@ -1,0 +1,86 @@
+{
+  "add_new_library_support:2026-08-11": {
+    "timestamp": "2026-08-11T12:41:30.086148Z",
+    "library": "io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha",
+    "starting_commit": "43481427d2b32d982fa5763dab61d5f362170c18",
+    "ending_commit": "d623a9e89da9ba341b2c495b4ec6c39423395607",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "1.10.0-alpha",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 15845,
+          "missed": 74350,
+          "ratio": 0.175675,
+          "total": 90195
+        },
+        "line": {
+          "covered": 4479,
+          "missed": 19870,
+          "ratio": 0.18395,
+          "total": 24349
+        },
+        "method": {
+          "covered": 906,
+          "missed": 4730,
+          "ratio": 0.160752,
+          "total": 5636
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 9250,
+      "issue_label": "library-new-request",
+      "library": "io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha",
+      "summary": "The artifact is self-contained OTLP protobuf bindings; its sole declared runtime dependency, protobuf-java 4.34.0, resolves transitively. Meaningful tests can build, serialize, and parse OTLP messages without services or configuration.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [
+        "Generated gRPC service-stub classes reference io.grpc types although the published module metadata declares no gRPC dependency; avoid exercising those stubs unless a later Gradle compile/runtime failure establishes a required gRPC test dependency."
+      ],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#9250 Support for io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.6-terra",
+      "input_tokens_used": 46140,
+      "output_tokens_used": 2351,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha/library-preparation-preflight/pi-generation-2026-08-11T12-14-12-718213Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 142724,
+      "cached_input_tokens_used": 853504,
+      "output_tokens_used": 11661,
+      "iterations": 3,
+      "cost_usd": 0.7451,
+      "generated_loc": 279,
+      "tested_library_loc": 4479,
+      "metadata_entries": 6,
+      "test_only_metadata_entries": 2,
+      "code_coverage_percent": 18.39
+    },
+    "artifacts": {
+      "metadata_file": "metadata/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/stats.json
+++ b/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "1.10.0-alpha",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 15845,
+        "missed" : 74350,
+        "ratio" : 0.175675,
+        "total" : 90195
+      },
+      "line" : {
+        "covered" : 4479,
+        "missed" : 19870,
+        "ratio" : 0.18395,
+        "total" : 24349
+      },
+      "method" : {
+        "covered" : 906,
+        "missed" : 4730,
+        "ratio" : 0.160752,
+        "total" : 5636
+      }
+    }
+  } ]
+}

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/.gitignore
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/build.gradle
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "io.opentelemetry.proto:opentelemetry-proto:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/gradle.properties
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha
+library.version = 1.10.0-alpha
+metadata.dir = io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/settings.gradle
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'io.opentelemetry.proto.opentelemetry-proto_tests'

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package io_opentelemetry_proto.opentelemetry_proto;
+
+import org.junit.jupiter.api.Test;
+
+class Opentelemetry_protoTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
@@ -9,6 +9,7 @@ package io_opentelemetry_proto.opentelemetry_proto;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.profiles.v1development.ExportProfilesServiceRequest;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
@@ -28,6 +29,12 @@ import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import io.opentelemetry.proto.metrics.v1.Sum;
+import io.opentelemetry.proto.profiles.v1development.Profile;
+import io.opentelemetry.proto.profiles.v1development.ProfilesDictionary;
+import io.opentelemetry.proto.profiles.v1development.ResourceProfiles;
+import io.opentelemetry.proto.profiles.v1development.Sample;
+import io.opentelemetry.proto.profiles.v1development.ScopeProfiles;
+import io.opentelemetry.proto.profiles.v1development.ValueType;
 import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
@@ -189,6 +196,49 @@ public class Opentelemetry_protoTest {
         assertThat(recordedPoint.getMax()).isEqualTo(8.7D);
         assertThat(recordedPoint.getExemplars(0).getAsDouble()).isEqualTo(4.2D);
         assertThat(recordedPoint.getExemplars(0).getFilteredAttributes(0).getKey()).isEqualTo("sampled");
+    }
+
+    @Test
+    void profilesExportRetainsDictionaryIndexedSampleData() {
+        ProfilesDictionary dictionary = ProfilesDictionary.newBuilder()
+                .addStringTable("")
+                .addStringTable("cpu")
+                .addStringTable("nanoseconds")
+                .build();
+        ValueType sampleType = ValueType.newBuilder()
+                .setTypeStrindex(1)
+                .setUnitStrindex(2)
+                .build();
+        Profile profile = Profile.newBuilder()
+                .setSampleType(sampleType)
+                .setTimeUnixNano(100L)
+                .setDurationNano(50L)
+                .setProfileId(ByteString.copyFromUtf8("profile-identifier"))
+                .addSamples(Sample.newBuilder()
+                        .setStackIndex(3)
+                        .addValues(17L)
+                        .addTimestampsUnixNano(125L))
+                .build();
+        ExportProfilesServiceRequest request = ExportProfilesServiceRequest.newBuilder()
+                .setDictionary(dictionary)
+                .addResourceProfiles(ResourceProfiles.newBuilder()
+                        .setResource(resource())
+                        .addScopeProfiles(ScopeProfiles.newBuilder()
+                                .setScope(scope())
+                                .addProfiles(profile)))
+                .build();
+
+        Profile exportedProfile = request.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
+
+        assertThat(request.hasDictionary()).isTrue();
+        assertThat(request.getDictionary().getStringTableList())
+                .containsExactly("", "cpu", "nanoseconds");
+        assertThat(exportedProfile.getSampleType().getTypeStrindex()).isEqualTo(1);
+        assertThat(exportedProfile.getSampleType().getUnitStrindex()).isEqualTo(2);
+        assertThat(exportedProfile.getProfileId()).isEqualTo(ByteString.copyFromUtf8("profile-identifier"));
+        assertThat(exportedProfile.getSamples(0).getStackIndex()).isEqualTo(3);
+        assertThat(exportedProfile.getSamples(0).getValuesList()).containsExactly(17L);
+        assertThat(exportedProfile.getSamples(0).getTimestampsUnixNanoList()).containsExactly(125L);
     }
 
     @Test

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
@@ -6,11 +6,193 @@
  */
 package io_opentelemetry_proto.opentelemetry_proto;
 
+import com.google.protobuf.ByteString;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.ScopeLogs;
+import io.opentelemetry.proto.logs.v1.SeverityNumber;
+import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import io.opentelemetry.proto.metrics.v1.Gauge;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
+import io.opentelemetry.proto.metrics.v1.Sum;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import io.opentelemetry.proto.trace.v1.TracesData;
 import org.junit.jupiter.api.Test;
 
-class Opentelemetry_protoTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Opentelemetry_protoTest {
+    private static final ByteString TRACE_ID = ByteString.copyFromUtf8("0123456789abcdef");
+    private static final ByteString SPAN_ID = ByteString.copyFromUtf8("01234567");
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void traceExportRequestRetainsResourceScopeAndSpanDetailsAfterSerialization() throws Exception {
+        Span span = Span.newBuilder()
+                .setTraceId(TRACE_ID)
+                .setSpanId(SPAN_ID)
+                .setParentSpanId(ByteString.copyFromUtf8("parent123"))
+                .setTraceState("vendor=value")
+                .setFlags(1)
+                .setName("GET /orders/{id}")
+                .setKind(Span.SpanKind.SPAN_KIND_SERVER)
+                .setStartTimeUnixNano(100L)
+                .setEndTimeUnixNano(250L)
+                .addAttributes(attribute("http.request.method", "GET"))
+                .addEvents(Span.Event.newBuilder()
+                        .setTimeUnixNano(150L)
+                        .setName("validated")
+                        .addAttributes(attribute("validation.result", "accepted")))
+                .addLinks(Span.Link.newBuilder()
+                        .setTraceId(ByteString.copyFromUtf8("fedcba9876543210"))
+                        .setSpanId(ByteString.copyFromUtf8("76543210"))
+                        .setFlags(1)
+                        .addAttributes(attribute("link.type", "causal")))
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_ERROR)
+                        .setMessage("upstream unavailable"))
+                .build();
+        ResourceSpans resourceSpans = ResourceSpans.newBuilder()
+                .setResource(resource())
+                .setSchemaUrl("https://opentelemetry.io/schemas/1.30.0")
+                .addScopeSpans(ScopeSpans.newBuilder()
+                        .setScope(scope())
+                        .setSchemaUrl("https://opentelemetry.io/schemas/1.30.0")
+                        .addSpans(span))
+                .build();
+        ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(resourceSpans)
+                .build();
+
+        ExportTraceServiceRequest parsed = ExportTraceServiceRequest.parseFrom(request.toByteArray());
+        Span parsedSpan = parsed.getResourceSpans(0).getScopeSpans(0).getSpans(0);
+
+        assertThat(parsed).isEqualTo(request);
+        assertThat(TracesData.parseFrom(TracesData.newBuilder().addResourceSpans(resourceSpans).build()
+                .toByteArray()).getResourceSpansCount()).isEqualTo(1);
+        assertThat(parsedSpan.getKind()).isEqualTo(Span.SpanKind.SPAN_KIND_SERVER);
+        assertThat(parsedSpan.getEvents(0).getAttributes(0).getValue().getStringValue()).isEqualTo("accepted");
+        assertThat(parsedSpan.getLinks(0).getTraceId()).isEqualTo(ByteString.copyFromUtf8("fedcba9876543210"));
+        assertThat(parsedSpan.getStatus().getCode()).isEqualTo(Status.StatusCode.STATUS_CODE_ERROR);
+    }
+
+    @Test
+    void metricsExportSupportsGaugeAndCumulativeSumDataPoints() throws Exception {
+        NumberDataPoint gaugePoint = NumberDataPoint.newBuilder()
+                .setStartTimeUnixNano(10L)
+                .setTimeUnixNano(20L)
+                .setAsDouble(23.5D)
+                .addAttributes(attribute("room", "kitchen"))
+                .build();
+        NumberDataPoint sumPoint = NumberDataPoint.newBuilder()
+                .setStartTimeUnixNano(10L)
+                .setTimeUnixNano(20L)
+                .setAsInt(42L)
+                .addAttributes(attribute("operation", "checkout"))
+                .build();
+        ResourceMetrics resourceMetrics = ResourceMetrics.newBuilder()
+                .setResource(resource())
+                .addScopeMetrics(ScopeMetrics.newBuilder()
+                        .setScope(scope())
+                        .addMetrics(Metric.newBuilder()
+                                .setName("temperature")
+                                .setDescription("Current temperature")
+                                .setUnit("Cel")
+                                .setGauge(Gauge.newBuilder().addDataPoints(gaugePoint)))
+                        .addMetrics(Metric.newBuilder()
+                                .setName("requests")
+                                .setUnit("1")
+                                .setSum(Sum.newBuilder()
+                                        .setAggregationTemporality(
+                                                AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE)
+                                        .setIsMonotonic(true)
+                                        .addDataPoints(sumPoint))))
+                .build();
+        ExportMetricsServiceRequest request = ExportMetricsServiceRequest.newBuilder()
+                .addResourceMetrics(resourceMetrics)
+                .build();
+
+        ExportMetricsServiceRequest parsed = ExportMetricsServiceRequest.parseFrom(request.toByteArray());
+        Metric parsedGauge = parsed.getResourceMetrics(0).getScopeMetrics(0).getMetrics(0);
+        Metric parsedSum = parsed.getResourceMetrics(0).getScopeMetrics(0).getMetrics(1);
+
+        assertThat(parsed).isEqualTo(request);
+        assertThat(MetricsData.parseFrom(MetricsData.newBuilder().addResourceMetrics(resourceMetrics).build()
+                .toByteArray()).getResourceMetricsCount()).isEqualTo(1);
+        assertThat(parsedGauge.getDataCase()).isEqualTo(Metric.DataCase.GAUGE);
+        assertThat(parsedGauge.getGauge().getDataPoints(0).getAsDouble()).isEqualTo(23.5D);
+        assertThat(parsedSum.getSum().getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE);
+        assertThat(parsedSum.getSum().getDataPoints(0).getAsInt()).isEqualTo(42L);
+    }
+
+    @Test
+    void logsExportPreservesSeverityBodyCorrelationAndResourceContext() throws Exception {
+        LogRecord record = LogRecord.newBuilder()
+                .setTimeUnixNano(500L)
+                .setObservedTimeUnixNano(510L)
+                .setSeverityNumber(SeverityNumber.SEVERITY_NUMBER_WARN)
+                .setSeverityText("WARN")
+                .setBody(AnyValue.newBuilder().setStringValue("payment authorization delayed"))
+                .addAttributes(attribute("order.id", "1234"))
+                .setTraceId(TRACE_ID)
+                .setSpanId(SPAN_ID)
+                .setFlags(1)
+                .setEventName("payment.authorization")
+                .build();
+        ResourceLogs resourceLogs = ResourceLogs.newBuilder()
+                .setResource(resource())
+                .setSchemaUrl("https://opentelemetry.io/schemas/1.30.0")
+                .addScopeLogs(ScopeLogs.newBuilder()
+                        .setScope(scope())
+                        .addLogRecords(record))
+                .build();
+        ExportLogsServiceRequest request = ExportLogsServiceRequest.newBuilder()
+                .addResourceLogs(resourceLogs)
+                .build();
+
+        ExportLogsServiceRequest parsed = ExportLogsServiceRequest.parseFrom(request.toByteArray());
+        LogRecord parsedRecord = parsed.getResourceLogs(0).getScopeLogs(0).getLogRecords(0);
+
+        assertThat(parsed).isEqualTo(request);
+        assertThat(parsedRecord.getSeverityNumber()).isEqualTo(SeverityNumber.SEVERITY_NUMBER_WARN);
+        assertThat(parsedRecord.getBody().getStringValue()).isEqualTo("payment authorization delayed");
+        assertThat(parsedRecord.getTraceId()).isEqualTo(TRACE_ID);
+        assertThat(parsedRecord.getEventName()).isEqualTo("payment.authorization");
+    }
+
+    private static Resource resource() {
+        return Resource.newBuilder()
+                .addAttributes(attribute("service.name", "checkout"))
+                .addAttributes(attribute("service.instance.id", "instance-1"))
+                .build();
+    }
+
+    private static InstrumentationScope scope() {
+        return InstrumentationScope.newBuilder()
+                .setName("checkout-instrumentation")
+                .setVersion("1.0")
+                .addAttributes(attribute("instrumentation.language", "java"))
+                .build();
+    }
+
+    private static KeyValue attribute(String key, String value) {
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build();
     }
 }

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/java/io_opentelemetry_proto/opentelemetry_proto/Opentelemetry_protoTest.java
@@ -18,7 +18,10 @@ import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.logs.v1.ScopeLogs;
 import io.opentelemetry.proto.logs.v1.SeverityNumber;
 import io.opentelemetry.proto.metrics.v1.AggregationTemporality;
+import io.opentelemetry.proto.metrics.v1.Exemplar;
 import io.opentelemetry.proto.metrics.v1.Gauge;
+import io.opentelemetry.proto.metrics.v1.Histogram;
+import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
@@ -137,6 +140,55 @@ public class Opentelemetry_protoTest {
         assertThat(parsedSum.getSum().getAggregationTemporality())
                 .isEqualTo(AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE);
         assertThat(parsedSum.getSum().getDataPoints(0).getAsInt()).isEqualTo(42L);
+    }
+
+    @Test
+    void histogramMetricRepresentsDistributionBucketsAndExemplars() {
+        Exemplar exemplar = Exemplar.newBuilder()
+                .setTimeUnixNano(15L)
+                .setAsDouble(4.2D)
+                .setTraceId(TRACE_ID)
+                .setSpanId(SPAN_ID)
+                .addFilteredAttributes(attribute("sampled", "true"))
+                .build();
+        HistogramDataPoint point = HistogramDataPoint.newBuilder()
+                .setStartTimeUnixNano(10L)
+                .setTimeUnixNano(20L)
+                .setCount(8L)
+                .setSum(27.5D)
+                .addBucketCounts(2L)
+                .addBucketCounts(3L)
+                .addBucketCounts(3L)
+                .addExplicitBounds(2.0D)
+                .addExplicitBounds(5.0D)
+                .setMin(1.1D)
+                .setMax(8.7D)
+                .addExemplars(exemplar)
+                .build();
+        Metric metric = Metric.newBuilder()
+                .setName("request.duration")
+                .setUnit("ms")
+                .setHistogram(Histogram.newBuilder()
+                        .setAggregationTemporality(AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA)
+                        .addDataPoints(point))
+                .build();
+
+        HistogramDataPoint recordedPoint = metric.getHistogram().getDataPoints(0);
+
+        assertThat(metric.getDataCase()).isEqualTo(Metric.DataCase.HISTOGRAM);
+        assertThat(metric.getHistogram().getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA);
+        assertThat(recordedPoint.getBucketCountsList()).containsExactly(2L, 3L, 3L);
+        assertThat(recordedPoint.getExplicitBoundsList()).containsExactly(2.0D, 5.0D);
+        assertThat(recordedPoint.getCount()).isEqualTo(8L);
+        assertThat(recordedPoint.hasSum()).isTrue();
+        assertThat(recordedPoint.getSum()).isEqualTo(27.5D);
+        assertThat(recordedPoint.hasMin()).isTrue();
+        assertThat(recordedPoint.getMin()).isEqualTo(1.1D);
+        assertThat(recordedPoint.hasMax()).isTrue();
+        assertThat(recordedPoint.getMax()).isEqualTo(8.7D);
+        assertThat(recordedPoint.getExemplars(0).getAsDouble()).isEqualTo(4.2D);
+        assertThat(recordedPoint.getExemplars(0).getFilteredAttributes(0).getKey()).isEqualTo("sampled");
     }
 
     @Test

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "io_opentelemetry_proto.opentelemetry_proto.Opentelemetry_protoTest"
+      },
+      "type" : "libcore.io.Memory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "io_opentelemetry_proto.opentelemetry_proto.Opentelemetry_protoTest"
+      },
+      "type" : "org.robolectric.Robolectric"
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/user-code-filter.json
@@ -1,0 +1,37 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.collector.logs.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.collector.metrics.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.collector.profiles.v1development.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.collector.trace.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.common.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.logs.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.metrics.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.profiles.v1development.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.resource.v1.**"
+    },
+    {
+      "includeClasses": "io.opentelemetry.proto.trace.v1.**"
+    }
+  ]
+}

--- a/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/user-code-filter.json
+++ b/tests/src/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/user-code-filter.json
@@ -1,37 +1,40 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.collector.logs.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.collector.logs.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.collector.metrics.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.collector.metrics.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.collector.profiles.v1development.**"
+      "includeClasses" : "io.opentelemetry.proto.collector.profiles.v1development.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.collector.trace.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.collector.trace.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.common.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.common.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.logs.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.logs.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.metrics.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.metrics.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.profiles.v1development.**"
+      "includeClasses" : "io.opentelemetry.proto.profiles.v1development.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.resource.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.resource.v1.**"
     },
     {
-      "includeClasses": "io.opentelemetry.proto.trace.v1.**"
+      "includeClasses" : "io.opentelemetry.proto.trace.v1.**"
+    },
+    {
+      "includeClasses" : "io_opentelemetry_proto.opentelemetry_proto.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #9250

This PR introduces tests and metadata for io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 142724
- Cached input tokens: 853504
- Output tokens: 11661
- Metadata entries: 6
- Test-only metadata entries: 2
- Iterations: 3
- Library coverage percentage: 18.39
- Generated lines of code: 279
- Tested library lines of code: 4479

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `a4dd27a853f7a7b19f38990797d581e7f5c4184d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 15845/90195 (17.57%)
- Line: 4479/24349 (18.39%)
- Method: 906/5636 (16.08%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
