### PR TITLE
[GenAI] Add support for com.amazonaws:aws-lambda-java-events:3.0.0 using gpt-5.6-terra

### DIFF
--- a/metadata/com.amazonaws/aws-lambda-java-events/3.0.0/reachability-metadata.json
+++ b/metadata/com.amazonaws/aws-lambda-java-events/3.0.0/reachability-metadata.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification$S3EventNotificationRecord"
+      },
+      "glob": "org/joda/time/tz/data/Europe/Belgrade"
+    },
+    {
+      "condition": {
+        "typeReached": "com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification$S3EventNotificationRecord"
+      },
+      "glob": "org/joda/time/tz/data/ZoneInfoMap"
+    }
+  ]
+}

--- a/metadata/com.amazonaws/aws-lambda-java-events/index.json
+++ b/metadata/com.amazonaws/aws-lambda-java-events/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "3.0.0",
+    "source-code-url" : "https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-events/$version$/aws-lambda-java-events-$version$-sources.jar",
+    "repository-url" : "https://github.com/aws/aws-lambda-java-libs",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-events/$version$/aws-lambda-java-events-$version$-javadoc.jar",
+    "description" : "AWS Lambda Java Events provides Java classes that model event payloads delivered to AWS Lambda functions by supported AWS services. It lets Java handlers consume strongly typed representations of events such as API Gateway, S3, SQS, SNS, and Kinesis notifications.",
+    "tested-versions" : [
+      "3.0.0"
+    ],
+    "allowed-packages" : [
+      "com.amazonaws.services.lambda.runtime.events"
+    ]
+  }
+]

--- a/stats/com.amazonaws/aws-lambda-java-events/3.0.0/execution-metrics.json
+++ b/stats/com.amazonaws/aws-lambda-java-events/3.0.0/execution-metrics.json
@@ -1,0 +1,83 @@
+{
+  "add_new_library_support:2026-08-13": {
+    "timestamp": "2026-08-13T08:41:06.061596Z",
+    "library": "com.amazonaws:aws-lambda-java-events:3.0.0",
+    "starting_commit": "73261894082eff7a3b7ae2e555fcdcc4e6157155",
+    "ending_commit": "b2996099684a48421e210eff3c62629c17b6da8e",
+    "strategy_name": "dynamic_access_main_sources_pi_gpt-5.6-terra",
+    "agent": "pi",
+    "model": "gpt-5.6-terra",
+    "status": "success",
+    "stats": {
+      "version": "3.0.0",
+      "dynamicAccess": {
+        "breakdown": {},
+        "coverageRatio": 1.0,
+        "coveredCalls": 0,
+        "totalCalls": 0
+      },
+      "libraryCoverage": {
+        "instruction": {
+          "covered": 1337,
+          "missed": 17725,
+          "ratio": 0.07014,
+          "total": 19062
+        },
+        "line": {
+          "covered": 407,
+          "missed": 3690,
+          "ratio": 0.099341,
+          "total": 4097
+        },
+        "method": {
+          "covered": 195,
+          "missed": 907,
+          "ratio": 0.176951,
+          "total": 1102
+        }
+      }
+    },
+    "library_preparation_preflight": {
+      "status": "completed",
+      "action": "no_action",
+      "issue_number": 7739,
+      "issue_label": "library-new-request",
+      "library": "com.amazonaws:aws-lambda-java-events:3.0.0",
+      "summary": "This is a self-contained Lambda event-model library: version 3.0.0 ships POJO event classes and only has the normal transitive `joda-time:2.6` runtime dependency. Meaningful construction, accessor, equality, and nested-event coverage needs no service, Docker image, property, or extra test dependency.",
+      "deterministic_setup": [],
+      "agent_guidance": "",
+      "risks": [],
+      "applied_setup": [],
+      "input_evidence": [
+        {
+          "name": "issue",
+          "summary": "#7739 Support for com.amazonaws:aws-lambda-java-events:3.0.0; label=library-new-request; body_chars=134"
+        },
+        {
+          "name": "existing_tests",
+          "summary": "0 existing test file path(s) included"
+        }
+      ],
+      "model": "gpt-5.6-terra",
+      "input_tokens_used": 30908,
+      "output_tokens_used": 1052,
+      "prompt_path": "library-preflight-prompt.txt",
+      "raw_response_path": "library-preflight-response.txt",
+      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.amazonaws:aws-lambda-java-events:3.0.0/library-preparation-preflight/pi-generation-2026-08-13T08-16-33-714398Z.log"
+    },
+    "metrics": {
+      "input_tokens_used": 81803,
+      "cached_input_tokens_used": 581632,
+      "output_tokens_used": 7164,
+      "iterations": 5,
+      "cost_usd": 0.4574,
+      "generated_loc": 157,
+      "tested_library_loc": 407,
+      "metadata_entries": 2,
+      "code_coverage_percent": 9.93
+    },
+    "artifacts": {
+      "metadata_file": "metadata/com.amazonaws/aws-lambda-java-events/3.0.0/reachability-metadata.json"
+    }
+  }
+}

