### PR TITLE
[GenAI] Add support for org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0 using gpt-5.6-terra

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/reachability-metadata.json
+++ b/metadata/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/reachability-metadata.json
@@ -1,0 +1,110 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.cbor.CBORFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.smile.SmileFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.xml.XmlMapper"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.fasterxml.jackson.dataformat.yaml.YAMLFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.google.gson.Gson"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "com.rometools.rome.feed.WireFeed"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "jakarta.json.bind.Jsonb"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "jakarta.xml.bind.Binder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "kotlinx.serialization.cbor.Cbor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "kotlinx.serialization.json.Json"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "kotlinx.serialization.protobuf.ProtoBuf"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OpaqueTokenIntrospectionConfiguration"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration"
+      },
+      "type" : "tools.jackson.databind.ObjectMapper"
+    }
+  ]
+}

--- a/metadata/org.springframework.boot/spring-boot-security-oauth2-resource-server/index.json
+++ b/metadata/org.springframework.boot/spring-boot-security-oauth2-resource-server/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "4.1.0",
+    "source-code-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-security-oauth2-resource-server/$version$/spring-boot-security-oauth2-resource-server-$version$-sources.jar",
+    "repository-url" : "https://github.com/spring-projects/spring-boot",
+    "test-code-url" : "https://github.com/spring-projects/spring-boot/tree/v$version$/module/spring-boot-security-oauth2-resource-server/src/test",
+    "documentation-url" : "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-security-oauth2-resource-server/$version$/spring-boot-security-oauth2-resource-server-$version$-javadoc.jar",
+    "description" : "This Spring Boot module auto-configures Spring Security OAuth 2 resource server support for servlet and reactive applications. It binds resource-server properties and configures JWT decoding or opaque-token introspection when the relevant Spring Security classes are present.",
+    "tested-versions" : [
+      "4.1.0"
+    ],
+    "allowed-packages" : [
+      "org.springframework.boot.security.oauth2.server.resource.autoconfigure"
+    ]
+  }
+]

