### PR TITLE
Drain issue queues by priority tier

### DIFF
--- a/forge/README.md
+++ b/forge/README.md
@@ -32,6 +32,7 @@ Common options:
 - `--parallelism N`: run up to `N` issue workflows in parallel. Maximum: 4.
 - `--review-limit N`: process up to `N` PR review tasks per label per cycle.
 - `--random-offset`: start new-library issue scans at a random offset instead of the newest issues first.
+- `--priority {high,priority,normal}`: process only the selected issue priority tier.
 - `--user-requested-only`: fetch only user-requested issue queue items, excluding configured automation and maintainer authors.
 - `--once`: run a single update/work cycle through `do_up_to_date_work.sh` and exit.
 - `--stop`: ask all Forge `do-work` loops for the current user to exit by creating `~/.metadata-forge-stop`.

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -21,6 +21,7 @@ LIBRARY_UPDATE_WORK_STRATEGY_NAME="${FORGE_LIBRARY_UPDATE_STRATEGY_NAME:-}"
 WORK_LABEL="${FORGE_WORK_LABEL:-library-new-request}"
 WORK_LIMIT="${FORGE_WORK_LIMIT:-1}"
 RANDOM_WORK_OFFSET="${FORGE_RANDOM_WORK_OFFSET:-0}"
+PRIORITY_TIER=""
 PARALLELISM="${FORGE_PARALLELISM:-1}"
 REVIEW_LABEL="${FORGE_REVIEW_LABEL:-}"
 REVIEW_LIMIT="${FORGE_REVIEW_LIMIT:-1}"
@@ -101,6 +102,8 @@ Options:
   --no-random-offset
       Start new-library issue scans from the beginning of the issue list. This
       is the default.
+  --priority {high,priority,normal}
+      Process only the selected issue priority tier in every issue queue.
   --parallelism N
       Run up to N issue workflows in parallel. Defaults to FORGE_PARALLELISM,
       then 1. The maximum is 4.
@@ -403,6 +406,9 @@ process_work_queues() {
         "--parallelism"
         "$PARALLELISM"
     )
+    if [[ -n "$PRIORITY_TIER" ]]; then
+        forge_metadata_args+=("--priority" "$PRIORITY_TIER")
+    fi
 
     run_step "Processing configured work queues via forge_metadata." \
         "$PYTHON_BIN" "$SCRIPT_DIR/forge_metadata.py" "${forge_metadata_args[@]}"
@@ -521,6 +527,15 @@ while [[ "$#" -gt 0 ]]; do
             RANDOM_WORK_OFFSET=0
             shift
             ;;
+        --priority)
+            require_option_value "$1" "${2:-}"
+            PRIORITY_TIER="$2"
+            shift 2
+            ;;
+        --priority=*)
+            PRIORITY_TIER="${1#*=}"
+            shift
+            ;;
         --parallelism)
             require_option_value "$1" "${2:-}"
             PARALLELISM="$2"
@@ -621,6 +636,13 @@ require_nonnegative_integer "FORGE_WORK_LIMIT" "$WORK_LIMIT"
 require_nonnegative_integer "FORGE_REVIEW_LIMIT" "$REVIEW_LIMIT"
 require_parallelism "$PARALLELISM"
 require_positive_integer "FORGE_DO_WORK_SLEEP_POLL_SECONDS" "$SLEEP_POLL_SECONDS"
+if [[ -n "$PRIORITY_TIER" \
+        && "$PRIORITY_TIER" != "high" \
+        && "$PRIORITY_TIER" != "priority" \
+        && "$PRIORITY_TIER" != "normal" ]]; then
+    echo "--priority must be high, priority, or normal." >&2
+    exit 1
+fi
 
 if [[ "$RANDOM_WORK_OFFSET" != "0" && "$RANDOM_WORK_OFFSET" != "1" ]]; then
     echo "FORGE_RANDOM_WORK_OFFSET must be 0 or 1." >&2

--- a/forge/docs/e2e.md
+++ b/forge/docs/e2e.md
@@ -112,6 +112,9 @@ The `9107` fixture is a publication-continuation smoke test: its marker starts a
 `publication` and points at durable execution metrics plus marker-local PR
 extras, so it verifies `.pending_metrics.json` reconstruction and dry-run PR
 body generation without invoking an agent-backed generation workflow.
+It also carries the `priority` label so a fixture label run with
+`--priority priority` can verify exclusive priority-tier selection without
+starting an agent-backed generation workflow.
 §FS-forge-run-continuation.2
 
 For `library-new-request` fixtures that use an already-supported dynamic-access

--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -25,8 +25,9 @@ A supported issue starts from a work label such as `library-new-request`,
 `library-update-request`, `fails-javac-compile`, `fails-java-run`, or
 `fails-native-image-run`. Section 2 (Scope) enumerates the queues Forge
 resolves, and its "Origin of the `fails-*` queues" subsection records where the
-`fails-*` work comes from. Within each pipeline scan batch, Forge processes
-`high-priority` issues first, then `priority` issues, then regular issues.
+`fails-*` work comes from. Forge drains each pipeline by priority tier rather
+than by scan batch: every `high-priority` issue first, then every `priority`
+issue, then the remaining issues.
 
 ## 2. Scope
 

--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -42,9 +42,16 @@ result window is therefore capped independently at GitHub's first
 Tier membership comes only from priority labels already present on GitHub;
 queue scanning and claim checks do not add priority labels automatically.
 
+Operators may restrict a queue run to exactly one tier with
+`--priority high`, `--priority priority`, or `--priority normal`. The `high`
+tier requires `high-priority`; the `priority` tier requires `priority` and
+excludes `high-priority`; the `normal` tier excludes both labels. Without this
+option, Forge drains all three tiers in order.
+
 Tiered draining applies to scans that start at offset `0`. A scan started from a
-random offset (§ORCH-forge-orchestration-spec) keeps paging the flat, unfiltered
-label query so that concurrent runners spread across the queue.
+random offset without `--priority` keeps paging the flat, unfiltered label query
+so that concurrent runners spread across the queue. With `--priority`, the
+offset—random or explicit—is relative only to the selected tier.
 
 Orchestration must claim exactly one issue per workflow run, dispatch the
 matching workflow driver, and either hand PR-eligible results to publication