--- a/stats/com.amazonaws/aws-lambda-java-events/3.0.0/stats.json
+++ b/stats/com.amazonaws/aws-lambda-java-events/3.0.0/stats.json
@@ -1,0 +1,31 @@
+{
+  "versions" : [ {
+    "version" : "3.0.0",
+    "dynamicAccess" : {
+      "breakdown" : { },
+      "coverageRatio" : 1.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 0
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 1337,
+        "missed" : 17725,
+        "ratio" : 0.07014,
+        "total" : 19062
+      },
+      "line" : {
+        "covered" : 407,
+        "missed" : 3690,
+        "ratio" : 0.099341,
+        "total" : 4097
+      },
+      "method" : {
+        "covered" : 195,
+        "missed" : 907,
+        "ratio" : 0.176951,
+        "total" : 1102
+      }
+    }
+  } ]
+}

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/.gitignore
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/build.gradle
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "com.amazonaws:aws-lambda-java-events:$libraryVersion"
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/gradle.properties
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = com.amazonaws:aws-lambda-java-events:3.0.0
+library.version = 3.0.0
+metadata.dir = com.amazonaws/aws-lambda-java-events/3.0.0/

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/settings.gradle
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'com.amazonaws.aws-lambda-java-events_tests'

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package com_amazonaws.aws_lambda_java_events;
+
+import org.junit.jupiter.api.Test;
+
+class Aws_lambda_java_eventsTest {
+    @Test
+    void test() throws Exception {
+        System.out.println("This is just a placeholder, implement your test");
+    }
+}

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
@@ -9,8 +9,13 @@ package com_amazonaws.aws_lambda_java_events;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.amazonaws.services.lambda.runtime.events.CloudWatchLogsEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamViewType;
 import java.util.List;
 import java.util.Map;
 import org.joda.time.DateTime;
