### PR TITLE
[GenAI] Mark org.springframework.boot:spring-boot-starter-batch as not for Native Image

### DIFF
--- a/metadata/org.springframework.boot/spring-boot-starter-batch/index.json
+++ b/metadata/org.springframework.boot/spring-boot-starter-batch/index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "not-for-native-image": true,
+    "reason": "The published JAR contains no JVM class files; it only aggregates dependencies.",
+    "replacement": "org.springframework.boot:spring-boot-batch:4.1.0"
+  }
+]


### PR DESCRIPTION

## What does this PR do?

Fixes: #9284

This PR records `org.springframework.boot:spring-boot-starter-batch` as `not-for-native-image`, so automation and downstream tools know this artifact is intentionally not a GraalVM Native Image reachability metadata target.

Reason:
- The published JAR contains no JVM class files; it only aggregates dependencies.

Replacement guidance:
- org.springframework.boot:spring-boot-batch:4.1.0

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `617737f914cf06e64c8baa9ea3bb90cf31f05353`

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
