### PR TITLE
[GenAI] Add support for org.springframework.security:spring-security-oauth2-jose:7.1.0 using gpt-5.6-terra

### DIFF
--- a/metadata/org.springframework.security/spring-security-oauth2-jose/7.1.0/reachability-metadata.json
+++ b/metadata/org.springframework.security/spring-security-oauth2-jose/7.1.0/reachability-metadata.json
@@ -1,0 +1,92 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.core.converter.ClaimConversionService"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.NimbusJwtEncoder"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.DPoPProofJwtDecoderFactory$JtiClaimValidator"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.JWKS"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.NimbusJwtDecoder"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.NimbusJwtEncoder"
+      },
+      "type" : "sun.security.provider.SHA2$SHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.jwt.DPoPProofJwtDecoderFactory"
+      },
+      "type" : "sun.security.rsa.RSAKeyFactory$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.core.converter.ObjectToURLConverter"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    }
+  ]
+}

--- a/metadata/org.springframework.security/spring-security-oauth2-jose/index.json
+++ b/metadata/org.springframework.security/spring-security-oauth2-jose/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "7.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-oauth2-jose/$version$/spring-security-oauth2-jose-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-security",
+    "test-code-url" : "https://github.com/spring-projects/spring-security/tree/$version$/oauth2/oauth2-jose/src/test/java",
+    "documentation-url" : "https://javadoc.io/doc/org.springframework.security/spring-security-oauth2-jose/$version$/index.html",
+    "description" : "Spring Security OAuth2 JOSE provides Java support for JSON Web Tokens and related JOSE structures, including token encoders, decoders, headers, and validators. It enables Spring Security applications to sign, decode, verify, and validate JWTs for OAuth 2.0 and OpenID Connect flows.",
+    "tested-versions" : [
+      "7.1.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.security.oauth2"
+    ]
+  }
+]

