### PR TITLE
Add reachability metadata for Flyway Oracle module

### DIFF
--- a/metadata/org.flywaydb/flyway-database-oracle/11.14.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-database-oracle/11.14.1/reachability-metadata.json
@@ -8,6 +8,26 @@
       "type": "org.flywaydb.database.oracle.OracleConfigurationExtension",
       "allDeclaredConstructors": true,
       "allPublicMethods": true
+    },
+    {
+      "condition": {
+        "typeReached": "org.flywaydb.core.internal.util.MergeUtils"
+      },
+      "type": "org.flywaydb.database.oracle.OracleConfigurationExtension",
+      "fields": [
+        {
+          "name": "sqlplus"
+        },
+        {
+          "name": "sqlplusWarn"
+        },
+        {
+          "name": "kerberosCacheFile"
+        },
+        {
+          "name": "walletLocation"
+        }
+      ]
     }
   ]
 }

--- a/metadata/org.flywaydb/flyway-database-oracle/11.14.1/reachability-metadata.json
+++ b/metadata/org.flywaydb/flyway-database-oracle/11.14.1/reachability-metadata.json
@@ -1,0 +1,13 @@
+{
+  "reflection": [
+    {
+      "type": "org.flywaydb.database.oracle.OracleDatabaseType",
+      "allDeclaredConstructors": true
+    },
+    {
+      "type": "org.flywaydb.database.oracle.OracleConfigurationExtension",
+      "allDeclaredConstructors": true,
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/metadata/org.flywaydb/flyway-database-oracle/index.json
+++ b/metadata/org.flywaydb/flyway-database-oracle/index.json
@@ -1,0 +1,17 @@
+[
+  {
+    "latest" : true,
+    "metadata-version" : "11.14.1",
+    "source-code-url" : "https://repo1.maven.org/maven2/org/flywaydb/flyway-database-oracle/$version$/flyway-database-oracle-$version$-sources.jar",
+    "repository-url" : "https://github.com/flyway/flyway",
+    "test-code-url" : "N/A",
+    "documentation-url" : "https://github.com/flyway/flyway/tree/flyway-$version$/documentation",
+    "description" : "This Flyway module adds Oracle Database support by providing Oracle-specific database type detection, configuration, and JDBC integration.",
+    "tested-versions" : [
+      "11.14.1"
+    ],
+    "allowed-packages" : [
+      "org.flywaydb"
+    ]
+  }
+]

--- a/stats/org.flywaydb/flyway-database-oracle/11.14.1/stats.json
+++ b/stats/org.flywaydb/flyway-database-oracle/11.14.1/stats.json
@@ -1,0 +1,37 @@
+{
+  "versions" : [ {
+    "version" : "11.14.1",
+    "dynamicAccess" : {
+      "breakdown" : {
+        "reflection" : {
+          "coverageRatio" : 0.0,
+          "coveredCalls" : 0,
+          "totalCalls" : 3
+        }
+      },
+      "coverageRatio" : 0.0,
+      "coveredCalls" : 0,
+      "totalCalls" : 3
+    },
+    "libraryCoverage" : {
+      "instruction" : {
+        "covered" : 25,
+        "missed" : 3865,
+        "ratio" : 0.006427,
+        "total" : 3890
+      },
+      "line" : {
+        "covered" : 6,
+        "missed" : 578,
+        "ratio" : 0.010274,
+        "total" : 584
+      },
+      "method" : {
+        "covered" : 5,
+        "missed" : 168,
+        "ratio" : 0.028902,
+        "total" : 173
+      }
+    }
+  } ]
+}

--- a/stats/org.flywaydb/flyway-database-oracle/11.14.1/stats.json
+++ b/stats/org.flywaydb/flyway-database-oracle/11.14.1/stats.json
@@ -15,21 +15,21 @@
     },
     "libraryCoverage" : {
       "instruction" : {
-        "covered" : 25,
-        "missed" : 3865,
-        "ratio" : 0.006427,
+        "covered" : 36,
+        "missed" : 3854,
+        "ratio" : 0.009254,
         "total" : 3890
       },
       "line" : {
-        "covered" : 6,
-        "missed" : 578,
-        "ratio" : 0.010274,
+        "covered" : 8,
+        "missed" : 576,
+        "ratio" : 0.013699,
         "total" : 584
       },
       "method" : {
-        "covered" : 5,
-        "missed" : 168,
-        "ratio" : 0.028902,
+        "covered" : 6,
+        "missed" : 167,
+        "ratio" : 0.034682,
         "total" : 173
       }
     }

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/.gitignore
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/.gitignore
@@ -1,0 +1,4 @@
+gradlew.bat
+gradlew
+gradle/
+build/

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/build.gradle
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/build.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+plugins {
+    id "org.graalvm.internal.tck"
+}
+
+// The coordinate test exercises shipped metadata through consumer-facing APIs.
+// §FS-repository-functional-spec.5.2
+String libraryVersion = tck.testedLibraryVersion.get()
+
+dependencies {
+    testImplementation "org.flywaydb:flyway-database-oracle:$libraryVersion"
+    testImplementation "org.assertj:assertj-core:3.22.0"
+}
+
+graalvmNative {
+    agent {
+        defaultMode = "conditional"
+        modes {
+            conditional {
+                userCodeFilterPath = "user-code-filter.json"
+            }
+        }
+    }
+}

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/gradle.properties
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/gradle.properties
@@ -1,0 +1,6 @@
+# Optional explicit tested library coordinates (format: group:artifact:version).
+# If omitted, fallback resolution in org.graalvm.internal.tck.gradle still uses
+# environment variable GVM_TCK_LC and then this property.
+library.coordinates = org.flywaydb:flyway-database-oracle:11.14.1
+library.version = 11.14.1
+metadata.dir = org.flywaydb/flyway-database-oracle/11.14.1/

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/settings.gradle
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+pluginManagement {
+    def tckPath = Objects.requireNonNullElse(
+            System.getenv("GVM_TCK_TCKDIR"),
+            "../../../../tck-build-logic"
+    )
+    includeBuild(tckPath)
+    repositories { mavenLocal(); gradlePluginPortal() }
+}
+
+plugins {
+    id "org.graalvm.internal.tck-settings" version "1.0.0-SNAPSHOT"
+}
+
+rootProject.name = 'org.flywaydb.flyway-database-oracle_tests'

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/src/test/java/flyway/database/oracle/FlywayDatabaseOracleTests.java
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/src/test/java/flyway/database/oracle/FlywayDatabaseOracleTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package flyway.database.oracle;
+
+import java.util.Map;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.flywaydb.core.internal.database.DatabaseType;
+import org.flywaydb.database.oracle.OracleConfigurationExtension;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Exercises Flyway Oracle plugin discovery and configuration through consumer-facing APIs.
+public class FlywayDatabaseOracleTests {
+
+    @Test
+    void discoversAndConfiguresOraclePlugins() {
+        FluentConfiguration configuration = Flyway.configure()
+                .configuration(Map.of(
+                        "flyway.oracle.sqlplus", "true",
+                        "flyway.oracle.sqlplusWarn", "true"));
+
+        DatabaseType databaseType = configuration.getPluginRegister()
+                .getInstancesOf(DatabaseType.class)
+                .stream()
+                .filter(type -> type.getName().equals("Oracle"))
+                .findFirst()
+                .orElseThrow();
+        OracleConfigurationExtension extension = configuration
+                .getConfigurationExtension(OracleConfigurationExtension.class);
+
+        assertThat(databaseType.handlesJDBCUrl("jdbc:oracle:thin:@localhost:1521/FREEPDB1"))
+                .isTrue();
+        assertThat(extension.getSqlplus()).isTrue();
+        assertThat(extension.getSqlplusWarn()).isTrue();
+    }
+}

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/src/test/java/flyway/database/oracle/FlywayDatabaseOracleTests.java
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/src/test/java/flyway/database/oracle/FlywayDatabaseOracleTests.java
@@ -19,25 +19,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// Exercises Flyway Oracle plugin discovery and configuration through consumer-facing APIs.
 public class FlywayDatabaseOracleTests {
 
+    private static final String ORACLE_JDBC_URL = "jdbc:oracle:thin:@localhost:1521/FREEPDB1";
+
     @Test
-    void discoversAndConfiguresOraclePlugins() {
+    void discoversOracleDatabaseType() {
+        FluentConfiguration configuration = Flyway.configure();
+        DatabaseType databaseType = getOracleDatabaseType(configuration);
+
+        assertThat(databaseType.handlesJDBCUrl(ORACLE_JDBC_URL)).isTrue();
+        assertThat(databaseType.handlesJDBCUrl("jdbc:postgresql://localhost/test")).isFalse();
+        assertThat(databaseType.getDriverClass(
+                        ORACLE_JDBC_URL, FlywayDatabaseOracleTests.class.getClassLoader()))
+                .isEqualTo("oracle.jdbc.OracleDriver");
+    }
+
+    @Test
+    void bindsAllOracleConfigurationFields() {
         FluentConfiguration configuration = Flyway.configure()
                 .configuration(Map.of(
                         "flyway.oracle.sqlplus", "true",
-                        "flyway.oracle.sqlplusWarn", "true"));
+                        "flyway.oracle.sqlplusWarn", "true",
+                        "flyway.oracle.kerberosCacheFile", "flyway-kerberos-cache",
+                        "flyway.oracle.walletLocation", "flyway-wallet"));
 
-        DatabaseType databaseType = configuration.getPluginRegister()
+        OracleConfigurationExtension extension = configuration
+                .getConfigurationExtension(OracleConfigurationExtension.class);
+
+        assertThat(extension.getSqlplus()).isTrue();
+        assertThat(extension.getSqlplusWarn()).isTrue();
+        assertThat(extension.getKerberosCacheFile()).isEqualTo("flyway-kerberos-cache");
+        assertThat(extension.getWalletLocation()).isEqualTo("flyway-wallet");
+    }
+
+    private static DatabaseType getOracleDatabaseType(FluentConfiguration configuration) {
+        return configuration.getPluginRegister()
                 .getInstancesOf(DatabaseType.class)
                 .stream()
                 .filter(type -> type.getName().equals("Oracle"))
                 .findFirst()
                 .orElseThrow();
-        OracleConfigurationExtension extension = configuration
-                .getConfigurationExtension(OracleConfigurationExtension.class);
-
-        assertThat(databaseType.handlesJDBCUrl("jdbc:oracle:thin:@localhost:1521/FREEPDB1"))
-                .isTrue();
-        assertThat(extension.getSqlplus()).isTrue();
-        assertThat(extension.getSqlplusWarn()).isTrue();
     }
 }

--- a/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/user-code-filter.json
+++ b/tests/src/org.flywaydb/flyway-database-oracle/11.14.1/user-code-filter.json
@@ -1,0 +1,13 @@
+{
+  "rules" : [
+    {
+      "excludeClasses" : "**"
+    },
+    {
+      "includeClasses" : "org.flywaydb.**"
+    },
+    {
+      "includeClasses" : "flyway.database.oracle.**"
+    }
+  ]
+}


### PR DESCRIPTION
The Flyway Oracle database module currently requires application-provided native-image reflection configuration for its database type and configuration extension.

This adds the missing metadata under the Flyway Oracle module for:
- org.flywaydb.database.oracle.OracleDatabaseType
- org.flywaydb.database.oracle.OracleConfigurationExtension

The existing Flyway core metadata already covers the core baseline and SLF4J logging classes, so those entries are intentionally not duplicated here.