### PR TITLE
[GenAI] Add support for org.springframework.security:spring-security-oauth2-resource-server:7.1.0 using gpt-5.6-terra

### DIFF
--- a/metadata/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/reachability-metadata.json
+++ b/metadata/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/reachability-metadata.json
@@ -1,0 +1,124 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.JwtBearerTokenAuthenticationConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadataClaimAccessor"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata$Builder"
+      },
+      "glob" : "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter"
+      },
+      "glob" : "commons-logging.properties"
+    }
+  ]
+}

--- a/metadata/org.springframework.security/spring-security-oauth2-resource-server/index.json
+++ b/metadata/org.springframework.security/spring-security-oauth2-resource-server/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "7.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-oauth2-resource-server/$version$/spring-security-oauth2-resource-server-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-security",
+    "test-code-url" : "https://github.com/spring-projects/spring-security/tree/$version$/oauth2/oauth2-resource-server/src/test",
+    "documentation-url" : "https://docs.spring.io/spring-security/reference/$version$/servlet/oauth2/resource-server/index.html",
+    "description" : "Spring Security OAuth2 Resource Server provides servlet and reactive support for protecting endpoints with OAuth 2.0 bearer tokens. It authenticates requests using JWT validation or opaque-token introspection and integrates the result into Spring Security's authentication and authorization infrastructure.",
+    "tested-versions" : [
+      "7.1.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.security.oauth2.server.resource"
+    ]
+  }
+]