--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -30,10 +30,19 @@ the contract for that producer is the repository functional spec's
 [Library version update automation](../../docs/functional-spec.md#fs-library-version-update-automation-library-version-update-automation)
 (root-namespace ID `FS-library-version-update-automation`).
 
-Queue scans rank issues within each fetched pipeline batch by label-derived
-urgency: `high-priority` first, `priority` second, and issues with neither label
-last. An issue carrying both priority labels remains in the highest tier, matching
-the repository status classification (§root/FS-repository-status-report.1).
+Queue scans drain a pipeline by label-derived urgency tier rather than ranking
+within a fetched batch: the scan pages through every `high-priority` issue
+first, then every `priority` issue, then issues carrying neither label. Each
+tier is a separate GitHub search that excludes the labels of the tiers above it,
+so an issue carrying both priority labels is served once, in the highest tier,
+matching the repository status classification (§root/FS-repository-status-report.1).
+A tier is left only once its search returns no further results, and its own
+result window is therefore capped independently at GitHub's first
+`GITHUB_SEARCH_MAX_RESULTS` matches.
+
+Tiered draining applies to scans that start at offset `0`. A scan started from a
+random offset (§ORCH-forge-orchestration-spec) keeps paging the flat, unfiltered
+label query so that concurrent runners spread across the queue.
 
 Orchestration must claim exactly one issue per workflow run, dispatch the
 matching workflow driver, and either hand PR-eligible results to publication

--- a/forge/docs/orchestration-scripts.md
+++ b/forge/docs/orchestration-scripts.md
@@ -39,6 +39,8 @@ matching the repository status classification (§root/FS-repository-status-repor
 A tier is left only once its search returns no further results, and its own
 result window is therefore capped independently at GitHub's first
 `GITHUB_SEARCH_MAX_RESULTS` matches.
+Tier membership comes only from priority labels already present on GitHub;
+queue scanning and claim checks do not add priority labels automatically.
 
 Tiered draining applies to scans that start at offset `0`. A scan started from a
 random offset (§ORCH-forge-orchestration-spec) keeps paging the flat, unfiltered

--- a/forge/fixture_github_issues/library-new-request-publication-continuation.yaml
+++ b/forge/fixture_github_issues/library-new-request-publication-continuation.yaml
@@ -7,6 +7,7 @@ title: "Add support for org.example:publication-resume:1.0.0"
 state: OPEN
 labels:
   - library-new-request
+  - priority
 assignees: []
 project:
   number: 30

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -200,8 +200,6 @@ DEFAULT_ISSUE_SCAN_BATCH_SIZE = 25
 ISSUE_SCAN_PROGRESS_LOG_INTERVAL = 100
 GITHUB_API_MAX_PAGE_SIZE = 100
 GITHUB_SEARCH_MAX_RESULTS = 1000
-PRIORITY_BLOCKING_LIBRARY_THRESHOLD = 10
-PRIORITY_BLOCKING_ISSUE_QUERY_CHUNK_SIZE = 25
 DEFAULT_TAKE_BLOCKED_ISSUES = True
 # GitHub validates GraphQL node cost against worst-case first values; 5 issues can exceed 500k here.
 ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE = 4
@@ -1603,151 +1601,6 @@ def pull_request_has_label(pr: dict, label_name: str) -> bool:
     return issue_has_label(pr, label_name)
 
 
-def get_open_issues_blocked_by_issue_counts(
-        issue_numbers: list[int],
-        minimum_count: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
-        chunk_size: int = PRIORITY_BLOCKING_ISSUE_QUERY_CHUNK_SIZE,
-) -> dict[int, int]:
-    """Return open issue counts blocked by each issue, capped after `minimum_count`."""
-    if minimum_count <= 0 or chunk_size <= 0:
-        return {}
-
-    owner, repo_name = REPO.split("/")
-    unique_issue_numbers = list(dict.fromkeys(issue_numbers))
-    counts = {issue_number: 0 for issue_number in unique_issue_numbers}
-    cursors: dict[int, str | None] = {issue_number: None for issue_number in unique_issue_numbers}
-    remaining_issue_numbers = set(unique_issue_numbers)
-
-    while remaining_issue_numbers:
-        batch = list(remaining_issue_numbers)[:chunk_size]
-        issue_fields = "\n".join(
-            f"""
-        issue_{issue_number}: issue(number: {issue_number}) {{
-          blocking(first: 100{f', after: "{cursors[issue_number]}"' if cursors[issue_number] else ""}) {{
-            nodes {{
-              number
-              closed
-            }}
-            pageInfo {{
-              hasNextPage
-              endCursor
-            }}
-          }}
-        }}
-            """
-            for issue_number in batch
-        )
-        query = f"""
-        query {{
-          repository(owner: "{owner}", name: "{repo_name}") {{
-{issue_fields}
-          }}
-        }}
-        """
-        result = gh_json("api", "graphql", "-f", f"query={query}", quiet=True)
-        repository = (
-            result.get("data", {})
-            .get("repository", {})
-        ) or {}
-
-        for issue_number in batch:
-            issue = repository.get(f"issue_{issue_number}")
-            blocking = issue.get("blocking", {}) if isinstance(issue, dict) else {}
-            for blocked_issue in blocking.get("nodes", []):
-                if isinstance(blocked_issue, dict) and not blocked_issue.get("closed", False):
-                    counts[issue_number] += 1
-                    if counts[issue_number] >= minimum_count:
-                        break
-
-            page_info = blocking.get("pageInfo", {}) if isinstance(blocking, dict) else {}
-            if counts[issue_number] >= minimum_count or not page_info.get("hasNextPage"):
-                remaining_issue_numbers.discard(issue_number)
-                continue
-
-            cursor = page_info.get("endCursor")
-            if cursor:
-                cursors[issue_number] = cursor
-            else:
-                remaining_issue_numbers.discard(issue_number)
-
-    return counts
-
-
-def mark_issue_numbers_blocking_many_libraries_as_priority(
-        issue_numbers: list[int],
-        threshold: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
-) -> set[int]:
-    """Apply the priority label to issues that block at least `threshold` open issues."""
-    priority_issue_numbers: set[int] = set()
-    if not issue_numbers:
-        return priority_issue_numbers
-
-    counts = get_open_issues_blocked_by_issue_counts(issue_numbers, threshold)
-    for issue_number in issue_numbers:
-        if counts.get(issue_number, 0) < threshold or issue_number in priority_issue_numbers:
-            continue
-        add_issue_label(issue_number, LABEL_PRIORITY)
-        priority_issue_numbers.add(issue_number)
-        log_stage(
-            "priority",
-            (
-                f"Issue #{issue_number} blocks at least {threshold} open issue(s); "
-                f"added label '{LABEL_PRIORITY}'"
-            ),
-        )
-    return priority_issue_numbers
-
-
-def mark_issues_blocking_many_libraries_as_priority(
-        issues: list[dict],
-        threshold: int = PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
-) -> None:
-    """Mark unprioritized issue payloads as priority when they block many open issues."""
-    candidate_issue_numbers = [
-        issue["number"]
-        for issue in issues
-        if isinstance(issue, dict)
-        and isinstance(issue.get("number"), int)
-        and not issue_has_label(issue, LABEL_PRIORITY)
-    ]
-    priority_issue_numbers = mark_issue_numbers_blocking_many_libraries_as_priority(
-        candidate_issue_numbers,
-        threshold,
-    )
-    for issue in issues:
-        issue_number = issue.get("number") if isinstance(issue, dict) else None
-        if issue_number in priority_issue_numbers:
-            add_issue_label_to_payload(issue, LABEL_PRIORITY)
-
-
-def try_mark_issues_blocking_many_libraries_as_priority(issues: list[dict]) -> None:
-    """Best-effort priority labeling for queue ordering."""
-    try:
-        mark_issues_blocking_many_libraries_as_priority(issues)
-    except GitHubRateLimitExceeded:
-        raise
-    except Exception as exc:
-        print(
-            "ERROR: Failed to mark blocker issues as priority; "
-            f"continuing without dependency priority updates: {format_github_exception_details(exc)}",
-            file=sys.stderr,
-        )
-
-
-def try_mark_issue_numbers_blocking_many_libraries_as_priority(issue_numbers: list[int]) -> None:
-    """Best-effort priority labeling for blockers discovered during claim checks."""
-    try:
-        mark_issue_numbers_blocking_many_libraries_as_priority(issue_numbers)
-    except GitHubRateLimitExceeded:
-        raise
-    except Exception as exc:
-        print(
-            "ERROR: Failed to mark blocker issues as priority; "
-            f"continuing without dependency priority updates: {format_github_exception_details(exc)}",
-            file=sys.stderr,
-        )
-
-
 @dataclass(frozen=True)
 class IssuePriorityTier:
     """One urgency tier of an issue queue, expressed as a GitHub label filter."""
@@ -1830,8 +1683,6 @@ def get_prioritized_issues_with_label(
             continue
         state.advance_within_tier(len(raw_issues))
         issues = filter_user_requested_issues(raw_issues, user_requested_only)
-        if not is_fixture_testing_enabled():
-            try_mark_issues_blocking_many_libraries_as_priority(issues)
         if issues:
             return issues, state
     return [], state
@@ -7765,7 +7616,6 @@ def try_claim_issue_with_local_lock(
     if not take_blocked_issues:
         open_blockers = get_open_blocking_issue_numbers(number)
         if open_blockers:
-            try_mark_issue_numbers_blocking_many_libraries_as_priority(open_blockers)
             record_issue_claim_cache_observations([
                 IssueClaimCacheObservation(
                     issue_number=number,

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -246,6 +246,9 @@ LABEL_PR_LIBRARY_UPDATE = "library-update-request"
 LABEL_PR_LIBRARY_BULK_UPDATE = "library-bulk-update"
 LABEL_HIGH_PRIORITY = "high-priority"
 LABEL_PRIORITY = "priority"
+PRIORITY_HIGH = "high"
+PRIORITY_NORMAL = "normal"
+PRIORITY_CHOICES: tuple[str, ...] = (PRIORITY_HIGH, LABEL_PRIORITY, PRIORITY_NORMAL)
 LABEL_HUMAN_INTERVENTION = "human-intervention"
 LABEL_HUMAN_INTERVENTION_FIXED = "human-intervention-fixed"
 LABEL_NOT_FOR_NATIVE_IMAGE = "not-for-native-image"
@@ -834,11 +837,21 @@ def count_issues_with_label(
         label: str,
         extra_labels: list[str] | None = None,
         user_requested_only: bool = False,
+        excluded_labels: list[str] | None = None,
 ) -> int:
     """Return GitHub's count of open issues carrying the given label set."""
     if is_fixture_testing_enabled():
-        return require_fixture_github_state().count_open_issues_by_label(label, extra_labels)
-    query = build_issue_search_query(label, extra_labels)
+        return require_fixture_github_state().count_open_issues_by_label(
+            label,
+            extra_labels,
+            excluded_labels,
+            excluded_authors=get_user_requested_issue_excluded_authors(user_requested_only),
+        )
+    query = build_issue_search_query(
+        label,
+        extra_labels,
+        [LABEL_NOT_FOR_NATIVE_IMAGE, *(excluded_labels or [])],
+    )
     return get_issue_search_count(query)
 
 
@@ -1613,10 +1626,21 @@ class IssuePriorityTier:
 # Drained in order; each tier excludes the labels of the tiers above it so that an
 # issue carrying several priority labels is served exactly once, in its highest tier.
 ISSUE_PRIORITY_TIERS: tuple[IssuePriorityTier, ...] = (
-    IssuePriorityTier(LABEL_HIGH_PRIORITY, (LABEL_HIGH_PRIORITY,), ()),
+    IssuePriorityTier(PRIORITY_HIGH, (LABEL_HIGH_PRIORITY,), ()),
     IssuePriorityTier(LABEL_PRIORITY, (LABEL_PRIORITY,), (LABEL_HIGH_PRIORITY,)),
-    IssuePriorityTier("regular", (), (LABEL_HIGH_PRIORITY, LABEL_PRIORITY)),
+    IssuePriorityTier(PRIORITY_NORMAL, (), (LABEL_HIGH_PRIORITY, LABEL_PRIORITY)),
 )
+
+
+ISSUE_PRIORITY_TIERS_BY_NAME: dict[str, IssuePriorityTier] = {
+    tier.name: tier
+    for tier in ISSUE_PRIORITY_TIERS
+}
+
+
+def get_issue_priority_tier(priority: str) -> IssuePriorityTier:
+    """Return the query filters for one CLI priority selector."""
+    return ISSUE_PRIORITY_TIERS_BY_NAME[priority]
 
 
 @dataclass
@@ -7743,17 +7767,22 @@ def format_issue_scan_position(
         offset: int,
         current_offset: int,
         scan_state: IssueQueueScanState,
+        priority: str | None = None,
 ) -> str:
     """Return a concise description of the current issue scan position."""
+    if priority is not None:
+        return f"{priority} tier, offset {current_offset}"
     if offset == 0:
         return scan_state.describe_position()
     return f"offset {current_offset}"
 
 
-def log_issue_scan_start(label: str, offset: int) -> None:
+def log_issue_scan_start(label: str, offset: int, priority: str | None = None) -> None:
     """Log where an issue scan starts."""
-    if offset == 0:
-        position = "draining the high-priority, priority, then regular tiers in turn"
+    if priority is not None:
+        position = f"in the {priority} tier from offset {offset}"
+    elif offset == 0:
+        position = "draining the high, priority, then normal tiers in turn"
     else:
         position = f"from offset {offset}"
     print()
@@ -7766,9 +7795,10 @@ def log_issue_scan_progress(
         offset: int,
         current_offset: int,
         scan_state: IssueQueueScanState,
+        priority: str | None = None,
 ) -> None:
     """Log issue scan progress after another interval of candidates was inspected."""
-    position = format_issue_scan_position(offset, current_offset, scan_state)
+    position = format_issue_scan_position(offset, current_offset, scan_state, priority)
     print()
     log_stage(
         "issue-scan",
@@ -7776,9 +7806,29 @@ def log_issue_scan_progress(
     )
 
 
-def resolve_random_issue_scan_offset(label: str, user_requested_only: bool = False) -> int:
+def resolve_random_issue_scan_offset(
+        label: str,
+        user_requested_only: bool = False,
+        priority: str | None = None,
+) -> int:
     """Choose a random searchable offset for an issue label."""
-    issue_count = count_issues_with_label(label, user_requested_only=user_requested_only)
+    tier: IssuePriorityTier | None = (
+        get_issue_priority_tier(priority)
+        if priority is not None
+        else None
+    )
+    if tier is None:
+        issue_count = count_issues_with_label(
+            label,
+            user_requested_only=user_requested_only,
+        )
+    else:
+        issue_count = count_issues_with_label(
+            label,
+            list(tier.extra_labels),
+            user_requested_only,
+            list(tier.excluded_labels),
+        )
     searchable_count = min(issue_count, GITHUB_SEARCH_MAX_RESULTS)
     if searchable_count <= 0:
         return 0
@@ -7794,6 +7844,7 @@ def process_fixture_issues_for_label(
         keep_tests_without_dynamic_access: bool,
         environment_already_validated: bool = False,
         user_requested_only: bool = False,
+        priority: str | None = None,
 ) -> int:
     """Run the local fixture issues for one label, sequentially, one `run.log` each.
 
@@ -7804,9 +7855,16 @@ def process_fixture_issues_for_label(
     if not environment_already_validated:
         validate_issue_processing_environment()
 
+    tier: IssuePriorityTier | None = (
+        get_issue_priority_tier(priority)
+        if priority is not None
+        else None
+    )
     issues = require_fixture_github_state().list_open_issues_by_label(
         label,
         limit,
+        extra_labels=list(tier.extra_labels) if tier is not None else None,
+        excluded_labels=list(tier.excluded_labels) if tier is not None else None,
         excluded_authors=get_user_requested_issue_excluded_authors(user_requested_only),
     )
     if not issues:
@@ -7848,6 +7906,7 @@ def process_issues_with_label(
         take_blocked_issues: bool = DEFAULT_TAKE_BLOCKED_ISSUES,
         environment_already_validated: bool = False,
         user_requested_only: bool = False,
+        priority: str | None = None,
 ) -> int:
     """
     Process up to `limit` claimable issues, skipping over unclaimed candidates.
@@ -7872,12 +7931,23 @@ def process_issues_with_label(
     next_scan_progress_log_count = ISSUE_SCAN_PROGRESS_LOG_INTERVAL
     current_offset = offset
     scan_state = IssueQueueScanState()
+    selected_tier: IssuePriorityTier | None = (
+        get_issue_priority_tier(priority)
+        if priority is not None
+        else None
+    )
+    selected_extra_labels: list[str] | None = (
+        list(selected_tier.extra_labels) if selected_tier is not None else None
+    )
+    selected_excluded_labels: list[str] | None = (
+        list(selected_tier.excluded_labels) if selected_tier is not None else None
+    )
     exhausted = False
     unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
     active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue] = {}
 
-    log_issue_scan_start(label, offset)
+    log_issue_scan_start(label, offset, priority)
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=parallelism)
     try:
@@ -7892,7 +7962,7 @@ def process_issues_with_label(
                         pending_issues.extend(resolve_next_issue_claim_candidate_batch(unresolved_candidates))
                     elif not exhausted:
                         fetch_limit = get_issue_scan_batch_size(remaining_limit, available_slots)
-                        if offset == 0:
+                        if priority is None and offset == 0:
                             issues, scan_state = get_prioritized_issues_with_label(
                                 label,
                                 fetch_limit,
@@ -7910,6 +7980,9 @@ def process_issues_with_label(
                                 label,
                                 fetch_limit,
                                 current_offset,
+                                selected_extra_labels,
+                                selected_excluded_labels,
+                                user_requested_only=user_requested_only,
                             )
                             current_offset += len(raw_issues)
                             if not raw_issues:
@@ -7949,6 +8022,7 @@ def process_issues_with_label(
                                 offset,
                                 current_offset,
                                 scan_state,
+                                priority,
                             )
                             next_scan_progress_log_count += ISSUE_SCAN_PROGRESS_LOG_INTERVAL
                         continue
@@ -8046,6 +8120,7 @@ def process_work_queues(
         parallelism_default: int = DEFAULT_PARALLELISM,
         random_offset_override: bool | None = None,
         user_requested_only_override: bool | None = None,
+        priority_override: str | None = None,
 ) -> None:
     """Process all configured issue and review queues in one Python process."""
     queue_configs = get_work_queue_configs_from_environment(work_strategy_name_override, random_offset_override)
@@ -8058,6 +8133,9 @@ def process_work_queues(
     )
     parallelism = get_env_parallelism("FORGE_PARALLELISM", parallelism_default)
     user_requested_only = resolve_user_requested_only(user_requested_only_override)
+    priority_kwargs: dict[str, str] = {}
+    if priority_override is not None:
+        priority_kwargs["priority"] = priority_override
     enabled_issue_queues = [queue_config for queue_config in queue_configs if queue_config.limit > 0]
 
     if is_shutdown_requested():
@@ -8097,6 +8175,7 @@ def process_work_queues(
                 keep_tests_without_dynamic_access,
                 user_requested_only=user_requested_only,
                 environment_already_validated=True,
+                **priority_kwargs,
             )
             continue
 
@@ -8106,6 +8185,7 @@ def process_work_queues(
             issue_scan_offset = resolve_random_issue_scan_offset(
                 queue_config.label,
                 user_requested_only=user_requested_only,
+                **priority_kwargs,
             )
             print()
             log_stage(
@@ -8124,6 +8204,7 @@ def process_work_queues(
             parallelism,
             user_requested_only=user_requested_only,
             environment_already_validated=True,
+            **priority_kwargs,
         )
 
     for review_queue_config in review_queue_configs:
@@ -8234,6 +8315,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Number of issues to skip from the start of the list (default: 0).",
     )
     parser.add_argument(
+        "--priority",
+        choices=PRIORITY_CHOICES,
+        help=(
+            "Process only one issue tier: high, priority, or normal. "
+            "Without this option, all tiers are drained in order."
+        ),
+    )
+    parser.add_argument(
         "--random-offset",
         dest="random_offset",
         action="store_true",
@@ -8286,6 +8375,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             parser.error("--fixture-testing cannot be combined with --random-offset/--no-random-offset")
     if args.random_offset is not None and args.label is None and not args.run_work_queues:
         parser.error("--random-offset/--no-random-offset can only be used with --label or --run-work-queues")
+    if args.priority is not None and args.label is None and not args.run_work_queues:
+        parser.error("--priority can only be used with --label or --run-work-queues")
     if args.random_offset is True and args.offset != 0:
         parser.error("--random-offset cannot be combined with --offset")
     return args
@@ -8417,6 +8508,7 @@ def main() -> None:
                 args.parallelism,
                 random_offset_override=args.random_offset,
                 user_requested_only_override=args.user_requested_only,
+                priority_override=args.priority,
             )
         elif args.review_pr is not None:
             authenticated_user = resolve_authenticated_user()
@@ -8448,6 +8540,7 @@ def main() -> None:
                 args.strategy_name,
                 args.keep_tests_without_dynamic_access,
                 user_requested_only=resolve_user_requested_only(args.user_requested_only),
+                priority=args.priority,
             )
         else:
             authenticated_user = resolve_authenticated_user()
@@ -8456,6 +8549,7 @@ def main() -> None:
             if args.random_offset is True:
                 issue_scan_offset = resolve_random_issue_scan_offset(
                     args.label,
+                    priority=args.priority,
                     user_requested_only=user_requested_only,
                 )
                 print()
@@ -8472,6 +8566,7 @@ def main() -> None:
                 args.parallelism,
                 take_blocked_issues=args.take_blocked_issues,
                 user_requested_only=user_requested_only,
+                priority=args.priority,
             )
         normal_exit = True
     except KeyboardInterrupt:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -763,8 +763,14 @@ def search_issues_with_label(
         limit: int,
         offset: int = 0,
         extra_labels: list[str] | None = None,
+        excluded_labels: list[str] | None = None,
 ) -> list[dict]:
-    """Fetch open issues that carry the given label using GitHub search pagination."""
+    """
+    Fetch open issues that carry the given label using GitHub search pagination.
+
+    `excluded_labels` are excluded on top of the always-excluded
+    `not-for-native-image` label, not instead of it.
+    """
     if limit <= 0:
         return []
     if offset >= GITHUB_SEARCH_MAX_RESULTS:
@@ -774,7 +780,11 @@ def search_issues_with_label(
     per_page = GITHUB_API_MAX_PAGE_SIZE
     page = (offset // per_page) + 1
     page_offset = offset % per_page
-    query = build_issue_search_query(label, extra_labels)
+    query = build_issue_search_query(
+        label,
+        extra_labels,
+        [LABEL_NOT_FOR_NATIVE_IMAGE, *(excluded_labels or [])],
+    )
     items = get_issue_search_page(query, page, per_page)
     return items[page_offset:page_offset + limit]
 
@@ -876,6 +886,7 @@ def get_issues_with_label(
         limit: int,
         offset: int = 0,
         extra_labels: list[str] | None = None,
+        excluded_labels: list[str] | None = None,
         user_requested_only: bool = False,
 ) -> list[dict]:
     """Fetch open issues that carry the given label (and any extra labels)."""
@@ -885,6 +896,7 @@ def get_issues_with_label(
             limit,
             offset,
             extra_labels,
+            excluded_labels,
             excluded_authors=get_user_requested_issue_excluded_authors(user_requested_only),
         )
     return search_issues_with_label(
@@ -892,6 +904,7 @@ def get_issues_with_label(
         limit,
         offset,
         extra_labels,
+        excluded_labels,
     )
 
 
@@ -1735,39 +1748,93 @@ def try_mark_issue_numbers_blocking_many_libraries_as_priority(issue_numbers: li
         )
 
 
+@dataclass(frozen=True)
+class IssuePriorityTier:
+    """One urgency tier of an issue queue, expressed as a GitHub label filter."""
+
+    name: str
+    extra_labels: tuple[str, ...]
+    excluded_labels: tuple[str, ...]
+
+
+# Drained in order; each tier excludes the labels of the tiers above it so that an
+# issue carrying several priority labels is served exactly once, in its highest tier.
+ISSUE_PRIORITY_TIERS: tuple[IssuePriorityTier, ...] = (
+    IssuePriorityTier(LABEL_HIGH_PRIORITY, (LABEL_HIGH_PRIORITY,), ()),
+    IssuePriorityTier(LABEL_PRIORITY, (LABEL_PRIORITY,), (LABEL_HIGH_PRIORITY,)),
+    IssuePriorityTier("regular", (), (LABEL_HIGH_PRIORITY, LABEL_PRIORITY)),
+)
+
+
+@dataclass
+class IssueQueueScanState:
+    """How far a prioritized queue scan has advanced through `ISSUE_PRIORITY_TIERS`."""
+
+    tier_index: int = 0
+    tier_offset: int = 0
+    scanned_count: int = 0
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether every priority tier has been drained."""
+        return self.tier_index >= len(ISSUE_PRIORITY_TIERS)
+
+    @property
+    def current_tier(self) -> IssuePriorityTier:
+        """The tier the scan is currently paging through."""
+        return ISSUE_PRIORITY_TIERS[self.tier_index]
+
+    def advance_within_tier(self, fetched_count: int) -> None:
+        """Record that `fetched_count` issues were fetched from the current tier."""
+        self.tier_offset += fetched_count
+        self.scanned_count += fetched_count
+
+    def advance_to_next_tier(self) -> None:
+        """Move to the next, less urgent tier and restart its pagination."""
+        self.tier_index += 1
+        self.tier_offset = 0
+
+    def describe_position(self) -> str:
+        """Return a concise description of the scan position for progress logs."""
+        if self.exhausted:
+            return "all priority tiers drained"
+        return f"{self.current_tier.name} tier, offset {self.tier_offset}"
+
+
 def get_prioritized_issues_with_label(
         label: str,
         limit: int,
-        priority_offset: int = 0,
-        regular_offset: int = 0,
-        priority_exhausted: bool = False,
+        scan_state: IssueQueueScanState | None = None,
         user_requested_only: bool = False,
-) -> tuple[list[dict], int, int, bool, bool]:
-    """Fetch one issue batch and rank high-priority, priority, then regular issues."""
-    regular_issues = get_issues_with_label(
-        label,
-        limit,
-        regular_offset,
-    )
-    regular_offset += len(regular_issues)
-    filtered_issues = filter_user_requested_issues(regular_issues, user_requested_only)
-    if not is_fixture_testing_enabled():
-        try_mark_issues_blocking_many_libraries_as_priority(filtered_issues)
-    sorted_issues = sorted(
-        filtered_issues,
-        key=issue_priority_rank,
-    )
-    exhausted = len(regular_issues) == 0
-    return sorted_issues, priority_offset, regular_offset, True, exhausted
+) -> tuple[list[dict], IssueQueueScanState]:
+    """
+    Fetch the next issue batch from the most urgent tier that still has issues.
 
-
-def issue_priority_rank(issue: dict) -> int:
-    """Return the queue rank required by §ORCH-forge-orchestration-spec."""
-    if issue_has_label(issue, LABEL_HIGH_PRIORITY):
-        return 0
-    if issue_has_label(issue, LABEL_PRIORITY):
-        return 1
-    return 2
+    Tiers are drained globally rather than ranked inside a batch: every
+    `high-priority` issue is served before any `priority` issue, and every
+    `priority` issue before any unlabeled one (§FS-forge-issue-resolution-goal).
+    An empty result means every tier is exhausted, so callers can stop scanning.
+    """
+    state = scan_state if scan_state is not None else IssueQueueScanState()
+    while not state.exhausted:
+        tier = state.current_tier
+        raw_issues = get_issues_with_label(
+            label,
+            limit,
+            state.tier_offset,
+            list(tier.extra_labels),
+            list(tier.excluded_labels),
+        )
+        if not raw_issues:
+            state.advance_to_next_tier()
+            continue
+        state.advance_within_tier(len(raw_issues))
+        issues = filter_user_requested_issues(raw_issues, user_requested_only)
+        if not is_fixture_testing_enabled():
+            try_mark_issues_blocking_many_libraries_as_priority(issues)
+        if issues:
+            return issues, state
+    return [], state
 
 
 def get_project_item_state(issue_number: int) -> tuple[str | None, str | None]:
@@ -7825,19 +7892,18 @@ def get_issue_scan_batch_size(_remaining_limit: int, _available_slots: int) -> i
 def format_issue_scan_position(
         offset: int,
         current_offset: int,
-        priority_offset: int,
-        regular_offset: int,
+        scan_state: IssueQueueScanState,
 ) -> str:
     """Return a concise description of the current issue scan position."""
     if offset == 0:
-        return f"priority offset {priority_offset}, regular offset {regular_offset}"
+        return scan_state.describe_position()
     return f"offset {current_offset}"
 
 
 def log_issue_scan_start(label: str, offset: int) -> None:
     """Log where an issue scan starts."""
     if offset == 0:
-        position = "from the most recently updated issues with high-priority-first ordering"
+        position = "draining the high-priority, priority, then regular tiers in turn"
     else:
         position = f"from offset {offset}"
     print()
@@ -7849,11 +7915,10 @@ def log_issue_scan_progress(
         scanned_count: int,
         offset: int,
         current_offset: int,
-        priority_offset: int,
-        regular_offset: int,
+        scan_state: IssueQueueScanState,
 ) -> None:
     """Log issue scan progress after another interval of candidates was inspected."""
-    position = format_issue_scan_position(offset, current_offset, priority_offset, regular_offset)
+    position = format_issue_scan_position(offset, current_offset, scan_state)
     print()
     log_stage(
         "issue-scan",
@@ -7956,10 +8021,8 @@ def process_issues_with_label(
     scanned_count = 0
     next_scan_progress_log_count = ISSUE_SCAN_PROGRESS_LOG_INTERVAL
     current_offset = offset
-    priority_offset = 0
-    regular_offset = 0
+    scan_state = IssueQueueScanState()
     exhausted = False
-    priority_exhausted = False
     unresolved_candidates: list[tuple[dict, CachedIssueClaimSkip | None]] = []
     pending_issues: list[tuple[dict, IssueClaimPreflight | None, CachedIssueClaimSkip | None]] = []
     active_futures: dict[concurrent.futures.Future[bool], ClaimedIssue] = {}
@@ -7980,18 +8043,15 @@ def process_issues_with_label(
                     elif not exhausted:
                         fetch_limit = get_issue_scan_batch_size(remaining_limit, available_slots)
                         if offset == 0:
-                            issues, priority_offset, regular_offset, priority_exhausted, exhausted = (
-                                get_prioritized_issues_with_label(
-                                    label,
-                                    fetch_limit,
-                                    priority_offset,
-                                    regular_offset,
-                                    priority_exhausted,
-                                    user_requested_only,
-                                )
+                            issues, scan_state = get_prioritized_issues_with_label(
+                                label,
+                                fetch_limit,
+                                scan_state,
+                                user_requested_only,
                             )
+                            exhausted = scan_state.exhausted
                             if not issues:
-                                if priority_offset == 0 and regular_offset == 0:
+                                if scan_state.scanned_count == 0:
                                     print()
                                     log_stage("issue-scan", f"No open issues found with label '{label}'")
                                 break
@@ -8038,8 +8098,7 @@ def process_issues_with_label(
                                 next_scan_progress_log_count,
                                 offset,
                                 current_offset,
-                                priority_offset,
-                                regular_offset,
+                                scan_state,
                             )
                             next_scan_progress_log_count += ISSUE_SCAN_PROGRESS_LOG_INTERVAL
                         continue

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -795,54 +795,6 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertEqual(set(preflights), set(issue_numbers))
         self.assertLessEqual(forge_metadata.ISSUE_CLAIM_PREFLIGHT_CHUNK_SIZE, 4)
 
-    def test_open_issues_blocked_by_issue_counts_use_blocking_edge(self) -> None:
-        blocking_nodes = [
-            {"number": issue_number, "closed": False}
-            for issue_number in range(1, 11)
-        ]
-        blocking_nodes.append({"number": 99, "closed": True})
-        response = {
-            "data": {
-                "repository": {
-                    "issue_1412": {
-                        "blocking": {
-                            "nodes": blocking_nodes,
-                            "pageInfo": {"hasNextPage": False, "endCursor": None},
-                        },
-                    },
-                },
-            },
-        }
-
-        with patch.object(forge_metadata, "gh_json", return_value=response) as gh_json:
-            counts = forge_metadata.get_open_issues_blocked_by_issue_counts([1412])
-
-        self.assertEqual(counts, {1412: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD})
-        gh_json.assert_called_once()
-        self.assertEqual(gh_json.call_args.kwargs, {"quiet": True})
-        self.assertIn("blocking(first: 100", gh_json.call_args.args[-1])
-        self.assertNotIn("blockedBy(first:", gh_json.call_args.args[-1])
-
-    def test_mark_issues_blocking_many_libraries_adds_priority_label_to_payload(self) -> None:
-        priority_issue = _search_issue(1412)
-        regular_issue = _search_issue(1413)
-
-        with patch.object(
-                forge_metadata,
-                "get_open_issues_blocked_by_issue_counts",
-                return_value={1412: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD, 1413: 9},
-        ), \
-                patch.object(forge_metadata, "add_issue_label") as add_issue_label, \
-                patch("sys.stdout", new_callable=io.StringIO):
-            forge_metadata.mark_issues_blocking_many_libraries_as_priority([
-                priority_issue,
-                regular_issue,
-            ])
-
-        add_issue_label.assert_called_once_with(1412, forge_metadata.LABEL_PRIORITY)
-        self.assertTrue(forge_metadata.issue_has_label(priority_issue, forge_metadata.LABEL_PRIORITY))
-        self.assertFalse(forge_metadata.issue_has_label(regular_issue, forge_metadata.LABEL_PRIORITY))
-
     def test_prioritized_issue_fetch_drains_each_tier_before_the_next(self) -> None:
         tier_issues = {
             (forge_metadata.LABEL_HIGH_PRIORITY,): [
@@ -869,8 +821,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
                 forge_metadata,
                 "get_issues_with_label",
                 side_effect=fake_get_issues,
-        ) as get_issues, \
-                patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
+        ) as get_issues:
             for _ in range(4):
                 issues, scan_state = forge_metadata.get_prioritized_issues_with_label(
                     forge_metadata.LABEL_LIBRARY_NEW,
@@ -1212,8 +1163,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
             {"number": 2, "author": {"login": "external-user"}, "labels": []},
         ]
 
-        with patch.object(forge_metadata, "get_issues_with_label", return_value=issues) as get_issues, \
-                patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
+        with patch.object(forge_metadata, "get_issues_with_label", return_value=issues) as get_issues:
             filtered, scan_state = forge_metadata.get_prioritized_issues_with_label(
                 forge_metadata.LABEL_LIBRARY_NEW,
                 25,
@@ -1237,8 +1187,7 @@ class IssueClaimPreflightTests(unittest.TestCase):
             [{"number": 2, "author": {"login": "external-user"}, "labels": []}],
         ]
 
-        with patch.object(forge_metadata, "get_issues_with_label", side_effect=batches) as get_issues, \
-                patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
+        with patch.object(forge_metadata, "get_issues_with_label", side_effect=batches) as get_issues:
             filtered, scan_state = forge_metadata.get_prioritized_issues_with_label(
                 forge_metadata.LABEL_LIBRARY_NEW,
                 25,
@@ -2386,7 +2335,7 @@ class IssueClaimLockTests(unittest.TestCase):
                 finally:
                     claim_lock.release()
 
-    def test_try_claim_issue_marks_open_blockers_that_block_many_libraries(self) -> None:
+    def test_try_claim_issue_does_not_prioritize_open_blockers(self) -> None:
         issue = {
             "number": 1412,
             "title": "Add support for org.example:lib:1.0.0",
@@ -2397,10 +2346,7 @@ class IssueClaimLockTests(unittest.TestCase):
             with patch.object(forge_metadata, "get_issue_claim_locks_root", return_value=lock_root), \
                     patch.object(forge_metadata, "refresh_issue_payload_for_claim", return_value=True), \
                     patch.object(forge_metadata, "get_open_blocking_issue_numbers", return_value=[1392]), \
-                    patch.object(
-                        forge_metadata,
-                        "try_mark_issue_numbers_blocking_many_libraries_as_priority",
-                    ) as mark_priority, \
+                    patch.object(forge_metadata, "add_issue_label") as add_issue_label, \
                     patch.object(forge_metadata, "get_issue_assignees") as get_issue_assignees:
                 self.assertIsNone(
                     forge_metadata.try_claim_issue(
@@ -2410,7 +2356,7 @@ class IssueClaimLockTests(unittest.TestCase):
                     )
                 )
 
-        mark_priority.assert_called_once_with([1392])
+        add_issue_label.assert_not_called()
         get_issue_assignees.assert_not_called()
 
     def test_try_claim_issue_refreshes_paused_issue_before_claim_checks(self) -> None:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -85,6 +85,15 @@ def _search_issue(
     }
 
 
+def _scan_state(scanned_count: int = 0, exhausted: bool = False) -> forge_metadata.IssueQueueScanState:
+    """Build the scan state a `get_prioritized_issues_with_label` stub would return."""
+    return forge_metadata.IssueQueueScanState(
+        tier_index=len(forge_metadata.ISSUE_PRIORITY_TIERS) if exhausted else 0,
+        tier_offset=0 if exhausted else scanned_count,
+        scanned_count=scanned_count,
+    )
+
+
 def _pull_request(
         number: int,
         label_names: list[str] | None = None,
@@ -834,39 +843,74 @@ class IssueClaimPreflightTests(unittest.TestCase):
         self.assertTrue(forge_metadata.issue_has_label(priority_issue, forge_metadata.LABEL_PRIORITY))
         self.assertFalse(forge_metadata.issue_has_label(regular_issue, forge_metadata.LABEL_PRIORITY))
 
-    def test_prioritized_issue_fetch_orders_high_priority_before_priority_and_regular(self) -> None:
-        regular_issue = _search_issue(1412)
-        priority_issue = _search_issue(1413)
-        high_priority_issue = _search_issue(1414, [forge_metadata.LABEL_HIGH_PRIORITY])
+    def test_prioritized_issue_fetch_drains_each_tier_before_the_next(self) -> None:
+        tier_issues = {
+            (forge_metadata.LABEL_HIGH_PRIORITY,): [
+                _search_issue(1414, [forge_metadata.LABEL_HIGH_PRIORITY]),
+            ],
+            (forge_metadata.LABEL_PRIORITY,): [
+                _search_issue(1413, [forge_metadata.LABEL_PRIORITY]),
+            ],
+            (): [_search_issue(1412)],
+        }
 
+        def fake_get_issues(
+                _label: str,
+                _limit: int,
+                offset: int = 0,
+                extra_labels: list[str] | None = None,
+                _excluded_labels: list[str] | None = None,
+        ) -> list[dict]:
+            return [] if offset else tier_issues[tuple(extra_labels or ())]
+
+        fetched: list[list[int]] = []
+        scan_state = None
         with patch.object(
                 forge_metadata,
                 "get_issues_with_label",
-                return_value=[regular_issue, priority_issue, high_priority_issue],
-        ), \
-                patch.object(
-                    forge_metadata,
-                "get_open_issues_blocked_by_issue_counts",
-                return_value={
-                    1412: 0,
-                    1413: forge_metadata.PRIORITY_BLOCKING_LIBRARY_THRESHOLD,
-                    1414: 0,
-                },
-                ), \
-                patch.object(forge_metadata, "add_issue_label"), \
-                patch("sys.stdout", new_callable=io.StringIO):
-            issues, priority_offset, regular_offset, priority_exhausted, exhausted = (
-                forge_metadata.get_prioritized_issues_with_label(
+                side_effect=fake_get_issues,
+        ) as get_issues, \
+                patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
+            for _ in range(4):
+                issues, scan_state = forge_metadata.get_prioritized_issues_with_label(
                     forge_metadata.LABEL_LIBRARY_NEW,
-                    3,
+                    25,
+                    scan_state,
                 )
+                fetched.append([issue["number"] for issue in issues])
+
+        self.assertEqual(fetched, [[1414], [1413], [1412], []])
+        self.assertTrue(scan_state.exhausted)
+        self.assertEqual(
+            [(call.args[2], call.args[3], call.args[4]) for call in get_issues.call_args_list],
+            [
+                (0, [forge_metadata.LABEL_HIGH_PRIORITY], []),
+                (1, [forge_metadata.LABEL_HIGH_PRIORITY], []),
+                (0, [forge_metadata.LABEL_PRIORITY], [forge_metadata.LABEL_HIGH_PRIORITY]),
+                (1, [forge_metadata.LABEL_PRIORITY], [forge_metadata.LABEL_HIGH_PRIORITY]),
+                (0, [], [forge_metadata.LABEL_HIGH_PRIORITY, forge_metadata.LABEL_PRIORITY]),
+                (1, [], [forge_metadata.LABEL_HIGH_PRIORITY, forge_metadata.LABEL_PRIORITY]),
+            ],
+        )
+
+    def test_tier_search_query_keeps_the_not_for_native_image_exclusion(self) -> None:
+        with patch.dict(os.environ, {"FORGE_ISSUE_SEARCH_CACHE": "0"}), \
+                patch.object(forge_metadata, "gh_json", return_value={"items": []}) as gh_json:
+            forge_metadata.search_issues_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                25,
+                excluded_labels=[forge_metadata.LABEL_HIGH_PRIORITY],
             )
 
-        self.assertEqual([issue["number"] for issue in issues], [1414, 1413, 1412])
-        self.assertEqual(priority_offset, 0)
-        self.assertEqual(regular_offset, 3)
-        self.assertTrue(priority_exhausted)
-        self.assertFalse(exhausted)
+        self.assertEqual(
+            gh_json.call_args.args[5],
+            (
+                f"q=repo:{forge_metadata.REPO} is:issue is:open "
+                f'label:"{forge_metadata.LABEL_LIBRARY_NEW}" '
+                f'-label:"{forge_metadata.LABEL_NOT_FOR_NATIVE_IMAGE}" '
+                f'-label:"{forge_metadata.LABEL_HIGH_PRIORITY}"'
+            ),
+        )
 
     def test_refresh_issue_payload_for_claim_skips_closed_issue(self) -> None:
         issue = _search_issue(1412, [forge_metadata.LABEL_LIBRARY_NEW])
@@ -1170,18 +1214,41 @@ class IssueClaimPreflightTests(unittest.TestCase):
 
         with patch.object(forge_metadata, "get_issues_with_label", return_value=issues) as get_issues, \
                 patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
-            filtered, _priority_offset, regular_offset, _priority_exhausted, exhausted = (
-                forge_metadata.get_prioritized_issues_with_label(
-                    forge_metadata.LABEL_LIBRARY_NEW,
-                    25,
-                    user_requested_only=True,
-                )
+            filtered, scan_state = forge_metadata.get_prioritized_issues_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                25,
+                user_requested_only=True,
             )
 
-        get_issues.assert_called_once_with(forge_metadata.LABEL_LIBRARY_NEW, 25, 0)
+        get_issues.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            25,
+            0,
+            [forge_metadata.LABEL_HIGH_PRIORITY],
+            [],
+        )
         self.assertEqual([issue["number"] for issue in filtered], [2])
-        self.assertEqual(regular_offset, 2)
-        self.assertFalse(exhausted)
+        self.assertEqual(scan_state.tier_offset, 2)
+        self.assertFalse(scan_state.exhausted)
+
+    def test_prioritized_issue_fetch_keeps_scanning_past_a_fully_filtered_batch(self) -> None:
+        batches = [
+            [{"number": 1, "author": {"login": "graalvmbot"}, "labels": []}],
+            [{"number": 2, "author": {"login": "external-user"}, "labels": []}],
+        ]
+
+        with patch.object(forge_metadata, "get_issues_with_label", side_effect=batches) as get_issues, \
+                patch.object(forge_metadata, "try_mark_issues_blocking_many_libraries_as_priority"):
+            filtered, scan_state = forge_metadata.get_prioritized_issues_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                25,
+                user_requested_only=True,
+            )
+
+        self.assertEqual([issue["number"] for issue in filtered], [2])
+        self.assertEqual(get_issues.call_count, 2)
+        self.assertEqual(scan_state.scanned_count, 2)
+        self.assertFalse(scan_state.exhausted)
 
     def test_random_issue_scan_offset_uses_open_issue_count(self) -> None:
         with patch.object(forge_metadata, "count_issues_with_label", return_value=500), \
@@ -1282,8 +1349,8 @@ class IssueClaimPreflightTests(unittest.TestCase):
                         forge_metadata,
                         "get_prioritized_issues_with_label",
                         side_effect=[
-                            ([skipped_issue], 0, 1, True, False),
-                            ([claimable_issue], 0, 2, True, False),
+                            ([skipped_issue], _scan_state(1)),
+                            ([claimable_issue], _scan_state(2)),
                         ],
                     ) as get_prioritized_issues_with_label, \
                     patch.object(
@@ -1323,17 +1390,13 @@ class IssueClaimPreflightTests(unittest.TestCase):
                 call(
                     forge_metadata.LABEL_LIBRARY_NEW,
                     forge_metadata.DEFAULT_ISSUE_SCAN_BATCH_SIZE,
-                    0,
-                    0,
-                    False,
+                    forge_metadata.IssueQueueScanState(),
                     False,
                 ),
                 call(
                     forge_metadata.LABEL_LIBRARY_NEW,
                     forge_metadata.DEFAULT_ISSUE_SCAN_BATCH_SIZE,
-                    0,
-                    1,
-                    True,
+                    _scan_state(1),
                     False,
                 ),
             ],
@@ -2054,7 +2117,7 @@ class IssueClaimCacheTests(unittest.TestCase):
                         patch.object(
                             forge_metadata,
                             "get_prioritized_issues_with_label",
-                            return_value=([cached_issue, claimable_issue], 0, 2, True, True),
+                            return_value=([cached_issue, claimable_issue], _scan_state(2, exhausted=True)),
                         ), \
                         patch.object(
                             forge_metadata,
@@ -2112,8 +2175,8 @@ class IssueClaimCacheTests(unittest.TestCase):
                         forge_metadata,
                         "get_prioritized_issues_with_label",
                         side_effect=[
-                            ([issue], 0, 1, True, False),
-                            ([], 0, 1, True, True),
+                            ([issue], _scan_state(1)),
+                            ([], _scan_state(1, exhausted=True)),
                         ],
                     ), \
                     patch.object(
@@ -2162,7 +2225,7 @@ class IssueClaimCacheTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_prioritized_issues_with_label",
-                        return_value=(issues, 0, len(issues), True, True),
+                        return_value=(issues, _scan_state(len(issues), exhausted=True)),
                     ), \
                     patch.object(
                         forge_metadata,
@@ -2225,7 +2288,7 @@ class IssueClaimCacheTests(unittest.TestCase):
                     patch.object(
                         forge_metadata,
                         "get_prioritized_issues_with_label",
-                        return_value=(issues, 0, len(issues), True, True),
+                        return_value=(issues, _scan_state(len(issues), exhausted=True)),
                     ), \
                     patch.object(
                         forge_metadata,

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -1222,6 +1222,22 @@ class IssueClaimPreflightTests(unittest.TestCase):
             user_requested_only=True,
         )
 
+    def test_random_issue_scan_offset_counts_only_selected_priority_tier(self) -> None:
+        with patch.object(forge_metadata, "count_issues_with_label", return_value=50) as count_issues, \
+                patch.object(forge_metadata.random, "randrange", return_value=12):
+            offset = forge_metadata.resolve_random_issue_scan_offset(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                priority=forge_metadata.PRIORITY_NORMAL,
+            )
+
+        self.assertEqual(offset, 12)
+        count_issues.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            [],
+            False,
+            [forge_metadata.LABEL_HIGH_PRIORITY, forge_metadata.LABEL_PRIORITY],
+        )
+
     def test_fixture_issue_listing_can_exclude_non_user_authors(self) -> None:
         state = FixtureGitHubState([
             FixtureIssue(
@@ -1649,6 +1665,24 @@ class WorkQueueSchedulerTests(unittest.TestCase):
 
         self.assertTrue(random_args.random_offset)
         self.assertFalse(no_random_args.random_offset)
+
+    def test_issue_queue_modes_accept_priority_tiers(self) -> None:
+        for priority in forge_metadata.PRIORITY_CHOICES:
+            with self.subTest(priority=priority):
+                work_queue_args = forge_metadata.parse_args([
+                    "--run-work-queues",
+                    "--priority",
+                    priority,
+                ])
+                label_args = forge_metadata.parse_args([
+                    "--label",
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    "--priority",
+                    priority,
+                ])
+
+                self.assertEqual(work_queue_args.priority, priority)
+                self.assertEqual(label_args.priority, priority)
 
     def test_issue_queue_modes_accept_user_requested_only_flag(self) -> None:
         work_queue_args = forge_metadata.parse_args(["--run-work-queues", "--user-requested-only"])
@@ -2265,6 +2299,57 @@ class IssueClaimCacheTests(unittest.TestCase):
         self.assertIn("Looked through 100 issue(s) for label 'library-new-request'", output)
         self.assertIn("Looked through 200 issue(s) for label 'library-new-request'", output)
         self.assertNotIn("Looked through 300 issue(s)", output)
+
+    def test_process_loop_fetches_only_selected_priority_tier(self) -> None:
+        priority = forge_metadata.PRIORITY_NORMAL
+        tier = forge_metadata.get_issue_priority_tier(priority)
+        with patch.object(forge_metadata, "validate_issue_processing_environment"), \
+                patch.object(forge_metadata, "get_prioritized_issues_with_label") as prioritized_fetch, \
+                patch.object(forge_metadata, "get_issues_with_label", return_value=[]) as get_issues, \
+                patch("sys.stdout", new_callable=io.StringIO):
+            processed = forge_metadata.process_issues_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                1,
+                0,
+                "/tmp/reachability",
+                "/tmp/metrics",
+                None,
+                False,
+                "automation-user",
+                1,
+                priority=priority,
+            )
+
+        self.assertEqual(processed, 0)
+        get_issues.assert_called_once_with(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            forge_metadata.DEFAULT_ISSUE_SCAN_BATCH_SIZE,
+            0,
+            list(tier.extra_labels),
+            list(tier.excluded_labels),
+            user_requested_only=False,
+        )
+        prioritized_fetch.assert_not_called()
+
+    def test_priority_choices_map_to_exclusive_label_filters(self) -> None:
+        expected_filters = {
+            forge_metadata.PRIORITY_HIGH: (
+                (forge_metadata.LABEL_HIGH_PRIORITY,),
+                (),
+            ),
+            forge_metadata.LABEL_PRIORITY: (
+                (forge_metadata.LABEL_PRIORITY,),
+                (forge_metadata.LABEL_HIGH_PRIORITY,),
+            ),
+            forge_metadata.PRIORITY_NORMAL: (
+                (),
+                (forge_metadata.LABEL_HIGH_PRIORITY, forge_metadata.LABEL_PRIORITY),
+            ),
+        }
+        for priority, filters in expected_filters.items():
+            with self.subTest(priority=priority):
+                tier = forge_metadata.get_issue_priority_tier(priority)
+                self.assertEqual((tier.extra_labels, tier.excluded_labels), filters)
 
 
 class ProjectItemStatusTests(unittest.TestCase):


### PR DESCRIPTION
Closes #9294

## What this does

Priority was only a tie-breaker inside one fetched batch: `get_prioritized_issues_with_label` pulled 25 issues with a flat label query and sorted those 25. A `high-priority` issue at position 40 of a queue waited behind 39 ordinary ones, and — because the flat query is capped at GitHub Search's first `GITHUB_SEARCH_MAX_RESULTS` matches — one past position 1000 was unreachable no matter its label. This makes the scan drain the queue tier by tier instead, which is the ordering [§FS-forge-issue-resolution-goal](forge/docs/functional-spec.md) already promised and [§ORCH-forge-orchestration-spec](forge/docs/orchestration-scripts.md) now describes.

## How a queue is drained

Three searches, consumed in order, each excluding the labels of the tiers above it so an issue carrying both labels is served exactly once, in its highest tier:

| Tier | Query |
|---|---|
| `high-priority` | `label:"high-priority"` |
| `priority` | `label:"priority" -label:"high-priority"` |
| regular | `-label:"high-priority" -label:"priority"` |

A tier is left only once its search returns nothing, so its result window is now capped independently rather than sharing one flat window. `IssueQueueScanState` carries the tier index and the offset within it; an empty return means every tier is drained, so the scan loop stops on that signal alone.

With 13 `high-priority` and 32 `priority` issues, a scan walks 13 → 25 → 7 → regular in batches of 25. Because pagination fetches 100 at a time and slices locally, that is one API call per tier under 100 issues — the tier-boundary probes re-slice a page the search cache already holds.

Scans started from a random offset, which spread concurrent runners across a queue, keep paging the flat unfiltered query.