--- a/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-08-12": {
+    "timestamp": "2026-08-12T07:50:25.961270Z",
+    "library": "org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0",
+    "starting_commit": "97603265cbc248ea29fe833ebc1fc872f8db014c",
+    "ending_commit": "74a53a8ac84fcecd854973c10270860b346ba072",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "4.1.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 501,
+          "missed": 1014,
+          "ratio": 0.330693,
+          "total": 1515
+        },
+        "line": {
+          "covered": 133,
+          "missed": 208,
+          "ratio": 0.390029,
+          "total": 341
+        },
+        "method": {
+          "covered": 51,
+          "missed": 76,
+          "ratio": 0.401575,
+          "total": 127
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "degraded",
+      "action": "no_action",
+      "issue_number": 9232,
+      "issue_label": "library-new-request",
+      "library": "org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0",
+      "summary": "Library preparation preflight did not produce usable advisory setup.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#9232 Support for org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0; label=library-new-request; body_chars=39"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "failure_reason": "ValueError: response did not contain a JSON object",
+      "model": "gpt-5.6-terra",
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0/library-preparation-preflight/pi-generation-2026-08-12T07-22-06-369309Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 76898,
+      "cached_input_tokens_used": 643584,
+      "output_tokens_used": 7111,
+      "iterations": 7,
+      "cost_usd": 0.4598,
+      "generated_loc": 94,
+      "tested_library_loc": 133,
+      "metadata_entries": 17,
+      "test_only_metadata_entries": 143,
+      "code_coverage_percent": 39.0
+    },
+    "artifacts": {
+      "metadata_file": "metadata/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/stats.json
+++ b/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "4.1.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 501,
+        "missed" : 1014,
+        "ratio" : 0.330693,
+        "total" : 1515
+      },
+      "line" : {
+        "covered" : 133,
+        "missed" : 208,
+        "ratio" : 0.390029,
+        "total" : 341
+      },
+      "method" : {
+        "covered" : 51,
+        "missed" : 76,
+        "ratio" : 0.401575,
+        "total" : 127
+      }
+    }
+  } ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/.gitignore
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/build.gradle
@@ -12,6 +12,8 @@ String libraryVersion = tck.testedLibraryVersion.get()
 
 dependencies {
     testImplementation "org.springframework.boot:spring-boot-security-oauth2-resource-server:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-autoconfigure:$libraryVersion"
+    testImplementation "org.springframework.boot:spring-boot-test:$libraryVersion"
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/build.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.springframework.boot:spring-boot-security-oauth2-resource-server:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/gradle.properties
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0
+library.version = 4.1.0
+metadata.dir = org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/settings.gradle
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.springframework.boot.spring-boot-security-oauth2-resource-server_tests'

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_springframework_boot.spring_boot_security_oauth2_resource_server;
+
+import org.junit.jupiter.api.Test;
+
+class Spring_boot_security_oauth2_resource_serverTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
@@ -6,11 +6,80 @@
  */
 package org_springframework_boot.spring_boot_security_oauth2_resource_server;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-class Spring_boot_security_oauth2_resource_serverTest {
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.io.ByteArrayResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Spring_boot_security_oauth2_resource_serverTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(OAuth2ResourceServerAutoConfiguration.class));
+
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void jwtPropertiesRetainResourceServerConfigurationAndReadPublicKey() throws Exception {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        OAuth2ResourceServerProperties.Jwt jwt = properties.getJwt();
+        String publicKey = "-----BEGIN PUBLIC KEY-----\nkey-material\n-----END PUBLIC KEY-----";
+
+        jwt.setIssuerUri("https://issuer.example.test");
+        jwt.setJwkSetUri("https://issuer.example.test/keys");
+        jwt.setJwsAlgorithms(List.of("RS256", "ES256"));
+        jwt.setAudiences(List.of("orders", "invoices"));
+        jwt.setAuthorityPrefix("ROLE_");
+        jwt.setAuthoritiesClaimDelimiter(",");
+        jwt.setAuthoritiesClaimName("roles");
+        jwt.setAuthoritiesExpressions(List.of("realm_access.roles", "groups"));
+        jwt.setPrincipalClaimName("preferred_username");
+        jwt.setPublicKeyLocation(new ByteArrayResource(publicKey.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(jwt.getIssuerUri()).isEqualTo("https://issuer.example.test");
+        assertThat(jwt.getJwkSetUri()).isEqualTo("https://issuer.example.test/keys");
+        assertThat(jwt.getJwsAlgorithms()).containsExactly("RS256", "ES256");
+        assertThat(jwt.getAudiences()).containsExactly("orders", "invoices");
+        assertThat(jwt.getAuthorityPrefix()).isEqualTo("ROLE_");
+        assertThat(jwt.getAuthoritiesClaimDelimiter()).isEqualTo(",");
+        assertThat(jwt.getAuthoritiesClaimName()).isEqualTo("roles");
+        assertThat(jwt.getAuthoritiesClaimExpressions()).containsExactly("realm_access.roles", "groups");
+        assertThat(jwt.getPrincipalClaimName()).isEqualTo("preferred_username");
+        assertThat(jwt.readPublicKey()).isEqualTo(publicKey);
     }
+
+    @Test
+    void autoConfigurationBindsJwtAndOpaqueTokenProperties() {
+        this.contextRunner
+                .withPropertyValues("spring.security.oauth2.resourceserver.jwt.issuer-uri=https://issuer.example.test",
+                        "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://issuer.example.test/keys",
+                        "spring.security.oauth2.resourceserver.jwt.audiences=orders,invoices",
+                        "spring.security.oauth2.resourceserver.jwt.authority-prefix=ROLE_",
+                        "spring.security.oauth2.resourceserver.jwt.authorities-claim-name=roles",
+                        "spring.security.oauth2.resourceserver.jwt.principal-claim-name=preferred_username",
+                        "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri=https://issuer.example.test/introspect",
+                        "spring.security.oauth2.resourceserver.opaquetoken.client-id=resource-server",
+                        "spring.security.oauth2.resourceserver.opaquetoken.client-secret=secret")
+                .run((context) -> {
+                    assertThat(context).hasSingleBean(OAuth2ResourceServerProperties.class);
+
+                    OAuth2ResourceServerProperties properties = context.getBean(OAuth2ResourceServerProperties.class);
+                    assertThat(properties.getJwt().getIssuerUri()).isEqualTo("https://issuer.example.test");
+                    assertThat(properties.getJwt().getJwkSetUri()).isEqualTo("https://issuer.example.test/keys");
+                    assertThat(properties.getJwt().getAudiences()).containsExactly("orders", "invoices");
+                    assertThat(properties.getJwt().getAuthorityPrefix()).isEqualTo("ROLE_");
+                    assertThat(properties.getJwt().getAuthoritiesClaimName()).isEqualTo("roles");
+                    assertThat(properties.getJwt().getPrincipalClaimName()).isEqualTo("preferred_username");
+                    assertThat(properties.getOpaquetoken().getIntrospectionUri())
+                            .isEqualTo("https://issuer.example.test/introspect");
+                    assertThat(properties.getOpaquetoken().getClientId()).isEqualTo("resource-server");
+                    assertThat(properties.getOpaquetoken().getClientSecret()).isEqualTo("secret");
+                });
+    }
+
 }

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/java/org_springframework_boot/spring_boot_security_oauth2_resource_server/Spring_boot_security_oauth2_resource_serverTest.java
@@ -16,6 +16,9 @@ import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OA
 import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +54,26 @@ public class Spring_boot_security_oauth2_resource_serverTest {
         assertThat(jwt.getAuthoritiesClaimExpressions()).containsExactly("realm_access.roles", "groups");
         assertThat(jwt.getPrincipalClaimName()).isEqualTo("preferred_username");
         assertThat(jwt.readPublicKey()).isEqualTo(publicKey);
+    }
+
+    @Test
+    void autoConfigurationCreatesJwtAuthenticationConverterFromAuthorityProperties() {
+        this.contextRunner
+                .withPropertyValues("spring.security.oauth2.resourceserver.jwt.authority-prefix=ROLE_",
+                        "spring.security.oauth2.resourceserver.jwt.authorities-claim-name=roles",
+                        "spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter=,")
+                .run((context) -> {
+                    JwtAuthenticationConverter converter = context.getBean(JwtAuthenticationConverter.class);
+                    Jwt jwt = Jwt.withTokenValue("token")
+                            .header("alg", "none")
+                            .claim("sub", "alice")
+                            .claim("roles", "read,write")
+                            .build();
+
+                    assertThat(converter.convert(jwt).getAuthorities())
+                            .extracting(GrantedAuthority::getAuthority)
+                            .contains("ROLE_read", "ROLE_write");
+                });
     }
 
     @Test

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,889 @@
+{
+  "reflection" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.annotation.PostConstruct"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.inject.Inject"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.inject.Named"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.inject.Provider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.inject.Qualifier"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.persistence.EntityManagerFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "jakarta.validation.Validator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "java.lang.Class[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "java.lang.String[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "java.lang.annotation.Documented"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "java.lang.annotation.Retention"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "java.lang.annotation.Target"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "javax.money.MonetaryAmount"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "kotlin.Metadata"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "kotlin.reflect.full.KClasses"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "kotlinx.coroutines.reactor.MonoKt"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Jdk14Logger",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Log4jApiLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.impl.LogFactoryImpl",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.impl.Slf4jLogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.commons.logging.impl.WeakHashtable",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.eclipse.core.runtime.FileLocator"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.reactivestreams.Publisher"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.beans.factory.BeanFactory",
+      "methods" : [
+        {
+          "name" : "getBean",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.beans.factory.FactoryBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.beans.factory.HierarchicalBeanFactory",
+      "methods" : [
+        {
+          "name" : "getParentBeanFactory",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.beans.factory.ListableBeanFactory",
+      "methods" : [
+        {
+          "name" : "getBeanNamesForType",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfiguration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureAfter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.AutoConfigureBefore"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnProperty"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication$Type"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationProperties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.ConditionalOnIssuerLocationJwtDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.ConditionalOnPublicKeyJwtDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.IssuerUriCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtConverterConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "jwtAuthenticationConverter",
+          "parameterTypes" : [
+            "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtConverterConfiguration$PropertiesCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtConverterConfiguration$PropertiesCondition$OnAuthoritiesExpressionsCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.JwtDecoderConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [
+            "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name" : "jwtDecoderByJwkKeySetUri",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.KeyValueCondition",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerAutoConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getJwt",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "getOpaquetoken",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties$Jwt",
+      "methods" : [
+        {
+          "name" : "getAudiences",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "setAudiences",
+          "parameterTypes" : [
+            "java.util.List"
+          ]
+        },
+        {
+          "name" : "setAuthoritiesClaimDelimiter",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setAuthoritiesClaimName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setAuthorityPrefix",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setIssuerUri",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setJwkSetUri",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setPrincipalClaimName",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties$Opaquetoken",
+      "methods" : [
+        {
+          "name" : "setClientId",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setClientSecret",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name" : "setIntrospectionUri",
+          "parameterTypes" : [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OpaqueTokenIntrospectionConfiguration",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        },
+        {
+          "name" : "opaqueTokenIntrospector",
+          "parameterTypes" : [
+            "org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods" : [
+        {
+          "name" : "byAnnotation",
+          "parameterTypes" : [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.ApplicationContextAware"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.annotation.Bean"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.annotation.Conditional"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.annotation.Configuration"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.annotation.Import"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods" : [
+        {
+          "name" : "<init>",
+          "parameterTypes" : [ ]
+        }
+      ]
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.core.annotation.AliasFor"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.core.annotation.Order"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.core.convert.converter.Converter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.jwt.JwtDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.jwt.NimbusJwtDecoder"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.stereotype.Component"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.stereotype.Indexed"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.boot.context.properties.ConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : {
+        "proxy" : [
+          "org.springframework.context.ConfigurableApplicationContext",
+          "org.springframework.boot.test.context.assertj.AssertableApplicationContext"
+        ]
+      }
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "type" : {
+        "lambda" : {
+          "declaringClass" : "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+          "interfaces" : [
+            "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter"
+          ]
+        }
+      }
+    }
+  ],
+  "resources" : [
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "META-INF/spring.components"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "META-INF/spring.factories"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "commons-logging.properties"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/autoconfigure/SecurityAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/autoconfigure/UserDetailsServiceAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition$OnAuthoritiesClaimName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition$OnAuthoritiesExpressions.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition$OnAuthoritiesExpressionsCondition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition$OnAuthorityPrefix.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition$OnPrincipalClaimName.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtConverterConfiguration$PropertiesCondition.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/JwtDecoderConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "org/springframework/boot/security/oauth2/server/resource/autoconfigure/OAuth2ResourceServerAutoConfiguration.class"
+    },
+    {
+      "condition" : {
+        "typeReached" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.Spring_boot_security_oauth2_resource_serverTest"
+      },
+      "glob" : "spring.properties"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "org.springframework.boot.security.oauth2.server.resource.autoconfigure.**"
+    }
+  ]
+}

--- a/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/user-code-filter.json
+++ b/tests/src/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "org.springframework.boot.security.oauth2.server.resource.autoconfigure.**"
+      "includeClasses" : "org.springframework.boot.security.oauth2.server.resource.autoconfigure.**"
+    },
+    {
+      "includeClasses" : "org_springframework_boot.spring_boot_security_oauth2_resource_server.**"
     }
   ]
 }


### PR DESCRIPTION

## What does this PR do?

Fixes: #9232

This PR introduces tests and metadata for org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 76898
- Cached input tokens: 643584
- Output tokens: 7111
- Metadata entries: 17
- Test-only metadata entries: 143
- Iterations: 7
- Library coverage percentage: 39.0
- Generated lines of code: 94
- Tested library lines of code: 133

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `a4dd27a853f7a7b19f38990797d581e7f5c4184d`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 501/1515 (33.07%)
- Line: 133/341 (39.00%)
- Method: 51/127 (40.16%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