--- a/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/execution-metrics.json
+++ b/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-08-11": {
+    "timestamp": "2026-08-11T14:31:15.083364Z",
+    "library": "org.springframework.security:spring-security-oauth2-resource-server:7.1.0",
+    "starting_commit": "3ff903648629366e657959ef0b022162ed33ff16",
+    "ending_commit": "0ed4fbb957ba946dcce0741052ce9551cf6bf035",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "7.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1027,
+          "missed": 5139,
+          "ratio": 0.166559,
+          "total": 6166
+        },
+        "line": {
+          "covered": 248,
+          "missed": 1295,
+          "ratio": 0.160726,
+          "total": 1543
+        },
+        "method": {
+          "covered": 89,
+          "missed": 343,
+          "ratio": 0.206019,
+          "total": 432
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 9231,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.security:spring-security-oauth2-resource-server:7.1.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#9231 Support for org.springframework.security:spring-security-oauth2-resource-server:7.1.0; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
+      "model": "gpt-5.6-terra",
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.security:spring-security-oauth2-resource-server:7.1.0/library-preparation-preflight/pi-generation-2026-08-11T13-50-08-884074Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 154973,
+      "cached_input_tokens_used": 1380864,
+      "output_tokens_used": 13243,
+      "iterations": 6,
+      "cost_usd": 0.9312,
+      "generated_loc": 196,
+      "tested_library_loc": 248,
+      "metadata_entries": 19,
+      "test_only_metadata_entries": 1,
+      "code_coverage_percent": 16.07
+    },
+    "artifacts": {
+      "metadata_file": "metadata/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/stats.json
+++ b/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "7.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1027,
+        "missed" : 5139,
+        "ratio" : 0.166559,
+        "total" : 6166
+      },
+      "line" : {
+        "covered" : 248,
+        "missed" : 1295,
+        "ratio" : 0.160726,
+        "total" : 1543
+      },
+      "method" : {
+        "covered" : 89,
+        "missed" : 343,
+        "ratio" : 0.206019,
+        "total" : 432
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/.gitignore
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/build.gradle
@@ -12,6 +12,7 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.security:spring-security-oauth2-resource-server:$libraryVersion"
+    testImplementation "org.springframework.security:spring-security-oauth2-jose:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/build.gradle
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.security:spring-security-oauth2-resource-server:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/gradle.properties
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.security:spring-security-oauth2-resource-server:7.1.0
+library.version = 7.1.0
+metadata.dir = org.springframework.security/spring-security-oauth2-resource-server/7.1.0/

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/settings.gradle
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.security.spring-security-oauth2-resource-server_tests'

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
@@ -6,11 +6,179 @@
  */
 package org_springframework_security.spring_security_oauth2_resource_server;
 
-import org.junit.jupiter.api.Test;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
-class Spring_security_oauth2_resource_serverTest {
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.BearerTokenError;
+import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.DelegatingJwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_security_oauth2_resource_serverTest {
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void protectedResourceMetadataExposesStandardAndCustomClaims() throws Exception {
+        OAuth2ProtectedResourceMetadata metadata = OAuth2ProtectedResourceMetadata.builder()
+                .resource("https://api.example.test")
+                .authorizationServer("https://issuer.example.test")
+                .authorizationServers(addToList("https://backup.example.test"))
+                .scope("orders.read")
+                .scopes(addToList("orders.write"))
+                .bearerMethod("header")
+                .bearerMethods(addToList("body"))
+                .resourceName("Orders API")
+                .tlsClientCertificateBoundAccessTokens(true)
+                .claim("tenant", "acme")
+                .claims(addClaim("audience", List.of("orders")))
+                .build();
+
+        assertThat(metadata.getResource()).isEqualTo(URI.create("https://api.example.test").toURL());
+        assertThat(metadata.getAuthorizationServers()).containsExactly(
+                URI.create("https://issuer.example.test").toURL(),
+                URI.create("https://backup.example.test").toURL());
+        assertThat(metadata.getScopes()).containsExactly("orders.read", "orders.write");
+        assertThat(metadata.getBearerMethodsSupported()).containsExactly("header", "body");
+        assertThat(metadata.getResourceName()).isEqualTo("Orders API");
+        assertThat(metadata.isTlsClientCertificateBoundAccessTokens()).isTrue();
+        assertThat(metadata.getClaims()).containsEntry("tenant", "acme")
+                .containsEntry("audience", List.of("orders"));
+    }
+
+    @Test
+    void jwtAuthoritiesConvertersReadConfiguredClaimsAndRemoveDuplicates() {
+        Jwt jwt = jwt(Map.of("scope", "read write", "permissions", "export|admin"));
+        JwtGrantedAuthoritiesConverter scopes = new JwtGrantedAuthoritiesConverter();
+        JwtGrantedAuthoritiesConverter permissions = new JwtGrantedAuthoritiesConverter();
+        permissions.setAuthoritiesClaimName("permissions");
+        permissions.setAuthoritiesClaimDelimiter("\\|");
+        permissions.setAuthorityPrefix("PERMISSION_");
+
+        DelegatingJwtGrantedAuthoritiesConverter converter =
+                new DelegatingJwtGrantedAuthoritiesConverter(scopes, scopes, permissions);
+        List<String> authorities = authorityNames(converter.convert(jwt));
+
+        assertThat(authorities).containsExactly("SCOPE_read", "SCOPE_write", "PERMISSION_export", "PERMISSION_admin");
+    }
+
+    @Test
+    void jwtAuthenticationConverterUsesConfiguredPrincipalAndAuthorities() {
+        Jwt jwt = jwt(Map.of("scope", "catalog.read", "preferred_username", "marie"));
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setPrincipalClaimName("preferred_username");
+
+        Authentication authentication = converter.convert(jwt);
+
+        assertThat(authentication.getName()).isEqualTo("marie");
+        assertThat(authorityNames(authentication.getAuthorities()))
+                .containsExactlyInAnyOrder("FACTOR_BEARER", "SCOPE_catalog.read");
+        assertThat(authentication.getCredentials()).isEqualTo(jwt);
+        assertThat(authentication.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void bearerAuthenticationRetainsPrincipalTokenAttributesAndAuthorities() {
+        Instant issuedAt = Instant.parse("2025-01-01T00:00:00Z");
+        DefaultOAuth2AuthenticatedPrincipal principal = new DefaultOAuth2AuthenticatedPrincipal(
+                "sam", Map.of("sub", "sam", "department", "sales"),
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER, "access-token", issuedAt, issuedAt.plusSeconds(300));
+        BearerTokenAuthentication authentication = new BearerTokenAuthentication(
+                principal, accessToken, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        BearerTokenAuthenticationToken unauthenticated = new BearerTokenAuthenticationToken("access-token");
+
+        assertThat(authentication.getName()).isEqualTo("sam");
+        assertThat(authentication.getToken()).isSameAs(accessToken);
+        assertThat(authentication.getTokenAttributes()).containsEntry("department", "sales");
+        assertThat(authorityNames(authentication.getAuthorities())).containsExactly("ROLE_USER");
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(unauthenticated.getToken()).isEqualTo("access-token");
+        assertThat(unauthenticated.getCredentials()).isEqualTo("access-token");
+        assertThat(unauthenticated.getPrincipal()).isEqualTo("access-token");
+        assertThat(unauthenticated.isAuthenticated()).isFalse();
+    }
+
+    @Test
+    void introspectionPrincipalAndBearerErrorsExposeOAuth2Values() {
+        OAuth2IntrospectionAuthenticatedPrincipal principal = new OAuth2IntrospectionAuthenticatedPrincipal(
+                "client-a", Map.of("sub", "subject-a", "active", true),
+                List.of(new SimpleGrantedAuthority("SCOPE_profile")));
+        BearerTokenError invalidRequest = BearerTokenErrors.invalidRequest("Malformed header");
+        BearerTokenError invalidToken = BearerTokenErrors.invalidToken("Expired token");
+        BearerTokenError insufficientScope = BearerTokenErrors.insufficientScope("Need orders.read", "orders.read");
+
+        assertThat(principal.getName()).isEqualTo("client-a");
+        assertThat(principal.getClaims()).containsEntry("active", true);
+        assertThat(authorityNames(principal.getAuthorities())).containsExactly("SCOPE_profile");
+        assertThat(invalidRequest.getErrorCode()).isEqualTo("invalid_request");
+        assertThat(invalidRequest.getHttpStatus().value()).isEqualTo(400);
+        assertThat(invalidToken.getErrorCode()).isEqualTo("invalid_token");
+        assertThat(invalidToken.getHttpStatus().value()).isEqualTo(401);
+        assertThat(insufficientScope.getErrorCode()).isEqualTo("insufficient_scope");
+        assertThat(insufficientScope.getHttpStatus().value()).isEqualTo(403);
+        assertThat(insufficientScope.getScope()).isEqualTo("orders.read");
+    }
+
+    private Jwt jwt(Map<String, Object> claims) {
+        return Jwt.withTokenValue("token-value")
+                .header("alg", "none")
+                .issuedAt(Instant.parse("2025-01-01T00:00:00Z"))
+                .expiresAt(Instant.parse("2025-01-01T00:05:00Z"))
+                .claims(putAllClaims(claims))
+                .build();
+    }
+
+    private List<String> authorityNames(Collection<? extends GrantedAuthority> authorities) {
+        List<String> names = new ArrayList<>();
+        for (GrantedAuthority authority : authorities) {
+            names.add(authority.getAuthority());
+        }
+        return names;
+    }
+
+    private Consumer<List<String>> addToList(String value) {
+        return new Consumer<>() {
+            @Override
+            public void accept(List<String> values) {
+                values.add(value);
+            }
+        };
+    }
+
+    private Consumer<Map<String, Object>> addClaim(String name, Object value) {
+        return new Consumer<>() {
+            @Override
+            public void accept(Map<String, Object> claims) {
+                claims.put(name, value);
+            }
+        };
+    }
+
+    private Consumer<Map<String, Object>> putAllClaims(Map<String, Object> source) {
+        return new Consumer<>() {
+            @Override
+            public void accept(Map<String, Object> claims) {
+                claims.putAll(source);
+            }
+        };
     }
 }

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
@@ -29,10 +29,12 @@ import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResour
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.DelegatingJwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtBearerTokenAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,6 +82,18 @@ public class Spring_security_oauth2_resource_serverTest {
         List<String> authorities = authorityNames(converter.convert(jwt));
 
         assertThat(authorities).containsExactly("SCOPE_read", "SCOPE_write", "PERMISSION_export", "PERMISSION_admin");
+    }
+
+    @Test
+    void expressionJwtAuthoritiesConverterReadsAuthoritiesFromClaimExpression() {
+        Jwt jwt = jwt(Map.of("resource_access", Map.of("orders", List.of("read", "write"))));
+        ExpressionJwtGrantedAuthoritiesConverter converter = new ExpressionJwtGrantedAuthoritiesConverter(
+                new SpelExpressionParser().parseExpression("['resource_access']['orders']"));
+        converter.setAuthorityPrefix("ORDER_");
+
+        List<String> authorities = authorityNames(converter.convert(jwt));
+
+        assertThat(authorities).containsExactly("ORDER_read", "ORDER_write");
     }
 
     @Test

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
@@ -15,11 +15,13 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
@@ -28,6 +30,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.DelegatingJwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtBearerTokenAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionAuthenticatedPrincipal;
 
@@ -92,6 +95,28 @@ public class Spring_security_oauth2_resource_serverTest {
                 .containsExactlyInAnyOrder("FACTOR_BEARER", "SCOPE_catalog.read");
         assertThat(authentication.getCredentials()).isEqualTo(jwt);
         assertThat(authentication.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void jwtBearerTokenAuthenticationConverterUsesCustomPrincipalConverter() {
+        Jwt jwt = jwt(Map.of("scope", "orders.read", "sub", "token-subject"));
+        DefaultOAuth2AuthenticatedPrincipal customPrincipal = new DefaultOAuth2AuthenticatedPrincipal(
+                "service-account", Map.of("client_id", "orders-client"),
+                List.of(new SimpleGrantedAuthority("ROLE_SERVICE")));
+        JwtBearerTokenAuthenticationConverter converter = new JwtBearerTokenAuthenticationConverter();
+        converter.setJwtPrincipalConverter(new Converter<>() {
+            @Override
+            public OAuth2AuthenticatedPrincipal convert(Jwt source) {
+                return customPrincipal;
+            }
+        });
+
+        BearerTokenAuthentication authentication = (BearerTokenAuthentication) converter.convert(jwt);
+
+        assertThat(authentication.getPrincipal()).isSameAs(customPrincipal);
+        assertThat(authentication.getName()).isEqualTo("service-account");
+        assertThat(authorityNames(authentication.getAuthorities())).containsExactly("SCOPE_orders.read");
+        assertThat(authentication.getToken().getTokenValue()).isEqualTo("token-value");
     }
 
     @Test

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/java/org_springframework_security/spring_security_oauth2_resource_server/Spring_security_oauth2_resource_serverTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_security.spring_security_oauth2_resource_server;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_security_oauth2_resource_serverTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_security.spring_security_oauth2_resource_server.Spring_security_oauth2_resource_serverTest"
+      },
+      "glob" : "spring.properties"
+    }
+  ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.security.oauth2.server.resource.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.security.oauth2.server.resource.**"
+      "includeClasses" : "org.springframework.security.oauth2.server.resource.**"
+    },
+    {
+      "includeClasses" : "org_springframework_security.spring_security_oauth2_resource_server.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #9231

This PR introduces tests and metadata for org.springframework.security:spring-security-oauth2-resource-server:7.1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 154973
- Cached input tokens: 1380864
- Output tokens: 13243
- Metadata entries: 19
- Test-only metadata entries: 1
- Iterations: 6
- Library coverage percentage: 16.07
- Generated lines of code: 196
- Tested library lines of code: 248

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `a4dd27a853f7a7b19f38990797d581e7f5c4184d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1027/6166 (16.66%)
- Line: 248/1543 (16.07%)
- Method: 89/432 (20.60%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
