### PR TITLE
Verify native tests after basic iterative runs

### DIFF
--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -9,16 +9,11 @@ import subprocess
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.metadata_index import resolve_test_version
-from utility_scripts.native_test_verification import (
-    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
-    global_output_dir,
-    verify_native_test_passes,
-)
+from utility_scripts.native_test_verification import global_output_dir
 from utility_scripts.stage_logger import log_stage
 
 
 BASIC_ITERATIVE_PERSISTENT_INSTRUCTIONS_PATH = "prompt_templates/persistent/basic_iterative_rules.md"
-DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
 
 
 """
@@ -103,10 +98,6 @@ class BasicIterativeStrategy(WorkflowStrategy):
         self.max_test_iterations = self.parameters["max-test-iterations"]
         self.max_failed_generations = self.parameters["max-failed-generations"]
         self.max_successful_generations = self.parameters["max-successful-generations"]
-        self.max_native_test_verification_iterations = self._parameter_int(
-            "max-native-test-verification-iterations",
-            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
-        )
         self.reachability_repo_path = self.context["reachability_repo_path"]
         self.group, self.artifact, self.version = self.library.split(":")
         self.test_version = str(
@@ -255,7 +246,9 @@ class BasicIterativeStrategy(WorkflowStrategy):
         # The loop above accepts a failing nativeTest as progress, so the gate is what
         # validates native-image behavior and traces misses this workflow cannot see —
         # including transitive-dependency metadata (§WF-basic-iterative).
-        if not self._run_native_test_verification_gate():
+        if not self._verify_native_test_gate(global_output_dir(
+            self.reachability_repo_path, self.group, self.artifact, self.test_version,
+        )):
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
@@ -270,30 +263,3 @@ class BasicIterativeStrategy(WorkflowStrategy):
             ),
         )
         return RUN_STATUS_SUCCESS, global_iterations, unittest_number
-
-    def _run_native_test_verification_gate(self) -> bool:
-        """Terminal gate: verify nativeTest passes; FAILED aborts the workflow."""
-        output_dir = global_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.test_version,
-        )
-        self._print_message(
-            f"native-test gate: starting output_dir={output_dir} "
-            f"budget={self.max_native_test_verification_iterations}"
-        )
-        result = verify_native_test_passes(
-            reachability_repo_path=self.reachability_repo_path,
-            coordinate=self.library,
-            output_dir=output_dir,
-            max_iterations=self.max_native_test_verification_iterations,
-        )
-        if result.status == NATIVE_TEST_GATE_FAILED:
-            log_path = result.last_native_test_log_path or "(none)"
-            self._print_message(
-                f"native-test gate FAILED after {result.iterations_used} cycles "
-                f"(last log: {log_path})"
-            )
-            return False
-        self._print_message(
-            f"native-test gate {result.status} after {result.iterations_used} cycles"
-        )
-        return True

--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -9,10 +9,16 @@ import subprocess
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.metadata_index import resolve_test_version
+from utility_scripts.native_test_verification import (
+    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
+    global_output_dir,
+    verify_native_test_passes,
+)
 from utility_scripts.stage_logger import log_stage
 
 
 BASIC_ITERATIVE_PERSISTENT_INSTRUCTIONS_PATH = "prompt_templates/persistent/basic_iterative_rules.md"
+DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
 
 
 """
@@ -97,6 +103,10 @@ class BasicIterativeStrategy(WorkflowStrategy):
         self.max_test_iterations = self.parameters["max-test-iterations"]
         self.max_failed_generations = self.parameters["max-failed-generations"]
         self.max_successful_generations = self.parameters["max-successful-generations"]
+        self.max_native_test_verification_iterations = self._parameter_int(
+            "max-native-test-verification-iterations",
+            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
+        )
         self.reachability_repo_path = self.context["reachability_repo_path"]
         self.group, self.artifact, self.version = self.library.split(":")
         self.test_version = str(
@@ -242,6 +252,16 @@ class BasicIterativeStrategy(WorkflowStrategy):
             )
             return RUN_STATUS_FAILURE, global_iterations, unittest_number
 