--- a/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/execution-metrics.json
+++ b/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-08-11": {
+    "timestamp": "2026-08-11T13:16:55.402570Z",
+    "library": "org.springframework.security:spring-security-oauth2-jose:7.1.0",
+    "starting_commit": "190bc4b528b38e8faddf3278da20a45534a7bcf9",
+    "ending_commit": "61d8493b7ee040bc2f9355f3e64115cc5d772d80",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "7.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 2462,
+          "missed": 4208,
+          "ratio": 0.369115,
+          "total": 6670
+        },
+        "line": {
+          "covered": 616,
+          "missed": 967,
+          "ratio": 0.389135,
+          "total": 1583
+        },
+        "method": {
+          "covered": 177,
+          "missed": 297,
+          "ratio": 0.373418,
+          "total": 474
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 9230,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.security:spring-security-oauth2-jose:7.1.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#9230 Support for org.springframework.security:spring-security-oauth2-jose:7.1.0; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
+      "model": "gpt-5.6-terra",
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.security:spring-security-oauth2-jose:7.1.0/library-preparation-preflight/pi-generation-2026-08-11T12-43-20-333203Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 143647,
+      "cached_input_tokens_used": 1138688,
+      "output_tokens_used": 16152,
+      "iterations": 6,
+      "cost_usd": 0.8861,
+      "generated_loc": 141,
+      "tested_library_loc": 616,
+      "metadata_entries": 14,
+      "test_only_metadata_entries": 29,
+      "code_coverage_percent": 38.91
+    },
+    "artifacts": {
+      "metadata_file": "metadata/org.springframework.security/spring-security-oauth2-jose/7.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/stats.json
+++ b/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "7.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 2462,
+        "missed" : 4208,
+        "ratio" : 0.369115,
+        "total" : 6670
+      },
+      "line" : {
+        "covered" : 616,
+        "missed" : 967,
+        "ratio" : 0.389135,
+        "total" : 1583
+      },
+      "method" : {
+        "covered" : 177,
+        "missed" : 297,
+        "ratio" : 0.373418,
+        "total" : 474
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/.gitignore
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.security:spring-security-oauth2-jose:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/gradle.properties
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.security:spring-security-oauth2-jose:7.1.0
+library.version = 7.1.0
+metadata.dir = org.springframework.security/spring-security-oauth2-jose/7.1.0/

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/settings.gradle
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.security.spring-security-oauth2-jose_tests'

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_security.spring_security_oauth2_jose;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_security_oauth2_joseTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
@@ -6,11 +6,102 @@
  */
 package org_springframework_security.spring_security_oauth2_jose;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class Spring_security_oauth2_joseTest {
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+public class Spring_security_oauth2_joseTest {
+    private static final String ISSUER = "https://issuer.example.test";
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void hmacEncoderAndDecoderRoundTripJwtHeadersAndClaims() {
+        SecretKey secretKey = hmacSecretKey();
+        JwtEncoder encoder = NimbusJwtEncoder.withSecretKey(secretKey).algorithm(MacAlgorithm.HS256).build();
+        JwtClaimsSet claims = claimsFor("customer-42");
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).type("JWT").build();
+
+        Jwt encoded = encoder.encode(JwtEncoderParameters.from(header, claims));
+
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey).macAlgorithm(MacAlgorithm.HS256).build();
+        decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(ISSUER));
+        Jwt decoded = decoder.decode(encoded.getTokenValue());
+
+        assertThat(encoded.getTokenValue()).contains(".");
+        assertThat(decoded.getHeaders()).containsEntry("alg", "HS256").containsEntry("typ", "JWT");
+        assertThat((String) decoded.getClaim("iss")).isEqualTo(ISSUER);
+        assertThat(decoded.getSubject()).isEqualTo("customer-42");
+        assertThat(decoded.getAudience()).containsExactly("orders-api", "billing-api");
+        assertThat(decoded.getClaims()).containsEntry("roles", List.of("ORDER_READ", "BILLING_READ"));
+        assertThat((Boolean) decoded.getClaim("active")).isTrue();
+        assertThat(decoded.getExpiresAt()).isAfter(decoded.getIssuedAt());
+    }
+
+    @Test
+    void issuerValidatorRejectsOtherwiseValidSignedTokenFromAnotherIssuer() {
+        SecretKey secretKey = hmacSecretKey();
+        JwtEncoder encoder = NimbusJwtEncoder.withSecretKey(secretKey).algorithm(MacAlgorithm.HS256).build();
+        Jwt encoded = encoder.encode(JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(),
+                claimsFor("customer-17")));
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey).macAlgorithm(MacAlgorithm.HS256).build();
+        decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer("https://other-issuer.example.test"));
+
+        assertThatThrownBy(() -> decoder.decode(encoded.getTokenValue()))
+                .isInstanceOf(JwtValidationException.class);
+    }
+
+    @Test
+    void rsaKeyPairEncoderAndPublicKeyDecoderRoundTripJwt() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        JwtEncoder encoder = NimbusJwtEncoder.withKeyPair((RSAPublicKey) keyPair.getPublic(),
+                (RSAPrivateKey) keyPair.getPrivate()).algorithm(SignatureAlgorithm.RS256).build();
+        JwtClaimsSet claims = claimsFor("service-account");
+
+        Jwt encoded = encoder.encode(JwtEncoderParameters.from(JwsHeader.with(SignatureAlgorithm.RS256).build(), claims));
+
+        JwtDecoder decoder = NimbusJwtDecoder.withPublicKey((RSAPublicKey) keyPair.getPublic())
+                .signatureAlgorithm(SignatureAlgorithm.RS256).build();
+        Jwt decoded = decoder.decode(encoded.getTokenValue());
+
+        assertThat(decoded.getHeaders()).containsEntry("alg", "RS256");
+        assertThat(decoded.getSubject()).isEqualTo("service-account");
+        assertThat(decoded.getClaims()).containsEntry("roles", List.of("ORDER_READ", "BILLING_READ"));
+    }
+
+    private JwtClaimsSet claimsFor(String subject) {
+        Instant issuedAt = Instant.now().minusSeconds(5);
+        return JwtClaimsSet.builder().issuer(ISSUER).subject(subject).audience(List.of("orders-api", "billing-api"))
+                .issuedAt(issuedAt).expiresAt(issuedAt.plusSeconds(300)).id("jwt-" + subject)
+                .claim("roles", List.of("ORDER_READ", "BILLING_READ")).claim("active", true).build();
+    }
+
+    private SecretKey hmacSecretKey() {
+        byte[] keyMaterial = "0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
+        return new SecretKeySpec(keyMaterial, "HmacSHA256");
     }
 }

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
@@ -16,11 +16,13 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -31,6 +33,7 @@ import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.MappedJwtClaimSetConverter;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
@@ -71,6 +74,21 @@ public class Spring_security_oauth2_joseTest {
 
         assertThatThrownBy(() -> decoder.decode(encoded.getTokenValue()))
                 .isInstanceOf(JwtValidationException.class);
+    }
+
+    @Test
+    void mappedClaimSetConverterCustomizesAndRemovesClaims() {
+        Converter<Object, Object> rolesConverter = (roles) -> ((List<?>) roles).stream().map(Object::toString)
+                .map(String::toLowerCase).toList();
+        Converter<Object, Object> claimRemovalConverter = (claim) -> null;
+        MappedJwtClaimSetConverter converter = MappedJwtClaimSetConverter.withDefaults(Map.of("roles", rolesConverter,
+                "temporary", claimRemovalConverter));
+
+        Map<String, Object> convertedClaims = converter.convert(Map.of("sub", "customer-42", "aud", "orders-api",
+                "roles", List.of("ORDER_READ", "BILLING_READ"), "temporary", "one-time-value"));
+
+        assertThat(convertedClaims).containsEntry("sub", "customer-42").containsEntry("aud", List.of("orders-api"))
+                .containsEntry("roles", List.of("order_read", "billing_read")).doesNotContainKey("temporary");
     }
 
     @Test

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_jose/Spring_security_oauth2_joseTest.java
@@ -9,14 +9,18 @@ package org_springframework_security.spring_security_oauth2_jose;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -25,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.DPoPProofContext;
+import org.springframework.security.oauth2.jwt.DPoPProofJwtDecoderFactory;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -92,6 +98,30 @@ public class Spring_security_oauth2_joseTest {
     }
 
     @Test