@@ -87,6 +92,36 @@ public class Aws_lambda_java_eventsTest {
                 .isEqualTo("priority");
         assertThat(event.getRecords().get(0).getSNS().getTimestamp()).isEqualTo(timestamp);
         assertThat(event.clone()).isEqualTo(event).isNotSameAs(event);
+    }
+
+    @Test
+    void dynamodbStreamEventRetainsImagesAndRecordMetadata() {
+        AttributeValue orderId = new AttributeValue().withS("order-42");
+        AttributeValue quantity = new AttributeValue().withN("3");
+        StreamRecord streamRecord = new StreamRecord()
+                .withKeys(Map.of("orderId", orderId))
+                .withSequenceNumber("496080000000000000001")
+                .withSizeBytes(128L)
+                .withStreamViewType(StreamViewType.NEW_AND_OLD_IMAGES);
+        streamRecord.addNewImageEntry("quantity", quantity);
+        streamRecord.addOldImageEntry("quantity", new AttributeValue().withN("2"));
+
+        DynamodbEvent.DynamodbStreamRecord record = new DynamodbEvent.DynamodbStreamRecord();
+        record.setEventID("event-1");
+        record.setEventName(OperationType.MODIFY);
+        record.setEventSource("aws:dynamodb");
+        record.setEventSourceARN("arn:aws:dynamodb:us-east-1:123456789012:table/orders/stream/2020-01-01");
+        record.setDynamodb(streamRecord);
+        DynamodbEvent event = new DynamodbEvent();
+        event.setRecords(List.of(record));
+
+        DynamodbEvent.DynamodbStreamRecord retainedRecord = event.getRecords().get(0);
+        assertThat(retainedRecord.getEventName()).isEqualTo(OperationType.MODIFY.name());
+        assertThat(retainedRecord.getDynamodb().getKeys().get("orderId").getS()).isEqualTo("order-42");
+        assertThat(retainedRecord.getDynamodb().getNewImage().get("quantity").getN()).isEqualTo("3");
+        assertThat(retainedRecord.getDynamodb().getOldImage().get("quantity").getN()).isEqualTo("2");
+        assertThat(retainedRecord.getDynamodb().getStreamViewType())
+                .isEqualTo(StreamViewType.NEW_AND_OLD_IMAGES.name());
     }
 
     @Test

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
@@ -16,6 +16,7 @@ import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeVal
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.OperationType;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamViewType;
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
 import java.util.List;
 import java.util.Map;
 import org.joda.time.DateTime;
