### PR TITLE
Generate stats for alias split successors

### DIFF
--- a/forge/docs/functional-spec.md
+++ b/forge/docs/functional-spec.md
@@ -384,7 +384,9 @@ version — using that entry's `metadata-version` and `test-version` when presen
 into `metadata/<group>/<artifact>/<failing-version>` and
 `tests/src/<group>/<artifact>/<failing-version>`. The PR then ships the new
 generated progress for the passing prefix and keeps baseline support for the
-successor range.
+successor range. Forge regenerates library stats for the failing version after
+creating the successor entry and publishes them under
+`stats/<group>/<artifact>/<failing-version>`.
 
 **Follow-up issue.** On every split, Forge also opens a `library-update-request`
 issue for the successor metadata version and holds it in `In Progress` so the

--- a/forge/tests/test_library_update_alias_split.py
+++ b/forge/tests/test_library_update_alias_split.py
@@ -1,0 +1,89 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from utility_scripts.library_update_alias_split import _apply_alias_split
+
+
+class LibraryUpdateAliasSplitTests(unittest.TestCase):
+    def test_apply_alias_split_generates_successor_stats_after_index_update(self) -> None:
+        group = "org.example"
+        artifact = "demo"
+        failed_version = "2.0"
+        successor_coordinates = f"{group}:{artifact}:{failed_version}"
+        entries: list[dict[str, Any]] = [
+            {
+                "metadata-version": "1.0",
+                "tested-versions": ["1.0", failed_version],
+                "latest": True,
+            },
+        ]
+        original_entry: dict[str, Any] = {
+            "metadata-version": "1.0",
+            "tested-versions": ["1.0", failed_version],
+            "latest": True,
+        }
+        gradle_environment = {"JAVA_HOME": "/graalvm"}
+        operations: list[str] = []
+
+        def record_index_write(*args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+            operations.append("index")
+
+        def record_stats_generation(*args: Any, **kwargs: Any) -> MagicMock:
+            del args, kwargs
+            operations.append("stats")
+            return MagicMock(returncode=0)
+
+        with (
+            patch("utility_scripts.library_update_alias_split._copy_tree_from_commit"),
+            patch(
+                "utility_scripts.library_update_alias_split.load_index_entries",
+                return_value=entries,
+            ),
+            patch(
+                "utility_scripts.library_update_alias_split._write_index_entries",
+                side_effect=record_index_write,
+            ),
+            patch(
+                "utility_scripts.library_update_alias_split.gradle_command_environment",
+                return_value=gradle_environment,
+            ),
+            patch(
+                "utility_scripts.library_update_alias_split.subprocess.run",
+                side_effect=record_stats_generation,
+            ) as run_command,
+        ):
+            _apply_alias_split(
+                repo_path="/repo",
+                base_ref="base-ref",
+                group=group,
+                artifact=artifact,
+                requested_coordinates=f"{group}:{artifact}:1.0",
+                target_metadata_version="1.0",
+                original_entry=original_entry,
+                tested_versions=["1.0", failed_version],
+                failed_index=1,
+                sweep={"commands": []},
+            )
+
+        self.assertEqual(["index", "stats"], operations)
+        run_command.assert_called_once_with(
+            [
+                "./gradlew",
+                "generateLibraryStats",
+                f"-Pcoordinates={successor_coordinates}",
+            ],
+            cwd="/repo",
+            env=gradle_environment,
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/library_update_alias_split.py
+++ b/forge/utility_scripts/library_update_alias_split.py
@@ -163,6 +163,7 @@ def maybe_split_library_update_tested_versions(
             os.path.join("metadata", group, artifact, "index.json"),
             os.path.join("metadata", group, artifact, split["successor_metadata_version"]),
             os.path.join("tests", "src", group, artifact, split["successor_metadata_version"]),
+            os.path.join("stats", group, artifact, split["successor_metadata_version"]),
         ],
         f"Split tested-version aliases for {coordinates}",
         cwd=repo_path,
@@ -401,6 +402,21 @@ def _apply_alias_split(
 
     entries.insert(target_index, successor_entry)
     _write_index_entries(repo_path, group, artifact, entries)
+    successor_coordinates = f"{group}:{artifact}:{failed_version}"
+    log_stage(
+        "generate-library-stats",
+        f"Running generateLibraryStats for split successor {successor_coordinates}",
+    )
+    subprocess.run(
+        [
+            "./gradlew",
+            "generateLibraryStats",
+            f"-Pcoordinates={successor_coordinates}",
+        ],
+        cwd=repo_path,
+        env=gradle_command_environment(repo_path),
+        check=True,
+    )
 
     return {
         "requested_coordinates": requested_coordinates,


### PR DESCRIPTION
Closes #9309

## What this does

Coverage-improvement alias splits create a new successor metadata version after normal library finalization has already generated stats. The successor therefore reached CI without the matching `stats/<group>/<artifact>/<version>/stats.json`.

Keep the fix at the split boundary required by [§FS-library-update-tested-version-split](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/functional-spec.md#fs-library-update-tested-version-split-library-update-tested-version-split): after writing the successor index entry, run

```console
./gradlew generateLibraryStats -Pcoordinates=<group>:<artifact>:<failing-version>
```

and stage the generated successor stats directory with the copied metadata and tests.

The command intentionally runs after the index update because library stats resolve their metadata-version bucket through that index. A focused mock test fixes that ordering and verifies the exact successor coordinate passed to Gradle.