+    void dpopProofDecoderFactoryValidatesSignedProofBoundToRequest() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        JwtEncoder encoder = NimbusJwtEncoder.withKeyPair(publicKey, (RSAPrivateKey) keyPair.getPrivate())
+                .algorithm(SignatureAlgorithm.RS256).build();
+        Instant issuedAt = Instant.now();
+        Jwt proof = encoder.encode(JwtEncoderParameters.from(
+                JwsHeader.with(SignatureAlgorithm.RS256).type("dpop+jwt").jwk(publicRsaJwk(publicKey)).build(),
+                JwtClaimsSet.builder().issuedAt(issuedAt).id(UUID.randomUUID().toString()).claim("htm", "POST")
+                        .claim("htu", "https://resource.example.test/orders").build()));
+        DPoPProofContext context = DPoPProofContext.withDPoPProof(proof.getTokenValue()).method("POST")
+                .targetUri("https://resource.example.test/orders").build();
+
+        Jwt decoded = new DPoPProofJwtDecoderFactory().createDecoder(context).decode(context.getDPoPProof());
+
+        assertThat(decoded.getHeaders()).containsEntry("typ", "dpop+jwt").containsKey("jwk");
+        assertThat(decoded.getId()).isEqualTo(proof.getId());
+        assertThat(decoded.getClaimAsString("htm")).isEqualTo("POST");
+        assertThat(decoded.getClaimAsString("htu")).isEqualTo("https://resource.example.test/orders");
+    }
+
+    @Test
     void rsaKeyPairEncoderAndPublicKeyDecoderRoundTripJwt() throws Exception {
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
         keyPairGenerator.initialize(2048);
@@ -116,6 +146,17 @@ public class Spring_security_oauth2_joseTest {
         return JwtClaimsSet.builder().issuer(ISSUER).subject(subject).audience(List.of("orders-api", "billing-api"))
                 .issuedAt(issuedAt).expiresAt(issuedAt.plusSeconds(300)).id("jwt-" + subject)
                 .claim("roles", List.of("ORDER_READ", "BILLING_READ")).claim("active", true).build();
+    }
+
+    private Map<String, Object> publicRsaJwk(RSAPublicKey publicKey) {
+        return Map.of("kty", "RSA", "n", base64UrlUnsigned(publicKey.getModulus()), "e",
+                base64UrlUnsigned(publicKey.getPublicExponent()));
+    }
+
+    private String base64UrlUnsigned(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        int offset = bytes.length > 1 && bytes[0] == 0 ? 1 : 0;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(Arrays.copyOfRange(bytes, offset, bytes.length));
     }
 
     private SecretKey hmacSecretKey() {

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,184 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "com.sun.crypto.provider.HmacCore$HmacSHA256",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "java.security.interfaces.RSAPrivateKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "java.security.interfaces.RSAPublicKey"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "java.util.ArrayList"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "java.util.HashMap"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "java.util.ImmutableCollections$List12"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "sun.security.provider.NativePRNG",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "sun.security.provider.SHA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "sun.security.rsa.RSAKeyPairGenerator$Legacy",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "type" : "sun.security.rsa.RSASignature$SHA256withRSA",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_jose.Spring_security_oauth2_joseTest"
+      },
+      "glob" : "commons-logging.properties"
+    }
+  ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.security.oauth2.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-jose/7.1.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.security.oauth2.**"
+      "includeClasses" : "org.springframework.security.oauth2.**"
+    },
+    {
+      "includeClasses" : "org_springframework_security.spring_security_oauth2_jose.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #9230

This PR introduces tests and metadata for org.springframework.security:spring-security-oauth2-jose:7.1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 143647
- Cached input tokens: 1138688
- Output tokens: 16152
- Metadata entries: 14
- Test-only metadata entries: 29
- Iterations: 6
- Library coverage percentage: 38.91
- Generated lines of code: 141
- Tested library lines of code: 616

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `a4dd27a853f7a7b19f38990797d581e7f5c4184d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 2462/6670 (36.91%)
- Line: 616/1583 (38.91%)
- Method: 177/474 (37.34%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