@@ -122,6 +123,31 @@ public class Aws_lambda_java_eventsTest {
         assertThat(retainedRecord.getDynamodb().getOldImage().get("quantity").getN()).isEqualTo("2");
         assertThat(retainedRecord.getDynamodb().getStreamViewType())
                 .isEqualTo(StreamViewType.NEW_AND_OLD_IMAGES.name());
+    }
+
+    @Test
+    void s3EventNotificationDecodesObjectKeysAndRetainsRecordDetails() {
+        S3EventNotification.UserIdentityEntity owner =
+                new S3EventNotification.UserIdentityEntity("bucket-owner");
+        S3EventNotification.S3BucketEntity bucket = new S3EventNotification.S3BucketEntity(
+                "order-uploads", owner, "arn:aws:s3:::order-uploads");
+        S3EventNotification.S3ObjectEntity object = new S3EventNotification.S3ObjectEntity(
+                "orders%2Forder+42.json", 128L, "etag-1", "version-1", "sequencer-1");
+        S3EventNotification.S3Entity s3 = new S3EventNotification.S3Entity("upload-config", bucket, object, "1.0");
+        S3EventNotification.S3EventNotificationRecord record = new S3EventNotification.S3EventNotificationRecord(
+                "us-east-1", "ObjectCreated:Put", "aws:s3", "2020-01-02T03:04:05.000Z", "2.1",
+                new S3EventNotification.RequestParametersEntity("192.0.2.1"),
+                new S3EventNotification.ResponseElementsEntity("id-2", "request-1"), s3,
+                new S3EventNotification.UserIdentityEntity("uploader"));
+        S3EventNotification event = new S3EventNotification(List.of(record));
+
+        S3EventNotification.S3EventNotificationRecord retainedRecord = event.getRecords().get(0);
+        assertThat(retainedRecord.getS3().getBucket().getName()).isEqualTo("order-uploads");
+        assertThat(retainedRecord.getS3().getObject().getUrlDecodedKey()).isEqualTo("orders/order 42.json");
+        assertThat(retainedRecord.getS3().getObject().getSizeAsLong()).isEqualTo(128L);
+        assertThat(retainedRecord.getS3().getObject().getSequencer()).isEqualTo("sequencer-1");
+        assertThat(retainedRecord.getRequestParameters().getSourceIPAddress()).isEqualTo("192.0.2.1");
+        assertThat(retainedRecord.getEventTime()).isEqualTo(DateTime.parse("2020-01-02T03:04:05.000Z"));
     }
 
     @Test

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/src/test/java/com_amazonaws/aws_lambda_java_events/Aws_lambda_java_eventsTest.java
@@ -6,11 +6,107 @@
  */
 package com_amazonaws.aws_lambda_java_events;
 
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.lambda.runtime.events.CloudWatchLogsEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import java.util.List;
+import java.util.Map;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
-class Aws_lambda_java_eventsTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Aws_lambda_java_eventsTest {
     @Test
-    void test() throws Exception {
-        System.out.println("This is just a placeholder, implement your test");
+    void apiGatewayEventsRetainRequestContextAndResponseDetails() {
+        APIGatewayProxyRequestEvent.RequestIdentity identity =
+                new APIGatewayProxyRequestEvent.RequestIdentity()
+                        .withAccountId("123456789012")
+                        .withSourceIp("192.0.2.1")
+                        .withUserAgent("integration-test");
+        APIGatewayProxyRequestEvent.ProxyRequestContext context =
+                new APIGatewayProxyRequestEvent.ProxyRequestContext()
+                        .withRequestId("request-1")
+                        .withStage("prod")
+                        .withHttpMethod("POST")
+                        .withIdentity(identity);
+        context.setAuthorizer(Map.of("principalId", "user-1"));
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent()
+                .withResource("/orders/{id}")
+                .withPath("/orders/42")
+                .withHttpMethod("POST")
+                .withHeaders(Map.of("content-type", "application/json"))
+                .withMultiValueHeaders(Map.of("accept", List.of("application/json", "text/plain")))
+                .withQueryStringParameters(Map.of("verbose", "true"))
+                .withPathParameters(Map.of("id", "42"))
+                .withStageVariables(Map.of("environment", "production"))
+                .withRequestContext(context)
+                .withBody("{\"name\":\"book\"}")
+                .withIsBase64Encoded(false);
+
+        assertThat(request.getRequestContext().getIdentity().getSourceIp()).isEqualTo("192.0.2.1");
+        assertThat(request.getMultiValueHeaders().get("accept")).containsExactly("application/json", "text/plain");
+        assertThat(request.clone()).isEqualTo(request).isNotSameAs(request);
+
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent()
+                .withStatusCode(201)
+                .withHeaders(Map.of("location", "/orders/42"))
+                .withBody("created")
+                .withIsBase64Encoded(false);
+
+        assertThat(response.getStatusCode()).isEqualTo(201);
+        assertThat(response.getHeaders()).containsEntry("location", "/orders/42");
+        assertThat(response.clone()).isEqualTo(response).isNotSameAs(response);
+    }
+
+    @Test
+    void snsEventPreservesRecordMessageAttributesAndTimestamp() {
+        SNSEvent.MessageAttribute attribute = new SNSEvent.MessageAttribute()
+                .withType("String")
+                .withValue("priority");
+        DateTime timestamp = new DateTime(2020, 1, 2, 3, 4);
+        SNSEvent.SNS sns = new SNSEvent.SNS()
+                .withMessageId("message-1")
+                .withTopicArn("arn:aws:sns:us-east-1:123456789012:orders")
+                .withSubject("order-created")
+                .withMessage("order 42")
+                .withTimestamp(timestamp)
+                .withMessageAttributes(Map.of("category", attribute));
+        SNSEvent.SNSRecord record = new SNSEvent.SNSRecord()
+                .withEventVersion("1.0")
+                .withEventSource("aws:sns")
+                .withEventSubscriptionArn("arn:aws:sns:subscription")
+                .withSns(sns);
+        SNSEvent event = new SNSEvent().withRecords(List.of(record));
+
+        assertThat(event.getRecords()).hasSize(1);
+        assertThat(event.getRecords().get(0).getSNS().getMessage()).isEqualTo("order 42");
+        assertThat(event.getRecords().get(0).getSNS().getMessageAttributes().get("category").getValue())
+                .isEqualTo("priority");
+        assertThat(event.getRecords().get(0).getSNS().getTimestamp()).isEqualTo(timestamp);
+        assertThat(event.clone()).isEqualTo(event).isNotSameAs(event);
+    }
+
+    @Test
+    void streamAndLogEventsExposeNestedPayloads() {
+        KinesisEvent.Record kinesisRecord = new KinesisEvent.Record();
+        kinesisRecord.setKinesisSchemaVersion("1.0");
+        KinesisEvent.KinesisEventRecord record = new KinesisEvent.KinesisEventRecord();
+        record.setEventID("shardId-000:1");
+        record.setEventSource("aws:kinesis");
+        record.setAwsRegion("us-east-1");
+        record.setKinesis(kinesisRecord);
+        KinesisEvent kinesisEvent = new KinesisEvent();
+        kinesisEvent.setRecords(List.of(record));
+
+        CloudWatchLogsEvent.AWSLogs logs = new CloudWatchLogsEvent.AWSLogs().withData("compressed-log-data");
+        CloudWatchLogsEvent logsEvent = new CloudWatchLogsEvent().withAwsLogs(logs);
+
+        assertThat(kinesisEvent.getRecords().get(0).getKinesis().getKinesisSchemaVersion()).isEqualTo("1.0");
+        assertThat(kinesisEvent.clone()).isEqualTo(kinesisEvent).isNotSameAs(kinesisEvent);
+        assertThat(logsEvent.getAwsLogs().getData()).isEqualTo("compressed-log-data");
+        assertThat(logsEvent.clone()).isEqualTo(logsEvent).isNotSameAs(logsEvent);
     }
 }

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/user-code-filter.json
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/user-code-filter.json
@@ -1,10 +1,13 @@
 {
-  "rules": [
+  "rules" : [
     {
-      "excludeClasses": "**"
+      "excludeClasses" : "**"
     },
     {
-      "includeClasses": "com.amazonaws.services.lambda.runtime.events.**"
+      "includeClasses" : "com.amazonaws.services.lambda.runtime.events.**"
+    },
+    {
+      "includeClasses" : "com_amazonaws.aws_lambda_java_events.**"
     }
   ]
 }

--- a/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/user-code-filter.json
+++ b/tests/src/com.amazonaws/aws-lambda-java-events/3.0.0/user-code-filter.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "excludeClasses": "**"
+    },
+    {
+      "includeClasses": "com.amazonaws.services.lambda.runtime.events.**"
+    }
+  ]
+}


### PR DESCRIPTION

## What does this PR do?

Fixes: #7739

This PR introduces tests and metadata for com.amazonaws:aws-lambda-java-events:3.0.0, enabling support for this library.

Summary:
- Strategy: dynamic_access_main_sources_pi_gpt-5.6-terra
- Agent: pi
- Model: gpt-5.6-terra
- Input tokens: 81803
- Cached input tokens: 581632
- Output tokens: 7164
- Metadata entries: 2
- Iterations: 5
- Library coverage percentage: 9.93
- Generated lines of code: 157
- Tested library lines of code: 407

### Forge

- Forge monitored branch: `master`
- Forge branch: `master`
- Forge commit hash: `617737f914cf06e64c8baa9ea3bb90cf31f05353`


Stats from `stats/<groupId>/<artifactId>/<metadata-version>/stats.json`:

Dynamic access coverage:
- Overall: 0/0 covered calls (100.00%)

Library coverage:
- Instruction: 1337/19062 (7.01%)
- Line: 407/4097 (9.93%)
- Method: 195/1102 (17.70%)

### Local CI Verification

- Status: `success`
- Commands run: 2
- Fixup attempts: 0