+        # The loop above accepts a failing nativeTest as progress, so the gate is what
+        # validates native-image behavior and traces misses this workflow cannot see —
+        # including transitive-dependency metadata (§WF-basic-iterative).
+        if not self._run_native_test_verification_gate():
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
+            )
+            return RUN_STATUS_FAILURE, global_iterations, unittest_number
+
         save_phase_update(
             self.continuation_marker_path,
             lambda marker: (
@@ -250,3 +270,30 @@ class BasicIterativeStrategy(WorkflowStrategy):
             ),
         )
         return RUN_STATUS_SUCCESS, global_iterations, unittest_number
+
+    def _run_native_test_verification_gate(self) -> bool:
+        """Terminal gate: verify nativeTest passes; FAILED aborts the workflow."""
+        output_dir = global_output_dir(
+            self.reachability_repo_path, self.group, self.artifact, self.test_version,
+        )
+        self._print_message(
+            f"native-test gate: starting output_dir={output_dir} "
+            f"budget={self.max_native_test_verification_iterations}"
+        )
+        result = verify_native_test_passes(
+            reachability_repo_path=self.reachability_repo_path,
+            coordinate=self.library,
+            output_dir=output_dir,
+            max_iterations=self.max_native_test_verification_iterations,
+        )
+        if result.status == NATIVE_TEST_GATE_FAILED:
+            log_path = result.last_native_test_log_path or "(none)"
+            self._print_message(
+                f"native-test gate FAILED after {result.iterations_used} cycles "
+                f"(last log: {log_path})"
+            )
+            return False
+        self._print_message(
+            f"native-test gate {result.status} after {result.iterations_used} cycles"
+        )
+        return True

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -22,17 +22,12 @@ from utility_scripts.dynamic_access_report import (
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.issue_requested_metadata import has_issue_requested_metadata_context
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
-from utility_scripts.native_test_verification import (
-    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
-    per_class_output_dir,
-    verify_native_test_passes,
-)
+from utility_scripts.native_test_verification import per_class_output_dir
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
 FALLBACK_STRATEGY_NAME = "basic_iterative_pi_gpt-5.6-sol"
-DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
 DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE = 5
 
 
@@ -67,10 +62,6 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         self.package = self.group
         self.max_class_iterations = self.parameters["max-iterations"]
         self.max_class_test_iterations = self.parameters["max-class-test-iterations"]
-        self.max_native_test_verification_iterations = self._parameter_int(
-            "max-native-test-verification-iterations",
-            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
-        )
         self.native_test_verification_batch_size = self._parameter_int(
             "native-test-verification-batch-size",
             DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE,
@@ -784,28 +775,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         output_dir = per_class_output_dir(
             self.reachability_repo_path, self.group, self.artifact, self.test_version, class_name,
         )
-        self._print_dynamic_access_detail(
-            f"native-test gate: starting class={class_name} output_dir={output_dir} "
-            f"budget={self.max_native_test_verification_iterations}",
-            indent_level=2,
-        )
-        result = verify_native_test_passes(
-            reachability_repo_path=self.reachability_repo_path,
-            coordinate=self.library,
-            output_dir=output_dir,
-            max_iterations=self.max_native_test_verification_iterations,
-        )
-        if result.status == NATIVE_TEST_GATE_FAILED:
-            log_path = result.last_native_test_log_path or "(none)"
-            self._print_dynamic_access_message(
-                f"native-test gate FAILED for {class_name} after {result.iterations_used} cycles "
-                f"(last log: {log_path})"
-            )
+        if not self._verify_native_test_gate(output_dir, label=class_name):
             return False
-        self._print_dynamic_access_detail(
-            f"native-test gate {result.status} for {class_name} after {result.iterations_used} cycles",
-            indent_level=2,
-        )
         self._commit_test_sources(f"Native-test gate fixes for {class_name}")
         self._latest_class_checkpoint = self._commit_library_metadata(
             f"Native metadata for {class_name}"

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -5,14 +5,7 @@
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
-from utility_scripts.native_test_verification import (
-    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
-    global_output_dir,
-    verify_native_test_passes,
-)
-
-
-DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
+from utility_scripts.native_test_verification import global_output_dir
 
 
 """
@@ -70,10 +63,6 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         self.group, self.artifact, self.version = self.library.split(":")
         self.package = self.group
         self.max_test_iterations = self.parameters["max-test-iterations"]
-        self.max_native_test_verification_iterations = self._parameter_int(
-            "max-native-test-verification-iterations",
-            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
-        )
 
     @property
     def _log_prefix(self) -> str:
@@ -157,7 +146,9 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             self._print_detail("agent: complete", indent_level=2)
 
         if workflow_status == RUN_STATUS_SUCCESS and self.fix_mode == JAVA_FIX_MODE_JAVA_RUN:
-            if not self._run_native_test_verification_gate():
+            if not self._verify_native_test_gate(global_output_dir(
+                self.reachability_repo_path, self.group, self.artifact, self.version,
+            )):
                 workflow_status = RUN_STATUS_FAILURE
 
         agent.clear_context()
@@ -175,34 +166,6 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
             )
         return workflow_status, global_iterations
-
-    def _run_native_test_verification_gate(self) -> bool:
-        """Terminal gate: verify nativeTest passes; FAILED aborts the workflow."""
-        output_dir = global_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.version,
-        )
-        self._print_message(
-            f"native-test gate: starting output_dir={output_dir} "
-            f"budget={self.max_native_test_verification_iterations}"
-        )
-        result = verify_native_test_passes(
-            reachability_repo_path=self.reachability_repo_path,
-            coordinate=self.library,
-            output_dir=output_dir,
-            max_iterations=self.max_native_test_verification_iterations,
-        )
-        if result.status == NATIVE_TEST_GATE_FAILED:
-            log_path = result.last_native_test_log_path or "(none)"
-            self._print_message(
-                f"native-test gate FAILED after {result.iterations_used} cycles "
-                f"(last log: {log_path})"
-            )
-            return False
-        self._print_message(
-            f"native-test gate {result.status} after {result.iterations_used} cycles"
-        )
-        return True
-
 
 @WorkflowStrategy.register("javac_iterative")
 class JavacIterativeStrategy(_JavaTestFixIterativeBase):

--- a/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
@@ -10,17 +10,12 @@ from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_S
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.dynamic_access_report import format_full_report, load_dynamic_access_coverage_report
 from utility_scripts.metadata_index import resolve_test_version
-from utility_scripts.native_test_verification import (
-    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
-    global_output_dir,
-    verify_native_test_passes,
-)
+from utility_scripts.native_test_verification import global_output_dir
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
 FALLBACK_STRATEGY_NAME = "basic_iterative_pi_gpt-5.6-sol"
-DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS = 40
 
 
 @WorkflowStrategy.register("optimistic_dynamic_access")
@@ -44,10 +39,6 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         )
         self.max_optimistic_iterations = self.parameters["max-optimistic-iterations"]
         self.max_test_iterations = self.parameters["max-test-iterations"]
-        self.max_native_test_verification_iterations = self._parameter_int(
-            "max-native-test-verification-iterations",
-            DEFAULT_MAX_NATIVE_TEST_VERIFICATION_ITERATIONS,
-        )
         self._last_dynamic_access_report_issue = "not_run"
         self.dynamic_access_report_path = os.path.join(
             self.reachability_repo_path,
@@ -176,7 +167,9 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
             successful_iterations += 1
 
-            if not self._run_native_test_verification_gate():
+            if not self._verify_native_test_gate(global_output_dir(
+                self.reachability_repo_path, self.group, self.artifact, self.test_version,
+            )):
                 self._print_failure_analysis(
                     "native_test_verification_gate_failed",
                     issue="nativeTest_did_not_pass_within_verification_budget",
@@ -202,35 +195,6 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
         )
         return RUN_STATUS_FAILURE, prompt_iterations, 0
-
-    def _run_native_test_verification_gate(self) -> bool:
-        """Run the bulk native-test verification gate; return True if PASSED."""
-        output_dir = global_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.test_version,
-        )
-        self._print_detail(
-            f"native-test gate: starting output_dir={output_dir} "
-            f"budget={self.max_native_test_verification_iterations}",
-            indent_level=2,
-        )
-        result = verify_native_test_passes(
-            reachability_repo_path=self.reachability_repo_path,
-            coordinate=self.library,
-            output_dir=output_dir,
-            max_iterations=self.max_native_test_verification_iterations,
-        )
-        if result.status == NATIVE_TEST_GATE_FAILED:
-            log_path = result.last_native_test_log_path or "(none)"
-            self._print_message(
-                f"native-test gate FAILED after {result.iterations_used} cycles "
-                f"(last log: {log_path})"
-            )
-            return False
-        self._print_detail(
-            f"native-test gate {result.status} after {result.iterations_used} cycles",
-            indent_level=2,
-        )
-        return True
 
     def _run_basic_iterative_fallback(self, agent, **kwargs):
         """Instantiate a BasicIterativeStrategy and delegate to it."""

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -35,6 +35,12 @@ from utility_scripts.metadata_index import (
     resolve_metadata_version,
     resolve_test_version,
 )
+from utility_scripts.native_test_verification import (
+    DEFAULT_MAX_ITERATIONS,
+    NativeTestVerificationResult,
+    STATUS_FAILED as NATIVE_TEST_GATE_FAILED,
+    verify_native_test_passes,
+)
 from utility_scripts.issue_requested_metadata import NO_REPORTER_METADATA_CONTEXT
 from utility_scripts.library_preparation_preflight import NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -130,6 +136,10 @@ class WorkflowStrategy(ABC):
             raise ValueError("Strategy is missing required field: model")
         self.prompts = self.strategy_obj.get("prompts", {})
         self.parameters = self.strategy_obj.get("parameters", {})
+        self.max_native_test_verification_iterations: int = self._parameter_int(
+            "max-native-test-verification-iterations",
+            DEFAULT_MAX_ITERATIONS,
+        )
         self.persistent_instructions = load_persistent_instructions(self.strategy_obj, **self.context)
         self.post_generation_intervention: dict | None = None
         self.continuation_marker_path: str | None = self.context.get("continuation_marker_path")
@@ -153,6 +163,34 @@ class WorkflowStrategy(ABC):
         if not isinstance(value, int) or value < 0:
             raise ValueError(f"Strategy parameter '{name}' must be a non-negative integer")
         return value
+
+    def _verify_native_test_gate(self, output_dir: str, label: str | None = None) -> bool:
+        """Run the shared native-test gate (§WF-native-test-verification-gate)."""
+        label_suffix: str = f" for {label}" if label else ""
+        log_stage(
+            "native-test-verify",
+            f"native-test gate: starting{label_suffix} output_dir={output_dir} "
+            f"budget={self.max_native_test_verification_iterations}",
+        )
+        result: NativeTestVerificationResult = verify_native_test_passes(
+            reachability_repo_path=self.context["reachability_repo_path"],
+            coordinate=self.context["library"],
+            output_dir=output_dir,
+            max_iterations=self.max_native_test_verification_iterations,
+        )
+        if result.status == NATIVE_TEST_GATE_FAILED:
+            log_path: str = result.last_native_test_log_path or "(none)"
+            log_stage(
+                "native-test-verify",
+                f"native-test gate FAILED{label_suffix} after {result.iterations_used} cycles "
+                f"(last log: {log_path})",
+            )
+            return False
+        log_stage(
+            "native-test-verify",
+            f"native-test gate {result.status}{label_suffix} after {result.iterations_used} cycles",
+        )
+        return True
 
     def _load_prompt(self, key: str) -> str:
         """Load and render a prompt template by key, substituting context values."""

--- a/forge/docs/strategies.md
+++ b/forge/docs/strategies.md
@@ -131,7 +131,10 @@ models, and iteration limits remain configuration data in
 ## STRAT-predefined-strategy-parameter-families: Parameter families
 
 The basic iterative bundles set `max-test-iterations`,
-`max-failed-generations`, and `max-successful-generations`. Java-fix bundles
+`max-failed-generations`, and `max-successful-generations`; they may also set
+`max-native-test-verification-iterations` for their terminal gate
+(§WF-native-test-verification-callers), which otherwise takes the shared
+default. Java-fix bundles
 set `max-test-iterations` and `source-context-types`. Per-class dynamic-access
 bundles set `max-iterations`, `max-class-test-iterations`, and
 `source-context-types`. Optimistic dynamic-access bundles set

--- a/forge/docs/workflows/add-new-library-support.md
+++ b/forge/docs/workflows/add-new-library-support.md
@@ -44,3 +44,14 @@ workflow delegates to only when no usable dynamic-access report exists at the
 start of a run — the report task fails, the report is missing or unparsable,
 reporting is disabled, or the report has zero dynamic-access calls
 (§WF-dynamic-access-fallback-and-failure).
+
+Once the loop has produced at least one committed test suite, the run ends with
+the native test verification gate (§WF-native-test-verification-gate). The loop
+accepts a failing `nativeTest` as progress, so the gate is what actually
+validates native-image behavior and what starts native metadata tracing
+(§WF-native-metadata-tracing) for misses this workflow cannot see — including
+metadata required only by the library's transitive dependencies, which no
+dynamic-access report for the requested artifact would ever list. The gate runs
+once per run against the global output directory and honors the same
+`max-native-test-verification-iterations` budget as every other caller
+(§WF-native-test-verification-callers); `FAILED` is a workflow failure.

--- a/forge/docs/workflows/dynamic-access.md
+++ b/forge/docs/workflows/dynamic-access.md
@@ -96,6 +96,11 @@ or the report has zero dynamic-access calls. Once a dynamic-access phase has
 started from a usable report, losing the report is a workflow failure, not a
 fallback condition.
 
+Falling back does not skip native-image validation. The basic iterative
+workflow runs its own terminal native test verification gate
+(§WF-basic-iterative), so a fallback run still reaches native metadata tracing
+for metadata the dynamic-access report could not have named.
+
 Dynamic-access workflows must fail when any of these conditions occur:
 
 1. A required native-test verification gate returns `FAILED`.

--- a/forge/docs/workflows/native-metadata-tracing.md
+++ b/forge/docs/workflows/native-metadata-tracing.md
@@ -486,10 +486,11 @@ intervention.
 | --- | --- | --- |
 | `dynamic_access_iterative` per-class loop | After every class with a coverage gain (Resolved or PartialCommit) (§WF-dynamic-access-workflow) | `tests/src/<group>/<artifact>/<version>/build/natively-collected/<class-key>/` |
 | `fix_java_run_fail` native-mode path | After the agent's final edit, as the success gate (§WF-java-fail-fix-workflow) | `tests/src/<group>/<artifact>/<version>/build/natively-collected/_global_/` |
+| `basic_iterative` loop | After the loop commits at least one test suite, as the terminal gate (§WF-basic-iterative) | `tests/src/<group>/<artifact>/<version>/build/natively-collected/_global_/` |
 
-The dynamic-access caller invokes the gate per class; the fix-native-run
-caller invokes it once per workflow run. Both treat `FAILED` as a hard
-workflow failure.
+The dynamic-access caller invokes the gate per class; the fix-native-run and
+basic iterative callers invoke it once per workflow run. All treat `FAILED` as
+a hard workflow failure.
 
 ## 9. Acceptance Criteria
 

--- a/forge/tests/test_basic_iterative_strategy.py
+++ b/forge/tests/test_basic_iterative_strategy.py
@@ -102,7 +102,7 @@ class BasicIterativeNativeTestGateTests(unittest.TestCase):
         strategy = _basic_strategy()
 
         with patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
             return_value=_gate_result(STATUS_PASSED),
         ) as verify:
             status, _, unittest_number = strategy.run(_FakeAgent(), "checkpoint-sha")
@@ -117,7 +117,7 @@ class BasicIterativeNativeTestGateTests(unittest.TestCase):
         strategy = _basic_strategy()
 
         with patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
             return_value=_gate_result(STATUS_PASSED),
         ) as verify:
             strategy.run(_FakeAgent(), "checkpoint-sha")
@@ -128,7 +128,7 @@ class BasicIterativeNativeTestGateTests(unittest.TestCase):
         strategy = _basic_strategy(**{"max-native-test-verification-iterations": 7})
 
         with patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
             return_value=_gate_result(STATUS_PASSED),
         ) as verify:
             strategy.run(_FakeAgent(), "checkpoint-sha")
@@ -139,7 +139,7 @@ class BasicIterativeNativeTestGateTests(unittest.TestCase):
         strategy = _basic_strategy()
 
         with patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
             return_value=_gate_result(STATUS_FAILED),
         ):
             status, _, _ = strategy.run(_FakeAgent(), "checkpoint-sha")
@@ -151,7 +151,7 @@ class BasicIterativeNativeTestGateTests(unittest.TestCase):
         agent = _FakeAgent(test_output="> Task :compileTestJava FAILED\n")
 
         with patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
         ) as verify:
             with patch("subprocess.run"):
                 status, _, unittest_number = strategy.run(agent, "checkpoint-sha")
@@ -222,7 +222,7 @@ class DynamicAccessFallbackNativeTestGateTests(unittest.TestCase):
             "ai_workflows.core.dynamic_access_iterative_strategy.load_strategy_by_name",
             return_value=fallback_obj,
         ), patch(
-            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            "ai_workflows.core.workflow_strategy.verify_native_test_passes",
             return_value=_gate_result(STATUS_PASSED),
         ) as verify:
             status, _, _ = strategy.run(_FakeAgent(), "checkpoint-sha")

--- a/forge/tests/test_basic_iterative_strategy.py
+++ b/forge/tests/test_basic_iterative_strategy.py
@@ -1,0 +1,236 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import unittest
+from unittest.mock import patch
+
+from ai_workflows.core.basic_iterative_strategy import BasicIterativeStrategy
+from ai_workflows.core.dynamic_access_iterative_strategy import DynamicAccessIterativeStrategy
+from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS
+from utility_scripts.dynamic_access_report import DynamicAccessCoverageReport
+from utility_scripts.native_test_verification import (
+    NativeTestVerificationResult,
+    STATUS_FAILED,
+    STATUS_PASSED,
+)
+
+
+LIBRARY = "org.example:lib:1.0.0"
+
+# A `./gradlew test` run that reached nativeTest and failed there. The basic
+# iterative loop accepts this as progress, which is exactly why the terminal
+# native-test gate has to run afterwards (§WF-basic-iterative).
+NATIVE_TEST_FAILED_OUTPUT = "> Task :nativeTest FAILED\n"
+
+
+class _FakeAgent:
+    """Minimal agent stub that always reports a nativeTest-stage test run."""
+
+    def __init__(self, test_output: str = NATIVE_TEST_FAILED_OUTPUT) -> None:
+        self.test_output = test_output
+        self.prompts: list[str] = []
+
+    def send_prompt(self, prompt: str) -> None:
+        self.prompts.append(prompt)
+
+    def run_test_command(self, command: str) -> str:
+        return self.test_output
+
+    def clear_context(self) -> None:
+        pass
+
+    def replace_persistent_instructions(self, instructions: str) -> None:
+        pass
+
+
+def _gate_result(status: str) -> NativeTestVerificationResult:
+    return NativeTestVerificationResult(
+        status=status,
+        output_dir="/tmp/natively-collected/_global_",
+        iterations_used=1,
+        last_native_test_log_path="/tmp/native-test.log",
+    )
+
+
+def _basic_strategy(**parameters) -> BasicIterativeStrategy:
+    strategy_parameters = {
+        "max-test-iterations": 1,
+        "max-failed-generations": 1,
+        "max-successful-generations": 1,
+    }
+    strategy_parameters.update(parameters)
+    return BasicIterativeStrategy(
+        {
+            "model": "test-model",
+            "prompts": {
+                "initial": "unused",
+                "after-successful-iteration": "unused",
+                "after-failed-iteration": "unused",
+            },
+            "parameters": strategy_parameters,
+        },
+        library=LIBRARY,
+        reachability_repo_path="/tmp/reachability",
+        test_version="1.0.0",
+    )
+
+
+class BasicIterativeNativeTestGateTests(unittest.TestCase):
+    """The terminal native-test gate runs for every basic iterative invocation."""
+
+    def setUp(self) -> None:
+        prompt_patch = patch(
+            "ai_workflows.core.workflow_strategy.load_prompt_template",
+            return_value="prompt",
+        )
+        instructions_patch = patch(
+            "ai_workflows.core.workflow_strategy.load_persistent_instructions",
+            return_value="instructions",
+        )
+        commit_patch = patch.object(
+            BasicIterativeStrategy,
+            "_commit_test_sources",
+            return_value="commit-sha",
+        )
+        for active_patch in (prompt_patch, instructions_patch, commit_patch):
+            active_patch.start()
+            self.addCleanup(active_patch.stop)
+
+    def test_gate_runs_after_a_successful_loop(self) -> None:
+        strategy = _basic_strategy()
+
+        with patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            return_value=_gate_result(STATUS_PASSED),
+        ) as verify:
+            status, _, unittest_number = strategy.run(_FakeAgent(), "checkpoint-sha")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        self.assertEqual(unittest_number, 1)
+        verify.assert_called_once()
+        self.assertEqual(verify.call_args.kwargs["coordinate"], LIBRARY)
+        self.assertTrue(verify.call_args.kwargs["output_dir"].endswith("natively-collected/_global_"))
+
+    def test_gate_uses_the_shared_default_budget(self) -> None:
+        strategy = _basic_strategy()
+
+        with patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            return_value=_gate_result(STATUS_PASSED),
+        ) as verify:
+            strategy.run(_FakeAgent(), "checkpoint-sha")
+
+        self.assertEqual(verify.call_args.kwargs["max_iterations"], 40)
+
+    def test_gate_budget_is_configurable(self) -> None:
+        strategy = _basic_strategy(**{"max-native-test-verification-iterations": 7})
+
+        with patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            return_value=_gate_result(STATUS_PASSED),
+        ) as verify:
+            strategy.run(_FakeAgent(), "checkpoint-sha")
+
+        self.assertEqual(verify.call_args.kwargs["max_iterations"], 7)
+
+    def test_gate_failure_fails_the_workflow(self) -> None:
+        strategy = _basic_strategy()
+
+        with patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            return_value=_gate_result(STATUS_FAILED),
+        ):
+            status, _, _ = strategy.run(_FakeAgent(), "checkpoint-sha")
+
+        self.assertEqual(status, RUN_STATUS_FAILURE)
+
+    def test_gate_is_skipped_when_no_test_suite_was_produced(self) -> None:
+        strategy = _basic_strategy()
+        agent = _FakeAgent(test_output="> Task :compileTestJava FAILED\n")
+
+        with patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+        ) as verify:
+            with patch("subprocess.run"):
+                status, _, unittest_number = strategy.run(agent, "checkpoint-sha")
+
+        self.assertEqual(status, RUN_STATUS_FAILURE)
+        self.assertEqual(unittest_number, 0)
+        verify.assert_not_called()
+
+
+class DynamicAccessFallbackNativeTestGateTests(unittest.TestCase):
+    """A 0/0 dynamic-access report still reaches native tracing through the fallback.
+
+    Regression test for the transitive-dependency metadata gap: the requested
+    artifact reports no dynamic-access call sites, the basic iterative fallback
+    generates a working test suite, and `nativeTest` still needs metadata that
+    only the native-test gate can trace (§WF-dynamic-access-fallback-and-failure).
+    """
+
+    def test_zero_call_report_falls_back_and_still_runs_the_gate(self) -> None:
+        empty_report = DynamicAccessCoverageReport(
+            coordinate=LIBRARY,
+            has_dynamic_access=False,
+            total_calls=0,
+            covered_calls=0,
+            classes=[],
+        )
+        strategy = DynamicAccessIterativeStrategy(
+            {
+                "model": "test-model",
+                "prompts": {"dynamic-access-iteration": "unused"},
+                "parameters": {
+                    "max-iterations": 1,
+                    "max-class-test-iterations": 1,
+                },
+            },
+            library=LIBRARY,
+            reachability_repo_path="/tmp/reachability",
+            test_version="1.0.0",
+        )
+        fallback_obj = {
+            "name": "basic_iterative_pi_gpt-5.6-sol",
+            "model": "test-model",
+            "prompts": {
+                "initial": "unused",
+                "after-successful-iteration": "unused",
+                "after-failed-iteration": "unused",
+            },
+            "parameters": {
+                "max-test-iterations": 1,
+                "max-failed-generations": 1,
+                "max-successful-generations": 1,
+            },
+        }
+
+        with patch(
+            "ai_workflows.core.workflow_strategy.load_prompt_template",
+            return_value="prompt",
+        ), patch(
+            "ai_workflows.core.workflow_strategy.load_persistent_instructions",
+            return_value="instructions",
+        ), patch.object(
+            BasicIterativeStrategy, "_commit_test_sources", return_value="commit-sha",
+        ), patch.object(
+            DynamicAccessIterativeStrategy,
+            "_generate_dynamic_access_report",
+            return_value=empty_report,
+        ), patch(
+            "ai_workflows.core.dynamic_access_iterative_strategy.load_strategy_by_name",
+            return_value=fallback_obj,
+        ), patch(
+            "ai_workflows.core.basic_iterative_strategy.verify_native_test_passes",
+            return_value=_gate_result(STATUS_PASSED),
+        ) as verify:
+            status, _, _ = strategy.run(_FakeAgent(), "checkpoint-sha")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        verify.assert_called_once()
+        self.assertEqual(verify.call_args.kwargs["coordinate"], LIBRARY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9315

## What this does

A library can need reachability metadata for dynamic access performed by its **transitive dependencies**, which no dynamic-access report for the requested artifact will ever list. When that report comes back `hasDynamicAccess=false` or `0/0`, both dynamic-access engines fall back to `basic_iterative` — and that workflow treats a failing `nativeTest` as *progress*, commits, and returns success. The native test verification gate never ran, so `runNativeTraceImage` was never reached and finalization sent the failure straight to Codex/Pi post-generation recovery.

#7020 is the reproducer: the generated `springdoc-openapi-starter-webmvc-ui` test boots Spring, `SpringFactoriesLoader` loads implementations from transitive Spring Boot dependencies, and `nativeTest` needs metadata for classes like `org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor`.

This adds the gate as the terminal step of `basic_iterative`.

## Where the gate goes

The issue frames this as a fallback problem, but the fix belongs one level down. `basic_iterative` is also a standalone registered workflow selected directly by `--strategy-name` and across the benchmark suite, and the *bulk* engine (`optimistic_dynamic_access`) has the identical `0/0` fallback. Putting the gate inside `BasicIterativeStrategy.run()` covers every trigger from one place, so neither `_run_basic_iterative_fallback` wrapper needs to change:

| Trigger | Covered |
| --- | --- |
| `dynamic_access_iterative` fallback on a `0/0` report | yes |
| `optimistic_dynamic_access` fallback on a `0/0` report | yes |
| Standalone `--strategy-name basic_iterative*` runs | yes |
| Benchmark suite runs | yes |

It sits after the `unittest_number == 0` guard, so a run that never produced a test suite still fails without paying for a gate invocation.

The implementation mirrors the two existing terminal-gate callers, `java_fix_iterative_strategy.py` and `optimistic_dynamic_access_strategy.py`: `global_output_dir(...)`, the shared `max-native-test-verification-iterations` budget (default 40, optional so no bundle in `predefined_strategies.json` has to change), and `FAILED` → `RUN_STATUS_FAILURE` with `PHASE_FIX` left pending. It passes `test_version` rather than `version`, because the generated test sources live under `tests/src/<group>/<artifact>/<test_version>/`.

Only a literal `FAILED` fails the run. `PASSED_WITH_INTERVENTION` is accepted, which is what makes the issue's "Codex only after native tracing fails or stalls" hold — the gate already runs Codex internally as its own last resort ([`native_test_verification.py`](forge/utility_scripts/native_test_verification.py) `_route_to_codex`), after tracing has been exhausted. No separate routing was needed.

## Spec changes

`FAILED` aborting the workflow follows the existing rule in [§WF-dynamic-access-fallback-and-failure](forge/docs/workflows/dynamic-access.md) — "a required native-test verification gate returns `FAILED`" is already listed as a hard failure — so this change makes the fallback path obey a rule it was previously sidestepping rather than introducing a new one.

- [§WF-basic-iterative](forge/docs/workflows/add-new-library-support.md) — the terminal gate, and why the loop's acceptance of a failing `nativeTest` makes it necessary
- [§WF-dynamic-access-fallback-and-failure](forge/docs/workflows/dynamic-access.md) — falling back no longer skips native-image validation
- [§WF-native-test-verification-callers](forge/docs/workflows/native-metadata-tracing.md) — third row in the callers table
- [§STRAT-predefined-strategy-parameter-families](forge/docs/strategies.md) — the optional budget parameter

## Coverage

`forge/tests/test_basic_iterative_strategy.py` is new — the fallback path had no test coverage at all. Six cases, including the one the issue asks for: `0/0` report → fallback → loop succeeds → gate invoked. The rest pin the budget default and override, `FAILED` → `RUN_STATUS_FAILURE`, and that the gate is skipped when no test suite was produced.

The hermetic fixture Forge E2E ([forge/docs/e2e.md](forge/docs/e2e.md)) has **not** been run against this yet.
