### PR TITLE
Improve code coverage for org.apache.kafka:kafka-streams:3.6.2

### DIFF
--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AdvancedKStreamApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AdvancedKStreamApiCoverageTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.TransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises the named and configured KStream overloads as one topology-building scenario. */
+public class AdvancedKStreamApiCoverageTest {
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldBuildConfiguredStreamBranchesJoinsAndProcessors() {
+        StreamsBuilder builder = new StreamsBuilder();
+        for (String storeName : List.of("store-a", "store-b", "store-c", "store-d", "store-e", "store-f", "store-g", "store-h")) {
+            builder.addStateStore(org.apache.kafka.streams.state.Stores.keyValueStoreBuilder(
+                    org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore(storeName), Serdes.String(), Serdes.String()));
+        }
+        KStream<String, String> source = builder.stream("advanced-stream-source",
+                Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> other = builder.stream("advanced-stream-other",
+                Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, Integer> table = builder.table("advanced-stream-table",
+                Consumed.with(Serdes.String(), Serdes.Integer()));
+        JoinWindows windows = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2));
+        StreamJoined<String, String, String> streamJoined = StreamJoined.with(
+                Serdes.String(), Serdes.String(), Serdes.String()).withName("configured-stream-join");
+
+        assertThat(source.merge(other, Named.as("merge-named"))).isNotNull();
+        assertThat(source.split()).isNotNull();
+        assertThat(source.split(Named.as("split-named")).branch((key, value) -> true).noDefaultBranch()).containsKey("split-named1");
+        assertThat(source.repartition(Repartitioned.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(source.through("advanced-through")).isNotNull();
+        source.to("advanced-output");
+        source.to("advanced-output-configured", Produced.with(Serdes.String(), Serdes.String()));
+        source.to((key, value, context) -> "advanced-dynamic-output");
+        source.to((key, value, context) -> "advanced-dynamic-output-configured",
+                Produced.with(Serdes.String(), Serdes.String()));
+
+        Materialized<String, String, org.apache.kafka.streams.state.KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+        assertThat(source.toTable()).isNotNull();
+        assertThat(source.toTable(Named.as("table-named"))).isNotNull();
+        assertThat(source.toTable(materialized)).isNotNull();
+        assertThat(source.toTable(Named.as("table-named-configured"), materialized)).isNotNull();
+        assertThat(source.groupBy((key, value) -> key, Grouped.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(source.join(other, (key, left, right) -> left + right, windows, streamJoined)).isNotNull();
+        assertThat(source.leftJoin(other, (key, left, right) -> String.valueOf(left) + right, windows,
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("configured-left-join"))).isNotNull();
+        assertThat(source.outerJoin(other, (key, left, right) -> String.valueOf(left) + right, windows,
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("configured-outer-join"))).isNotNull();
+        assertThat(source.join(table, (key, left, right) -> left.length() + right, Joined.with(
+                Serdes.String(), Serdes.String(), Serdes.Integer()))).isNotNull();
+        assertThat(source.leftJoin(table, (key, left, right) -> left.length() + right, Joined.with(
+                Serdes.String(), Serdes.String(), Serdes.Integer()))).isNotNull();
+
+        KStream<String, String> transformed = source.transform(new StringTransformerSupplier(), Named.as("transform-named"), "store-a");
+        assertThat(transformed).isNotNull();
+        assertThat(source.flatTransform(new FlatStringTransformerSupplier(), Named.as("flat-transform-named"), "store-b")).isNotNull();
+        assertThat(source.transformValues(new StringValueTransformerSupplier(), Named.as("value-transform-named"), "store-c")).isNotNull();
+        assertThat(source.transformValues(new KeyedValueTransformerSupplier(), "store-d")).isNotNull();
+        assertThat(source.transformValues(new KeyedValueTransformerSupplier(), Named.as("keyed-value-transform"), "store-e")).isNotNull();
+        assertThat(source.flatTransformValues(new StringFlatValueTransformerSupplier(), Named.as("flat-value-transform"), "store-f")).isNotNull();
+        assertThat(source.flatTransformValues(new KeyedFlatValueTransformerSupplier(), "store-g")).isNotNull();
+        assertThat(source.flatTransformValues(new KeyedFlatValueTransformerSupplier(), Named.as("keyed-flat-value-transform"), "store-h")).isNotNull();
+
+        assertThat(builder.build().describe().toString()).contains("advanced-stream-source", "advanced-through");
+    }
+
+    private static final class StringTransformerSupplier implements TransformerSupplier<String, String, KeyValue<String, String>> {
+        @Override public Transformer<String, String, KeyValue<String, String>> get() {
+            return new StringTransformer();
+        }
+    }
+
+    private static final class FlatStringTransformerSupplier implements TransformerSupplier<String, String, Iterable<KeyValue<String, String>>> {
+        @Override public Transformer<String, String, Iterable<KeyValue<String, String>>> get() {
+            return new FlatStringTransformer();
+        }
+    }
+
+    private static final class StringTransformer implements Transformer<String, String, KeyValue<String, String>> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public KeyValue<String, String> transform(String key, String value) {
+            return KeyValue.pair(key, value);
+        }
+        @Override public void close() { }
+    }
+
+    private static final class FlatStringTransformer implements Transformer<String, String, Iterable<KeyValue<String, String>>> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public Iterable<KeyValue<String, String>> transform(String key, String value) {
+            return List.of(KeyValue.pair(key, value));
+        }
+        @Override public void close() { }
+    }
+
+    private static final class StringValueTransformerSupplier implements ValueTransformerSupplier<String, String> {
+        @Override public ValueTransformer<String, String> get() {
+            return new StringValueTransformer();
+        }
+    }
+
+    private static final class StringValueTransformer implements ValueTransformer<String, String> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public String transform(String value) {
+            return value.toUpperCase();
+        }
+        @Override public void close() { }
+    }
+
+    private static final class KeyedValueTransformerSupplier implements ValueTransformerWithKeySupplier<String, String, String> {
+        @Override public ValueTransformerWithKey<String, String, String> get() {
+            return new KeyedValueTransformer();
+        }
+    }
+
+    private static final class KeyedValueTransformer implements ValueTransformerWithKey<String, String, String> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public String transform(String readOnlyKey, String value) {
+            return readOnlyKey + value;
+        }
+        @Override public void close() { }
+    }
+
+    private static final class StringFlatValueTransformerSupplier implements ValueTransformerSupplier<String, Iterable<String>> {
+        @Override public ValueTransformer<String, Iterable<String>> get() {
+            return new StringFlatValueTransformer();
+        }
+    }
+
+    private static final class StringFlatValueTransformer implements ValueTransformer<String, Iterable<String>> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public Iterable<String> transform(String value) {
+            return List.of(value, value + "-copy");
+        }
+        @Override public void close() { }
+    }
+
+    private static final class KeyedFlatValueTransformerSupplier implements ValueTransformerWithKeySupplier<String, String, Iterable<String>> {
+        @Override public ValueTransformerWithKey<String, String, Iterable<String>> get() {
+            return new KeyedFlatValueTransformer();
+        }
+    }
+
+    private static final class KeyedFlatValueTransformer implements ValueTransformerWithKey<String, String, Iterable<String>> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public Iterable<String> transform(String key, String value) {
+            return List.of(key + value);
+        }
+        @Override public void close() { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AdvancedKTableApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AdvancedKTableApiCoverageTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.SessionWindowedKStream;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.TimeWindowedKStream;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises KTable overloads and the grouped/windowed table subsystems. */
+public class AdvancedKTableApiCoverageTest {
+    @Test
+    void shouldConfigureAllTableTransformsAndJoins() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> left = builder.table("advanced-table-left", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> right = builder.table("advanced-table-right", Consumed.with(Serdes.String(), Serdes.String()));
+        builder.addStateStore(org.apache.kafka.streams.state.Stores.keyValueStoreBuilder(
+                org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("table-store-a"), Serdes.String(), Serdes.String()));
+        builder.addStateStore(org.apache.kafka.streams.state.Stores.keyValueStoreBuilder(
+                org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("table-store-b"), Serdes.String(), Serdes.String()));
+        builder.addStateStore(org.apache.kafka.streams.state.Stores.keyValueStoreBuilder(
+                org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("table-store-c"), Serdes.String(), Serdes.String()));
+        builder.addStateStore(org.apache.kafka.streams.state.Stores.keyValueStoreBuilder(
+                org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("table-store-d"), Serdes.String(), Serdes.String()));
+        Materialized<String, String, org.apache.kafka.streams.state.KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+
+        assertThat(left.filter((key, value) -> value != null)).isNotNull();
+        assertThat(left.filter((key, value) -> value != null, Named.as("filter-named"))).isNotNull();
+        assertThat(left.filterNot((key, value) -> value.isEmpty(), Named.as("filter-not-named"))).isNotNull();
+        assertThat(left.filter((key, value) -> true, Named.as("filter-materialized"), materialized)).isNotNull();
+        assertThat(left.filterNot((key, value) -> false, Named.as("filter-not-materialized"), materialized)).isNotNull();
+        assertThat(left.mapValues(value -> value.length())).isNotNull();
+        assertThat(left.mapValues(value -> value.length(), Named.as("map-values-named"))).isNotNull();
+        assertThat(left.mapValues((key, value) -> key + value, Named.as("map-values-keyed"))).isNotNull();
+        assertThat(left.mapValues((key, value) -> key + value, Named.as("map-values-keyed-materialized"), materialized)).isNotNull();
+
+        ValueTransformerWithKeySupplier<String, String, String> transformer = () -> new ValueTransformerWithKey<>() {
+            @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+            @Override public String transform(String key, String value) {
+                return key + value;
+            }
+            @Override public void close() { }
+        };
+        assertThat(left.transformValues(transformer, "table-store-a")).isNotNull();
+        assertThat(left.transformValues(transformer, Named.as("table-transform-named"), "table-store-b")).isNotNull();
+        assertThat(left.transformValues(transformer, materialized, "table-store-c")).isNotNull();
+        assertThat(left.transformValues(transformer, materialized, Named.as("table-transform-configured"), "table-store-d")).isNotNull();
+        assertThat(left.toStream()).isNotNull();
+        assertThat(left.toStream(Named.as("to-stream-named"))).isNotNull();
+        assertThat(left.toStream((key, value) -> key + "-mapped", Named.as("to-stream-mapped"))).isNotNull();
+
+        assertThat(left.join(right, (a, b) -> a + b)).isNotNull();
+        assertThat(left.join(right, (a, b) -> a + b, Named.as("join-named"))).isNotNull();
+        assertThat(left.join(right, (a, b) -> a + b, materialized)).isNotNull();
+        assertThat(left.join(right, (a, b) -> a + b, Named.as("join-configured"), materialized)).isNotNull();
+        assertThat(left.leftJoin(right, (a, b) -> String.valueOf(a) + b, Named.as("left-named"))).isNotNull();
+        assertThat(left.leftJoin(right, (a, b) -> String.valueOf(a) + b, Named.as("left-configured"), materialized)).isNotNull();
+        assertThat(left.outerJoin(right, (a, b) -> String.valueOf(a) + b)).isNotNull();
+        assertThat(left.outerJoin(right, (a, b) -> String.valueOf(a) + b, Named.as("outer-named"))).isNotNull();
+        assertThat(left.outerJoin(right, (a, b) -> String.valueOf(a) + b, Named.as("outer-configured"), materialized)).isNotNull();
+
+        assertThat(left.join(right, value -> value, (a, b) -> a + b, Named.as("foreign-named"), materialized)).isNotNull();
+        assertThat(left.join(right, value -> value, (a, b) -> a + b,
+                org.apache.kafka.streams.kstream.TableJoined.as("foreign-table-joined"), materialized)).isNotNull();
+        assertThat(left.leftJoin(right, value -> value, (a, b) -> String.valueOf(a) + b,
+                org.apache.kafka.streams.kstream.TableJoined.as("foreign-left"), materialized)).isNotNull();
+        assertThat(left.queryableStoreName()).isNull();
+        assertThat(builder.build().describe().toString()).contains("advanced-table-left");
+    }
+
+    @Test
+    void shouldAggregateGroupedAndWindowedStreamsWithOptions() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> table = builder.table("advanced-group-table", Consumed.with(Serdes.String(), Serdes.String()));
+        KGroupedTable<String, String> groupedTable = table.groupBy(
+                (key, value) -> KeyValue.pair(key, value), Grouped.with(Serdes.String(), Serdes.String()));
+        Materialized<String, Long, org.apache.kafka.streams.state.KeyValueStore<Bytes, byte[]>> counts =
+                Materialized.with(Serdes.String(), Serdes.Long());
+        assertThat(groupedTable.count()).isNotNull();
+        assertThat(groupedTable.count(Named.as("table-count-named"))).isNotNull();
+        assertThat(groupedTable.count(Named.as("table-count-configured"), counts)).isNotNull();
+        assertThat(groupedTable.aggregate(() -> "", (key, value, aggregate) -> aggregate + value,
+                (key, value, aggregate) -> aggregate + value, Named.as("table-aggregate-named"))).isNotNull();
+
+        KStream<String, String> source = builder.stream("advanced-window-source",
+                Consumed.with(Serdes.String(), Serdes.String()));
+        KGroupedStream<String, String> grouped = source.groupByKey();
+        TimeWindowedKStream<String, String> time = grouped.windowedBy(TimeWindows.of(Duration.ofSeconds(5)));
+        assertThat(time.count(Named.as("time-count"))).isNotNull();
+        assertThat(time.count(Named.as("time-count-materialized"),
+                Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(time.reduce((a, b) -> a + b, Named.as("time-reduce"))).isNotNull();
+        assertThat(time.reduce((a, b) -> a + b, Named.as("time-reduce-materialized"),
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(time.aggregate(() -> "", (key, value, aggregate) -> aggregate + value,
+                Named.as("time-aggregate-named"))).isNotNull();
+        assertThat(time.emitStrategy(org.apache.kafka.streams.kstream.EmitStrategy.onWindowClose())).isNotNull();
+
+        SessionWindowedKStream<String, String> session = grouped.windowedBy(SessionWindows.with(Duration.ofSeconds(3)));
+        assertThat(session.count(Named.as("session-count"))).isNotNull();
+        assertThat(session.count(Named.as("session-count-materialized"),
+                Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(session.reduce((a, b) -> a + b, Named.as("session-reduce"),
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(session.aggregate(() -> "", (key, value, aggregate) -> aggregate + value,
+                (key, aggregate, merged) -> aggregate + merged, Named.as("session-aggregate"),
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(session.emitStrategy(org.apache.kafka.streams.kstream.EmitStrategy.onWindowClose())).isNotNull();
+
+        assertThat(grouped.windowedBy(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(2), Duration.ofSeconds(1)))
+                .count(Named.as("sliding-count"))).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("advanced-window-source");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchContextTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchContextTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.internals.ForwardingDisabledProcessorContext;
+import org.apache.kafka.streams.processor.internals.StoreToProcessorContextAdapter;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Verifies delegation and metadata behavior of processor contexts used by user processors. */
+public class ApiCoverageBatchContextTest {
+    @Test
+    void shouldDelegateEveryReadableProcessorContextProperty() {
+        NativeCoverageFixtures.SimpleProcessorContext delegate =
+                new NativeCoverageFixtures.SimpleProcessorContext(99L);
+        ForwardingDisabledProcessorContext context = new ForwardingDisabledProcessorContext(delegate);
+
+        assertThat(context.applicationId()).isEqualTo("coverage");
+        assertThat(context.taskId()).isEqualTo(new TaskId(0, 0));
+        assertThat(context.keySerde()).isInstanceOf(Serdes.StringSerde.class);
+        assertThat(context.valueSerde()).isInstanceOf(Serdes.StringSerde.class);
+        assertThat(context.stateDir()).isEqualTo(new File("build/native-coverage-state"));
+        assertThat(context.metrics()).isNull();
+        assertThat(context.topic()).isEqualTo("orders");
+        assertThat(context.partition()).isEqualTo(3);
+        assertThat(context.offset()).isEqualTo(17L);
+        assertThat(context.headers()).isNotNull();
+        assertThat(context.timestamp()).isEqualTo(99L);
+        assertThat(context.appConfigs()).containsEntry("prefix.key", "value");
+        assertThat(context.appConfigsWithPrefix("prefix.")).containsEntry("key", "value");
+        assertThat(context.currentSystemTimeMs()).isEqualTo(1000L);
+        assertThat(context.currentStreamTimeMs()).isEqualTo(900L);
+        context.commit();
+        StateStore store = org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("registered").get();
+        context.register(store, (key, value) -> { });
+        assertThat(delegate.committed()).isTrue();
+        assertThatThrownBy(() -> context.forward("key", "value")).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> context.forward("key", "value", To.all())).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void shouldAdaptStateStoreContextToLegacyProcessorContext() {
+        ProcessorContext context = StoreToProcessorContextAdapter.adapt(NativeCoverageFixtures.stateStoreContext());
+        assertThat(context.applicationId()).isEqualTo("coverage");
+        assertThat(context.taskId()).isEqualTo(new TaskId(0, 0));
+        assertThat(context.keySerde()).isInstanceOf(Serdes.StringSerde.class);
+        assertThat(context.valueSerde()).isInstanceOf(Serdes.StringSerde.class);
+        assertThat(context.stateDir()).isEqualTo(new File("build/native-coverage-state"));
+        assertThat(context.metrics()).isNull();
+        assertThat(context.appConfigs()).containsEntry("adapter.key", "value");
+        assertThat(context.appConfigsWithPrefix("adapter.")).containsEntry("key", "value");
+        assertThatThrownBy(context::topic).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::partition).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::offset).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::timestamp).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::headers).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::currentSystemTimeMs).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(context::currentStreamTimeMs).isInstanceOf(UnsupportedOperationException.class);
+        context.register(Stores.inMemoryKeyValueStore("adapter-registered").get(), (key, value) -> { });
+        assertThatThrownBy(context::commit).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void shouldRunProcessorMetadataThroughTheMockContext() {
+        InternalMockProcessorContext<?, ?> context = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("metadata", String.class, String.class), NativeCoverageFixtures.recordCollector());
+        context.initialize();
+        context.addProcessorMetadataKeyValue("orders", 42L);
+        assertThat(context.processorMetadataForKey("orders")).isEqualTo(42L);
+        assertThat(context.appConfigsWithPrefix("")).isNotNull();
+        assertThat(context.metrics()).isNotNull();
+    }
+
+    @Test
+    void shouldPassSchedulingToAProcessorContext() {
+        NativeCoverageFixtures.SimpleProcessorContext delegate =
+                new NativeCoverageFixtures.SimpleProcessorContext(99L);
+        ForwardingDisabledProcessorContext context = new ForwardingDisabledProcessorContext(delegate);
+        assertThat(context.schedule(Duration.ofSeconds(1), PunctuationType.STREAM_TIME,
+                timestamp -> { })).isNotNull();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchDslTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchDslTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.CogroupedKStream;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives the public stream, table, cogroup, and window scenarios behind internal DSL nodes. */
+public class ApiCoverageBatchDslTest {
+    @Test
+    void shouldExerciseUncoveredStreamOverloadsWithAJoinedTable() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> stream = builder.stream("batch-dsl-stream", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> other = builder.stream("batch-dsl-other", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> table = builder.table("batch-dsl-table", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        JoinWindows windows = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2));
+        StreamJoined<String, String, String> joined = StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String());
+        Materialized<String, String, KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+
+        assertThat(stream.filterNot((key, value) -> value.isBlank())).isNotNull();
+        assertThat(stream.flatMap((key, value) -> java.util.List.of(KeyValue.pair(key, value)))).isNotNull();
+        assertThat(stream.groupBy((key, value) -> key)).isNotNull();
+        assertThat(stream.join(other, (key, left, right) -> left + right, windows, joined)).isNotNull();
+        assertThat(stream.leftJoin(other, (key, left, right) -> left + right, windows, joined)).isNotNull();
+        assertThat(stream.join(table, (key, left, right) -> left + right,
+                org.apache.kafka.streams.kstream.Joined.with(Serdes.String(), Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(stream.leftJoin(table, (key, left, right) -> left + right,
+                org.apache.kafka.streams.kstream.Joined.with(Serdes.String(), Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(stream.merge(other)).isNotNull();
+        assertThat(stream.peek((key, value) -> assertThat(value).isNotBlank())).isNotNull();
+        assertThat(stream.toTable(Named.as("batch-table"), materialized)).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("batch-dsl-stream");
+    }
+
+    @Test
+    void shouldExerciseAllKTableForeignJoinConfigurationForms() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> left = builder.table("batch-table-left", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> right = builder.table("batch-table-right", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        Materialized<String, String, KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+        java.util.function.Function<String, String> foreignKey = value -> value;
+        org.apache.kafka.streams.kstream.ValueJoiner<String, String, String> joiner = (a, b) -> a + b;
+
+        assertThat(left.filterNot((key, value) -> value.isEmpty())).isNotNull();
+        assertThat(left.mapValues((key, value) -> key + value)).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner)).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner, Named.as("foreign-named"))).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner, TableJoined.as("foreign-table"))).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner, materialized)).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner, Named.as("foreign-materialized"), materialized)).isNotNull();
+        assertThat(left.join(right, foreignKey, joiner, TableJoined.as("foreign-both"), materialized)).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner)).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner, Named.as("left-named"))).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner, TableJoined.as("left-table"))).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner, materialized)).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner, Named.as("left-materialized"), materialized)).isNotNull();
+        assertThat(left.leftJoin(right, foreignKey, joiner, TableJoined.as("left-both"), materialized)).isNotNull();
+        assertThat(left.join(left, (a, b) -> a + b, Named.as("self-join"))).isNotNull();
+        assertThat(left.leftJoin(left, (a, b) -> String.valueOf(a) + b, Named.as("self-left-join"))).isNotNull();
+        assertThat(left.outerJoin(left, (a, b) -> String.valueOf(a) + b, Named.as("self-outer-join"))).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("batch-table-left");
+    }
+
+    @Test
+    void shouldAggregateRegularSlidingSessionAndTimeCogroups() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KGroupedStream<String, String> first = builder.stream("batch-cogroup-first", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        KGroupedStream<String, String> second = builder.stream("batch-cogroup-second", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        CogroupedKStream<String, String> cogroup = first.cogroup((key, value, aggregate) -> aggregate + value);
+        cogroup = cogroup.cogroup(second, (key, value, aggregate) -> aggregate + value);
+        Materialized<String, String, KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+
+        assertThat(cogroup.aggregate(() -> "")).isNotNull();
+        assertThat(cogroup.aggregate(() -> "", materialized)).isNotNull();
+        assertThat(cogroup.aggregate(() -> "", Named.as("cogroup-named"))).isNotNull();
+        assertThat(cogroup.aggregate(() -> "", Named.as("cogroup-both"), materialized)).isNotNull();
+        assertThat(cogroup.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(3))).aggregate(() -> "")).isNotNull();
+        assertThat(cogroup.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(3)))
+                .aggregate(() -> "", Named.as("time-named"))).isNotNull();
+        assertThat(cogroup.windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(3)))
+                .aggregate(() -> "", Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(cogroup.windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2))).aggregate(() -> "")).isNotNull();
+        assertThat(cogroup.windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2)))
+                .aggregate(() -> "", Named.as("sliding-named"))).isNotNull();
+        assertThat(cogroup.windowedBy(SessionWindows.with(Duration.ofSeconds(2)))
+                .aggregate(() -> "", (key, left, right) -> left + right)).isNotNull();
+        assertThat(cogroup.windowedBy(SessionWindows.with(Duration.ofSeconds(2)))
+                .aggregate(() -> "", (key, left, right) -> left + right, Named.as("session-named"),
+                        Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("batch-cogroup-first");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchProcessorTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchProcessorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.ForeachProcessor;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.apache.kafka.streams.kstream.internals.KStreamFlatTransformValues;
+import org.apache.kafka.streams.kstream.internals.KStreamTransformValues;
+import org.apache.kafka.streams.kstream.internals.KStreamPrint;
+import org.apache.kafka.streams.kstream.internals.StreamStreamJoinUtil;
+import org.apache.kafka.streams.kstream.internals.TransformerSupplierAdapter;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.DefaultStreamPartitioner;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.junit.jupiter.api.Test;
+import org.apache.kafka.test.InternalMockProcessorContext;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Runs processor suppliers through records and checks their public lifecycle contracts. */
+public class ApiCoverageBatchProcessorTest {
+    @Test
+    void shouldProcessFlatValuesAndForeachRecords() {
+        ValueTransformerWithKeySupplier<String, String, Iterable<String>> supplier = () ->
+                new ValueTransformerWithKey<>() {
+                    @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+                    @Override public Iterable<String> transform(String key, String value) {
+                        return List.of(key + value, value);
+                    }
+                    @Override public void close() { }
+                };
+        KStreamFlatTransformValues<String, String, String> flatValues = new KStreamFlatTransformValues<>(supplier);
+        Processor<String, String, String, String> processor = flatValues.get();
+        org.apache.kafka.test.InternalMockProcessorContext<String, String> context =
+                new org.apache.kafka.test.InternalMockProcessorContext<>(new java.io.File("build/api-flat"),
+                        Serdes.String(), Serdes.String(), NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        processor.init(context);
+        processor.process(new Record<>("k", "v", 10L));
+        processor.close();
+        assertThat(flatValues.stores()).isNull();
+
+        ForeachProcessor<String, String> foreach = new ForeachProcessor<>((key, value) -> assertThat(value).isEqualTo("v"));
+        foreach.process(new Record<>("k", "v", 10L));
+        KStreamPrint<String, String> print = new KStreamPrint<>((key, value) -> assertThat(key).isEqualTo("k"));
+        Processor<String, String, Void, Void> printProcessor = print.get();
+        printProcessor.init(new InternalMockProcessorContext<>());
+        printProcessor.process(new Record<>("k", "v", 10L));
+        printProcessor.close();
+        assertThat(print.get()).isNotNull();
+    }
+
+    @Test
+    void shouldTransformValuesThroughTheProcessorLifecycle() throws Exception {
+        AtomicBoolean initialized = new AtomicBoolean();
+        AtomicBoolean closed = new AtomicBoolean();
+        ValueTransformerWithKeySupplier<String, String, String> supplier = () -> new ValueTransformerWithKey<>() {
+            @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) {
+                initialized.set(true);
+            }
+            @Override public String transform(String key, String value) {
+                assertThat(key).isEqualTo("customer");
+                assertThat(value).isEqualTo("pending");
+                return "ready";
+            }
+            @Override public void close() {
+                closed.set(true);
+            }
+        };
+        Constructor<KStreamTransformValues> constructor = KStreamTransformValues.class.getDeclaredConstructor(
+                ValueTransformerWithKeySupplier.class);
+        constructor.setAccessible(true);
+        KStreamTransformValues<String, String, String> stage = constructor.newInstance(supplier);
+        Processor<String, String, String, String> processor = stage.get();
+        org.apache.kafka.test.InternalMockProcessorContext<String, String> context =
+                new org.apache.kafka.test.InternalMockProcessorContext<>(
+                        new java.io.File("build/api-transform-values"), Serdes.String(), Serdes.String(),
+                        NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        processor.init(context);
+        processor.process(new Record<>("customer", "pending", 10L));
+        processor.close();
+        assertThat(stage.stores()).isNull();
+        assertThat(initialized).isTrue();
+        assertThat(closed).isTrue();
+    }
+
+    @Test
+    void shouldAdaptLegacyTransformersAndPartitionWindowedKeys() {
+        org.apache.kafka.streams.kstream.TransformerSupplier<String, String, KeyValue<String, String>> legacy =
+                () -> new org.apache.kafka.streams.kstream.Transformer<>() {
+                    @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+                    @Override public KeyValue<String, String> transform(String key, String value) {
+                        return KeyValue.pair(key, value);
+                    }
+                    @Override public void close() { }
+                };
+        TransformerSupplierAdapter<String, String, String, String> adapter = new TransformerSupplierAdapter<>(legacy);
+        assertThat(adapter.get().transform("key", "value")).isNotNull();
+        assertThat(adapter.stores()).isNull();
+        new WrappingNullableUtils();
+
+        DefaultStreamPartitioner<String, String> partitioner = new DefaultStreamPartitioner<>(Serdes.String().serializer());
+        assertThat(partitioner.partition("orders", "key", "value", 4)).isBetween(0, 3);
+        TimeWindowedSerializer<String> windowedSerializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        WindowedStreamPartitioner<String, String> windowedPartitioner = new WindowedStreamPartitioner<>(windowedSerializer);
+        Windowed<String> windowed = new Windowed<>("key", new TimeWindow(1, 2));
+        assertThat(windowedPartitioner.partition("orders", windowed, "value", 4)).isBetween(0, 3);
+        org.apache.kafka.streams.processor.StreamPartitioner rawPartitioner = windowedPartitioner;
+        assertThat((Integer) rawPartitioner.partition("orders", windowed, "value", 4)).isBetween(0, 3);
+    }
+
+    @Test
+    void shouldInvokeDefaultProcessorLifecycleAndRejectSkippedJoinRecords() throws Exception {
+        FixedKeyProcessor<String, String, String> fixed = new FixedKeyProcessor<>() {
+            @Override public void process(FixedKeyRecord<String, String> record) {
+                assertThat(record.value()).isEqualTo("value");
+            }
+        };
+        fixed.init(new InternalMockProcessorContext<>());
+        Constructor<FixedKeyRecord> constructor = FixedKeyRecord.class.getDeclaredConstructor(
+                Object.class, Object.class, long.class, org.apache.kafka.common.header.Headers.class);
+        constructor.setAccessible(true);
+        fixed.process(constructor.newInstance("key", "value", 1L, null));
+        fixed.close();
+        Processor<String, String, String, String> processor = new Processor<>() {
+            @Override public void process(Record<String, String> record) {
+                assertThat(record.key()).isEqualTo("key");
+            }
+        };
+        processor.init(new InternalMockProcessorContext<>());
+        processor.process(new Record<>("key", "value", 1L));
+        processor.close();
+        org.apache.kafka.common.metrics.Metrics metrics = new org.apache.kafka.common.metrics.Metrics();
+        assertThat(StreamStreamJoinUtil.skipRecord(new Record<>(null, "value", 1L),
+                org.slf4j.LoggerFactory.getLogger(ApiCoverageBatchProcessorTest.class), metrics.sensor("join"),
+                new InternalMockProcessorContext<>())).isTrue();
+        metrics.close();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchStateTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchStateTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.internals.ClientUtils;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.streams.processor.internals.CorruptedRecord;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.internals.LeftOrRightValue;
+import org.apache.kafka.streams.state.internals.LeftOrRightValueSerializer;
+import org.apache.kafka.streams.state.internals.PrefixedSessionKeySchemas;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises state-key codecs, cache operations, and small internal value services through real round trips. */
+public class ApiCoverageBatchStateTest {
+    @Test
+    void shouldRoundTripBothPrefixedSessionKeyLayouts() {
+        Windowed<String> session = new Windowed<>("customer", new SessionWindow(10L, 30L));
+        byte[] keyFirst = PrefixedSessionKeySchemas.KeyFirstSessionKeySchema.toBinary(
+                session, Serdes.String().serializer(), "orders");
+        byte[] timeFirst = PrefixedSessionKeySchemas.TimeFirstSessionKeySchema.toBinary(
+                session, Serdes.String().serializer(), "orders");
+        assertThat(PrefixedSessionKeySchemas.KeyFirstSessionKeySchema.from(
+                keyFirst, Serdes.String().deserializer(), "orders")).isEqualTo(session);
+        assertThat(PrefixedSessionKeySchemas.TimeFirstSessionKeySchema.from(
+                timeFirst, Serdes.String().deserializer(), "orders")).isEqualTo(session);
+        assertThat(PrefixedSessionKeySchemas.KeyFirstSessionKeySchema.from(Bytes.wrap(keyFirst))).isNotNull();
+        assertThat(PrefixedSessionKeySchemas.TimeFirstSessionKeySchema.from(Bytes.wrap(timeFirst))).isNotNull();
+    }
+
+    @Test
+    void shouldSerializeLeftAndRightValuesAndUseTheThreadCache() throws Exception {
+        LeftOrRightValueSerializer<String, Integer> serializer =
+                new LeftOrRightValueSerializer<>(Serdes.String().serializer(), Serdes.Integer().serializer());
+        LeftOrRightValue<String, Integer> left = LeftOrRightValue.makeLeftValue("left");
+        LeftOrRightValue<String, Integer> right = LeftOrRightValue.makeRightValue(7);
+        assertThat(serializer.serialize("orders", left)).isNotEmpty();
+        assertThat(serializer.serialize("orders", right)).isNotEmpty();
+        serializer.close();
+
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(new Metrics(), "api-client", "api-thread", Time.SYSTEM);
+        ThreadCache cache = new ThreadCache(new LogContext("api-cache "), 1024L, streamsMetrics);
+        String namespace = ThreadCache.nameSpaceFromTaskIdAndStore("0_0", "orders");
+        assertThat(ThreadCache.taskIDfromCacheName(namespace)).isEqualTo("0_0");
+        assertThat(ThreadCache.underlyingStoreNamefromCacheName(namespace)).isEqualTo("orders");
+        Class<?> entryType = Class.forName("org.apache.kafka.streams.state.internals.LRUCacheEntry");
+        Constructor<?> entryConstructor = entryType.getDeclaredConstructor(byte[].class);
+        entryConstructor.setAccessible(true);
+        Object entry = entryConstructor.newInstance(new byte[] {1});
+        Method putIfAbsent = ThreadCache.class.getMethod("putIfAbsent", String.class, Bytes.class, entryType);
+        Method get = ThreadCache.class.getMethod("get", String.class, Bytes.class);
+        Method delete = ThreadCache.class.getMethod("delete", String.class, Bytes.class);
+        assertThat(putIfAbsent.invoke(cache, namespace, Bytes.wrap(new byte[] {1}), entry)).isNull();
+        assertThat(putIfAbsent.invoke(cache, namespace, Bytes.wrap(new byte[] {1}), entry)).isSameAs(entry);
+        assertThat(cache.size()).isPositive();
+        assertThat(get.invoke(cache, namespace, Bytes.wrap(new byte[] {1}))).isSameAs(entry);
+        assertThat(delete.invoke(cache, namespace, Bytes.wrap(new byte[] {1}))).isSameAs(entry);
+    }
+
+    @Test
+    void shouldCreateLatencyAndStateStoreSensors() {
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "sensor-client", "sensor-thread", Time.SYSTEM);
+        Sensor latency = streamsMetrics.addLatencyRateTotalSensor("node", "operation", "latency",
+                Sensor.RecordingLevel.INFO, "tag", "value");
+        Sensor suppression = StateStoreMetrics.suppressionBufferSizeSensor("store", "task", "thread", streamsMetrics);
+        assertThat(latency).isNotNull();
+        assertThat(suppression).isNotNull();
+        assertThat(streamsMetrics.metrics()).isNotEmpty();
+        metrics.close();
+    }
+
+    @Test
+    void shouldExposeClientIdentifiersAndCorruptedRecordIdentity() throws Exception {
+        new ClientUtils();
+        assertThat(ClientUtils.extractThreadId("StreamThread-7")).isEqualTo("StreamThread-7");
+        assertThat(ClientUtils.getTaskProducerClientId("application", new TaskId(2, 3)))
+                .contains("application", "2_3");
+        assertThat(ClientUtils.getEndOffsets(KafkaFuture.completedFuture(Map.of()))).isEmpty();
+
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("orders", 1, 4L, new byte[] {1}, new byte[] {2});
+        Constructor<CorruptedRecord> corruptedConstructor = CorruptedRecord.class.getDeclaredConstructor(ConsumerRecord.class);
+        corruptedConstructor.setAccessible(true);
+        CorruptedRecord corrupted = corruptedConstructor.newInstance(record);
+        CorruptedRecord same = corruptedConstructor.newInstance(record);
+        assertThat(corrupted).isEqualTo(same);
+        assertThat(corrupted.hashCode()).isEqualTo(same.hashCode());
+        assertThat(corrupted.toString()).contains("orders");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchSuppressTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchSuppressTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.kafka.streams.kstream.internals.suppress;
+
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Verifies suppression policy configuration and the time definitions used by window close behavior. */
+public class ApiCoverageBatchSuppressTest {
+    @Test
+    void shouldConfigureEagerAndStrictBufferPolicies() {
+        EagerBufferConfigImpl eager = new EagerBufferConfigImpl(5L, 100L, Map.of("retention.ms", "1000"));
+        assertThat(eager.withMaxRecords(10L)).isNotNull();
+        assertThat(eager.withMaxBytes(200L)).isNotNull();
+        assertThat(eager.withLoggingDisabled()).isNotNull();
+        assertThat(eager.withLoggingEnabled(Map.of("cleanup.policy", "compact"))).isNotNull();
+
+        StrictBufferConfigImpl strict = new StrictBufferConfigImpl();
+        assertThat(strict.withMaxRecords(10L)).isNotNull();
+        assertThat(strict.withMaxBytes(200L)).isNotNull();
+        assertThat(strict.withLoggingDisabled()).isNotNull();
+        assertThat(strict.withLoggingEnabled(Map.of("cleanup.policy", "compact"))).isNotNull();
+        assertThat(strict.shutDownWhenFull()).isNotNull();
+    }
+
+    @Test
+    void shouldNameAndCompareSuppressionPolicies() {
+        SuppressedInternal<Windowed<String>> first = suppressedInternal("orders");
+        SuppressedInternal<Windowed<String>> same = suppressedInternal("orders");
+        assertThat(first.withName("renamed")).isNotNull();
+        assertThat(first).isEqualTo(same);
+        assertThat(first.hashCode()).isEqualTo(same.hashCode());
+        assertThat(first.toString()).contains("orders");
+
+        FinalResultsSuppressionBuilder<Windowed<String>> finalBuilder =
+                new FinalResultsSuppressionBuilder<>("final", Suppressed.BufferConfig.unbounded().withNoBound());
+        assertThat(finalBuilder.withName("final-renamed")).isNotNull();
+        assertThat(finalBuilder.buildFinalResultsSuppression(Duration.ofSeconds(1))).isNotNull();
+        assertThat(finalBuilder.equals(finalBuilder)).isTrue();
+        assertThat(finalBuilder.hashCode()).isNotZero();
+    }
+
+    @Test
+    void shouldUseRecordAndWindowEndTimesForSuppression() {
+        org.apache.kafka.streams.processor.ProcessorContext context =
+                org_apache_kafka.kafka_streams.NativeCoverageFixtures.processorContext(77L);
+        Windowed<String> window = new Windowed<>("key", new TimeWindow(10L, 20L));
+        TimeDefinitions.RecordTimeDefinition<String> record = TimeDefinitions.RecordTimeDefinition.instance();
+        TimeDefinitions.WindowEndTimeDefinition<Windowed<String>> end = TimeDefinitions.WindowEndTimeDefinition.instance();
+        assertThat(record.time(context, "key")).isEqualTo(77L);
+        assertThat(record.type()).isNotNull();
+        assertThat(end.time(context, window)).isEqualTo(20L);
+        assertThat(end.type()).isNotNull();
+    }
+
+    private static SuppressedInternal<Windowed<String>> suppressedInternal(String name) {
+        return new SuppressedInternal<>(name, Duration.ofSeconds(2), Suppressed.BufferConfig.unbounded(),
+                TimeDefinitions.WindowEndTimeDefinition.instance(), true);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchValuesTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageBatchValuesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
+import org.apache.kafka.streams.internals.UpgradeFromValues;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.kstream.internals.NamedInternal;
+import org.apache.kafka.streams.kstream.internals.UnlimitedWindow;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.processor.api.Record;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Verifies public value objects, codecs, enums, and configuration names used by the streams API. */
+public class ApiCoverageBatchValuesTest {
+    @Test
+    void shouldRoundTripWindowedRecordsAndFixedKeyValues() throws Exception {
+        Windowed<String> timeWindow = new Windowed<>("order", new org.apache.kafka.streams.kstream.internals.TimeWindow(10, 20));
+        TimeWindowedSerializer<String> timeSerializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        TimeWindowedDeserializer<String> timeDeserializer = new TimeWindowedDeserializer<>(Serdes.String().deserializer(), 10L);
+        byte[] timeBytes = timeSerializer.serialize("orders", timeWindow);
+        assertThat(timeDeserializer.deserialize("orders", timeBytes)).isEqualTo(timeWindow);
+
+        Windowed<String> sessionWindow = new Windowed<>("order", new org.apache.kafka.streams.kstream.internals.SessionWindow(10, 20));
+        SessionWindowedSerializer<String> sessionSerializer = new SessionWindowedSerializer<>(Serdes.String().serializer());
+        SessionWindowedDeserializer<String> sessionDeserializer = new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+        byte[] sessionBytes = sessionSerializer.serialize("orders", sessionWindow);
+        assertThat(sessionDeserializer.deserialize("orders", sessionBytes)).isEqualTo(sessionWindow);
+        assertThat(WindowedSerdes.sessionWindowedSerdeFrom(String.class)).isNotNull();
+        assertThat(new WindowedSerdes.SessionWindowedSerde<>()).isNotNull();
+
+        Headers headers = new RecordHeaders().add("trace", new byte[] {1});
+        FixedKeyRecord<String, Integer> original = fixedKeyRecord("order", 3, 100L, headers);
+        FixedKeyRecord<String, Integer> same = fixedKeyRecord("order", 3, 100L, headers);
+        assertThat(original).isEqualTo(same);
+        assertThat(original.hashCode()).isEqualTo(same.hashCode());
+        assertThat(original.toString()).contains("order", "100");
+        assertThat(original.withTimestamp(200L).timestamp()).isEqualTo(200L);
+        assertThat(original.withHeaders(new RecordHeaders().add("route", new byte[] {2})).headers()).isNotEqualTo(headers);
+        Record<String, Integer> record = new Record<>("order", 3, 100L);
+        assertThat(record.withTimestamp(101L).timestamp()).isEqualTo(101L);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K, V> FixedKeyRecord<K, V> fixedKeyRecord(K key, V value, long timestamp, Headers headers)
+            throws Exception {
+        Constructor<FixedKeyRecord> constructor = FixedKeyRecord.class.getDeclaredConstructor(
+                Object.class, Object.class, long.class, Headers.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(key, value, timestamp, headers);
+    }
+
+    @Test
+    void shouldUseEveryNamedOperationFactoryAsAStableConfiguration() {
+        assertThat(NamedInternal.with("internal").withName("renamed").name()).isEqualTo("renamed");
+        assertThat(NamedInternal.empty().withName("filled").name()).isEqualTo("filled");
+        assertThat(Named.as("named").withName("renamed")).isNotNull();
+        assertThat(Branched.<String, String>as("branch").withName("renamed")).isNotNull();
+        assertThat(Consumed.with(Serdes.String(), Serdes.String()).withName("input")).isNotNull();
+        assertThat(Grouped.with(Serdes.String(), Serdes.String()).withName("group")).isNotNull();
+        assertThat(Joined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("join")).isNotNull();
+        assertThat(Printed.<String, String>toSysOut().withName("print")).isNotNull();
+        assertThat(Produced.with(Serdes.String(), Serdes.String()).withName("output")).isNotNull();
+        assertThat(Repartitioned.with(Serdes.String(), Serdes.String()).withName("repartition")).isNotNull();
+        assertThat(StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("stream-join")).isNotNull();
+        assertThat(TableJoined.as("table-join").withName("table-renamed")).isNotNull();
+        assertThat(Suppressed.untilTimeLimit(Duration.ofSeconds(1), Suppressed.BufferConfig.unbounded()).withName("suppressed")).isNotNull();
+    }
+
+    @Test
+    void shouldInspectEnumsAndWindowPartitionBehavior() {
+        assertThat(KafkaStreams.State.valueOf("CREATED")).isEqualTo(KafkaStreams.State.CREATED);
+        assertThat(KafkaStreams.State.values()).contains(KafkaStreams.State.RUNNING);
+        assertThat(Topology.AutoOffsetReset.valueOf("EARLIEST")).isEqualTo(Topology.AutoOffsetReset.EARLIEST);
+        assertThat(Topology.AutoOffsetReset.values()).isNotEmpty();
+        assertThat(DeserializationExceptionHandler.DeserializationHandlerResponse.valueOf("FAIL")).isNotNull();
+        assertThat(DeserializationExceptionHandler.DeserializationHandlerResponse.values()).isNotEmpty();
+        assertThat(ProductionExceptionHandler.ProductionExceptionHandlerResponse.values()).isNotEmpty();
+        assertThat(StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.values()).isNotEmpty();
+        assertThat(StreamsConfigUtils.ProcessingMode.values()).isNotEmpty();
+        assertThat(UpgradeFromValues.values()).isNotEmpty();
+        assertThat(EmitStrategy.StrategyType.values()).isNotEmpty();
+        assertThat(Materialized.StoreType.values()).isNotEmpty();
+        assertThat(PunctuationType.values()).contains(PunctuationType.STREAM_TIME);
+        assertThat(org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction.values()).isNotEmpty();
+
+        UnlimitedWindow unlimited = new UnlimitedWindow(100L);
+        assertThat(unlimited.overlap(new UnlimitedWindow(200L))).isTrue();
+        assertThat(UnlimitedWindows.of().startOn(java.time.Instant.ofEpochMilli(100))).isNotNull();
+        JoinWindows windows = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2));
+        assertThatThrownBy(() -> windows.windowsFor(100L)).isInstanceOf(UnsupportedOperationException.class);
+        StreamPartitioner<String, String> partitioner = (topic, key, value, partitions) -> 1;
+        assertThat(partitioner.partitions("orders", "key", "value", 3)).contains(java.util.Set.of(1));
+        assertThat(new KeyQueryMetadata(null, java.util.Set.of(), 0).hashCode()).isNotZero();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopDslTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopDslTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.suppress.EagerBufferConfigImpl;
+import org.apache.kafka.streams.kstream.internals.suppress.FinalResultsSuppressionBuilder;
+import org.apache.kafka.streams.kstream.internals.suppress.StrictBufferConfigImpl;
+import org.apache.kafka.streams.kstream.internals.suppress.SuppressedInternal;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives the public topology DSL through the join, grouping, suppression, and window subsystems. */
+public class ApiCoverageLoopDslTest {
+    @Test
+    void shouldBuildAllWindowedGroupingAndJoinVariants() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> left = builder.stream("coverage-dsl-left",
+                Consumed.with(Serdes.String(), Serdes.String()).withName("consumed"));
+        KStream<String, String> right = builder.stream("coverage-dsl-right");
+        KTable<String, String> table = builder.table("coverage-dsl-table");
+        Materialized<String, Long, org.apache.kafka.streams.state.KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.Long());
+        ValueJoiner<String, String, String> joiner = (a, b) -> String.valueOf(a) + b;
+        StreamJoined<String, String, String> streamJoined = StreamJoined.with(
+                Serdes.String(), Serdes.String(), Serdes.String()).as("stream-joined");
+        JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2));
+
+        assertThat(left.leftJoin(right, joiner, joinWindows, streamJoined)).isNotNull();
+        assertThat(left.outerJoin(right, joiner, joinWindows, StreamJoined.with(
+                Serdes.String(), Serdes.String(), Serdes.String()).as("outer-joined"))).isNotNull();
+        assertThat(left.leftJoin(table, joiner)).isNotNull();
+        assertThat(left.leftJoin(table, joiner)).isNotNull();
+        KGroupedStream<String, String> grouped = left.groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        assertThat(grouped.cogroup((key, value, aggregate) -> aggregate + value)).isNotNull();
+        assertThat(grouped.windowedBy(TimeWindows.of(Duration.ofSeconds(5))).count(
+                Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(grouped.windowedBy(TimeWindows.of(Duration.ofSeconds(5))).reduce((a, b) -> a + b,
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(grouped.windowedBy(TimeWindows.of(Duration.ofSeconds(5))).aggregate(
+                () -> "", (key, value, aggregate) -> aggregate + value, Named.as("time-aggregate"),
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(grouped.windowedBy(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1)))
+                .count(Named.as("sliding-count"), Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(grouped.windowedBy(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1)))
+                .reduce((a, b) -> a + b, Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(grouped.windowedBy(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1)))
+                .aggregate(() -> "", (key, value, aggregate) -> aggregate + value, Named.as("sliding-aggregate"))).isNotNull();
+        assertThat(grouped.windowedBy(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1)))
+                .emitStrategy(EmitStrategy.onWindowClose())).isNotNull();
+        assertThat(grouped.windowedBy(SessionWindows.with(Duration.ofSeconds(4))).aggregate(
+                () -> "", (key, value, aggregate) -> aggregate + value,
+                (key, aggregate, merged) -> aggregate + merged)).isNotNull();
+        assertThat(grouped.windowedBy(SessionWindows.with(Duration.ofSeconds(4))).aggregate(
+                () -> "", (key, value, aggregate) -> aggregate + value,
+                (key, aggregate, merged) -> aggregate + merged, Named.as("session-aggregate"),
+                Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+
+        KTable<String, String> suppressedSource = builder.table("coverage-suppression-table");
+        assertThat(suppressedSource.suppress(org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit(
+                Duration.ofSeconds(1), org.apache.kafka.streams.kstream.Suppressed.BufferConfig.maxRecords(10)))).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("coverage-dsl-left", "coverage-dsl-table");
+    }
+
+    @Test
+    void shouldExerciseConfigurationValueObjectsAndNamedOperations() {
+        assertThat(Named.as("named").withName("renamed")).isNotNull();
+        assertThat(Branched.as("branch").withName("branch-renamed")).isNotNull();
+        assertThat(Consumed.with(Serdes.String(), Serdes.String()).withName("input")).isNotNull();
+        assertThat(Grouped.with(Serdes.String(), Serdes.String()).withName("group")).isNotNull();
+        assertThat(Printed.<String, String>toSysOut().withName("print")).isNotNull();
+        assertThat(Repartitioned.<String, String>with(Serdes.String(), Serdes.String()).withName("repartition")).isNotNull();
+        assertThat(Produced.with(Serdes.String(), Serdes.String()).withName("output")).isNotNull();
+
+        EagerBufferConfigImpl eager = new EagerBufferConfigImpl(10, 100, Map.of("segment.ms", "1"));
+        assertThat(eager.withMaxRecords(4).withMaxBytes(40).withLoggingDisabled()).isNotNull();
+        eager.withLoggingEnabled(Map.of("segment.ms", "2"));
+        assertThat(eager.isLoggingEnabled()).isTrue();
+        assertThat(eager.bufferFullStrategy()).isNotNull();
+        assertThat(eager).isEqualTo(new EagerBufferConfigImpl(10, 100, Map.of("segment.ms", "1")));
+        assertThat(eager.hashCode()).isEqualTo(new EagerBufferConfigImpl(10, 100, Map.of("segment.ms", "1")).hashCode());
+        assertThat(eager.toString()).contains("EagerBufferConfig");
+
+        StrictBufferConfigImpl strict = new StrictBufferConfigImpl();
+        assertThat(strict.withMaxRecords(3).withMaxBytes(30).withLoggingDisabled()).isNotNull();
+        strict.withLoggingEnabled(Map.of("retention.ms", "10"));
+        assertThat(strict.isLoggingEnabled()).isTrue();
+        assertThat(strict).isEqualTo(new StrictBufferConfigImpl());
+        assertThat(strict.hashCode()).isEqualTo(new StrictBufferConfigImpl().hashCode());
+        assertThat(strict.toString()).contains("StrictBufferConfig");
+
+        FinalResultsSuppressionBuilder<Windowed<String>> finalBuilder =
+                new FinalResultsSuppressionBuilder<>("final-name", new StrictBufferConfigImpl());
+        SuppressedInternal<Windowed<String>> suppression = finalBuilder.buildFinalResultsSuppression(Duration.ofSeconds(2));
+        assertThat(suppression).isNotNull();
+        assertThat(finalBuilder.name()).isEqualTo("final-name");
+        assertThat(finalBuilder.withName("other")).isNotNull();
+        assertThat(finalBuilder.toString()).contains("final-name");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopGraphTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopGraphTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
+import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilder;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode;
+import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
+import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
+import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableProcessorNode;
+import org.apache.kafka.streams.kstream.internals.graph.TableSourceNode;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Verifies the graph objects produced while public stream builders assemble a topology. */
+public class ApiCoverageLoopGraphTest {
+    @Test
+    void shouldManageGraphParentsChildrenAndSourceSerdes() {
+        InternalStreamsBuilder streamsBuilder = new InternalStreamsBuilder(new InternalTopologyBuilder());
+        assertThat(streamsBuilder.root()).isNotNull();
+        streamsBuilder.buildAndOptimizeTopology();
+        assertThat(streamsBuilder.root().children()).isEmpty();
+
+        ConsumedInternal<String, String> consumed = new ConsumedInternal<>(
+                Consumed.with(Serdes.String(), Serdes.String()));
+        StreamSourceNode<String, String> source = new StreamSourceNode<>(
+                "source", List.of("topic"), consumed);
+        StreamSourceNode<String, String> other = new StreamSourceNode<>(
+                "other", List.of("other-topic"), consumed);
+        assertThat(source.keySerde()).isNotNull();
+        assertThat(source.valueSerde()).isNotNull();
+        source.merge(other);
+        assertThat(source.toString()).contains("source");
+
+        GraphNode child = new EmptyGraphNode("child");
+        source.addChild(child);
+        assertThat(source.children()).contains(child);
+        assertThat(source.removeChild(child)).isTrue();
+        source.addChild(child);
+        source.clearChildren();
+        assertThat(source.children()).isEmpty();
+    }
+
+    @Test
+    void shouldBuildProcessorAndRepartitionGraphNodes() {
+        FixedKeyProcessorSupplier<String, String, String> fixedSupplier = () -> new FixedKeyProcessor<>() {
+            @Override public void init(org.apache.kafka.streams.processor.api.FixedKeyProcessorContext<String, String> context) { }
+            @Override public void process(org.apache.kafka.streams.processor.api.FixedKeyRecord<String, String> record) { }
+        };
+        ProcessorParameters<String, String, String, String> parameters = new ProcessorParameters<>(fixedSupplier, "fixed");
+        assertThat(parameters.fixedKeyProcessorSupplier()).isSameAs(fixedSupplier);
+        assertThat(parameters.processorName()).isEqualTo("fixed");
+
+        TableProcessorNode<String, String> tableProcessor = new TableProcessorNode<>("table-processor", parameters, null);
+        assertThat(tableProcessor.processorParameters()).isSameAs(parameters);
+        assertThat(tableProcessor.toString()).contains("table-processor");
+
+        TableSourceNode<String, String> tableSource = TableSourceNode.<String, String>tableSourceNodeBuilder()
+                .withNodeName("table-source")
+                .withSourceName("source")
+                .withTopic("topic")
+                .withConsumedInternal(new ConsumedInternal<>(Consumed.with(Serdes.String(), Serdes.String())))
+                .withProcessorParameters(parameters)
+                .isGlobalKTable(false)
+                .build();
+        tableSource.reuseSourceTopicForChangeLog(true);
+        assertThat(tableSource.keySerde()).isNotNull();
+        assertThat(tableSource.valueSerde()).isNotNull();
+
+        OptimizableRepartitionNode<String, String> repartition =
+                OptimizableRepartitionNode.<String, String>optimizableRepartitionNodeBuilder()
+                        .withNodeName("repartition-node")
+                        .withProcessorParameters(parameters)
+                        .withKeySerde(Serdes.String())
+                        .withValueSerde(Serdes.String())
+                        .withSinkName("sink")
+                        .withSourceName("source")
+                        .withRepartitionTopic("repartition-topic")
+                        .build();
+        assertThat(repartition.keySerde()).isNotNull();
+        assertThat(repartition.valueSerde()).isNotNull();
+        assertThat(repartition.repartitionTopic()).isEqualTo("repartition-topic");
+
+        StreamStreamJoinNode.StreamStreamJoinNodeBuilder<String, String, String, String> joinBuilder =
+                StreamStreamJoinNode.streamStreamJoinNodeBuilder();
+        assertThat(joinBuilder.withNodeName("join-node")
+                .withValueJoiner((key, left, right) -> left + right)
+                .withJoined(Joined.with(Serdes.String(), Serdes.String(), Serdes.String()))).isNotNull();
+    }
+
+    private static final class EmptyGraphNode extends GraphNode {
+        private EmptyGraphNode(String name) {
+            super(name);
+        }
+        @Override public void writeToTopology(InternalTopologyBuilder builder) { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopTopologyInternalsTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopTopologyInternalsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
+import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.QuickUnion;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Builds low-level topology descriptions and verifies their public graph contracts. */
+public class ApiCoverageLoopTopologyInternalsTest {
+    @Test
+    void shouldDescribeSourcesProcessorsSinksAndStores() {
+        InternalTopologyBuilder builder = new InternalTopologyBuilder();
+        builder.setApplicationId("coverage-topology");
+        builder.addSource(null, "source", null, Serdes.String().deserializer(), Serdes.String().deserializer(), "orders");
+        ProcessorSupplier<String, String, String, String> supplier = () -> new org.apache.kafka.streams.processor.api.Processor<>() {
+            @Override
+            public void process(Record<String, String> record) {
+                // This processor is intentionally a pass-through topology component.
+            }
+        };
+        builder.addProcessor("processor", supplier, "source");
+        builder.addStateStore(Stores.keyValueStoreBuilder(
+                Stores.inMemoryKeyValueStore("store"), Serdes.String(), Serdes.String()), "processor");
+        builder.addSink("sink", "output", Serdes.String().serializer(), Serdes.String().serializer(), null, "processor");
+
+        assertThat(builder.allStateStoreNames()).contains("store");
+        assertThat(builder.stateStores()).containsKey("store");
+        assertThat(builder.sourceTopicsForStore("store")).contains("orders");
+        assertThat(builder.decoratePseudoTopic("output")).contains("output");
+        assertThat(builder.isStoreVersioned("store")).isFalse();
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> builder.getHistoryRetention("store"))
+                .isInstanceOf(IllegalStateException.class);
+        builder.maybeUpdateCopartitionSourceGroups("source", "processor");
+
+        ProcessorTopology topology = builder.buildSubtopology(0);
+        assertThat(topology.sourceTopics()).contains("orders");
+        assertThat(topology.processorConnectedStateStores("processor")).contains("store");
+        assertThat(topology.hasPersistentLocalStore()).isFalse();
+        assertThat(topology.hasPersistentGlobalStore()).isFalse();
+        assertThat(topology.toString()).contains("processor");
+        assertThat(topology.toString("  ")).contains("processor");
+        topology.updateSourceTopics(Map.of("source", List.of("orders", "returns")));
+        assertThat(topology.sourceTopics()).contains("returns");
+    }
+
+    @Test
+    void shouldConnectDescriptionNodesAndPreserveValueSemantics() {
+        InternalTopologyBuilder.Source source = new InternalTopologyBuilder.Source(
+                "source", Set.of("orders"), null);
+        InternalTopologyBuilder.Source patternSource = new InternalTopologyBuilder.Source(
+                "pattern-source", null, Pattern.compile("returns-.*"));
+        InternalTopologyBuilder.Processor processor = new InternalTopologyBuilder.Processor("processor", Set.of("store"));
+        InternalTopologyBuilder.Sink<String, String> sink = new InternalTopologyBuilder.Sink<>("sink", "output");
+        source.addSuccessor(processor);
+        processor.addPredecessor(source);
+        processor.addSuccessor(sink);
+        sink.addPredecessor(processor);
+
+        assertThat(source.topicSet()).containsExactly("orders");
+        assertThat(patternSource.topicPattern().matcher("returns-eu").matches()).isTrue();
+        assertThat(source.successors()).containsExactly(processor);
+        assertThat(processor.stores()).containsExactly("store");
+        assertThat(sink.topicNameExtractor()).isNull();
+        InternalTopologyBuilder.Sink<String, String> dynamicSink = new InternalTopologyBuilder.Sink<>(
+                "dynamic", (key, value, context) -> "dynamic-" + key);
+        assertThat(dynamicSink.topicNameExtractor().extract("k", "v", null)).isEqualTo("dynamic-k");
+        assertThat(sink.predecessors()).containsExactly(processor);
+
+        InternalTopologyBuilder.TopologyDescription description = new InternalTopologyBuilder.TopologyDescription();
+        assertThat(description.subtopologies()).isEmpty();
+        assertThat(description.globalStores()).isEmpty();
+        assertThat(description).isEqualTo(new InternalTopologyBuilder.TopologyDescription());
+        assertThat(description.hashCode()).isEqualTo(new InternalTopologyBuilder.TopologyDescription().hashCode());
+        assertThat(description.toString()).isNotNull();
+    }
+
+    @Test
+    void shouldUseQuickUnionAndBuildPublicDslTopology() {
+        QuickUnion<String> union = new QuickUnion<>();
+        union.add("orders");
+        union.add("returns");
+        assertThat(union.exists("orders")).isTrue();
+        assertThat(union.exists("missing")).isFalse();
+        assertThat(union.root("orders")).isEqualTo("orders");
+        assertThat(union.root("returns")).isEqualTo("returns");
+
+        org.apache.kafka.streams.StreamsBuilder streamsBuilder = new org.apache.kafka.streams.StreamsBuilder();
+        streamsBuilder.stream("orders", Consumed.with(Serdes.String(), Serdes.String())).to("output");
+        Topology topology = streamsBuilder.build();
+        assertThat(topology.describe().toString()).contains("orders", "output");
+        assertThat(topology.describe().hashCode()).isEqualTo(topology.describe().hashCode());
+        assertThat(new TopologyConfig(new StreamsConfig(Map.of(
+                StreamsConfig.APPLICATION_ID_CONFIG, "topology-config",
+                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"))).toString()).isNotNull();
+    }
+
+    @Test
+    void shouldRenderAndCloseProcessorNodes() {
+        ProcessorNode<String, String, String, String> node = new ProcessorNode<>("node");
+        ProcessorNode<String, String, String, String> child = new ProcessorNode<>("child");
+        node.addChild(child);
+        assertThat(node.children()).containsExactly(child);
+        assertThat(node.isTerminalNode()).isFalse();
+        assertThat(child.isTerminalNode()).isTrue();
+        assertThat(node.toString()).contains("node");
+        assertThat(node.toString("--")).contains("node");
+        node.punctuate(5L, timestamp -> { });
+        org.assertj.core.api.Assertions.assertThatThrownBy(node::close)
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(node.toString()).contains("node");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopValueContractsTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopValueContractsTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.ChangedDeserializer;
+import org.apache.kafka.streams.kstream.internals.ChangedSerializer;
+import org.apache.kafka.streams.state.internals.LeftOrRightValue;
+import org.apache.kafka.streams.state.internals.LeftOrRightValueSerde;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.kstream.internals.emitstrategy.WindowCloseStrategy;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.processor.BatchingStateRestoreCallback;
+import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.internals.ProcessorMetadata;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises public codecs, timestamp policies, and small state/value contracts as users consume them. */
+public class ApiCoverageLoopValueContractsTest {
+    @Test
+    void shouldRoundTripProcessorContextAndMetadata() {
+        ProcessorRecordContext context = new ProcessorRecordContext(
+                23L, 41L, 2, "orders", new RecordHeaders().add("trace", new byte[] {1}));
+        ProcessorRecordContext copy = ProcessorRecordContext.deserialize(ByteBuffer.wrap(context.serialize()));
+        assertThat(copy).isEqualTo(context);
+        assertThatThrownBy(copy::hashCode).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(copy.toString()).contains("orders");
+        assertThat(copy.residentMemorySizeEstimate()).isPositive();
+
+        ProcessorMetadata metadata = new ProcessorMetadata(new HashMap<>(Map.of("orders", 3L)));
+        metadata.put("payments", 7L);
+        metadata.setNeedsCommit(true);
+        assertThat(metadata.needsCommit()).isTrue();
+        ProcessorMetadata restored = ProcessorMetadata.deserialize(metadata.serialize());
+        assertThat(restored.get("orders")).isEqualTo(3L);
+        assertThat(restored.get("payments")).isEqualTo(7L);
+        assertThat(restored.needsCommit()).isFalse();
+        ProcessorMetadata update = new ProcessorMetadata(Map.of("orders", 9L));
+        restored.update(update);
+        assertThat(restored.get("orders")).isEqualTo(9L);
+        assertThat(restored).isEqualTo(ProcessorMetadata.deserialize(restored.serialize()));
+    }
+
+    @Test
+    void shouldRoundTripTimeAndSessionWindowSerdes() {
+        Windowed<String> timeWindow = new Windowed<>("key", new TimeWindow(10L, 20L));
+        TimeWindowedSerializer<String> timeSerializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        TimeWindowedDeserializer<String> timeDeserializer = new TimeWindowedDeserializer<>(
+                Serdes.String().deserializer(), 10L);
+        byte[] timeBytes = timeSerializer.serialize("orders", timeWindow);
+        assertThat(timeDeserializer.deserialize("orders", timeBytes)).isEqualTo(timeWindow);
+        TimeWindowedSerializer rawTimeSerializer = timeSerializer;
+        assertThat(rawTimeSerializer.serialize("orders", timeWindow)).isEqualTo(timeBytes);
+
+        Windowed<String> sessionWindow = new Windowed<>("key", new SessionWindow(30L, 50L));
+        SessionWindowedSerializer<String> sessionSerializer =
+                new SessionWindowedSerializer<>(Serdes.String().serializer());
+        SessionWindowedDeserializer<String> sessionDeserializer =
+                new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+        byte[] sessionBytes = sessionSerializer.serialize("orders", sessionWindow);
+        assertThat(sessionDeserializer.deserialize("orders", sessionBytes)).isEqualTo(sessionWindow);
+        SessionWindowedSerializer rawSessionSerializer = sessionSerializer;
+        assertThat(rawSessionSerializer.serialize("orders", sessionWindow)).isEqualTo(sessionBytes);
+    }
+
+    @Test
+    void shouldRoundTripChangedValuesAndGeneratedProtocolMessages() {
+        ChangedSerializer<String> serializer = new ChangedSerializer<>(Serdes.String().serializer());
+        ChangedDeserializer<String> deserializer = new ChangedDeserializer<>(Serdes.String().deserializer());
+        Change<String> change = new Change<>("new", "old", true);
+        byte[] bytes = serializer.serialize("orders", change);
+        assertThat(deserializer.deserialize("orders", bytes)).isEqualTo(change);
+        assertThat(serializer.serialize("orders", new RecordHeaders(), change)).isEqualTo(bytes);
+        assertThat(deserializer.deserialize("orders", new RecordHeaders(), bytes)).isEqualTo(change);
+        byte[] notLatestBytes = serializer.serialize("orders", new Change<>(null, "old", true));
+        notLatestBytes = java.util.Arrays.copyOf(notLatestBytes, notLatestBytes.length + 1);
+        notLatestBytes[notLatestBytes.length - 2] = 0;
+        notLatestBytes[notLatestBytes.length - 1] = 3;
+        Change<String> decodedNotLatest = deserializer.deserialize("orders", notLatestBytes);
+        assertThat(decodedNotLatest.newValue).isNull();
+        assertThat(decodedNotLatest.oldValue).isEqualTo("old");
+        assertThat(decodedNotLatest.isLatest).isFalse();
+        serializer.close();
+        deserializer.close();
+
+        SubscriptionInfoData data = new SubscriptionInfoData()
+                .setVersion(1).setLatestSupportedVersion(2).setUserEndPoint(new byte[] {1});
+        SubscriptionInfoData copy = data.duplicate();
+        assertThat(copy).isEqualTo(data);
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag()
+                .setKey(new byte[] {1}).setValue(new byte[] {2});
+        assertThat(tag.duplicate()).isEqualTo(tag);
+        SubscriptionInfoData.TaskId task = new SubscriptionInfoData.TaskId().setTopicGroupId(1).setPartition(2);
+        assertThat(task.duplicate()).isEqualTo(task);
+        SubscriptionInfoData.PartitionToOffsetSum partition = new SubscriptionInfoData.PartitionToOffsetSum()
+                .setPartition(2).setOffsetSum(3L);
+        assertThat(partition.duplicate()).isEqualTo(partition);
+        SubscriptionInfoData.TaskOffsetSum offset = new SubscriptionInfoData.TaskOffsetSum()
+                .setTopicGroupId(1).setPartition(2).setOffsetSum(3L);
+        assertThat(offset.duplicate()).isEqualTo(offset);
+    }
+
+    @Test
+    void shouldRoundTripLeftAndRightSerdeValues() {
+        LeftOrRightValueSerde<String, Integer> serde = new LeftOrRightValueSerde<>(
+                Serdes.String(), Serdes.Integer());
+        LeftOrRightValue<String, Integer> left = LeftOrRightValue.makeLeftValue("left");
+        LeftOrRightValue<String, Integer> right = LeftOrRightValue.makeRightValue(7);
+        assertThat(serde.deserializer().deserialize("join", serde.serializer().serialize("join", left)))
+                .isEqualTo(left);
+        assertThat(serde.deserializer().deserialize("join", serde.serializer().serialize("join", right)))
+                .isEqualTo(right);
+    }
+
+    @Test
+    void shouldExposeWindowAndEnumValueContracts() {
+        assertThat(UnlimitedWindows.of().hashCode()).isEqualTo(UnlimitedWindows.of().hashCode());
+        assertThat(new WindowCloseStrategy().type()).isEqualTo(
+                org.apache.kafka.streams.kstream.EmitStrategy.StrategyType.ON_WINDOW_CLOSE);
+        assertThat(org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.valueOf("EMIT"))
+                .isEqualTo(org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.EMIT);
+        assertThat(org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction.values())
+                .contains(org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction.DELETE_KEY_NO_PROPAGATE);
+    }
+
+    @Test
+    void shouldResolvePublicProtocolAndLifecycleEnums() {
+        assertThat(org.apache.kafka.streams.KafkaStreams.State.values()).contains(org.apache.kafka.streams.KafkaStreams.State.CREATED);
+        assertThat(org.apache.kafka.streams.KafkaStreams.State.valueOf("CREATED"))
+                .isEqualTo(org.apache.kafka.streams.KafkaStreams.State.CREATED);
+        assertThat(org.apache.kafka.streams.Topology.AutoOffsetReset.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.Topology.AutoOffsetReset.valueOf("EARLIEST"))
+                .isEqualTo(org.apache.kafka.streams.Topology.AutoOffsetReset.EARLIEST);
+        assertThat(org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse.values())
+                .isNotEmpty();
+        assertThat(org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse.values())
+                .isNotEmpty();
+        assertThat(org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.values())
+                .isNotEmpty();
+        assertThat(org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.internals.UpgradeFromValues.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.kstream.EmitStrategy.StrategyType.values()).contains(
+                org.apache.kafka.streams.kstream.EmitStrategy.StrategyType.ON_WINDOW_CLOSE);
+        assertThat(org.apache.kafka.streams.kstream.Materialized.StoreType.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.processor.PunctuationType.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.values()).isNotEmpty();
+    }
+
+    @Test
+    void shouldApplyInvalidTimestampPoliciesAndCompareTaskIds() {
+        ConsumerRecord<Object, Object> invalid = new ConsumerRecord<>("orders", 3, 1L, -1L,
+                TimestampType.CREATE_TIME, 0L, 0, 0, null, null, new RecordHeaders());
+        ConsumerRecord<Object, Object> valid = new ConsumerRecord<>("orders", 3, 2L, 99L,
+                TimestampType.CREATE_TIME, 0L, 0, 0, null, null, new RecordHeaders());
+        assertThat(new LogAndSkipOnInvalidTimestamp().extract(invalid, 12L)).isEqualTo(-1L);
+        assertThat(new UsePartitionTimeOnInvalidTimestamp().extract(invalid, 12L)).isEqualTo(12L);
+        assertThat(new FailOnInvalidTimestamp().extract(valid, 12L)).isEqualTo(99L);
+        assertThatThrownBy(() -> new FailOnInvalidTimestamp().extract(invalid, 12L))
+                .isInstanceOf(RuntimeException.class);
+
+        TaskId first = new TaskId(1, 2);
+        TaskId second = new TaskId(2, 0);
+        Comparable comparable = first;
+        assertThat(comparable.compareTo(second)).isNegative();
+    }
+
+    @Test
+    void shouldDeliverDefaultBatchRestoreCallbacks() {
+        AtomicReference<Collection<KeyValue<byte[], byte[]>>> restored = new AtomicReference<>();
+        BatchingStateRestoreCallback callback = new BatchingStateRestoreCallback() {
+            @Override
+            public void restoreAll(Collection<KeyValue<byte[], byte[]>> records) {
+                restored.set(records);
+            }
+        };
+        assertThatThrownBy(() -> callback.restore(new byte[] {1}, new byte[] {2}))
+                .isInstanceOf(UnsupportedOperationException.class);
+        callback.restoreAll(List.of(KeyValue.pair(new byte[] {1}, new byte[] {2})));
+        assertThat(restored.get()).hasSize(1);
+        assertThat(restored.get().iterator().next().key).containsExactly(1);
+        assertThat(restored.get().iterator().next().value).containsExactly(2);
+
+        AtomicReference<Collection<KeyValue<byte[], byte[]>>> empty = new AtomicReference<>();
+        callback.restoreAll(List.of());
+        empty.set(List.of());
+        assertThat(empty.get()).isEmpty();
+        assertThat(Bytes.wrap(new byte[] {1})).isEqualTo(Bytes.wrap(new byte[] {1}));
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopValueObjectsTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ApiCoverageLoopValueObjectsTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.CombinedKey;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.CombinedKeySchema;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionResponseWrapper;
+import org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper;
+import org.apache.kafka.streams.internals.UpgradeFromValues;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.ValueAndTimestampSerde;
+import org.apache.kafka.streams.state.internals.ValueAndTimestampSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises foreign-key records, protocol values, and timestamped serialization contracts. */
+public class ApiCoverageLoopValueObjectsTest {
+    @Test
+    void shouldRoundTripForeignKeyAndSubscriptionValues() {
+        CombinedKeySchema<String, String> schema = new CombinedKeySchema<>(
+                () -> "foreign-topic", Serdes.String(), () -> "primary-topic", Serdes.String());
+        schema.init(null);
+        byte[] foreign = Serdes.String().serializer().serialize("foreign-topic", "foreign");
+        byte[] primary = Serdes.String().serializer().serialize("primary-topic", "primary");
+        byte[] encoded = ByteBuffer.allocate(4 + foreign.length + primary.length)
+                .putInt(foreign.length).put(foreign).put(primary).array();
+        CombinedKey<String, String> key = schema.fromBytes(Bytes.wrap(encoded));
+        assertThat(key.getForeignKey()).isEqualTo("foreign");
+        assertThat(key.getPrimaryKey()).isEqualTo("primary");
+        assertThat(key).isEqualTo(schema.fromBytes(Bytes.wrap(encoded)));
+        assertThat(key.hashCode()).isEqualTo(schema.fromBytes(Bytes.wrap(encoded)).hashCode());
+        assertThat(key.toString()).contains("foreign", "primary");
+
+        SubscriptionWrapper<String> subscription = new SubscriptionWrapper<>(
+                new long[] {1L, 2L}, SubscriptionWrapper.Instruction.DELETE_KEY_AND_PROPAGATE, "primary", (byte) 0, Integer.valueOf(4));
+        SubscriptionWrapper<String> oldForm = new SubscriptionWrapper<>(
+                new long[] {1L, 2L}, SubscriptionWrapper.Instruction.DELETE_KEY_AND_PROPAGATE, "primary", 5);
+        assertThat(subscription.getHash()).containsExactly(1L, 2L);
+        assertThat(subscription.getInstruction()).isEqualTo(SubscriptionWrapper.Instruction.DELETE_KEY_AND_PROPAGATE);
+        assertThat(subscription.getPrimaryKey()).isEqualTo("primary");
+        assertThat(subscription.getVersion()).isEqualTo((byte) 0);
+        assertThat(subscription.getPrimaryPartition()).isEqualTo(4);
+        assertThat(subscription).isNotEqualTo(oldForm);
+        assertThat(subscription.hashCode()).isNotEqualTo(0);
+        assertThat(subscription.toString()).contains("primary");
+        for (SubscriptionWrapper.Instruction instruction : SubscriptionWrapper.Instruction.values()) {
+            assertThat(SubscriptionWrapper.Instruction.valueOf(instruction.name())).isSameAs(instruction);
+            assertThat(SubscriptionWrapper.Instruction.fromValue(instruction.getValue())).isSameAs(instruction);
+        }
+
+        SubscriptionResponseWrapper<String> response = new SubscriptionResponseWrapper<>(
+                new long[] {5L}, "foreign-value", (byte) 0, 4);
+        SubscriptionResponseWrapper<String> responseOld = new SubscriptionResponseWrapper<>(
+                new long[] {5L}, "foreign-value", 4);
+        assertThat(response.getOriginalValueHash()).containsExactly(5L);
+        assertThat(response.getForeignValue()).isEqualTo("foreign-value");
+        assertThat(response.getVersion()).isEqualTo((byte) 0);
+        assertThat(response.getPrimaryPartition()).isEqualTo(4);
+        assertThat(response).isEqualTo(responseOld);
+        assertThat(response.hashCode()).isEqualTo(responseOld.hashCode());
+        assertThat(response.toString()).contains("foreign-value");
+    }
+
+    @Test
+    void shouldPreserveGeneratedProtocolMessageVersionsAndCopies() {
+        SubscriptionInfoData data = new SubscriptionInfoData().setVersion(2).setLatestSupportedVersion(4);
+        SubscriptionInfoData copy = data.duplicate();
+        assertThat(copy).isEqualTo(data);
+        assertThat(copy).isNotSameAs(data);
+        assertThat(data.lowestSupportedVersion()).isLessThanOrEqualTo(data.highestSupportedVersion());
+
+        SubscriptionInfoData.TaskId task = new SubscriptionInfoData.TaskId().setTopicGroupId(7).setPartition(2);
+        SubscriptionInfoData.TaskId taskCopy = task.duplicate();
+        assertThat(taskCopy).isEqualTo(task);
+        assertThat(taskCopy).isNotSameAs(task);
+        assertThat(task.hashCode()).isEqualTo(taskCopy.hashCode());
+        assertThat(task.lowestSupportedVersion()).isLessThanOrEqualTo(task.highestSupportedVersion());
+
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag();
+        assertThat(tag.duplicate()).isEqualTo(tag);
+        assertThat(tag.lowestSupportedVersion()).isLessThanOrEqualTo(tag.highestSupportedVersion());
+        SubscriptionInfoData.PartitionToOffsetSum partition = new SubscriptionInfoData.PartitionToOffsetSum();
+        assertThat(partition.duplicate()).isEqualTo(partition);
+        assertThat(partition.lowestSupportedVersion()).isLessThanOrEqualTo(partition.highestSupportedVersion());
+        SubscriptionInfoData.TaskOffsetSum offset = new SubscriptionInfoData.TaskOffsetSum();
+        assertThat(offset.duplicate()).isEqualTo(offset);
+        assertThat(offset.lowestSupportedVersion()).isLessThanOrEqualTo(offset.highestSupportedVersion());
+    }
+
+    @Test
+    void shouldHandleTimestampAndRecordTimeContracts() {
+        ValueAndTimestampSerde<String> serde = new ValueAndTimestampSerde<>(Serdes.String());
+        byte[] first = serde.serializer().serialize("topic", ValueAndTimestamp.make("value", 10));
+        byte[] sameValueLater = serde.serializer().serialize("topic", ValueAndTimestamp.make("value", 11));
+        byte[] changed = serde.serializer().serialize("topic", ValueAndTimestamp.make("other", 12));
+        assertThat(ValueAndTimestampSerializer.valuesAreSameAndTimeIsIncreasing(first, sameValueLater)).isTrue();
+        assertThat(ValueAndTimestampSerializer.valuesAreSameAndTimeIsIncreasing(first, changed)).isFalse();
+        serde.configure(Map.of(), false);
+        serde.close();
+
+        ProcessorContext context = NativeCoverageFixtures.processorContext(123L);
+        assertThat(context.timestamp()).isEqualTo(123L);
+        Windowed<String> windowed = new Windowed<>("key", new TimeWindow(100, 200));
+        assertThat(windowed.window().end()).isEqualTo(200L);
+
+        assertThat(UpgradeFromValues.getValueFromString("3.4")).isEqualTo(UpgradeFromValues.UPGRADE_FROM_34);
+        assertThat(UpgradeFromValues.valueOf("UPGRADE_FROM_34")).isEqualTo(UpgradeFromValues.UPGRADE_FROM_34);
+        assertThat(UpgradeFromValues.values()).contains(UpgradeFromValues.UPGRADE_FROM_34);
+        assertThat(new Windowed<>("key", new SessionWindow(1, 2)).toString()).contains("key");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AssignmentGraphApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/AssignmentGraphApiCoverageTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
+import org.apache.kafka.streams.processor.internals.assignment.Graph;
+import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssignor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises assignment flow solving and the empty-cluster rack-aware assignment contract. */
+public class AssignmentGraphApiCoverageTest {
+    @Test
+    void shouldSolveMinCostFlowAndExposeResidualEdges() {
+        Graph<Integer> graph = new Graph<>();
+        graph.addEdge(0, 1, 1, 7, 1);
+        graph.setSourceNode(0);
+        graph.setSinkNode(1);
+        assertThat(graph.nodes()).containsExactly(0, 1);
+        assertThat(graph.edges(0)).containsKey(1);
+        assertThat(graph.isResidualGraph()).isFalse();
+
+        graph.solveMinCostFlow();
+        assertThat(graph.totalCost()).isEqualTo(7L);
+        Graph<Integer> residual = graph.residualGraph();
+        assertThat(residual.isResidualGraph()).isTrue();
+        assertThat(residual.nodes()).containsExactly(0, 1);
+        assertThat(residual.edges(0)).containsKey(1);
+
+        Graph<Integer>.Edge edge = graph.edges(0).get(1);
+        Graph<Integer>.Edge same = graph.new Edge(1, 1, 7, 0, 1);
+        assertThat(same).isEqualTo(graph.new Edge(1, 1, 7, 0, 1));
+        assertThat(edge.toString()).contains("1");
+        assertThat(edge.hashCode()).isEqualTo(edge.hashCode());
+    }
+
+    @Test
+    void shouldInspectRackAwareStateAndOptimizeEmptyAssignments() throws Exception {
+        RackAwareTaskAssignor assignor = new RackAwareTaskAssignor(
+                Cluster.empty(), Map.of(), Map.of(), Map.of(), Map.of(), null,
+                assignmentConfigs(), org.apache.kafka.common.utils.Time.SYSTEM);
+        Set<String> topics = new java.util.HashSet<>();
+        assertThat(assignor.racksForPartition()).isEmpty();
+        assertThat(assignor.populateTopicsToDescribe(topics, false)).isTrue();
+        assertThat(topics).isEmpty();
+        assertThat(assignor.optimizeActiveTasks(new TreeSet<>(), new TreeMap<>(), 0, 0)).isZero();
+        assertThat(assignor.optimizeStandbyTasks(new TreeMap<>(), 0, 0,
+                (source, destination, task, clients) -> true)).isZero();
+
+        TaskId task = new TaskId(6, 0);
+        TopicPartition partition = new TopicPartition("rack-topic", 0);
+        Node node = new Node(0, "rack-host", 9092, "rack-a");
+        Cluster cluster = new Cluster("rack-cluster", List.of(node),
+                List.of(new PartitionInfo("rack-topic", 0, node, new Node[] {node}, new Node[] {node})),
+                Set.of(), Set.of());
+        UUID clientId = UUID.randomUUID();
+        org.apache.kafka.streams.processor.internals.assignment.ClientState client =
+                new org.apache.kafka.streams.processor.internals.assignment.ClientState(
+                        Set.of(), Set.of(), Map.of(), Map.of(), 1, clientId);
+        client.assignActive(task);
+        RackAwareTaskAssignor populated = new RackAwareTaskAssignor(cluster,
+                Map.of(task, Set.of(partition)), Map.of(), Map.of(),
+                Map.of(clientId, Map.of("rack", Optional.of("rack-a"))), null,
+                rackAssignmentConfigs(), org.apache.kafka.common.utils.Time.SYSTEM);
+        assertThat(populated.canEnableRackAwareAssignor()).isTrue();
+        assertThat(populated.optimizeActiveTasks(new TreeSet<>(Set.of(task)),
+                new TreeMap<>(Map.of(clientId, client)), 0, 0)).isGreaterThanOrEqualTo(0L);
+    }
+
+    private static AssignorConfiguration.AssignmentConfigs rackAssignmentConfigs() throws Exception {
+        Constructor<AssignorConfiguration.AssignmentConfigs> constructor =
+                AssignorConfiguration.AssignmentConfigs.class.getDeclaredConstructor(
+                        Long.class, Integer.class, Integer.class, Long.class, List.class,
+                        Integer.class, Integer.class, String.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(0L, 1, 1, 60_000L, new ArrayList<String>(), 1, 1, "min_traffic");
+    }
+
+    private static AssignorConfiguration.AssignmentConfigs assignmentConfigs() throws Exception {
+        Constructor<AssignorConfiguration.AssignmentConfigs> constructor =
+                AssignorConfiguration.AssignmentConfigs.class.getDeclaredConstructor(
+                        Long.class, Integer.class, Integer.class, Long.class, List.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(0L, 1, 1, 60_000L, new ArrayList<String>());
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ChangeLoggingStoreApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ChangeLoggingStoreApiCoverageTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises change-logging store wrappers through the public store-builder APIs. */
+public class ChangeLoggingStoreApiCoverageTest {
+    @Test
+    void shouldReadSessionStateThroughBothKeyRangeDirections() {
+        StoreBuilder<SessionStore<String, byte[]>> builder = new SessionStoreBuilder<String, byte[]>(
+                Stores.inMemorySessionStore("logging-session", Duration.ofMinutes(1)),
+                org.apache.kafka.common.serialization.Serdes.String(),
+                org.apache.kafka.common.serialization.Serdes.ByteArray(), org.apache.kafka.common.utils.Time.SYSTEM)
+                .withLoggingEnabled(Map.of());
+        SessionStore<String, byte[]> store = builder.build();
+        InternalMockProcessorContext<?, ?> context = context();
+        store.init((ProcessorContext) context, store);
+
+        Windowed<String> window = new Windowed<>("key", new SessionWindow(10L, 20L));
+        store.put(window, new byte[] {9});
+        assertThat(store.fetch("key").hasNext()).isTrue();
+        assertThat(store.backwardFetch("key").hasNext()).isTrue();
+        assertThat(store.fetch("key", "key").hasNext()).isTrue();
+        assertThat(store.backwardFetch("key", "key").hasNext()).isTrue();
+        assertThat(store.findSessions("key", 0L, 30L).hasNext()).isTrue();
+        assertThat(store.backwardFindSessions("key", 0L, 30L).hasNext()).isTrue();
+        assertThat(store.fetchSession("key", 10L, 20L)).containsExactly(9);
+    }
+
+    @Test
+    void shouldDeleteAndBatchWriteThroughKeyValueWrappers() {
+        StoreBuilder<KeyValueStore<Bytes, byte[]>> builder = new KeyValueStoreBuilder<Bytes, byte[]>(
+                Stores.inMemoryKeyValueStore("logging-kv"),
+                org.apache.kafka.common.serialization.Serdes.Bytes(),
+                org.apache.kafka.common.serialization.Serdes.ByteArray(), org.apache.kafka.common.utils.Time.SYSTEM)
+                .withLoggingEnabled(Map.of());
+        KeyValueStore<Bytes, byte[]> store = builder.build();
+        InternalMockProcessorContext<?, ?> context = context();
+        store.init((ProcessorContext) context, store);
+        Bytes key = Bytes.wrap(new byte[] {2});
+        store.put(key, new byte[] {3});
+        assertThat(store.delete(key)).containsExactly(3);
+        assertThat(store.get(key)).isNull();
+
+        StoreBuilder<TimestampedKeyValueStore<String, String>> timestampedBuilder = new TimestampedKeyValueStoreBuilder<>(
+                Stores.inMemoryKeyValueStore("logging-timestamped"),
+                org.apache.kafka.common.serialization.Serdes.String(),
+                org.apache.kafka.common.serialization.Serdes.String(), org.apache.kafka.common.utils.Time.SYSTEM)
+                .withLoggingEnabled(Map.of());
+        TimestampedKeyValueStore<String, String> timestamped = timestampedBuilder.build();
+        timestamped.init((ProcessorContext) context, timestamped);
+        timestamped.put("key", org.apache.kafka.streams.state.ValueAndTimestamp.make("value", 40L));
+        assertThat(timestamped.get("key").value()).isEqualTo("value");
+        assertThat(ByteBuffer.allocate(12).putLong(40L).put(new byte[] {4}).array()).hasSize(12);
+        timestamped.putAll(List.of(KeyValue.pair("other", org.apache.kafka.streams.state.ValueAndTimestamp.make("other", 41L))));
+        assertThat(timestamped.get("other").value()).isEqualTo("other");
+    }
+
+    private static InternalMockProcessorContext<?, ?> context() {
+        InternalMockProcessorContext<?, ?> context = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("logging-context", String.class, byte[].class),
+                NativeCoverageFixtures.recordCollector());
+        context.initialize();
+        context.setTime(1L);
+        return context;
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CheckpointAndStoreLifecycleCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CheckpointAndStoreLifecycleCoverageTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises checkpoint persistence through its public file-backed API. */
+public class CheckpointAndStoreLifecycleCoverageTest {
+    @Test
+    void shouldWriteReadAndDeleteOffsetCheckpoint() throws Exception {
+        File checkpointFile = new File("build/deep-offset-checkpoint/checkpoint");
+        Files.createDirectories(checkpointFile.toPath().getParent());
+        OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
+        TopicPartition first = new TopicPartition("deep-topic", 0);
+        TopicPartition second = new TopicPartition("deep-topic", 1);
+        checkpoint.write(Map.of(first, 17L, second, 23L));
+        assertThat(checkpoint.read()).containsEntry(first, 17L).containsEntry(second, 23L);
+        checkpoint.delete();
+        assertThat(checkpoint.read()).isEmpty();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CompositeStoreApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/CompositeStoreApiCoverageTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.CompositeReadOnlyKeyValueStore;
+import org.apache.kafka.streams.state.internals.CompositeReadOnlySessionStore;
+import org.apache.kafka.streams.state.internals.CompositeReadOnlyWindowStore;
+import org.apache.kafka.streams.state.internals.StateStoreProvider;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Verifies empty query results when no stream thread owns a queryable store. */
+public class CompositeStoreApiCoverageTest {
+    private static final StateStoreProvider EMPTY_PROVIDER = new StateStoreProvider() {
+        @Override
+        public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+            return List.of();
+        }
+    };
+
+    @Test
+    void shouldReturnEmptyKeyValueQueriesWithoutStores() {
+        CompositeReadOnlyKeyValueStore<String, String> keyValue = new CompositeReadOnlyKeyValueStore<>(
+                EMPTY_PROVIDER, QueryableStoreTypes.keyValueStore(), "store");
+        assertThat(keyValue.get("key")).isNull();
+        assertThat(keyValue.approximateNumEntries()).isZero();
+        assertEmpty(keyValue.all());
+        assertEmpty(keyValue.range("a", "z"));
+        assertEmpty(keyValue.reverseRange("a", "z"));
+        assertEmpty(keyValue.prefixScan("a", Serdes.String().serializer()));
+        assertEmpty(keyValue.reverseAll());
+    }
+
+    @Test
+    void shouldMergeMultipleKeyValueStoresThroughPublicCompositeQueries() {
+        KeyValueStore<String, String> first = Stores.keyValueStoreBuilder(
+                Stores.inMemoryKeyValueStore("composite-first"), Serdes.String(), Serdes.String()).build();
+        KeyValueStore<String, String> second = Stores.keyValueStoreBuilder(
+                Stores.inMemoryKeyValueStore("composite-second"), Serdes.String(), Serdes.String()).build();
+        org.apache.kafka.test.InternalMockProcessorContext<?, ?> context = new org.apache.kafka.test.InternalMockProcessorContext<>(
+                new java.io.File("build/composite-key-value"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        context.setTime(1L);
+        first.init((org.apache.kafka.streams.processor.StateStoreContext) context, first);
+        second.init((org.apache.kafka.streams.processor.StateStoreContext) context, second);
+        first.put("a", "one");
+        second.put("b", "two");
+        second.put("c", "three");
+        StateStoreProvider provider = new StateStoreProvider() {
+            @Override
+            public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+                return (List<T>) List.of(first, second);
+            }
+        };
+        CompositeReadOnlyKeyValueStore<String, String> composite = new CompositeReadOnlyKeyValueStore<>(
+                provider, QueryableStoreTypes.keyValueStore(), "composite-key-value");
+        KeyValueIterator<String, String> all = composite.all();
+        assertThat(all.hasNext()).isTrue();
+        assertThat(all.next()).isEqualTo(KeyValue.pair("a", "one"));
+        assertThat(all.hasNext()).isTrue();
+        all.next();
+        all.close();
+        KeyValueIterator<String, String> range = composite.range("a", "z");
+        while (range.hasNext()) {
+            range.next();
+        }
+        range.close();
+        KeyValueIterator<String, String> reverse = composite.reverseAll();
+        assertThat(reverse.hasNext()).isTrue();
+        reverse.next();
+        reverse.close();
+        first.close();
+        second.close();
+    }
+
+    @Test
+    void shouldReturnEmptyWindowQueriesWithoutStores() {
+        CompositeReadOnlyWindowStore<String, String> window = new CompositeReadOnlyWindowStore<>(
+                EMPTY_PROVIDER, QueryableStoreTypes.windowStore(), "window");
+        Instant start = Instant.ofEpochMilli(0);
+        Instant end = Instant.ofEpochMilli(10);
+        assertThat(window.fetch("key", 1L)).isNull();
+        assertEmpty(window.fetch("key", start, end));
+        assertEmpty(window.backwardFetch("key", start, end));
+        assertEmpty(window.fetch("a", "z", start, end));
+        assertEmpty(window.backwardFetch("a", "z", start, end));
+        assertEmpty(window.all());
+        assertEmpty(window.backwardAll());
+        assertEmpty(window.fetchAll(start, end));
+        assertEmpty(window.backwardFetchAll(start, end));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldMergeSessionStoresThroughPublicCompositeIterators() {
+        org.apache.kafka.streams.state.SessionStore<String, String> session1 =
+                new org.apache.kafka.streams.state.internals.SessionStoreBuilder<>(
+                        Stores.inMemorySessionStore("composite-session-one", Duration.ofMinutes(1)),
+                        Serdes.String(), Serdes.String(), org.apache.kafka.common.utils.Time.SYSTEM).build();
+        org.apache.kafka.streams.state.SessionStore<String, String> session2 =
+                new org.apache.kafka.streams.state.internals.SessionStoreBuilder<>(
+                        Stores.inMemorySessionStore("composite-session-two", Duration.ofMinutes(1)),
+                        Serdes.String(), Serdes.String(), org.apache.kafka.common.utils.Time.SYSTEM).build();
+        org.apache.kafka.test.InternalMockProcessorContext<?, ?> context = new org.apache.kafka.test.InternalMockProcessorContext<>(
+                new java.io.File("build/composite-session"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        context.setTime(1L);
+        session1.init((org.apache.kafka.streams.processor.StateStoreContext) context, session1);
+        session2.init((org.apache.kafka.streams.processor.StateStoreContext) context, session2);
+        session1.put(new Windowed<>("a", new SessionWindow(1L, 2L)), "one");
+        session2.put(new Windowed<>("a", new SessionWindow(3L, 4L)), "two");
+        StateStoreProvider sessions = new StateStoreProvider() {
+            @Override
+            public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+                return (List<T>) List.of(session1, session2);
+            }
+        };
+        CompositeReadOnlySessionStore<String, String> compositeSession = new CompositeReadOnlySessionStore<>(
+                sessions, QueryableStoreTypes.sessionStore(), "composite-session");
+        KeyValueIterator<Windowed<String>, String> found = compositeSession.findSessions("a", 0L, 10L);
+        assertThat(found.hasNext()).isTrue();
+        found.next();
+        found.close();
+        KeyValueIterator<Windowed<String>, String> backward = compositeSession.backwardFindSessions("a", 0L, 10L);
+        assertThat(backward.hasNext()).isTrue();
+        backward.next();
+        backward.close();
+        session1.close();
+        session2.close();
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldMergeWindowStoresThroughPublicCompositeQueries() {
+        WindowStore<String, String> first = new org.apache.kafka.streams.state.internals.WindowStoreBuilder<>(
+                Stores.inMemoryWindowStore("composite-window-one", Duration.ofMinutes(1), Duration.ofSeconds(10), false),
+                Serdes.String(), Serdes.String(), org.apache.kafka.common.utils.Time.SYSTEM).build();
+        WindowStore<String, String> second = new org.apache.kafka.streams.state.internals.WindowStoreBuilder<>(
+                Stores.inMemoryWindowStore("composite-window-two", Duration.ofMinutes(1), Duration.ofSeconds(10), false),
+                Serdes.String(), Serdes.String(), org.apache.kafka.common.utils.Time.SYSTEM).build();
+        org.apache.kafka.test.InternalMockProcessorContext<?, ?> context = new org.apache.kafka.test.InternalMockProcessorContext<>(
+                new java.io.File("build/composite-window"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        context.setTime(1L);
+        first.init((org.apache.kafka.streams.processor.StateStoreContext) context, first);
+        second.init((org.apache.kafka.streams.processor.StateStoreContext) context, second);
+        first.put("a", "one", 10L);
+        second.put("a", "two", 20L);
+        StateStoreProvider windows = new StateStoreProvider() {
+            @Override
+            public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+                return (List<T>) List.of(first, second);
+            }
+        };
+        CompositeReadOnlyWindowStore<String, String> composite = new CompositeReadOnlyWindowStore<>(
+                windows, QueryableStoreTypes.windowStore(), "composite-window");
+        KeyValueIterator<Windowed<String>, String> all = composite.fetchAll(Instant.ofEpochMilli(0L), Instant.ofEpochMilli(30L));
+        assertThat(all.hasNext()).isTrue();
+        all.next();
+        assertThat(all.hasNext()).isTrue();
+        all.next();
+        all.close();
+        KeyValueIterator<Windowed<String>, String> reverse = composite.backwardFetchAll(Instant.ofEpochMilli(0L), Instant.ofEpochMilli(30L));
+        assertThat(reverse.hasNext()).isTrue();
+        reverse.next();
+        reverse.close();
+        first.close();
+        second.close();
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldQueryPersistentTimestampedStoreThroughCompositeWindowApi() {
+        TimestampedWindowStore<String, String> timestamped = (TimestampedWindowStore<String, String>) Stores
+                .timestampedWindowStoreBuilder(
+                        Stores.persistentWindowStore("composite-timestamped-window", java.time.Duration.ofMinutes(1),
+                                java.time.Duration.ofSeconds(10), false), Serdes.String(), Serdes.String())
+                .build();
+        org.apache.kafka.test.InternalMockProcessorContext<?, ?> context = new org.apache.kafka.test.InternalMockProcessorContext<>(
+                new java.io.File("build/composite-timestamped-window"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        timestamped.init((org.apache.kafka.streams.processor.StateStoreContext) context, timestamped);
+        timestamped.put("key", ValueAndTimestamp.make("value", 100L), 100L);
+
+        StateStoreProvider provider = new StateStoreProvider() {
+            @Override
+            public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+                return (List<T>) List.of((ReadOnlyWindowStore) timestamped);
+            }
+        };
+        CompositeReadOnlyWindowStore<String, Object> composite = new CompositeReadOnlyWindowStore<>(
+                provider, QueryableStoreTypes.windowStore(), "composite-timestamped-window");
+        Instant start = Instant.ofEpochMilli(50L);
+        Instant end = Instant.ofEpochMilli(150L);
+        assertThat(composite.fetch("key", start, end).hasNext()).isTrue();
+        assertThat(composite.backwardFetch("key", start, end).hasNext()).isTrue();
+        assertThat(composite.fetchAll(start, end).hasNext()).isTrue();
+        assertThat(composite.backwardFetchAll(start, end).hasNext()).isTrue();
+
+        timestamped.close();
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void shouldDriveLegacyPersistentWindowAdapterFromCompositeQueries() {
+        TimestampedWindowStore<String, String> timestamped = (TimestampedWindowStore<String, String>) Stores
+                .timestampedWindowStoreBuilder(
+                        Stores.persistentWindowStore("composite-legacy-window", java.time.Duration.ofMinutes(1),
+                                java.time.Duration.ofSeconds(10), false), Serdes.String(), Serdes.String())
+                .build();
+        org.apache.kafka.test.InternalMockProcessorContext<?, ?> context = new org.apache.kafka.test.InternalMockProcessorContext<>(
+                new java.io.File("build/composite-legacy-window"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        context.initialize();
+        timestamped.init((org.apache.kafka.streams.processor.StateStoreContext) context, timestamped);
+        timestamped.put("key", ValueAndTimestamp.make("value", 100L), 100L);
+
+        StateStoreProvider provider = new StateStoreProvider() {
+            @Override
+            public <T> List<T> stores(String name, org.apache.kafka.streams.state.QueryableStoreType<T> type) {
+                return (List<T>) List.of((ReadOnlyWindowStore) timestamped);
+            }
+        };
+        CompositeReadOnlyWindowStore<String, Object> composite = new CompositeReadOnlyWindowStore<>(
+                provider, QueryableStoreTypes.windowStore(), "composite-legacy-window");
+        Instant start = Instant.ofEpochMilli(50L);
+        Instant end = Instant.ofEpochMilli(150L);
+        WindowStoreIterator<Object> forward = composite.fetch("key", start, end);
+        assertThat(forward.hasNext()).isTrue();
+        forward.close();
+        WindowStoreIterator<Object> backward = composite.backwardFetch("key", start, end);
+        assertThat(backward.hasNext()).isTrue();
+        backward.close();
+        KeyValueIterator<Windowed<String>, Object> ranged = composite.fetch("a", "z", start, end);
+        assertThat(ranged.hasNext()).isTrue();
+        ranged.close();
+        KeyValueIterator<Windowed<String>, Object> backwardRanged = composite.backwardFetch("a", "z", start, end);
+        assertThat(backwardRanged.hasNext()).isTrue();
+        backwardRanged.close();
+        KeyValueIterator<Windowed<String>, Object> all = composite.fetchAll(start, end);
+        assertThat(all.hasNext()).isTrue();
+        all.close();
+        KeyValueIterator<Windowed<String>, Object> backwardAll = composite.backwardFetchAll(start, end);
+        assertThat(backwardAll.hasNext()).isTrue();
+        backwardAll.close();
+        timestamped.close();
+    }
+
+    @Test
+    void shouldReturnEmptySessionQueriesWithoutStores() {
+        CompositeReadOnlySessionStore<String, String> session = new CompositeReadOnlySessionStore<>(
+                EMPTY_PROVIDER, QueryableStoreTypes.sessionStore(), "session");
+        assertEmpty(session.fetch("key"));
+        assertEmpty(session.backwardFetch("key"));
+        assertEmpty(session.fetch("a", "z"));
+        assertEmpty(session.backwardFetch("a", "z"));
+        assertThat(session.fetchSession("key", 0L, 10L)).isNull();
+        assertEmpty(session.findSessions("key", 0L, 10L));
+        assertEmpty(session.backwardFindSessions("key", 0L, 10L));
+        assertEmpty(session.findSessions("a", "z", 0L, 10L));
+        assertEmpty(session.backwardFindSessions("a", "z", 0L, 10L));
+    }
+
+    private static void assertEmpty(KeyValueIterator<?, ?> iterator) {
+        assertThat(iterator.hasNext()).isFalse();
+        iterator.close();
+    }
+
+    private static void assertEmpty(WindowStoreIterator<?> iterator) {
+        assertThat(iterator.hasNext()).isFalse();
+        iterator.close();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ConfigurationAndSerializationApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ConfigurationAndSerializationApiCoverageTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.BrokerNotFoundException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.InvalidStateStorePartitionException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.StreamsNotStartedException;
+import org.apache.kafka.streams.errors.StreamsRebalancingException;
+import org.apache.kafka.streams.errors.StreamsStoppedException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
+import org.apache.kafka.streams.errors.UnknownTopologyException;
+import org.apache.kafka.streams.internals.UpgradeFromValues;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises independent public configuration objects and wire-format adapters. */
+public class ConfigurationAndSerializationApiCoverageTest {
+    @Test
+    void shouldConfigureSerdeAndTopologyOptions() {
+        assertThat(Joined.with(Serdes.String(), Serdes.String(), Serdes.Integer(), "join", Duration.ofSeconds(2))
+                .withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
+                .withOtherValueSerde(Serdes.Integer()).withGracePeriod(Duration.ofSeconds(3))
+                .withName("renamed").gracePeriod()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(Joined.<String, String, Integer>keySerde(Serdes.String()).keySerde()).isNotNull();
+        assertThat(Joined.<String, String, Integer>valueSerde(Serdes.String()).valueSerde()).isNotNull();
+        assertThat(Joined.<String, String, Integer>otherValueSerde(Serdes.Integer()).otherValueSerde()).isNotNull();
+        assertThat(Joined.<String, String, Integer>as("named")).isNotNull();
+
+        Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String())
+                .withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
+                .withTimestampExtractor((record, previous) -> record.timestamp())
+                .withOffsetResetPolicy(Topology.AutoOffsetReset.EARLIEST).withName("input");
+        assertThat(consumed).isEqualTo(consumed);
+        assertThat(Consumed.<String, String>as("source")).isNotNull();
+        assertThat(Consumed.with(Topology.AutoOffsetReset.LATEST)).isNotNull();
+        assertThat(Consumed.with((record, previous) -> record.timestamp())).isNotNull();
+
+        assertThat(Grouped.<String, String>as("group").withKeySerde(Serdes.String()).withValueSerde(Serdes.String()).withName("g")).isNotNull();
+        assertThat(Grouped.<String, String>keySerde(Serdes.String()).withName("k")).isNotNull();
+        assertThat(Grouped.<String, String>valueSerde(Serdes.String()).withName("v")).isNotNull();
+        assertThat(Grouped.with("named", Serdes.String(), Serdes.String())).isNotNull();
+
+        assertThat(Repartitioned.<String, String>as("r").withNumberOfPartitions(2)
+                .withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
+                .withStreamPartitioner((topic, key, value, partitions) -> 0).withName("r2")).isNotNull();
+        assertThat(Repartitioned.<String, String>numberOfPartitions(2)).isNotNull();
+        assertThat(Repartitioned.<String, String>streamPartitioner((topic, key, value, partitions) -> 0)).isNotNull();
+        assertThat(Produced.<String, String>as("p").withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
+                .withStreamPartitioner((topic, key, value, partitions) -> 0).withName("p2")).isNotNull();
+        assertThat(Produced.<String, String>keySerde(Serdes.String())).isNotNull();
+        assertThat(Produced.<String, String>valueSerde(Serdes.String())).isNotNull();
+        assertThat(Produced.<String, String>streamPartitioner((topic, key, value, partitions) -> 0)).isNotNull();
+    }
+
+    @Test
+    void shouldConfigureMaterializationBranchesPrintingAndWindows() {
+        Materialized<String, String, org.apache.kafka.streams.state.KeyValueStore<Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+        assertThat(materialized.withCachingDisabled().withCachingEnabled().withLoggingDisabled()
+                .withLoggingEnabled(Map.of("retention.ms", "1000"))
+                .withRetention(Duration.ofSeconds(10)).withStoreType(Materialized.StoreType.ROCKS_DB)).isSameAs(materialized);
+        assertThat(Materialized.<String, String>as(Stores.inMemoryWindowStore("window", Duration.ofSeconds(1), Duration.ofSeconds(1), false))).isNotNull();
+        assertThat(Materialized.<String, String>as(Stores.inMemorySessionStore("session", Duration.ofSeconds(1)))).isNotNull();
+
+        assertThat(Branched.<String, String>withConsumer(stream -> assertThat(stream).isNotNull())).isNotNull();
+        assertThat(Branched.<String, String>withConsumer(stream -> { }, "branch")).isNotNull();
+        assertThat(Branched.<String, String>withFunction(stream -> stream, "mapped")).isNotNull();
+        assertThat(Branched.<String, String>withFunction(stream -> stream)).isNotNull();
+        assertThat(Printed.<String, String>toFile("build/api-print.txt")
+                .withKeyValueMapper((key, value) -> key + value).withName("print")).isNotNull();
+
+        JoinWindows windows = JoinWindows.of(Duration.ofSeconds(2)).before(Duration.ofSeconds(1))
+                .after(Duration.ofSeconds(3)).grace(Duration.ofSeconds(4));
+        assertThat(windows.size()).isEqualTo(Duration.ofSeconds(4).toMillis());
+        assertThat(windows).isEqualTo(JoinWindows.ofTimeDifferenceAndGrace(Duration.ofSeconds(2), Duration.ofSeconds(4))
+                .before(Duration.ofSeconds(1)).after(Duration.ofSeconds(3)));
+        assertThat(windows.hashCode()).isEqualTo(windows.hashCode());
+        assertThat(windows.toString()).contains("beforeMs");
+        assertThat(Stores.lruMap("cache", 4).name()).isEqualTo("cache");
+        assertThat(Stores.persistentVersionedKeyValueStore("versions", Duration.ofSeconds(5)).name()).isEqualTo("versions");
+    }
+
+    @Test
+    void shouldRoundTripSessionKeysAndUsePublicHashUtilities() {
+        Windowed<String> key = new Windowed<>("session", new SessionWindow(10, 20));
+        SessionWindowedSerializer<String> serializer = new SessionWindowedSerializer<>(Serdes.String().serializer());
+        serializer.configure(Map.of(), false);
+        byte[] encoded = serializer.serialize("topic", key);
+        assertThat(serializer.serializeBaseKey("topic", key)).isNotEmpty();
+        SessionWindowedDeserializer<String> deserializer = new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+        deserializer.configure(Map.of(), false);
+        assertThat(deserializer.deserialize("topic", encoded)).isEqualTo(key);
+        serializer.close();
+        deserializer.close();
+        assertThat(new SessionWindowedSerializer<String>()).isNotNull();
+        assertThat(new SessionWindowedDeserializer<String>()).isNotNull();
+        assertThat(new WindowedSerdes.TimeWindowedSerde<String>().forChangelog(true)).isNotNull();
+        assertThat(new WindowedSerdes.TimeWindowedSerde<String>()).isNotNull();
+
+        assertThat(org.apache.kafka.streams.state.internals.Murmur3.hash32(new byte[] {1, 2, 3})).isNotZero();
+        assertThat(org.apache.kafka.streams.state.internals.Murmur3.hash32(1L)).isNotZero();
+        assertThat(org.apache.kafka.streams.state.internals.Murmur3.hash32(1L, 2L)).isNotZero();
+        assertThat(org.apache.kafka.streams.state.internals.Murmur3.hash64(new byte[] {1, 2, 3})).isNotZero();
+        assertThat(new FailOnInvalidTimestamp().extract(new org.apache.kafka.clients.consumer.ConsumerRecord<Object, Object>(
+                "topic", 0, 1L, 12L, TimestampType.CREATE_TIME, -1L, -1, -1, "k", "v"), 0L)).isEqualTo(12L);
+        assertThat(org.apache.kafka.streams.internals.ApiUtils.validateMillisecondInstant(Instant.ofEpochMilli(12), "timestamp")).isEqualTo(12L);
+        assertThat(UpgradeFromValues.values()).isNotEmpty();
+        assertThat(UpgradeFromValues.valueOf(UpgradeFromValues.values()[0].name())).isNotNull();
+    }
+
+    @Test
+    void shouldPreserveExceptionCauseInformation() {
+        Throwable cause = new IllegalStateException("cause");
+        assertThat(new BrokerNotFoundException("broker", cause).getCause()).isSameAs(cause);
+        assertThat(new BrokerNotFoundException(cause).getCause()).isSameAs(cause);
+        assertThat(new InvalidStateStoreException("store", cause).getCause()).isSameAs(cause);
+        assertThat(new InvalidStateStoreException(cause).getCause()).isSameAs(cause);
+        assertThat(new InvalidStateStorePartitionException("partition").getMessage()).contains("partition");
+        assertThat(new InvalidStateStorePartitionException("partition", cause).getCause()).isSameAs(cause);
+        assertThat(new LockException("lock", cause).getCause()).isSameAs(cause);
+        assertThat(new LockException(cause).getCause()).isSameAs(cause);
+        assertThat(new ProcessorStateException("state", cause).getCause()).isSameAs(cause);
+        assertThat(new ProcessorStateException(cause).getCause()).isSameAs(cause);
+        assertThat(new StateStoreMigratedException("migrated", cause).getCause()).isSameAs(cause);
+        assertThat(new StateStoreNotAvailableException("unavailable", cause).getCause()).isSameAs(cause);
+        assertThat(new StreamsNotStartedException("not-started", cause).getCause()).isSameAs(cause);
+        assertThat(new StreamsRebalancingException("rebalancing", cause).getCause()).isSameAs(cause);
+        assertThat(new StreamsStoppedException("stopped", cause).getCause()).isSameAs(cause);
+        assertThat(new TaskAssignmentException("assignment", cause).getCause()).isSameAs(cause);
+        assertThat(new TaskIdFormatException("format", cause).getCause()).isSameAs(cause);
+        assertThat(new TaskMigratedException("migrated", cause).getCause()).isSameAs(cause);
+        assertThat(new UnknownStateStoreException("unknown", cause).getCause()).isSameAs(cause);
+        assertThat(new UnknownStateStoreException("unknown").getMessage()).contains("unknown");
+        assertThat(new UnknownTopologyException("topology", "detail").getMessage()).contains("detail");
+        assertThat(new UnknownTopologyException("topology", cause, "detail").getCause()).isSameAs(cause);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepInternalLifecycleCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepInternalLifecycleCoverageTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.processor.Cancellable;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.ChangelogRegister;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.TaskManager;
+import org.apache.kafka.streams.processor.internals.TasksRegistry;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives processor-context and rebalance lifecycle entries through concrete collaborators. */
+public class DeepInternalLifecycleCoverageTest {
+    @Test
+    void shouldDelegateContextLifecycleToAnActiveStreamTask() {
+        StreamsConfig config = streamsConfig();
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "lifecycle-client", "lifecycle-thread", Time.SYSTEM);
+        StateDirectory stateDirectory = new StateDirectory(config, Time.SYSTEM, false, false);
+        ThreadCache cache = new ThreadCache(new LogContext("lifecycle "), 1024L, streamsMetrics);
+        ProcessorStateManager stateManager = new ProcessorStateManager(
+                new TaskId(0, 0), Task.TaskType.ACTIVE, false, new LogContext("lifecycle "), stateDirectory,
+                new EmptyChangelogRegister(), Map.of(), Set.of(), false);
+        ProcessorContextImpl context = new ProcessorContextImpl(
+                new TaskId(0, 0), config, stateManager, streamsMetrics, cache);
+        MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        org.apache.kafka.streams.processor.internals.RecordCollector collector = NativeCoverageFixtures.recordCollector();
+        StreamTask task = new StreamTask(
+                new TaskId(0, 0), Set.of(new TopicPartition("lifecycle", 0)), lifecycleTopology(), consumer,
+                new TopologyConfig(config).getTaskConfig(),
+                streamsMetrics, stateDirectory, cache, Time.SYSTEM, stateManager,
+                collector, context, new LogContext("lifecycle "));
+        try {
+            assertThat(context.stateManager()).isSameAs(stateManager);
+            assertThat(context.recordCollector()).isSameAs(collector);
+            assertThat(context.currentStreamTimeMs()).isEqualTo(-1L);
+
+            context.commit();
+            assertThat(task.commitRequested()).isTrue();
+        } finally {
+            stateManager.close();
+            stateDirectory.close();
+            consumer.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    void shouldSchedulePunctuationThroughAnInitializedStreamTask() {
+        StreamsConfig config = streamsConfig();
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "schedule-client", "schedule-thread", Time.SYSTEM);
+        StateDirectory stateDirectory = new StateDirectory(config, Time.SYSTEM, false, false);
+        ThreadCache cache = new ThreadCache(new LogContext("schedule "), 1024L, streamsMetrics);
+        ProcessorStateManager stateManager = new ProcessorStateManager(
+                new TaskId(0, 0), Task.TaskType.ACTIVE, false, new LogContext("schedule "), stateDirectory,
+                new EmptyChangelogRegister(), Map.of(), Set.of(), false);
+        ProcessorContextImpl context = new ProcessorContextImpl(
+                new TaskId(0, 0), config, stateManager, streamsMetrics, cache);
+        MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        TopicPartition partition = new TopicPartition("schedule", 0);
+        consumer.assign(Set.of(partition));
+        consumer.updateBeginningOffsets(Map.of(partition, 0L));
+        consumer.updateEndOffsets(Map.of(partition, 0L));
+        AtomicReference<Cancellable> scheduled = new AtomicReference<>();
+        StreamTask task = new StreamTask(
+                new TaskId(0, 0), Set.of(partition), schedulingTopology(scheduled), consumer,
+                new TopologyConfig(config).getTaskConfig(), streamsMetrics, stateDirectory, cache, Time.SYSTEM,
+                stateManager, NativeCoverageFixtures.recordCollector(), context, new LogContext("schedule "));
+        try {
+            task.initializeIfNeeded();
+            task.completeRestoration(ignored -> { });
+            assertThat(scheduled.get()).isNotNull();
+            scheduled.get().cancel();
+        } finally {
+            stateManager.close();
+            stateDirectory.close();
+            consumer.close();
+            metrics.close();
+        }
+    }
+
+    @Test
+    void shouldDelegateProducerBlockedTimeAndRevocationCallbacks() throws Exception {
+        StreamsConfig config = streamsConfig();
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "rebalance-client", "rebalance-thread", Time.SYSTEM);
+        TopologyMetadata topologyMetadata = new TopologyMetadata(new InternalTopologyBuilder(), config);
+        Object activeTaskCreator = newActiveTaskCreator(config, streamsMetrics, topologyMetadata);
+        TaskManager taskManager = newTaskManager(activeTaskCreator, topologyMetadata, config);
+        assertThat(taskManager.totalProducerBlockedTime()).isZero();
+
+        MockConsumer<byte[], byte[]> mainConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        MockConsumer<byte[], byte[]> restoreConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        StreamThread streamThread = new StreamThread(
+                Time.SYSTEM, config, null, mainConsumer, restoreConsumer, null, "earliest", taskManager,
+                streamsMetrics, topologyMetadata, "rebalance-thread", new LogContext("rebalance "),
+                new AtomicInteger(), new AtomicLong(), new ConcurrentLinkedQueue<>(), () -> { },
+                (error, recoverable) -> { }, size -> { });
+        java.lang.reflect.Method rebalanceListenerMethod = StreamThread.class.getDeclaredMethod("rebalanceListener");
+        rebalanceListenerMethod.setAccessible(true);
+        ConsumerRebalanceListener rebalanceListener =
+                (ConsumerRebalanceListener) rebalanceListenerMethod.invoke(streamThread);
+        java.lang.reflect.Method setStateMethod = StreamThread.class.getDeclaredMethod(
+                "setState", StreamThread.State.class);
+        setStateMethod.setAccessible(true);
+        setStateMethod.invoke(streamThread, StreamThread.State.STARTING);
+        rebalanceListener.onPartitionsRevoked(ListOf.partition(new TopicPartition("lifecycle", 0)));
+        assertThat(streamThread.state()).isEqualTo(StreamThread.State.PARTITIONS_REVOKED);
+
+        mainConsumer.close();
+        restoreConsumer.close();
+        topologyMetadata.unregisterThread(streamThread.getName());
+        metrics.close();
+    }
+
+    private static Object newActiveTaskCreator(StreamsConfig config, StreamsMetricsImpl streamsMetrics,
+            TopologyMetadata topologyMetadata) throws Exception {
+        Class<?> creatorClass = Class.forName("org.apache.kafka.streams.processor.internals.ActiveTaskCreator");
+        java.lang.reflect.Constructor<?> constructor = creatorClass.getDeclaredConstructor(
+                TopologyMetadata.class, StreamsConfig.class, StreamsMetricsImpl.class, StateDirectory.class,
+                Class.forName("org.apache.kafka.streams.processor.internals.ChangelogReader"),
+                ThreadCache.class, Time.class, org.apache.kafka.streams.KafkaClientSupplier.class,
+                String.class, UUID.class, org.slf4j.Logger.class, boolean.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(topologyMetadata, config, streamsMetrics, null, null, null, Time.SYSTEM, null,
+                "rebalance-thread", UUID.randomUUID(), org.slf4j.LoggerFactory.getLogger(
+                        DeepInternalLifecycleCoverageTest.class), false);
+    }
+
+    private static TaskManager newTaskManager(Object activeTaskCreator, TopologyMetadata topologyMetadata,
+            StreamsConfig config) throws Exception {
+        Class<?> creatorClass = Class.forName("org.apache.kafka.streams.processor.internals.ActiveTaskCreator");
+        java.lang.reflect.Constructor<TaskManager> constructor = TaskManager.class.getDeclaredConstructor(
+                Time.class,
+                Class.forName("org.apache.kafka.streams.processor.internals.ChangelogReader"),
+                UUID.class, String.class, creatorClass,
+                Class.forName("org.apache.kafka.streams.processor.internals.StandbyTaskCreator"),
+                TasksRegistry.class, TopologyMetadata.class,
+                org.apache.kafka.clients.admin.Admin.class, StateDirectory.class,
+                Class.forName("org.apache.kafka.streams.processor.internals.StateUpdater"));
+        constructor.setAccessible(true);
+        return constructor.newInstance(Time.SYSTEM, null, UUID.randomUUID(), "rebalance", activeTaskCreator, null,
+                new EmptyTasksRegistry(), topologyMetadata, null, null, null);
+    }
+
+    private static ProcessorTopology lifecycleTopology() {
+        InternalTopologyBuilder builder = new InternalTopologyBuilder();
+        builder.setApplicationId("deep-lifecycle");
+        builder.addSource(null, "source", null, new StringDeserializer(), new StringDeserializer(), "lifecycle");
+        return builder.buildTopology();
+    }
+
+    private static ProcessorTopology schedulingTopology(AtomicReference<Cancellable> scheduled) {
+        InternalTopologyBuilder builder = new InternalTopologyBuilder();
+        builder.setApplicationId("deep-lifecycle");
+        builder.addSource(null, "source", null, new StringDeserializer(), new StringDeserializer(), "schedule");
+        builder.addProcessor("schedule-processor", () -> new Processor<String, String, String, String>() {
+            @Override
+            public void init(ProcessorContext<String, String> processorContext) {
+                scheduled.set(processorContext.schedule(Duration.ofMillis(1), PunctuationType.STREAM_TIME,
+                        timestamp -> { }));
+            }
+
+            @Override
+            public void process(Record<String, String> record) {
+            }
+        }, "source");
+        return builder.buildTopology();
+    }
+
+    private static StreamsConfig streamsConfig() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "deep-lifecycle");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        return new StreamsConfig(properties);
+    }
+
+    private static final class ListOf {
+        private ListOf() {
+        }
+
+        static <T> java.util.List<T> empty() {
+            return java.util.List.of();
+        }
+
+        static <T> java.util.List<T> partition(T value) {
+            return java.util.List.of(value);
+        }
+    }
+
+    private static final class EmptyChangelogRegister implements ChangelogRegister {
+        @Override
+        public void register(TopicPartition partition, ProcessorStateManager stateManager) {
+        }
+
+        @Override
+        public void register(Set<TopicPartition> partitions, ProcessorStateManager stateManager) {
+        }
+
+        @Override
+        public void unregister(Collection<TopicPartition> partitions) {
+        }
+    }
+
+    private static final class EmptyTasksRegistry implements TasksRegistry {
+        @Override public Map<TaskId, Set<TopicPartition>> drainPendingActiveTasksForTopologies(Set<String> topologies) {
+            return Map.of();
+        }
+        @Override public Map<TaskId, Set<TopicPartition>> drainPendingStandbyTasksForTopologies(Set<String> topologies) {
+            return Map.of();
+        }
+        @Override public void addPendingActiveTasksToCreate(Map<TaskId, Set<TopicPartition>> tasks) { }
+        @Override public void addPendingStandbyTasksToCreate(Map<TaskId, Set<TopicPartition>> tasks) { }
+        @Override public void clearPendingTasksToCreate() { }
+        @Override public Set<TopicPartition> removePendingTaskToRecycle(TaskId taskId) {
+            return Set.of();
+        }
+        @Override public boolean hasPendingTasksToRecycle() {
+            return false;
+        }
+        @Override public void addPendingTaskToRecycle(TaskId taskId, Set<TopicPartition> partitions) { }
+        @Override public Set<TopicPartition> removePendingTaskToUpdateInputPartitions(TaskId taskId) {
+            return Set.of();
+        }
+        @Override public void addPendingTaskToUpdateInputPartitions(TaskId taskId, Set<TopicPartition> partitions) { }
+        @Override public boolean removePendingTaskToCloseDirty(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingTaskToCloseDirty(TaskId taskId) { }
+        @Override public boolean removePendingTaskToCloseClean(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingTaskToCloseClean(TaskId taskId) { }
+        @Override public Set<Task> drainPendingTasksToInit() {
+            return Set.of();
+        }
+        @Override public void addPendingTasksToInit(Collection<Task> tasks) { }
+        @Override public boolean hasPendingTasksToInit() {
+            return false;
+        }
+        @Override public boolean removePendingActiveTaskToSuspend(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingActiveTaskToSuspend(TaskId taskId) { }
+        @Override public void addActiveTasks(Collection<Task> tasks) { }
+        @Override public void addStandbyTasks(Collection<Task> tasks) { }
+        @Override public void addTask(Task task) { }
+        @Override public void removeTask(Task task) { }
+        @Override public void replaceActiveWithStandby(org.apache.kafka.streams.processor.internals.StandbyTask task) { }
+        @Override public void replaceStandbyWithActive(StreamTask task) { }
+        @Override public boolean updateActiveTaskInputPartitions(Task task, Set<TopicPartition> partitions) {
+            return false;
+        }
+        @Override public void clear() { }
+        @Override public Task activeTasksForInputPartition(TopicPartition partition) {
+            return null;
+        }
+        @Override public Task task(TaskId taskId) {
+            return null;
+        }
+        @Override public Collection<Task> tasks(Collection<TaskId> taskIds) {
+            return Collections.emptyList();
+        }
+        @Override public Collection<Task> activeTasks() {
+            return Collections.emptyList();
+        }
+        @Override public Set<Task> allTasks() {
+            return Set.of();
+        }
+        @Override public Map<TaskId, Task> allTasksPerId() {
+            return Map.of();
+        }
+        @Override public Set<TaskId> allTaskIds() {
+            return Set.of();
+        }
+        @Override public boolean contains(TaskId taskId) {
+            return false;
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepMetricsCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepMetricsCoverageTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecorder;
+import org.junit.jupiter.api.Test;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.Cache;
+import org.rocksdb.LRUCache;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.Statistics;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives RocksDB metric recording through the recorder's public entry point. */
+public class DeepMetricsCoverageTest {
+    @Test
+    void shouldRecordStatisticsWithEmptyAndNonEmptyRatios() throws Exception {
+        RocksDB.loadLibrary();
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "deep-coverage-client", "deep-thread",
+                Time.SYSTEM);
+        RocksDBMetricsRecorder recorder = new RocksDBMetricsRecorder("deep-scope", "deep-store");
+        recorder.init(streamsMetrics, new TaskId(0, 0));
+
+        Path databasePath = Files.createTempDirectory("deep-metrics");
+        Cache cache = new LRUCache(1 << 20);
+        BlockBasedTableConfig tableConfig = new BlockBasedTableConfig().setBlockCache(cache);
+        try (cache;
+             Statistics statistics = new Statistics();
+             Options options = new Options().setCreateIfMissing(true)
+                     .setStatistics(statistics).setTableFormatConfig(tableConfig);
+             RocksDB database = RocksDB.open(options, databasePath.toString())) {
+            recorder.addValueProviders("segment", database, cache, statistics);
+            database.put(new byte[] {1}, new byte[] {2});
+            recorder.record(1L);
+            recorder.record(2L);
+        }
+
+        assertThat(recorder.storeName()).isEqualTo("deep-store");
+        assertThat(recorder.taskId()).isEqualTo(new TaskId(0, 0));
+        metrics.close();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepPersistentStoreCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepPersistentStoreCoverageTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.VersionedRecord;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives persistent, cached, timestamped, session, window, and versioned stores via public builders. */
+public class DeepPersistentStoreCoverageTest {
+    @Test
+    void shouldDriveCachedPersistentKeyValueFamilies() {
+        StoreResources resources = new StoreResources("deep-kv");
+        try {
+            KeyValueStore<String, String> store = new KeyValueStoreBuilder<>(
+                    Stores.persistentKeyValueStore("deep-kv"), Serdes.String(), Serdes.String(), Time.SYSTEM)
+                    .withCachingEnabled().withLoggingEnabled(Map.of()).build();
+            init(store, resources.context);
+            store.put("one", "1");
+            store.put("two", "2");
+            store.putAll(List.of(KeyValue.pair("three", "3")));
+            assertThat(store.get("one")).isEqualTo("1");
+            assertThat(store.all().hasNext()).isTrue();
+            assertThat(store.range("one", "two").hasNext()).isTrue();
+            assertThat(store.reverseRange("one", "two").hasNext()).isTrue();
+            assertThat(store.reverseAll().hasNext()).isTrue();
+            assertThat(store.prefixScan("o", Serdes.String().serializer()).hasNext()).isTrue();
+            store.flush();
+            assertThat(store.approximateNumEntries()).isEqualTo(3L);
+            assertThat(store.all().hasNext()).isTrue();
+            assertThat(store.delete("one")).isEqualTo("1");
+            store.close();
+
+            TimestampedKeyValueStore<String, String> timestamped = new TimestampedKeyValueStoreBuilder<>(
+                    Stores.persistentKeyValueStore("deep-timestamped-kv"), Serdes.String(), Serdes.String(), Time.SYSTEM)
+                    .withCachingEnabled().withLoggingEnabled(Map.of()).build();
+            init(timestamped, resources.context);
+            timestamped.put("key", ValueAndTimestamp.make("value", 10L));
+            timestamped.putAll(List.of(KeyValue.pair("other", ValueAndTimestamp.make("other", 11L))));
+            assertThat(timestamped.get("key").value()).isEqualTo("value");
+            assertThat(timestamped.all().hasNext()).isTrue();
+            assertThat(timestamped.reverseAll().hasNext()).isTrue();
+            assertThat(timestamped.prefixScan("o", Serdes.String().serializer()).hasNext()).isTrue();
+            assertThat(timestamped.approximateNumEntries()).isGreaterThanOrEqualTo(0L);
+            timestamped.flush();
+            timestamped.close();
+        } finally {
+            resources.close();
+        }
+    }
+
+    @Test
+    void shouldDriveCachedPersistentSessionAndWindowFamilies() {
+        StoreResources resources = new StoreResources("deep-windows");
+        try {
+            SessionStore<String, String> session = new SessionStoreBuilder<>(
+                    Stores.persistentSessionStore("deep-session", Duration.ofMinutes(2)),
+                    Serdes.String(), Serdes.String(), Time.SYSTEM)
+                    .withCachingEnabled().withLoggingEnabled(Map.of()).build();
+            init(session, resources.context);
+            session.put(new Windowed<>("key", new SessionWindow(10L, 20L)), "session");
+            assertThat(session.fetch("key").hasNext()).isTrue();
+            assertThat(session.backwardFetch("key").hasNext()).isTrue();
+            assertThat(session.fetch("key", "key").hasNext()).isTrue();
+            assertThat(session.backwardFetch("key", "key").hasNext()).isTrue();
+            assertThat(session.findSessions("key", 0L, 30L).hasNext()).isTrue();
+            assertThat(session.backwardFindSessions("key", 0L, 30L).hasNext()).isTrue();
+            assertThat(session.fetchSession("key", 10L, 20L)).isEqualTo("session");
+            session.flush();
+            session.remove(new Windowed<>("key", new SessionWindow(10L, 20L)));
+            session.close();
+
+            WindowStore<String, String> window = new WindowStoreBuilder<>(
+                    Stores.persistentWindowStore("deep-window", Duration.ofMinutes(2), Duration.ofSeconds(10), false),
+                    Serdes.String(), Serdes.String(), Time.SYSTEM)
+                    .withCachingEnabled().withLoggingEnabled(Map.of()).build();
+            init(window, resources.context);
+            window.put("key", "first", 100L);
+            window.put("key", "second", 110L);
+            assertThat(window.fetch("key", 50L, 150L).hasNext()).isTrue();
+            assertThat(window.backwardFetch("key", 50L, 150L).hasNext()).isTrue();
+            assertThat(window.fetch("key", java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(window.backwardFetch("key", java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(window.fetch("key", "key", 50L, 150L).hasNext()).isTrue();
+            assertThat(window.backwardFetch("key", "key", 50L, 150L).hasNext()).isTrue();
+            assertThat(window.fetchAll(50L, 150L).hasNext()).isTrue();
+            assertThat(window.backwardFetchAll(50L, 150L).hasNext()).isTrue();
+            assertThat(window.fetchAll(java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(window.backwardFetchAll(java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(window.all().hasNext()).isTrue();
+            assertThat(window.backwardAll().hasNext()).isTrue();
+            window.flush();
+            window.close();
+
+            WindowStore<String, String> inMemoryWindow = new WindowStoreBuilder<>(
+                    Stores.inMemoryWindowStore("deep-memory-window", Duration.ofMinutes(2), Duration.ofSeconds(10), false),
+                    Serdes.String(), Serdes.String(), Time.SYSTEM).build();
+            init(inMemoryWindow, resources.context);
+            inMemoryWindow.put("key", "first", 100L);
+            inMemoryWindow.put("key", "second", 100L);
+            org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> all =
+                    inMemoryWindow.fetchAll(50L, 150L);
+            assertThat(all.hasNext()).isTrue();
+            all.next();
+            all.close();
+            inMemoryWindow.close();
+
+            TimestampedWindowStore<String, String> timestampedWindow = new TimestampedWindowStoreBuilder<>(
+                    Stores.persistentWindowStore("deep-timestamped-window", Duration.ofMinutes(2), Duration.ofSeconds(10), false),
+                    Serdes.String(), Serdes.String(), Time.SYSTEM)
+                    .withCachingEnabled().withLoggingEnabled(Map.of()).build();
+            init(timestampedWindow, resources.context);
+            timestampedWindow.put("key", ValueAndTimestamp.make("value", 120L), 120L);
+            assertThat(timestampedWindow.fetch("key", 50L, 150L).hasNext()).isTrue();
+            assertThat(timestampedWindow.backwardFetch("key", 50L, 150L).hasNext()).isTrue();
+            assertThat(timestampedWindow.fetch("key", java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(timestampedWindow.backwardFetch("key", java.time.Instant.ofEpochMilli(50L), java.time.Instant.ofEpochMilli(150L)).hasNext()).isTrue();
+            assertThat(timestampedWindow.fetchAll(50L, 150L).hasNext()).isTrue();
+            assertThat(timestampedWindow.backwardFetchAll(50L, 150L).hasNext()).isTrue();
+            assertThat(timestampedWindow.all().hasNext()).isTrue();
+            assertThat(timestampedWindow.backwardAll().hasNext()).isTrue();
+            timestampedWindow.flush();
+            timestampedWindow.close();
+        } finally {
+            resources.close();
+        }
+    }
+
+    @Test
+    void shouldWriteAndReadMultipleVersionsThroughVersionedStore() {
+        StoreResources resources = new StoreResources("deep-versioned");
+        try {
+            VersionedKeyValueStore<String, String> store = new VersionedKeyValueStoreBuilder<>(
+                    Stores.persistentVersionedKeyValueStore("deep-versioned", Duration.ofMinutes(5)),
+                    Serdes.String(), Serdes.String(), Time.SYSTEM).build();
+            init(store, resources.context);
+            assertThat(store.put("key", "old", 10L)).isEqualTo(VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED);
+            assertThat(store.put("key", "new", 20L)).isEqualTo(VersionedKeyValueStore.PUT_RETURN_CODE_VALID_TO_UNDEFINED);
+            assertThat(store.put("key", "middle", 15L)).isEqualTo(20L);
+            VersionedRecord<String> at16 = store.get("key", 16L);
+            assertThat(at16.value()).isEqualTo("middle");
+            assertThat(at16.timestamp()).isEqualTo(15L);
+            assertThat(store.get("key").value()).isEqualTo("new");
+            assertThat(store.delete("key", 15L).value()).isEqualTo("middle");
+            store.flush();
+            store.close();
+        } finally {
+            resources.close();
+        }
+    }
+
+    private static void init(org.apache.kafka.streams.processor.StateStore store, InternalMockProcessorContext<?, ?> context) {
+        store.init((StateStoreContext) context, store);
+    }
+
+    private static final class StoreResources {
+        private final Metrics metrics = new Metrics();
+        private final StreamsMetricsImpl streamsMetrics;
+        private final ThreadCache cache;
+        private final InternalMockProcessorContext<?, ?> context;
+
+        private StoreResources(String name) {
+            deleteDirectory(Path.of("build", name));
+            streamsMetrics = new StreamsMetricsImpl(metrics, name, name + "-thread", Time.SYSTEM);
+            cache = new ThreadCache(new LogContext(name + " "), 1024L, streamsMetrics);
+            context = new InternalMockProcessorContext<>(new File("build/" + name), Serdes.String(), Serdes.String(),
+                    NativeCoverageFixtures.recordCollector(), cache);
+            context.initialize();
+            context.setTime(1L);
+        }
+
+        private void close() {
+            metrics.close();
+        }
+
+        private static void deleteDirectory(Path directory) {
+            if (Files.exists(directory)) {
+                try (java.util.stream.Stream<Path> paths = Files.walk(directory)) {
+                    paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (java.io.IOException exception) {
+                            throw new RuntimeException(exception);
+                        }
+                    });
+                } catch (java.io.IOException exception) {
+                    throw new RuntimeException(exception);
+                }
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepStateDirectoryCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepStateDirectoryCoverageTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.StateDirectory;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives task and named-topology state-directory cleanup through its public lifecycle API. */
+public class DeepStateDirectoryCoverageTest {
+    @Test
+    void shouldCreateAndCleanTaskDirectories() throws Exception {
+        Path statePath = Path.of("build", "deep-state-directory");
+        deleteRecursively(statePath);
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "deep-state-directory");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, statePath.toString());
+        StateDirectory directory = new StateDirectory(new StreamsConfig(properties), Time.SYSTEM, true, true);
+        try {
+            directory.initializeProcessId();
+            File taskDirectory = directory.getOrCreateDirectoryForTask(new TaskId(2, 3));
+            Files.writeString(taskDirectory.toPath().resolve("state"), "state");
+            assertThat(taskDirectory).exists();
+            directory.clean();
+            assertThat(directory.getOrCreateDirectoryForTask(new TaskId(2, 3))).exists();
+            directory.clearLocalStateForNamedTopology("deep-named-topology");
+        } finally {
+            directory.close();
+            deleteRecursively(statePath);
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws Exception {
+        if (Files.exists(path)) {
+            try (java.util.stream.Stream<Path> paths = Files.walk(path)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepStateStorageCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepStateStorageCoverageTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.state.internals.PrefixedWindowKeySchemas;
+import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSide;
+import org.apache.kafka.streams.state.internals.TimestampedKeyAndJoinSideSerde;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives public state-key and timestamped-join serde entries through their decoding paths. */
+public class DeepStateStorageCoverageTest {
+    @Test
+    void shouldDecodeBothPrefixedWindowKeyLayouts() {
+        Bytes key = Bytes.wrap(new byte[] {1, 2, 3});
+        Windowed<Bytes> window = new Windowed<>(key, new TimeWindow(1_000L, 1_100L));
+
+        byte[] keyFirst = PrefixedWindowKeySchemas.KeyFirstWindowKeySchema
+                .toStoreKeyBinary(window, 7)
+                .get();
+        Windowed<Bytes> decodedKeyFirst = PrefixedWindowKeySchemas.KeyFirstWindowKeySchema
+                .fromStoreBytesKey(keyFirst, 100L);
+        assertThat(decodedKeyFirst.key()).isEqualTo(key);
+        assertThat(decodedKeyFirst.window().start()).isEqualTo(1_000L);
+        assertThat(decodedKeyFirst.window().end()).isEqualTo(1_100L);
+
+        byte[] timeFirst = PrefixedWindowKeySchemas.TimeFirstWindowKeySchema
+                .toStoreKeyBinary(window, 9)
+                .get();
+        Windowed<Bytes> decodedTimeFirst = PrefixedWindowKeySchemas.TimeFirstWindowKeySchema
+                .fromStoreBytesKey(timeFirst, 100L);
+        assertThat(decodedTimeFirst.key()).isEqualTo(key);
+        assertThat(decodedTimeFirst.window().start()).isEqualTo(1_000L);
+        assertThat(decodedTimeFirst.window().end()).isEqualTo(1_100L);
+        assertThat(Arrays.equals(keyFirst, timeFirst)).isFalse();
+    }
+
+    @Test
+    void shouldDeserializeTimestampedKeyAndJoinSide() {
+        TimestampedKeyAndJoinSideSerde<String> serde = new TimestampedKeyAndJoinSideSerde<>(
+                org.apache.kafka.common.serialization.Serdes.String());
+        TimestampedKeyAndJoinSide<String> original = TimestampedKeyAndJoinSide.make(true, "join-key", 42L);
+
+        byte[] encoded = serde.serializer().serialize("topic", original);
+        TimestampedKeyAndJoinSide<String> decoded = serde.deserializer().deserialize("topic", encoded);
+
+        assertThat(decoded).isEqualTo(original);
+        assertThat(decoded.isLeftSide()).isTrue();
+        assertThat(decoded.getKey()).isEqualTo("join-key");
+        assertThat(decoded.getTimestamp()).isEqualTo(42L);
+        serde.serializer().close();
+        serde.deserializer().close();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepTopologyConstructionCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/DeepTopologyConstructionCoverageTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Builds public Kafka Streams topologies for processor, join, and window paths. */
+public class DeepTopologyConstructionCoverageTest {
+    @Test
+    void shouldBuildWindowTransformAndJoinProcessorsThroughPublicDsl() {
+        StreamsBuilder builder = new StreamsBuilder();
+        Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
+        Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
+        KStream<String, String> events = builder.stream("deep-events", consumed);
+        KStream<String, String> other = builder.stream("deep-other", consumed);
+        KTable<String, String> lookup = builder.table("deep-lookup", consumed);
+
+        events.flatTransformValues(() -> new org.apache.kafka.streams.kstream.ValueTransformerWithKey<String, String, Iterable<String>>() {
+            @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+            @Override public Iterable<String> transform(String key, String value) {
+                return java.util.List.of(value, key + value);
+            }
+            @Override public void close() { }
+        }).to("deep-flat-output", produced);
+        events.join(other, (key, left, right) -> left + right,
+                JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5)),
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()))
+                .to("deep-stream-join-output", produced);
+        events.join(lookup, (key, left, right) -> left + right).to("deep-table-join-output", produced);
+
+        KGroupedStream<String, String> grouped = events.groupByKey(Grouped.with(Serdes.String(), Serdes.String()));
+        grouped.windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(4)))
+                .aggregate(() -> "", (key, value, aggregate) -> aggregate + value)
+                .toStream()
+                .map((window, value) -> KeyValue.pair(window.key(), value))
+                .to("deep-sliding-output", produced);
+        grouped.windowedBy(SessionWindows.with(Duration.ofSeconds(4)))
+                .aggregate(() -> "", (key, value, aggregate) -> aggregate + value,
+                        (key, left, right) -> left + right)
+                .toStream()
+                .map((window, value) -> KeyValue.pair(window.key(), value))
+                .to("deep-session-output", produced);
+
+        assertThat(builder.build().describe().toString()).contains("deep-events", "deep-sliding-output");
+    }
+
+    @Test
+    void shouldBuildPatternSourcesAndOptimizedRepartitionThroughPublicBuilder() {
+        StreamsBuilder builder = new StreamsBuilder();
+        Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
+        KStream<String, String> keyed = builder.stream("optimization-input", consumed)
+                .selectKey((key, value) -> value)
+                .filter((key, value) -> value != null);
+        keyed.groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .count()
+                .toStream()
+                .to("optimization-output", Produced.with(Serdes.String(), Serdes.Long()));
+        builder.stream(Pattern.compile("pattern-input-.*"), consumed).to("pattern-output", Produced.with(
+                Serdes.String(), Serdes.String()));
+        Properties properties = new Properties();
+        properties.put(org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG, "deep-optimization");
+        properties.put(org.apache.kafka.streams.StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, "all");
+        assertThat(builder.build(properties).describe().toString()).contains("optimization-output", "pattern-output");
+    }
+
+    @Test
+    void shouldBuildAllPublicTableJoinShapesAndRepartitionedForeignJoin() {
+        StreamsBuilder builder = new StreamsBuilder();
+        Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
+        Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
+        KTable<String, String> left = builder.table("deep-left", consumed);
+        KTable<String, String> right = builder.table("deep-right", consumed);
+        KTable<String, String> foreign = builder.table("deep-foreign", consumed);
+
+        left.join(right, (a, b) -> a + b).toStream().to("deep-inner-output", produced);
+        left.leftJoin(right, (a, b) -> String.valueOf(a) + b).toStream().to("deep-left-output", produced);
+        left.outerJoin(right, (a, b) -> String.valueOf(a) + b).toStream().to("deep-outer-output", produced);
+        left.join(foreign, value -> value, (a, b) -> a + b,
+                TableJoined.as("deep-foreign-join")).toStream().to("deep-foreign-output", produced);
+        left.leftJoin(foreign, value -> value, (a, b) -> String.valueOf(a) + b,
+                TableJoined.as("deep-foreign-left")).toStream().to("deep-foreign-left-output", produced);
+        left.filter((key, value) -> value != null)
+                .mapValues((key, value) -> key + value)
+                .toStream().to("deep-table-transform-output", produced);
+
+        assertThat(builder.build().describe().toString()).contains("deep-left", "deep-foreign-output");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalAssignmentApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalAssignmentApiCoverageTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
+import org.apache.kafka.streams.processor.internals.assignment.ClientState;
+import org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor;
+import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
+import org.apache.kafka.streams.processor.internals.assignment.RackAwareTaskAssignor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives assignment state and topology metadata through their public contracts. */
+public class InternalAssignmentApiCoverageTest {
+    @Test
+    void shouldAssignAndRevokeActiveAndStandbyTasks() {
+        TaskId active = new TaskId(1, 0);
+        TaskId standby = new TaskId(2, 0);
+        ClientState empty = new ClientState();
+        ClientState state = new ClientState(Set.of(active), Set.of(standby), Map.of(active, 4L), Map.of("rack", "a"), 1);
+        assertThat(empty.capacity()).isZero();
+        state.assignActive(active);
+        assertThat(state.activeTasks()).contains(active);
+        state.assignActiveToConsumer(active, "consumer-a");
+        state.assignStandby(standby);
+        state.assignStandbyToConsumer(standby, "consumer-a");
+        assertThat(state.assignedActiveTasksByConsumer().get("consumer-a")).contains(active);
+        assertThat(state.assignedStandbyTasksByConsumer().get("consumer-a")).contains(standby);
+        state.revokeActiveFromConsumer(active, "consumer-a");
+        assertThat(state.revokingActiveTasksByConsumer().get("consumer-a")).contains(active);
+        assertThat(state.standbyTasks()).contains(standby);
+        state.unassignActive(active);
+        assertThat(state.currentAssignment()).contains("standby");
+        assertThat(state.toString()).contains("standbyTasks");
+    }
+
+    @Test
+    void shouldUseFallbackAssignmentForAnEmptyTaskSet() throws Exception {
+        FallbackPriorTaskAssignor assignor = new FallbackPriorTaskAssignor();
+        TaskId task = new TaskId(3, 0);
+        ClientState client = new ClientState(Set.of(), Set.of(), Map.of(), Map.of(), 1);
+        Class<?> configType = Class.forName(
+                "org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration$AssignmentConfigs");
+        Constructor<?> configConstructor = configType.getDeclaredConstructor(
+                Long.class, Integer.class, Integer.class, Long.class, java.util.List.class);
+        configConstructor.setAccessible(true);
+        Object configs = configConstructor.newInstance(0L, 1, 0, 60000L, new ArrayList<String>());
+        @SuppressWarnings("unchecked")
+        org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs typedConfigs =
+                (org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration.AssignmentConfigs) configs;
+        assertThat(assignor.assign(Map.of(UUID.randomUUID(), client), Set.of(task), Set.of(), null, typedConfigs)).isTrue();
+    }
+
+    @Test
+    void shouldMoveCaughtUpTasksAcrossClientsThroughHighAvailabilityAssignment() throws Exception {
+        TaskId first = new TaskId(4, 0);
+        TaskId second = new TaskId(5, 0);
+        UUID firstClient = UUID.randomUUID();
+        UUID secondClient = UUID.randomUUID();
+        ClientState owner = new ClientState(Set.of(first), Set.of(second), Map.of(first, 0L, second, 0L), Map.of(), 1,
+                firstClient);
+        ClientState destination = new ClientState(Set.of(), Set.of(), Map.of(first, 0L, second, 0L), Map.of(), 1,
+                secondClient);
+        AssignorConfiguration.AssignmentConfigs configs = assignmentConfigs(0L, 1, 2);
+        RackAwareTaskAssignor rackAware = new RackAwareTaskAssignor(Cluster.empty(), Map.of(), Map.of(), Map.of(),
+                Map.of(), null, configs, org.apache.kafka.common.utils.Time.SYSTEM);
+        boolean probingRebalance = new HighAvailabilityTaskAssignor().assign(
+                Map.of(firstClient, owner, secondClient, destination), Set.of(first, second), Set.of(second), rackAware,
+                configs);
+        assertThat(owner.assignedTaskCount()).isGreaterThanOrEqualTo(0);
+        assertThat(destination.assignedTaskCount()).isGreaterThanOrEqualTo(0);
+        assertThat(probingRebalance).isIn(true, false);
+    }
+
+    @Test
+    void shouldResolveTopologyMetadataAndOffsetPolicies() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "metadata-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        StreamsConfig config = new StreamsConfig(properties);
+        InternalTopologyBuilder topologyBuilder = new InternalTopologyBuilder();
+        topologyBuilder.setApplicationId("metadata-api");
+        topologyBuilder.addSource(Topology.AutoOffsetReset.EARLIEST, "source", null,
+                Serdes.String().deserializer(), Serdes.String().deserializer(), "metadata-input");
+        TopologyMetadata metadata = new TopologyMetadata(topologyBuilder, config);
+        assertThat(metadata.offsetResetStrategy("metadata-input")).isEqualTo(org.apache.kafka.clients.consumer.OffsetResetStrategy.EARLIEST);
+        assertThat(metadata.nodeToSourceTopics(new TaskId(0, 0))).isNotNull();
+        assertThat(metadata.getStoreForChangelogTopic("missing-changelog")).isEmpty();
+        assertThat(metadata.fullSourceTopicNamesForTopology(TopologyMetadata.UNNAMED_TOPOLOGY)).contains("metadata-input");
+        assertThat(metadata.toString()).isNotNull();
+    }
+
+    private static AssignorConfiguration.AssignmentConfigs assignmentConfigs(long acceptableRecoveryLag,
+            int numStandbyReplicas, int maxWarmupReplicas) throws Exception {
+        Constructor<AssignorConfiguration.AssignmentConfigs> constructor =
+                AssignorConfiguration.AssignmentConfigs.class.getDeclaredConstructor(
+                        Long.class, Integer.class, Integer.class, Long.class, java.util.List.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(acceptableRecoveryLag, numStandbyReplicas, maxWarmupReplicas,
+                60000L, new ArrayList<String>());
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalTopicManagerApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalTopicManagerApiCoverageTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.internals.InternalTopicManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises the no-topic and no-op lifecycle contracts of the internal topic manager. */
+public class InternalTopicManagerApiCoverageTest {
+    @Test
+    void shouldValidateAndSetUpAnEmptyInternalTopicPlan() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "topic-manager-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        StreamsConfig config = new StreamsConfig(properties);
+        InternalTopicManager manager = new InternalTopicManager(Time.SYSTEM, null, config);
+
+        assertThat(manager.validate(Map.of())).isNotNull();
+        manager.setup(Map.of());
+        assertThat(manager.getTopicPartitionInfo(Set.of())).isEmpty();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalUtilityApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/InternalUtilityApiCoverageTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.streams.errors.LogAndFailExceptionHandler;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.internals.PendingUpdateAction;
+import org.apache.kafka.streams.processor.internals.ProcessorMetadata;
+import org.apache.kafka.streams.processor.internals.ToInternal;
+import org.apache.kafka.streams.processor.internals.TopicPartitionMetadata;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises public utility state machines and error handlers with observable results. */
+public class InternalUtilityApiCoverageTest {
+    @Test
+    void shouldUpdateForwardingAndPendingActions() {
+        ToInternal forwarding = new ToInternal();
+        forwarding.update(To.child("child").withTimestamp(17L));
+        assertThat(forwarding.child()).isEqualTo("child");
+        assertThat(forwarding.timestamp()).isEqualTo(17L);
+        assertThat(forwarding.hasTimestamp()).isTrue();
+        ToInternal copied = new ToInternal(To.all().withTimestamp(19L));
+        assertThat(copied.hasTimestamp()).isTrue();
+        assertThat(copied.timestamp()).isEqualTo(19L);
+
+        TopicPartition partition = new TopicPartition("input", 0);
+        assertThat(PendingUpdateAction.createCloseClean()).isNotNull();
+        assertThat(PendingUpdateAction.createCloseDirty()).isNotNull();
+        assertThat(PendingUpdateAction.createSuspend()).isNotNull();
+        assertThat(PendingUpdateAction.createRecycleTask(Set.of(partition)).getInputPartitions()).contains(partition);
+        assertThat(PendingUpdateAction.createUpdateInputPartition(Set.of(partition)).getInputPartitions()).contains(partition);
+    }
+
+    @Test
+    void shouldEncodeProcessorMetadataAndTopicPartitionState() {
+        ProcessorMetadata processorMetadata = new ProcessorMetadata(new HashMap<>(Map.of("store", 8L)));
+        processorMetadata.put("other", 9L);
+        processorMetadata.setNeedsCommit(true);
+        assertThat(processorMetadata.get("store")).isEqualTo(8L);
+        assertThat(processorMetadata.needsCommit()).isTrue();
+        assertThat(ProcessorMetadata.deserialize(processorMetadata.serialize())).isEqualTo(processorMetadata);
+
+        TopicPartitionMetadata metadata = new TopicPartitionMetadata(123L, processorMetadata);
+        TopicPartitionMetadata decoded = TopicPartitionMetadata.decode(metadata.encode());
+        assertThat(decoded.partitionTime()).isEqualTo(123L);
+        assertThat(decoded.processorMetadata()).isEqualTo(processorMetadata);
+        assertThat(decoded).isEqualTo(metadata);
+        assertThat(decoded.hashCode()).isEqualTo(metadata.hashCode());
+    }
+
+    @Test
+    void shouldReportQueryResultsAndPositionBounds() {
+        Position position = Position.emptyPosition().withComponent("topic", 0, 4L);
+        assertThat(PositionBound.unbounded().isUnbounded()).isTrue();
+        assertThat(PositionBound.at(position).isUnbounded()).isFalse();
+        assertThat(PositionBound.at(position).position()).isEqualTo(position);
+
+        StateQueryResult<String> queryResult = new StateQueryResult<>();
+        QueryResult<String> first = QueryResult.forResult("first");
+        queryResult.addResult(0, first);
+        assertThat(queryResult.getOnlyPartitionResult()).isSameAs(first);
+        assertThat(queryResult.getPartitionResults()).containsEntry(0, first);
+        queryResult.setGlobalResult(QueryResult.forResult("global"));
+        assertThat(queryResult.getGlobalResult().getResult()).isEqualTo("global");
+        assertThat(queryResult.toString()).contains("first");
+    }
+
+    @Test
+    void shouldReturnDocumentedHandlerResponses() {
+        ConsumerRecord<byte[], byte[]> record = new ConsumerRecord<>("topic", 0, 1L, new byte[] {1}, new byte[] {2});
+        Exception failure = new IllegalArgumentException("bad input");
+        LogAndContinueExceptionHandler continueHandler = new LogAndContinueExceptionHandler();
+        continueHandler.configure(Map.of());
+        org.apache.kafka.streams.processor.ProcessorContext context = (org.apache.kafka.streams.processor.ProcessorContext) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {org.apache.kafka.streams.processor.ProcessorContext.class},
+                (proxy, method, args) -> method.getName().equals("taskId") ? new org.apache.kafka.streams.processor.TaskId(0, 0) : null);
+        assertThat(continueHandler.handle(context, record, failure))
+                .isEqualTo(DeserializationExceptionHandler.DeserializationHandlerResponse.CONTINUE);
+        LogAndFailExceptionHandler failHandler = new LogAndFailExceptionHandler();
+        failHandler.configure(Map.of());
+        assertThat(failHandler.handle(context, record, failure))
+                .isEqualTo(DeserializationExceptionHandler.DeserializationHandlerResponse.FAIL);
+        DefaultProductionExceptionHandler productionHandler = new DefaultProductionExceptionHandler();
+        productionHandler.configure(Map.of());
+        assertThat(productionHandler.handle(new ProducerRecord<>("topic", new byte[] {1}, new byte[] {2}), failure))
+                .isEqualTo(org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse.FAIL);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KStreamApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KStreamApiCoverageTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Builds realistic stream topologies through the public KStream API. */
+public class KStreamApiCoverageTest {
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldComposeStreamTransformationsAndSinks() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> input = builder.stream("api-stream-input", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> other = builder.stream("api-stream-other", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> table = builder.table("api-stream-table", Consumed.with(Serdes.String(), Serdes.String()));
+
+        KStream<String, String> filtered = input.filter((key, value) -> value != null, Named.as("filter"))
+                .filterNot((key, value) -> value.isEmpty(), Named.as("filter-not"));
+        KStream<String, Integer> mapped = filtered
+                .map((key, value) -> KeyValue.pair(key, value.length()), Named.as("map"))
+                .mapValues(Integer::intValue, Named.as("map-values"));
+        KStream<String, Integer> expanded = mapped
+                .flatMap((key, value) -> List.of(KeyValue.pair(key, value), KeyValue.pair(key + "-copy", value)), Named.as("flat-map"))
+                .flatMapValues(value -> List.of(value, value + 1), Named.as("flat-map-values"));
+        expanded.peek((key, value) -> assertThat(value).isPositive(), Named.as("peek"));
+        expanded.foreach((key, value) -> assertThat(key).isNotNull(), Named.as("foreach"));
+        expanded.print(Printed.<String, Integer>toSysOut().withLabel("api-stream"));
+
+        KStream<String, String> strings = input.merge(other, Named.as("merge"));
+        strings.repartition(Repartitioned.with(Serdes.String(), Serdes.String()).withName("repartition"));
+        strings.through("api-stream-through", Produced.with(Serdes.String(), Serdes.String()));
+        strings.to("api-stream-output", Produced.with(Serdes.String(), Serdes.String()));
+        strings.to((key, value, recordContext) -> "api-stream-dynamic-output", Produced.with(Serdes.String(), Serdes.String()));
+        strings.toTable(Named.as("to-table"), Materialized.with(Serdes.String(), Serdes.String()));
+        strings.groupBy((key, value) -> key, Grouped.with(Serdes.String(), Serdes.String())).count();
+        strings.groupByKey(Grouped.with(Serdes.String(), Serdes.String())).count();
+
+        KStream<String, String>[] branches = strings.branch(
+                Named.as("branches"), (key, value) -> value.startsWith("a"), (key, value) -> true);
+        assertThat(branches).hasSize(2);
+        assertThat(strings.split(Named.as("split")).branch((key, value) -> value.length() > 1).defaultBranch()).isNotNull();
+        assertThat(strings).isNotNull();
+
+        assertThat(input.join(other, (left, right) -> left + right, JoinWindows.ofTimeDifferenceWithNoGrace(java.time.Duration.ofSeconds(5)))).isNotNull();
+        assertThat(input.leftJoin(other, (left, right) -> left + right, JoinWindows.ofTimeDifferenceWithNoGrace(java.time.Duration.ofSeconds(5)))).isNotNull();
+        assertThat(input.outerJoin(other, (left, right) -> String.valueOf(left) + right, JoinWindows.ofTimeDifferenceWithNoGrace(java.time.Duration.ofSeconds(5)))).isNotNull();
+        assertThat(input.join(table, (left, right) -> left + right)).isNotNull();
+        assertThat(input.leftJoin(table, (left, right) -> left + right)).isNotNull();
+
+        assertThat(builder.build()).isNotNull();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldExerciseGlobalJoinsAndRepartitionDefaults() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> stream = builder.stream("api-global-join-input", Consumed.with(Serdes.String(), Serdes.String()));
+        KStream<String, String> other = builder.stream("api-global-join-other", Consumed.with(Serdes.String(), Serdes.String()));
+        org.apache.kafka.streams.kstream.GlobalKTable<String, String> global = builder.globalTable("api-global-join-table");
+        assertThat(stream.join(other, (left, right) -> left + right,
+                JoinWindows.ofTimeDifferenceWithNoGrace(java.time.Duration.ofSeconds(1)),
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(stream.join(other, (left, right) -> left + right,
+                JoinWindows.ofTimeDifferenceWithNoGrace(java.time.Duration.ofSeconds(1)),
+                StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(stream.join(global, (key, value) -> key, (left, right) -> left + right)).isNotNull();
+        assertThat(stream.join(global, (key, value) -> key, (left, right) -> left + right, Named.as("global-join"))).isNotNull();
+        assertThat(stream.leftJoin(global, (key, value) -> key, (left, right) -> String.valueOf(left) + right)).isNotNull();
+        assertThat(stream.leftJoin(global, (key, value) -> key, (left, right) -> String.valueOf(left) + right, Named.as("global-left"))).isNotNull();
+        assertThat(stream.groupBy((String key, String value) -> key,
+                Grouped.<String, String>with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(stream.flatMapValues(value -> List.of(value)).repartition()).isNotNull();
+        assertThat(stream.mapValues(value -> value.toUpperCase())).isNotNull();
+        assertThat(builder.build().describe().toString()).contains("api-global-join");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldCreateProcessorAndTransformerStages() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> input = builder.stream("api-process-input", Consumed.with(Serdes.String(), Serdes.String()));
+        input.process(() -> new NoopProcessor());
+        assertThat(input.process(new ApiProcessorSupplier())).isNotNull();
+        assertThat(input.processValues(() -> new ApiFixedKeyProcessor())).isNotNull();
+        assertThat(input.transform(() -> new ApiTransformer())).isNotNull();
+        assertThat(input.transformValues(() -> new ApiValueTransformer())).isNotNull();
+        assertThat(input.flatTransformValues(() -> new ApiFlatValueTransformer())).isNotNull();
+        Topology topology = builder.build();
+        assertThat(topology.describe().toString()).contains("api-process-input");
+    }
+
+    private static final class NoopProcessor implements Processor<String, String> {
+        @Override public void init(ProcessorContext context) { }
+        @Override public void process(String key, String value) { }
+        @Override public void close() { }
+    }
+
+    private static final class ApiProcessorSupplier implements org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, String, String> {
+        @Override public org.apache.kafka.streams.processor.api.Processor<String, String, String, String> get() {
+            return new ApiProcessor();
+        }
+    }
+
+    private static final class ApiProcessor implements org.apache.kafka.streams.processor.api.Processor<String, String, String, String> {
+        @Override public void init(org.apache.kafka.streams.processor.api.ProcessorContext<String, String> context) { }
+        @Override public void process(org.apache.kafka.streams.processor.api.Record<String, String> record) { }
+    }
+
+    private static final class ApiFixedKeyProcessor implements org.apache.kafka.streams.processor.api.FixedKeyProcessor<String, String, String> {
+        @Override public void init(org.apache.kafka.streams.processor.api.FixedKeyProcessorContext<String, String> context) { }
+        @Override public void process(org.apache.kafka.streams.processor.api.FixedKeyRecord<String, String> record) { }
+    }
+
+    private static final class ApiFlatValueTransformer implements ValueTransformer<String, Iterable<String>> {
+        @Override public void init(ProcessorContext context) { }
+        @Override public Iterable<String> transform(String value) {
+            return List.of(value);
+        }
+        @Override public void close() { }
+    }
+
+    private static final class ApiValueTransformer implements ValueTransformer<String, String> {
+        @Override public void init(ProcessorContext context) { }
+        @Override public String transform(String value) {
+            return value;
+        }
+        @Override public void close() { }
+    }
+
+    private static final class ApiTransformer implements Transformer<String, String, KeyValue<String, String>> {
+        @Override public void init(ProcessorContext context) { }
+        @Override public KeyValue<String, String> transform(String key, String value) {
+            return KeyValue.pair(key, value);
+        }
+        @Override public void close() { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KTableAndWindowApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KTableAndWindowApiCoverageTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises table joins, materialization, grouping, and windowed aggregations. */
+public class KTableAndWindowApiCoverageTest {
+    @Test
+    void shouldJoinFilterTransformAndMaterializeTables() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> left = builder.table("api-table-left", Consumed.with(Serdes.String(), Serdes.String()));
+        KTable<String, String> right = builder.table("api-table-right", Consumed.with(Serdes.String(), Serdes.String()));
+        Materialized<String, String, org.apache.kafka.streams.state.KeyValueStore<org.apache.kafka.common.utils.Bytes, byte[]>> materialized =
+                Materialized.with(Serdes.String(), Serdes.String());
+
+        KTable<String, String> joined = left.join(right, (a, b) -> a + b, Named.as("table-join-named"), materialized);
+        assertThat(left.join(right, (a, b) -> a + b, Named.as("join"))).isNotNull();
+        assertThat(left.leftJoin(right, (a, b) -> String.valueOf(a) + b)).isNotNull();
+        assertThat(left.leftJoin(right, (a, b) -> String.valueOf(a) + b, materialized)).isNotNull();
+        assertThat(left.outerJoin(right, (a, b) -> String.valueOf(a) + b, materialized)).isNotNull();
+        assertThat(left.filter((key, value) -> value != null, materialized)).isNotNull();
+        assertThat(left.filterNot((key, value) -> value.isEmpty(), materialized)).isNotNull();
+        assertThat(left.mapValues((org.apache.kafka.streams.kstream.ValueMapper<String, String>) String::toUpperCase, materialized)).isNotNull();
+        assertThat(left.mapValues((key, value) -> key + value, materialized)).isNotNull();
+        assertThat(left.toStream((key, value) -> key + "-stream", Named.as("table-to-stream"))).isNotNull();
+        assertThat(left.suppress(Suppressed.untilTimeLimit(Duration.ofSeconds(1), Suppressed.BufferConfig.unbounded()))).isNotNull();
+
+        KTable<String, String> foreign = builder.table("api-table-foreign", Consumed.with(Serdes.String(), Serdes.String()));
+        assertThat(left.join(foreign, value -> value, (a, b) -> a + b)).isNotNull();
+        assertThat(left.join(foreign, value -> value, (a, b) -> a + b, Named.as("foreign-named"))).isNotNull();
+        assertThat(left.leftJoin(foreign, value -> value, (a, b) -> String.valueOf(a) + b)).isNotNull();
+        assertThat(joined).isNotNull();
+        assertThat(builder.build()).isNotNull();
+    }
+
+    @Test
+    void shouldAggregateTablesAndWindowedStreams() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KTable<String, String> table = builder.table("api-grouped-table", Consumed.with(Serdes.String(), Serdes.String()));
+        KGroupedTable<String, String> grouped = table.groupBy((key, value) -> KeyValue.pair(key, value), Grouped.with(Serdes.String(), Serdes.String()));
+        assertThat(grouped.reduce((oldValue, newValue) -> newValue, (oldValue, newValue) -> oldValue)).isNotNull();
+        assertThat(grouped.aggregate(() -> "", (key, value, aggregate) -> aggregate + value, (key, value, aggregate) -> aggregate + value)).isNotNull();
+
+        KStream<String, String> stream = builder.stream("api-window-input", Consumed.with(Serdes.String(), Serdes.String()));
+        assertThat(stream.groupByKey().windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).count()).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).count(Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).reduce((a, b) -> a + b)).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(10))).aggregate(() -> "", (key, value, aggregate) -> aggregate + value)).isNotNull();
+
+        assertThat(stream.groupByKey().windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5))).count()).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5))).count(Materialized.with(Serdes.String(), Serdes.Long()))).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5))).reduce((a, b) -> a + b)).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(5))).aggregate(() -> "", (key, value, aggregate) -> aggregate + value, (key, left, right) -> left + right)).isNotNull();
+
+        assertThat(stream.groupByKey().windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5))).count()).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5))).reduce((a, b) -> a + b)).isNotNull();
+        assertThat(stream.groupByKey().windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(5))).aggregate(() -> "", (key, value, aggregate) -> aggregate + value)).isNotNull();
+        assertThat(builder.build()).isNotNull();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/KafkaStreamsApiCoverageTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.test.MockClientSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises lifecycle configuration and safe pre-start KafkaStreams queries. */
+public class KafkaStreamsApiCoverageTest {
+    @Test
+    void shouldConfigureLifecycleAndInspectAnUnstartedApplication() {
+        Topology topology = topology();
+        Properties properties = properties();
+        KafkaStreams streams = new KafkaStreams(topology, properties, Time.SYSTEM);
+        try {
+            streams.setUncaughtExceptionHandler((Thread.UncaughtExceptionHandler) (thread, exception) -> { });
+            streams.setUncaughtExceptionHandler(exception -> org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT);
+            streams.setGlobalStateRestoreListener(new StateRestoreListener() {
+                @Override public void onRestoreStart(org.apache.kafka.common.TopicPartition topicPartition, String storeName, long startOffset, long endOffset) { }
+                @Override public void onBatchRestored(org.apache.kafka.common.TopicPartition topicPartition, String storeName, long batchEndOffset, long numRestored) { }
+                @Override public void onRestoreEnd(org.apache.kafka.common.TopicPartition topicPartition, String storeName, long totalRestored) { }
+            });
+            assertThat(streams.metrics()).isNotNull();
+            assertThat(streams.localThreadsMetadata()).isNotNull();
+            assertThat(streams.metadataForLocalThreads()).isNotNull();
+            assertThatThrownBy(streams::allMetadata).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.allMetadataForStore("missing")).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.streamsMetadataForStore("missing")).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.queryMetadataForKey("missing", "key", Serdes.String().serializer())).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.queryMetadataForKey("missing", "key", (org.apache.kafka.streams.processor.StreamPartitioner<String, Object>) (topic, key, value, numPartitions) -> 0)).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.store(org.apache.kafka.streams.StoreQueryParameters.fromNameAndType(
+                    "missing", org.apache.kafka.streams.state.QueryableStoreTypes.<String, String>keyValueStore()))).isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(streams::metadataForAllStreamsClients).isInstanceOf(RuntimeException.class);
+            assertThat(streams.allLocalStorePartitionLags()).isNotNull();
+            streams.pause();
+            assertThat(streams.isPaused()).isTrue();
+            streams.resume();
+            assertThat(streams.isPaused()).isFalse();
+        } finally {
+            streams.close(new KafkaStreams.CloseOptions().timeout(Duration.ZERO).leaveGroup(false));
+        }
+    }
+
+    @Test
+    void shouldStartAndStopWithTheMockClientSupplier() throws InterruptedException {
+        MockClientSupplier supplier = mockClientSupplier();
+        KafkaStreams streams = new KafkaStreams(topology(), properties(), supplier, Time.SYSTEM);
+        try {
+            streams.start();
+            Thread.sleep(250L);
+            assertThat(streams.state()).isNotEqualTo(KafkaStreams.State.CREATED);
+            assertThat(streams.addStreamThread()).isPresent();
+            assertThat(streams.removeStreamThread()).isPresent();
+        } finally {
+            streams.close(new KafkaStreams.CloseOptions().timeout(Duration.ofSeconds(5)).leaveGroup(false));
+        }
+    }
+
+    @Test
+    void shouldAcceptAllPublicConstructionFormsAndCloseOptions() {
+        Topology topology = topology();
+        Properties properties = properties();
+        KafkaStreams streamsWithSupplier = new KafkaStreams(topology, properties(), mockClientSupplier(), Time.SYSTEM);
+        KafkaStreams streamsWithConfig = new KafkaStreams(topology, new StreamsConfig(properties()), Time.SYSTEM);
+        try {
+            assertThat(new KafkaStreams.CloseOptions().timeout(Duration.ofMillis(1)).leaveGroup(true)).isNotNull();
+            assertThat(streamsWithSupplier.state()).isEqualTo(KafkaStreams.State.CREATED);
+            assertThat(streamsWithConfig.state()).isEqualTo(KafkaStreams.State.CREATED);
+        } finally {
+            streamsWithSupplier.close(Duration.ZERO);
+            streamsWithConfig.close(Duration.ZERO);
+        }
+    }
+
+    private static Topology topology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.stream("api-kafka-streams-input").to("api-kafka-streams-output");
+        builder.globalTable("api-kafka-streams-global-input",
+                org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()));
+        return builder.build();
+    }
+
+    private static MockClientSupplier mockClientSupplier() {
+        MockClientSupplier supplier = new MockClientSupplier();
+        Node node = new Node(0, "localhost", 9092);
+        Node controller = new Node(-1, "localhost", 9092);
+        java.util.List<PartitionInfo> partitions = java.util.List.of(
+                new PartitionInfo("api-kafka-streams-input", 0, node, new Node[] {node}, new Node[] {node}),
+                new PartitionInfo("api-kafka-streams-global-input", 0, node, new Node[] {node}, new Node[] {node}));
+        supplier.setCluster(new Cluster("api-cluster", java.util.List.of(node, controller), partitions,
+                java.util.Set.of(), java.util.Set.of(), controller));
+        supplier.consumer.updatePartitions("api-kafka-streams-input", java.util.List.of(partitions.get(0)));
+        supplier.consumer.updateEndOffsets(java.util.Map.of(
+                new org.apache.kafka.common.TopicPartition("api-kafka-streams-input", 0), 0L));
+        supplier.restoreConsumer.updatePartitions("api-kafka-streams-global-input", java.util.List.of(partitions.get(1)));
+        supplier.restoreConsumer.updateBeginningOffsets(java.util.Map.of(
+                new org.apache.kafka.common.TopicPartition("api-kafka-streams-global-input", 0), 0L));
+        supplier.restoreConsumer.updateEndOffsets(java.util.Map.of(
+                new org.apache.kafka.common.TopicPartition("api-kafka-streams-global-input", 0), 0L));
+        return supplier;
+    }
+
+    private static Properties properties() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "api-kafka-streams-" + java.util.UUID.randomUUID());
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.STATE_DIR_CONFIG, "build/api-kafka-streams-" + java.util.UUID.randomUUID());
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        return properties;
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/LowLevelStateApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/LowLevelStateApiCoverageTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.streams.state.internals.Maybe;
+import org.apache.kafka.streams.state.internals.Murmur3;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises deterministic low-level state utilities through their public contracts. */
+public class LowLevelStateApiCoverageTest {
+    @Test
+    void shouldProduceTheSameHashForWholeAndChunkedInput() {
+        byte[] value = {1, 2, 3, 4, 5, 6, 7};
+        Murmur3.IncrementalHash32 incremental = new Murmur3.IncrementalHash32();
+        incremental.start(Murmur3.DEFAULT_SEED);
+        incremental.add(value, 0, 3);
+        incremental.add(value, 3, value.length - 3);
+        assertThat(incremental.end()).isEqualTo(Murmur3.hash32(value));
+    }
+
+    @Test
+    void shouldDistinguishDefinedAndUndefinedValues() {
+        Maybe<String> defined = Maybe.defined("value");
+        Maybe<String> undefined = Maybe.undefined();
+        assertThat(defined.isDefined()).isTrue();
+        assertThat(defined.getNullableValue()).isEqualTo("value");
+        assertThat(undefined.isDefined()).isFalse();
+        org.assertj.core.api.Assertions.assertThatThrownBy(undefined::getNullableValue)
+                .isInstanceOf(java.util.NoSuchElementException.class);
+        assertThat(defined).isNotEqualTo(undefined);
+        assertThat(defined.hashCode()).isEqualTo(Maybe.defined("value").hashCode());
+        assertThat(defined.toString()).contains("value");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/NamedTopologyApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/NamedTopologyApiCoverageTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Builds and inspects a named topology through the public named-topology facade. */
+public class NamedTopologyApiCoverageTest {
+    @Test
+    void shouldBuildNamedTopologyAndReportPreStartQueryFailures() {
+        KafkaStreamsNamedTopologyWrapper streams = new KafkaStreamsNamedTopologyWrapper(properties());
+        try {
+            NamedTopologyBuilder builder = streams.newNamedTopologyBuilder("orders");
+            builder.stream("named-orders", org.apache.kafka.streams.kstream.Consumed.with(Serdes.String(), Serdes.String()))
+                    .to("named-orders-output");
+            NamedTopology topology = builder.build();
+            assertThat(topology).isNotNull();
+            assertThat(streams.getFullTopologyDescription()).isEmpty();
+            assertThat(streams.getAllTopologies()).isEmpty();
+            assertThat(streams.newNamedTopologyBuilder("empty").build()).isNotNull();
+            streams.start(topology);
+            assertThat(streams.getFullTopologyDescription()).contains("orders");
+            assertThat(streams.getAllTopologies()).extracting(NamedTopology::name).contains("orders");
+            assertThatThrownBy(() -> streams.store(NamedTopologyStoreQueryParameters
+                    .fromNamedTopologyAndStoreNameAndType("orders", "missing", QueryableStoreTypes.keyValueStore())))
+                    .isInstanceOf(RuntimeException.class);
+            assertThatThrownBy(() -> streams.queryMetadataForKey("missing", "key", Serdes.String().serializer(), "missing"))
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(streams.allStreamsClientsMetadataForTopology("orders")).isNotNull();
+            assertThatThrownBy(() -> streams.streamsMetadataForStore("missing", "orders"))
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(streams.allLocalStorePartitionLagsForTopology("orders")).isNotNull();
+            streams.pauseNamedTopology("orders");
+            assertThat(streams.isNamedTopologyPaused("orders")).isTrue();
+            streams.resumeNamedTopology("orders");
+            assertThat(streams.isNamedTopologyPaused("orders")).isFalse();
+            Collection<NamedTopology> topologies = streams.getAllTopologies();
+            assertThat(topologies).hasSize(1);
+            assertThat(streams.removeNamedTopology("orders")).isNotNull();
+            assertThat(streams.getAllTopologies()).isEmpty();
+            streams.cleanUpNamedTopology("orders");
+        } finally {
+            streams.close(java.time.Duration.ZERO);
+        }
+    }
+
+    private static Properties properties() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "named-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        return properties;
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/NativeCoverageFixtures.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/NativeCoverageFixtures.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.test.MockRecordCollector;
+import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.processor.Cancellable;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.api.RecordMetadata;
+import org.apache.kafka.streams.processor.StateStoreContext;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+/** Small concrete test doubles that work in JVM and Native Image test runs. */
+public final class NativeCoverageFixtures {
+    private NativeCoverageFixtures() {
+    }
+
+    static MockRecordCollector recordCollector() {
+        return new MockRecordCollector();
+    }
+
+    public static ProcessorContext processorContext(long timestamp) {
+        return new SimpleProcessorContext(timestamp);
+    }
+
+    static StateStoreContext stateStoreContext() {
+        return new SimpleStateStoreContext();
+    }
+
+    static final class SimpleProcessorContext implements ProcessorContext {
+        private final long timestamp;
+        private boolean committed;
+
+        SimpleProcessorContext(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        boolean committed() {
+            return committed;
+        }
+
+        @Override
+        public String applicationId() {
+            return "coverage";
+        }
+
+        @Override
+        public TaskId taskId() {
+            return new TaskId(0, 0);
+        }
+
+        @Override
+        public Serde<?> keySerde() {
+            return Serdes.String();
+        }
+
+        @Override
+        public Serde<?> valueSerde() {
+            return Serdes.String();
+        }
+
+        @Override
+        public File stateDir() {
+            return new File("build/native-coverage-state");
+        }
+
+        @Override
+        public StreamsMetrics metrics() {
+            return null;
+        }
+
+        @Override
+        public void register(StateStore store, StateRestoreCallback callback) {
+        }
+
+        @Override
+        public <S extends StateStore> S getStateStore(String name) {
+            return null;
+        }
+
+        @Override
+        public Cancellable schedule(Duration interval, PunctuationType type, Punctuator punctuator) {
+            return () -> { };
+        }
+
+        @Override
+        public <K, V> void forward(K key, V value) {
+            throw new RuntimeException("forward disabled for coverage fixture");
+        }
+
+        @Override
+        public <K, V> void forward(K key, V value, To to) {
+            throw new RuntimeException("forward disabled for coverage fixture");
+        }
+
+        @Override
+        public void commit() {
+            committed = true;
+        }
+
+        @Override
+        public String topic() {
+            return "orders";
+        }
+
+        @Override
+        public int partition() {
+            return 3;
+        }
+
+        @Override
+        public long offset() {
+            return 17L;
+        }
+
+        @Override
+        public Headers headers() {
+            return new RecordHeaders();
+        }
+
+        @Override
+        public long timestamp() {
+            return timestamp;
+        }
+
+        @Override
+        public Map<String, Object> appConfigs() {
+            return Map.of("prefix.key", "value");
+        }
+
+        @Override
+        public Map<String, Object> appConfigsWithPrefix(String prefix) {
+            return Map.of("key", "value");
+        }
+
+        @Override
+        public long currentSystemTimeMs() {
+            return 1000L;
+        }
+
+        @Override
+        public long currentStreamTimeMs() {
+            return 900L;
+        }
+    }
+
+    private static final class SimpleStateStoreContext implements StateStoreContext {
+        @Override
+        public String applicationId() {
+            return "coverage";
+        }
+
+        @Override
+        public TaskId taskId() {
+            return new TaskId(0, 0);
+        }
+
+        @Override
+        public Optional<RecordMetadata> recordMetadata() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Serde<?> keySerde() {
+            return Serdes.String();
+        }
+
+        @Override
+        public Serde<?> valueSerde() {
+            return Serdes.String();
+        }
+
+        @Override
+        public File stateDir() {
+            return new File("build/native-coverage-state");
+        }
+
+        @Override
+        public StreamsMetrics metrics() {
+            return null;
+        }
+
+        @Override
+        public void register(StateStore store, StateRestoreCallback callback) {
+        }
+
+        @Override
+        public void register(StateStore store, StateRestoreCallback callback,
+                org.apache.kafka.streams.processor.CommitCallback commitCallback) {
+        }
+
+        @Override
+        public Map<String, Object> appConfigs() {
+            return Map.of("adapter.key", "value");
+        }
+
+        @Override
+        public Map<String, Object> appConfigsWithPrefix(String prefix) {
+            return Map.of("key", "value");
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/OptionsAndExceptionsApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/OptionsAndExceptionsApiCoverageTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises option objects, enum contracts, and exception handling behavior. */
+public class OptionsAndExceptionsApiCoverageTest {
+    @Test
+    void shouldConfigureStreamAndTableJoinOptions() {
+        StreamJoined<String, String, Integer> joined = StreamJoined.with(
+                Serdes.String(), Serdes.String(), Serdes.Integer());
+        assertThat(StreamJoined.<String, String, Integer>with(
+                Stores.inMemoryWindowStore("left-supplier", Duration.ofSeconds(2), Duration.ofSeconds(1), false),
+                Stores.inMemoryWindowStore("right-supplier", Duration.ofSeconds(2), Duration.ofSeconds(1), false)))
+                .isNotNull();
+        StreamJoined<String, String, Integer> configured = joined.withKeySerde(Serdes.String()).withValueSerde(Serdes.String())
+                .withOtherValueSerde(Serdes.Integer()).withStoreName("join-store")
+                .withThisStoreSupplier(Stores.inMemoryWindowStore("this", Duration.ofSeconds(1), Duration.ofSeconds(1), false))
+                .withOtherStoreSupplier(Stores.inMemoryWindowStore("other", Duration.ofSeconds(1), Duration.ofSeconds(1), false))
+                .withLoggingEnabled(Map.of("retention.ms", "1")).withLoggingDisabled()
+                .withName("join-name");
+        assertThat(configured).isNotNull();
+        assertThat(configured.toString()).contains("join-store");
+
+        org.apache.kafka.streams.processor.StreamPartitioner<String, Void> partitioner = (topic, key, value, partitions) -> 0;
+        TableJoined<String, String> tableJoined = TableJoined.with(partitioner, partitioner)
+                .withPartitioner(partitioner).withOtherPartitioner(partitioner).withName("table-name");
+        assertThat(tableJoined).isNotNull();
+        assertThat(TableJoined.<String, String>as("table").withName("renamed")).isNotNull();
+    }
+
+    @Test
+    void shouldConfigureSuppressionBuffersAndEnumerations() {
+        assertThat(Suppressed.BufferConfig.maxBytes(1024).withMaxRecords(10).emitEarlyWhenFull()).isNotNull();
+        assertThat(Suppressed.BufferConfig.maxRecords(10).withMaxBytes(1024).withLoggingDisabled()).isNotNull();
+        assertThat(Suppressed.BufferConfig.unbounded().withNoBound().withLoggingEnabled(Map.of())).isNotNull();
+        assertThat(Suppressed.untilWindowCloses(Suppressed.BufferConfig.unbounded())).isNotNull();
+        assertThat(Topology.AutoOffsetReset.valueOf("EARLIEST")).isEqualTo(Topology.AutoOffsetReset.EARLIEST);
+        assertThat(Topology.AutoOffsetReset.values()).isNotEmpty();
+        assertThat(StreamsConfigUtils.ProcessingMode.valueOf("AT_LEAST_ONCE")).isNotNull();
+        assertThat(StreamsConfigUtils.ProcessingMode.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.KafkaStreams.State.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse.values()).isNotEmpty();
+        assertThat(ProductionExceptionHandler.ProductionExceptionHandlerResponse.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.kstream.EmitStrategy.StrategyType.values()).isNotEmpty();
+        assertThat(org.apache.kafka.streams.kstream.Materialized.StoreType.values()).isNotEmpty();
+        assertThat(WindowedSerdes.sessionWindowedSerdeFrom(String.class)).isNotNull();
+    }
+
+    @Test
+    void shouldPreserveExceptionCausesAndUseProductionHandlerDefault() {
+        Exception cause = new IllegalArgumentException("bad record");
+        assertThat(new TopologyException("message").getMessage()).contains("message");
+        assertThat(new TopologyException("message", cause).getCause()).isSameAs(cause);
+        assertThat(new TopologyException(cause).getCause()).isSameAs(cause);
+        assertThat(new TaskAssignmentException(cause).getCause()).isSameAs(cause);
+        assertThat(new TaskIdFormatException(cause).getCause()).isSameAs(cause);
+        DefaultProductionExceptionHandler handler = new DefaultProductionExceptionHandler();
+        assertThat(handler.handleSerializationException(new ProducerRecord<>("topic", "key", "value"), cause))
+                .isEqualTo(ProductionExceptionHandler.ProductionExceptionHandlerResponse.FAIL);
+        KafkaClientSupplier supplier = new KafkaClientSupplier() {
+            @Override public org.apache.kafka.clients.producer.Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+                return null;
+            }
+            @Override public org.apache.kafka.clients.consumer.Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
+                return null;
+            }
+            @Override public org.apache.kafka.clients.consumer.Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
+                return null;
+            }
+            @Override public org.apache.kafka.clients.consumer.Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
+                return null;
+            }
+        };
+        assertThatThrownBy(() -> supplier.getAdmin(Map.of())).isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ProcessorRecordApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ProcessorRecordApiCoverageTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.processor.api.Record;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises immutable Processor API records through their transformation contract. */
+public class ProcessorRecordApiCoverageTest {
+    @Test
+    void shouldPreserveRecordFieldsAcrossImmutableTransformations() {
+        Headers headers = new RecordHeaders().add("source", new byte[] {1});
+        Record<String, Integer> original = new Record<>("order-1", 3, 100L, headers);
+        Record<String, Integer> equivalent = new Record<>("order-1", 3, 100L, headers);
+
+        assertThat(original.key()).isEqualTo("order-1");
+        assertThat(original.value()).isEqualTo(3);
+        assertThat(original.timestamp()).isEqualTo(100L);
+        assertThat(original.headers()).isEqualTo(headers);
+        assertThat(original).isEqualTo(equivalent);
+        assertThat(original.hashCode()).isEqualTo(equivalent.hashCode());
+        assertThat(original.toString()).contains("order-1", "100");
+
+        Record<String, Integer> retimestamped = original.withTimestamp(200L);
+        Record<String, String> remapped = original.withKey("order-2").withValue("ready");
+        Headers replacement = new RecordHeaders().add("route", new byte[] {2});
+        Record<String, Integer> rerouted = original.withHeaders(replacement);
+        assertThat(retimestamped.timestamp()).isEqualTo(200L);
+        assertThat(remapped.key()).isEqualTo("order-2");
+        assertThat(remapped.value()).isEqualTo("ready");
+        assertThat(rerouted.headers()).isEqualTo(replacement);
+        assertThat(original.timestamp()).isEqualTo(100L);
+        assertThat(original.value()).isEqualTo(3);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ProtocolAndAssignmentApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ProtocolAndAssignmentApiCoverageTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageSizeAccumulator;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.internals.generated.SubscriptionInfoData;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStoreQueryParameters;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises generated protocol records and assignment state through public methods. */
+public class ProtocolAndAssignmentApiCoverageTest {
+    @Test
+    void shouldBuildAndRoundTripGeneratedSubscriptionRecords() {
+        SubscriptionInfoData.TaskId taskId = new SubscriptionInfoData.TaskId()
+                .setTopicGroupId(2).setPartition(3);
+        SubscriptionInfoData.PartitionToOffsetSum partitionOffset = new SubscriptionInfoData.PartitionToOffsetSum()
+                .setPartition(3).setOffsetSum(42L);
+        SubscriptionInfoData.TaskOffsetSum offsetSum = new SubscriptionInfoData.TaskOffsetSum()
+                .setTopicGroupId(2).setPartition(3).setOffsetSum(42L).setNamedTopology("orders")
+                .setPartitionToOffsetSum(List.of());
+        SubscriptionInfoData.ClientTag tag = new SubscriptionInfoData.ClientTag().setKey(new byte[] {1}).setValue(new byte[] {2});
+        SubscriptionInfoData data = new SubscriptionInfoData()
+                .setVersion(11).setLatestSupportedVersion(11).setProcessId(Uuid.randomUuid())
+                .setPrevTasks(List.of()).setStandbyTasks(List.of())
+                .setUserEndPoint(new byte[] {127, 0, 0, 1}).setTaskOffsetSums(List.of(offsetSum))
+                .setUniqueField((byte) 7).setErrorCode(0).setClientTags(List.of(tag));
+
+        assertThat(data.apiKey()).isEqualTo((short) -1);
+        assertThat(data.prevTasks()).isEmpty();
+        assertThat(data.standbyTasks()).isEmpty();
+        assertThat(data.taskOffsetSums()).containsExactly(offsetSum);
+        assertThat(data.clientTags()).containsExactly(tag);
+        assertThat(data.userEndPoint()).containsExactly((byte) 127, (byte) 0, (byte) 0, (byte) 1);
+        assertThat(data.uniqueField()).isEqualTo((byte) 7);
+        assertThat(data.errorCode()).isZero();
+        assertThat(data.duplicate()).isEqualTo(data);
+        assertThat(data.hashCode()).isEqualTo(data.duplicate().hashCode());
+        assertThat(data.toString()).contains("orders");
+        assertThat(data.unknownTaggedFields()).isEmpty();
+        assertThat(data.lowestSupportedVersion()).isEqualTo(SubscriptionInfoData.LOWEST_SUPPORTED_VERSION);
+        assertThat(data.highestSupportedVersion()).isEqualTo(SubscriptionInfoData.HIGHEST_SUPPORTED_VERSION);
+
+        assertThat(taskId.topicGroupId()).isEqualTo(2);
+        assertThat(taskId.partition()).isEqualTo(3);
+        assertThat(taskId.duplicate()).isEqualTo(taskId);
+        assertThat(taskId.toString()).contains("partition=3");
+        assertThat(taskId.unknownTaggedFields()).isEmpty();
+        assertThat(offsetSum.topicGroupId()).isEqualTo(2);
+        assertThat(offsetSum.partition()).isEqualTo(3);
+        assertThat(offsetSum.offsetSum()).isEqualTo(42L);
+        assertThat(offsetSum.namedTopology()).isEqualTo("orders");
+        assertThat(offsetSum.partitionToOffsetSum()).isEmpty();
+        assertThat(offsetSum.duplicate()).isEqualTo(offsetSum);
+        assertThat(offsetSum.unknownTaggedFields()).isEmpty();
+        assertThat(partitionOffset.partition()).isEqualTo(3);
+        assertThat(partitionOffset.offsetSum()).isEqualTo(42L);
+        assertThat(partitionOffset.duplicate()).isEqualTo(partitionOffset);
+        assertThat(partitionOffset.unknownTaggedFields()).isEmpty();
+        assertThat(tag.key()).containsExactly((byte) 1);
+        assertThat(tag.value()).containsExactly((byte) 2);
+        assertThat(tag.duplicate()).isEqualTo(tag);
+        assertThat(tag.unknownTaggedFields()).isEmpty();
+
+        assertThat(new SubscriptionInfoData(read(data, SubscriptionInfoData.HIGHEST_SUPPORTED_VERSION),
+                SubscriptionInfoData.HIGHEST_SUPPORTED_VERSION)).isEqualTo(data);
+        assertThat(new SubscriptionInfoData.TaskOffsetSum(read(offsetSum,
+                SubscriptionInfoData.TaskOffsetSum.HIGHEST_SUPPORTED_VERSION),
+                SubscriptionInfoData.TaskOffsetSum.HIGHEST_SUPPORTED_VERSION)).isEqualTo(offsetSum);
+        assertThat(new SubscriptionInfoData.PartitionToOffsetSum(read(partitionOffset,
+                SubscriptionInfoData.PartitionToOffsetSum.HIGHEST_SUPPORTED_VERSION),
+                SubscriptionInfoData.PartitionToOffsetSum.HIGHEST_SUPPORTED_VERSION)).isEqualTo(partitionOffset);
+        assertThat(new SubscriptionInfoData.TaskId(read(taskId, SubscriptionInfoData.TaskId.HIGHEST_SUPPORTED_VERSION),
+                SubscriptionInfoData.TaskId.HIGHEST_SUPPORTED_VERSION)).isEqualTo(taskId);
+        assertThat(new SubscriptionInfoData.ClientTag(read(tag, SubscriptionInfoData.ClientTag.HIGHEST_SUPPORTED_VERSION),
+                SubscriptionInfoData.ClientTag.HIGHEST_SUPPORTED_VERSION)).isEqualTo(tag);
+    }
+
+    @Test
+    void shouldEncodeAssignmentSubscriptionAndNamedStoreQueries() {
+        TaskId active = new TaskId(1, 2);
+        TaskId standby = new TaskId(2, 3);
+        SubscriptionInfo info = new SubscriptionInfo(7, 7, UUID.randomUUID(), "host:1",
+                Map.of(active, -2L, standby, 10L), (byte) 1, 0, Map.of("rack", "a"));
+        assertThat(info.prevTasks()).contains(active);
+        assertThat(info.standbyTasks()).contains(standby);
+        assertThat(info.taskOffsetSums()).containsEntry(active, -2L);
+        assertThat(info.clientTags()).isEmpty();
+        assertThat(info.userEndPoint()).isEqualTo("host:1");
+        assertThat(info.encode().remaining()).isPositive();
+        assertThat(SubscriptionInfo.decode(info.encode())).isEqualTo(info);
+        assertThat(SubscriptionInfo.getActiveTasksFromTaskOffsetSumMap(Map.of(active, -2L))).contains(active);
+        assertThat(SubscriptionInfo.getStandbyTasksFromTaskOffsetSumMap(Map.of(standby, 1L))).contains(standby);
+        assertThat(info.hashCode()).isEqualTo(SubscriptionInfo.decode(info.encode()).hashCode());
+        assertThat(info.toString()).contains("SubscriptionInfoData");
+
+        org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo assignment =
+                new org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo(
+                        7, List.of(active), Map.of(standby, Set.of(new TopicPartition("orders", 0))),
+                        Map.of(new HostInfo("localhost", 8080), Set.of(new TopicPartition("orders", 0))),
+                        Map.of(new HostInfo("standby", 8081), Set.of(new TopicPartition("orders", 1))), 42);
+        assertThat(org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo.decode(assignment.encode()))
+                .isEqualTo(assignment);
+
+        NamedTopologyStoreQueryParameters<org.apache.kafka.streams.state.ReadOnlyKeyValueStore<String, String>> named =
+                NamedTopologyStoreQueryParameters.fromNamedTopologyAndStoreNameAndType("orders", "store", QueryableStoreTypes.keyValueStore());
+        StoreQueryParameters<?> configured = named.withPartition(1).enableStaleStores();
+        assertThat(named.topologyName()).isEqualTo("orders");
+        assertThat(configured.partition()).isEqualTo(1);
+        assertThat(configured.staleStoresEnabled()).isTrue();
+        assertThat(named).isEqualTo(named);
+        assertThat(named.hashCode()).isEqualTo(named.hashCode());
+    }
+
+    private static ByteBufferAccessor read(org.apache.kafka.common.protocol.Message message, short version) {
+        MessageSizeAccumulator size = new MessageSizeAccumulator();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        message.addSize(size, cache, version);
+        ByteBuffer buffer = ByteBuffer.allocate(size.totalSize());
+        ByteBufferAccessor accessor = new ByteBufferAccessor(buffer);
+        message.write(accessor, cache, version);
+        accessor.flip();
+        return accessor;
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/PublicApiValueCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/PublicApiValueCoverageTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.streams.errors.BrokerNotFoundException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.errors.MissingSourceTopicException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StateStoreMigratedException;
+import org.apache.kafka.streams.errors.StateStoreNotAvailableException;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.StreamsNotStartedException;
+import org.apache.kafka.streams.errors.StreamsRebalancingException;
+import org.apache.kafka.streams.errors.StreamsStoppedException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.errors.TaskCorruptedException;
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
+import org.apache.kafka.streams.kstream.Branched;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Repartitioned;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TableJoined;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.processor.TaskId;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises the small value objects and configuration factories as a user would. */
+public class PublicApiValueCoverageTest {
+    @Test
+    void shouldUseValueObjectsAndQueryParameters() {
+        KeyValue<String, Integer> pair = KeyValue.pair("one", 1);
+        assertThat(pair).isEqualTo(KeyValue.pair("one", 1));
+        assertThat(pair.hashCode()).isEqualTo(KeyValue.pair("one", 1).hashCode());
+        assertThat(pair.toString()).contains("one");
+
+        Windowed<String> window = new Windowed<>("key", new org.apache.kafka.streams.kstream.internals.TimeWindow(1, 2));
+        assertThat(window.hashCode()).isEqualTo(new Windowed<>("key", new org.apache.kafka.streams.kstream.internals.TimeWindow(1, 2)).hashCode());
+
+        HostInfoHolder hosts = new HostInfoHolder();
+        KeyQueryMetadata metadata = new KeyQueryMetadata(hosts.active, Set.of(hosts.standby), 3);
+        assertThat(metadata.activeHost()).isEqualTo(hosts.active);
+        assertThat(metadata.getActiveHost()).isEqualTo(hosts.active);
+        assertThat(metadata.standbyHosts()).containsExactly(hosts.standby);
+        assertThat(metadata.getStandbyHosts()).containsExactly(hosts.standby);
+        assertThat(metadata.partition()).isEqualTo(3);
+        assertThat(metadata.getPartition()).isEqualTo(3);
+        assertThat(metadata).isEqualTo(new KeyQueryMetadata(hosts.active, Set.of(hosts.standby), 3));
+        assertThat(metadata.toString()).contains("partition=3");
+
+        StoreQueryParameters<org.apache.kafka.streams.state.ReadOnlyKeyValueStore<String, String>> params = StoreQueryParameters.fromNameAndType(
+                "store", org.apache.kafka.streams.state.QueryableStoreTypes.<String, String>keyValueStore());
+        assertThat(params.storeName()).isEqualTo("store");
+        assertThat(params.queryableStoreType()).isNotNull();
+        assertThat(params.partition()).isNull();
+        assertThat(params.staleStoresEnabled()).isFalse();
+        assertThat(params.enableStaleStores().staleStoresEnabled()).isTrue();
+        assertThat(params.withPartition(2).partition()).isEqualTo(2);
+        assertThat(params.toString()).contains("store");
+        assertThat(params.toString()).contains("store", "staleStores=false");
+
+        assertThat(org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore()).isNotNull();
+        assertThat(org.apache.kafka.streams.state.QueryableStoreTypes.sessionStore()).isNotNull();
+        assertThat(org.apache.kafka.streams.state.QueryableStoreTypes.windowStore()).isNotNull();
+        assertThat(org.apache.kafka.streams.state.QueryableStoreTypes.timestampedKeyValueStore()).isNotNull();
+        assertThat(org.apache.kafka.streams.state.QueryableStoreTypes.timestampedWindowStore()).isNotNull();
+    }
+
+    @Test
+    void shouldBuildNamedWindowAndSuppressionOptions() {
+        assertThat(Named.as("named").withName("renamed")).isNotNull();
+        assertThat(Branched.<String, String>as("branch").withName("renamed")).isNotNull();
+        assertThat(Consumed.with(Serdes.String(), Serdes.String()).withName("input").withName("renamed")).isNotNull();
+        assertThat(Grouped.with(Serdes.String(), Serdes.String()).withName("group").withName("renamed")).isNotNull();
+        assertThat(Joined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("join").withName("renamed")).isNotNull();
+        assertThat(Joined.with(Serdes.String(), Serdes.String(), Serdes.String(), "named-join")).isNotNull();
+        assertThat(Produced.with(Serdes.String(), Serdes.String()).withName("output").withName("renamed")).isNotNull();
+        assertThat(Repartitioned.with(Serdes.String(), Serdes.String()).withName("repartition").withName("renamed")).isNotNull();
+        assertThat(StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName("stream-join").withName("renamed")).isNotNull();
+        assertThat(TableJoined.as("table-join").withName("renamed")).isNotNull();
+        assertThat(Printed.<String, String>toSysOut().withName("print").withName("renamed")).isNotNull();
+        assertThat(Suppressed.untilTimeLimit(Duration.ofSeconds(1), Suppressed.BufferConfig.unbounded()).withName("suppressed-name")).isNotNull();
+
+        assertThat(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofSeconds(2)).inactivityGap()).isEqualTo(Duration.ofSeconds(2).toMillis());
+        assertThat(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2)).timeDifferenceMs()).isEqualTo(Duration.ofSeconds(2).toMillis());
+        assertThat(TimeWindows.ofSizeWithNoGrace(Duration.ofSeconds(2)).size()).isEqualTo(Duration.ofSeconds(2).toMillis());
+        assertThat(JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofSeconds(2)).size()).isEqualTo(Duration.ofSeconds(2).toMillis() * 2);
+        assertThat(UnlimitedWindows.of()).isNotNull();
+        assertThat(EmitStrategy.onWindowClose()).isNotNull();
+        assertThat(EmitStrategy.StrategyType.ON_WINDOW_CLOSE.forType(EmitStrategy.StrategyType.ON_WINDOW_CLOSE)).isNotNull();
+        assertThat(Suppressed.BufferConfig.unbounded()).isNotNull();
+        assertThat(Materialized.<String, String, org.apache.kafka.streams.state.KeyValueStore<org.apache.kafka.common.utils.Bytes, byte[]>>as(Materialized.StoreType.IN_MEMORY)).isNotNull();
+        assertThat(Materialized.<String, String>as(StoresSupplierHolder.supplier())).isNotNull();
+        assertThat(WindowedSerdes.timeWindowedSerdeFrom(String.class)).isNotNull();
+        assertThat(WindowedSerdes.timeWindowedSerdeFrom(String.class, 1000L)).isNotNull();
+    }
+
+    @Test
+    void shouldReadStreamsConfigurationAndTaskIdentifiers() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "api-values");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        StreamsConfig config = new StreamsConfig(properties);
+        assertThat(config.configDef()).isNotNull();
+        assertThat(config.consumerPrefix("x")).isEqualTo("consumer.x");
+        assertThat(config.producerPrefix("x")).isEqualTo("producer.x");
+        assertThat(config.adminClientPrefix("x")).isEqualTo("admin.x");
+        assertThat(config.mainConsumerPrefix("x")).isEqualTo("main.consumer.x");
+        assertThat(config.restoreConsumerPrefix("x")).isEqualTo("restore.consumer.x");
+        assertThat(config.globalConsumerPrefix("x")).isEqualTo("global.consumer.x");
+        assertThat(config.clientTagPrefix("x")).isEqualTo("client.tag.x");
+        assertThat(config.defaultTimestampExtractor()).isNotNull();
+        assertThat(config.defaultDeserializationExceptionHandler()).isNotNull();
+        assertThat(config.getGlobalConsumerConfigs("client")).isNotEmpty();
+
+        TaskId id = new TaskId(4, 7);
+        ByteBuffer buffer = ByteBuffer.allocate(32);
+        id.writeTo(buffer, 0);
+        buffer.flip();
+        assertThat(TaskId.readFrom(buffer, 0)).isEqualTo(id);
+
+        assertThat(org.apache.kafka.streams.KafkaStreams.State.valueOf("RUNNING").isRunningOrRebalancing()).isTrue();
+        assertThat(org.apache.kafka.streams.KafkaStreams.State.values()).contains(org.apache.kafka.streams.KafkaStreams.State.NOT_RUNNING);
+        assertThat(new TopologyConfig(new StreamsConfig(properties)).isNamedTopology()).isFalse();
+        assertThat(Topology.AutoOffsetReset.values()).isNotEmpty();
+    }
+
+    @Test
+    void shouldRoundTripProtocolAndLifecycleEnumValues() {
+        assertEnumRoundTrip(org.apache.kafka.streams.KafkaStreams.State.values(), org.apache.kafka.streams.KafkaStreams.State.class);
+        assertEnumRoundTrip(Topology.AutoOffsetReset.values(), Topology.AutoOffsetReset.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse.values(),
+                org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse.values(),
+                org.apache.kafka.streams.errors.ProductionExceptionHandler.ProductionExceptionHandlerResponse.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.values(),
+                org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.values(),
+                org.apache.kafka.streams.internals.StreamsConfigUtils.ProcessingMode.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.internals.UpgradeFromValues.values(),
+                org.apache.kafka.streams.internals.UpgradeFromValues.class);
+        assertEnumRoundTrip(EmitStrategy.StrategyType.values(), EmitStrategy.StrategyType.class);
+        assertEnumRoundTrip(Materialized.StoreType.values(), Materialized.StoreType.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction.values(),
+                org.apache.kafka.streams.kstream.internals.foreignkeyjoin.SubscriptionWrapper.Instruction.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.values(),
+                org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.PunctuationType.values(),
+                org.apache.kafka.streams.processor.PunctuationType.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.values(),
+                org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.internals.StreamThread.State.values(),
+                org.apache.kafka.streams.processor.internals.StreamThread.State.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.internals.Task.State.values(),
+                org.apache.kafka.streams.processor.internals.Task.State.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.internals.Task.TaskType.values(),
+                org.apache.kafka.streams.processor.internals.Task.TaskType.class);
+        assertEnumRoundTrip(org.apache.kafka.streams.processor.internals.assignment.AssignorError.values(),
+                org.apache.kafka.streams.processor.internals.assignment.AssignorError.class);
+    }
+
+    @Test
+    void shouldRenderTheStreamsConfigurationDocumentation() {
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream original = System.out;
+        try {
+            System.setOut(new java.io.PrintStream(output));
+            StreamsConfig.main(new String[0]);
+        } finally {
+            System.setOut(original);
+        }
+        assertThat(output.toString(java.nio.charset.StandardCharsets.UTF_8))
+                .contains("streamsconfigs_application.id");
+    }
+
+    private static <E extends Enum<E>> void assertEnumRoundTrip(E[] values, Class<E> type) {
+        assertThat(values).isNotEmpty();
+        for (E value : values) {
+            assertThat(Enum.valueOf(type, value.name())).isSameAs(value);
+        }
+    }
+
+    @Test
+    void shouldPreserveExceptionCausesAndTaskIds() {
+        TaskId task = new TaskId(1, 2);
+        StreamsException[] exceptions = {
+                new StreamsException("message"), new StreamsException(new IllegalArgumentException()),
+                new StreamsException("message", new IllegalArgumentException()),
+                new StreamsException("message", task), new StreamsException(new IllegalArgumentException(), task),
+                new StreamsException("message", new IllegalArgumentException(), task)
+        };
+        for (StreamsException exception : exceptions) {
+            exception.setTaskId(task);
+            assertThat(exception.taskId()).contains(task);
+        }
+        assertThat(new TaskCorruptedException(Set.of(task)).corruptedTasks()).contains(task);
+        assertThat(new TaskCorruptedException(Set.of(task), new OffsetOutOfRangeException(Map.of())).corruptedTasks()).contains(task);
+        assertThat(new MissingSourceTopicException("missing")).hasMessage("missing");
+        assertThat(new TaskMigratedException("migrated")).hasMessageContaining("migrated");
+        assertThat(new BrokerNotFoundException("x")).hasMessage("x");
+        assertThat(new InvalidStateStoreException("x")).hasMessage("x");
+        assertThat(new LockException("x")).hasMessage("x");
+        assertThat(new ProcessorStateException("x")).hasMessage("x");
+        assertThat(new StateStoreMigratedException("x")).hasMessage("x");
+        assertThat(new StateStoreNotAvailableException("x")).hasMessage("x");
+        assertThat(new StreamsNotStartedException("x")).hasMessage("x");
+        assertThat(new StreamsRebalancingException("x")).hasMessage("x");
+        assertThat(new StreamsStoppedException("x")).hasMessage("x");
+        assertThat(new TaskAssignmentException("x")).hasMessage("x");
+        assertThat(new TaskIdFormatException("x")).hasMessageContaining("x");
+    }
+
+    private static final class HostInfoHolder {
+        private final HostInfo active = new HostInfo("active", 1);
+        private final HostInfo standby = new HostInfo("standby", 2);
+    }
+
+    private static final class StoresSupplierHolder {
+        private static org.apache.kafka.streams.state.KeyValueBytesStoreSupplier supplier() {
+            return org.apache.kafka.streams.state.Stores.inMemoryKeyValueStore("store");
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/PublicMetadataAndTimestampApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/PublicMetadataAndTimestampApiCoverageTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.TaskMetadata;
+import org.apache.kafka.streams.processor.ThreadMetadata;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.internals.TaskMetadataImpl;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises public task metadata, timestamp policy, and forwarding value contracts. */
+public class PublicMetadataAndTimestampApiCoverageTest {
+    @Test
+    void shouldExposeTaskAndThreadMetadataConsistently() {
+        TopicPartition partition = new TopicPartition("orders", 2);
+        TaskMetadata task = new TaskMetadata("0_2", Set.of(partition), Map.of(partition, 11L),
+                Map.of(partition, 20L), Optional.of(77L));
+        TaskMetadata sameTask = new TaskMetadata("0_2", Set.of(partition), Map.of(partition, 11L),
+                Map.of(partition, 20L), Optional.of(77L));
+
+        assertThat(task.taskId()).isEqualTo("0_2");
+        assertThat(task.topicPartitions()).containsExactly(partition);
+        assertThat(task.committedOffsets()).containsEntry(partition, 11L);
+        assertThat(task.endOffsets()).containsEntry(partition, 20L);
+        assertThat(task.timeCurrentIdlingStarted()).contains(77L);
+        assertThat(task).isEqualTo(sameTask);
+        assertThat(task.hashCode()).isEqualTo(sameTask.hashCode());
+        assertThat(task.toString()).contains("0_2", "orders");
+
+        ThreadMetadata thread = new ThreadMetadata("stream-thread-1", "RUNNING", "consumer-1",
+                "restore-1", Set.of("producer-1"), "admin-1", Set.of(task), Set.of(sameTask));
+        assertThat(thread.threadState()).isEqualTo("RUNNING");
+        assertThat(thread.threadName()).isEqualTo("stream-thread-1");
+        assertThat(thread.consumerClientId()).isEqualTo("consumer-1");
+        assertThat(thread.restoreConsumerClientId()).isEqualTo("restore-1");
+        assertThat(thread.producerClientIds()).containsExactly("producer-1");
+        assertThat(thread.adminClientId()).isEqualTo("admin-1");
+        assertThat(thread.activeTasks()).contains(task);
+        assertThat(thread.standbyTasks()).contains(sameTask);
+        assertThat(thread).isEqualTo(new ThreadMetadata("stream-thread-1", "RUNNING", "consumer-1",
+                "restore-1", Set.of("producer-1"), "admin-1", Set.of(sameTask), Set.of(task)));
+        assertThat(thread.hashCode()).isNotZero();
+        assertThat(thread.toString()).contains("stream-thread-1", "RUNNING");
+    }
+
+    @Test
+    void shouldExposeInternalTaskMetadataAndLagCalculations() {
+        TopicPartition partition = new TopicPartition("payments", 1);
+        org.apache.kafka.streams.processor.TaskId taskId = new org.apache.kafka.streams.processor.TaskId(3, 1);
+        TaskMetadataImpl task = new TaskMetadataImpl(taskId, Set.of(partition),
+                Map.of(partition, 8L), Map.of(partition, 13L), Optional.of(55L));
+        TaskMetadataImpl same = new TaskMetadataImpl(taskId, Set.of(partition),
+                Map.of(partition, 8L), Map.of(partition, 13L), Optional.of(55L));
+        assertThat(task.taskId()).isEqualTo(taskId);
+        assertThat(task.topicPartitions()).containsExactly(partition);
+        assertThat(task.committedOffsets()).containsEntry(partition, 8L);
+        assertThat(task.endOffsets()).containsEntry(partition, 13L);
+        assertThat(task.timeCurrentIdlingStarted()).contains(55L);
+        assertThat(task).isEqualTo(same);
+        assertThat(task.hashCode()).isEqualTo(same.hashCode());
+        assertThat(task.toString()).contains("3_1", "payments");
+    }
+
+    @Test
+    void shouldRoundTripTaskIdsAndForwardingDestinations() throws Exception {
+        TaskId taskId = new TaskId(4, 7);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        taskId.writeTo(new DataOutputStream(bytes), 0);
+        TaskId decoded = TaskId.readFrom(new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())), 0);
+        assertThat(decoded).isEqualTo(taskId);
+        assertThat(TaskId.parse(taskId.toString())).isEqualTo(taskId);
+        assertThat(taskId.compareTo(new TaskId(5, 0))).isNegative();
+
+        To child = To.child("orders-child").withTimestamp(19L);
+        To sameChild = To.child("orders-child").withTimestamp(19L);
+        assertThat(child).isEqualTo(sameChild);
+        assertThatThrownBy(child::hashCode).isInstanceOf(UnsupportedOperationException.class);
+        assertThat(child.toString()).contains("orders-child", "19");
+        assertThat(To.all()).isNotEqualTo(child);
+    }
+
+    @Test
+    void shouldApplyTimestampPoliciesToValidAndLegacyRecords() {
+        ConsumerRecord<Object, Object> valid = new ConsumerRecord<>("orders", 0, 3L, 42L,
+                TimestampType.CREATE_TIME, -1, -1, -1, "key", "value");
+        ConsumerRecord<Object, Object> invalid = new ConsumerRecord<>("orders", 0, 4L, "key", "value");
+
+        FailOnInvalidTimestamp fail = new FailOnInvalidTimestamp();
+        assertThat(fail.extract(valid, 8L)).isEqualTo(42L);
+        assertThatThrownBy(() -> fail.extract(invalid, 8L)).isInstanceOf(StreamsException.class);
+        assertThatThrownBy(() -> fail.onInvalidTimestamp(invalid, -1L, 8L)).isInstanceOf(StreamsException.class);
+
+        LogAndSkipOnInvalidTimestamp skip = new LogAndSkipOnInvalidTimestamp();
+        assertThat(skip.extract(valid, 8L)).isEqualTo(42L);
+        assertThat(skip.extract(invalid, 8L)).isEqualTo(-1L);
+        assertThat(skip.onInvalidTimestamp(invalid, -1L, 8L)).isEqualTo(-1L);
+
+        UsePartitionTimeOnInvalidTimestamp partitionTime = new UsePartitionTimeOnInvalidTimestamp();
+        assertThat(partitionTime.extract(valid, 8L)).isEqualTo(42L);
+        assertThat(partitionTime.extract(invalid, 123L)).isEqualTo(123L);
+        assertThatThrownBy(() -> partitionTime.onInvalidTimestamp(invalid, -1L, -1L))
+                .isInstanceOf(StreamsException.class);
+
+        long before = System.currentTimeMillis();
+        long wallclock = new WallclockTimestampExtractor().extract(valid, 8L);
+        assertThat(wallclock).isBetween(before, System.currentTimeMillis());
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ReadOnlyTaskApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/ReadOnlyTaskApiCoverageTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
+import org.apache.kafka.streams.processor.internals.Task;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Verifies that the read-only task adapter exposes state while rejecting mutations. */
+public class ReadOnlyTaskApiCoverageTest {
+    private static final TopicPartition INPUT = new TopicPartition("input", 0);
+    private static final TaskId TASK_ID = new TaskId(2, 3);
+
+    @Test
+    void shouldExposeTheUnderlyingTaskState() {
+        RecordingTask delegate = new RecordingTask();
+        ReadOnlyTask task = new ReadOnlyTask(delegate);
+
+        assertThat(task.id()).isEqualTo(TASK_ID);
+        assertThat(task.isActive()).isFalse();
+        assertThat(task.inputPartitions()).containsExactly(INPUT);
+        assertThat(task.changelogPartitions()).containsExactly(INPUT);
+        assertThat(task.state()).isEqualTo(Task.State.RUNNING);
+        assertThat(task.commitRequested()).isTrue();
+        assertThat(task.needsInitializationOrRestoration()).isFalse();
+        assertThat(task.changelogOffsets()).containsEntry(INPUT, 7L);
+    }
+
+    @Test
+    void shouldRejectOperationsThatCouldChangeTheTask() {
+        ReadOnlyTask task = new ReadOnlyTask(new RecordingTask());
+
+        assertReadOnly(() -> task.initializeIfNeeded());
+        assertReadOnly(() -> task.addPartitionsForOffsetReset(Set.of(INPUT)));
+        assertReadOnly(() -> task.completeRestoration(ignored -> { }));
+        assertReadOnly(task::suspend);
+        assertReadOnly(task::resume);
+        assertReadOnly(task::closeDirty);
+        assertReadOnly(task::closeClean);
+        assertReadOnly(() -> task.updateInputPartitions(Set.of(INPUT), Map.of()));
+        assertReadOnly(() -> task.maybeCheckpoint(true));
+        assertReadOnly(() -> task.markChangelogAsCorrupted(List.of(INPUT)));
+        assertReadOnly(task::revive);
+        assertReadOnly(task::prepareRecycle);
+        assertReadOnly(() -> task.addRecords(INPUT, List.of()));
+        assertReadOnly(() -> task.process(10L));
+        assertReadOnly(() -> task.recordProcessBatchTime(10L));
+        assertReadOnly(() -> task.recordProcessTimeRatioAndBufferSize(10L, 2L));
+        assertReadOnly(task::maybePunctuateStreamTime);
+        assertReadOnly(task::maybePunctuateSystemTime);
+        assertReadOnly(task::prepareCommit);
+        assertReadOnly(() -> task.postCommit(true));
+        assertReadOnly(task::purgeableOffsets);
+        assertReadOnly(() -> task.maybeInitTaskTimeoutOrThrow(10L, new RuntimeException("timeout")));
+        assertReadOnly(task::clearTaskTimeout);
+        assertReadOnly(() -> task.recordRestoration(Time.SYSTEM, 10L, true));
+        assertReadOnly(task::commitNeeded);
+        assertReadOnly(() -> task.getStore("store"));
+        assertReadOnly(task::committedOffsets);
+        assertReadOnly(task::highWaterMark);
+        assertReadOnly(task::timeCurrentIdlingStarted);
+        assertReadOnly(task::stateManager);
+    }
+
+    private static void assertReadOnly(Runnable operation) {
+        assertThatThrownBy(() -> operation.run())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("This task is read-only");
+    }
+
+    private static void assertReadOnly(BooleanSupplier operation) {
+        assertThatThrownBy(operation::getAsBoolean)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("This task is read-only");
+    }
+
+    @FunctionalInterface
+    private interface BooleanSupplier {
+        boolean getAsBoolean();
+    }
+
+    private static final class RecordingTask implements Task {
+        @Override
+        public void initializeIfNeeded() { }
+
+        @Override
+        public void completeRestoration(Consumer<Set<TopicPartition>> callback) { }
+
+        @Override
+        public void suspend() { }
+
+        @Override
+        public void resume() { }
+
+        @Override
+        public void closeDirty() { }
+
+        @Override
+        public void closeClean() { }
+
+        @Override
+        public void updateInputPartitions(Set<TopicPartition> inputPartitions,
+                                          Map<String, List<String>> storeNameToSourceTopics) { }
+
+        @Override
+        public void maybeCheckpoint(boolean enforce) { }
+
+        @Override
+        public void markChangelogAsCorrupted(java.util.Collection<TopicPartition> partitions) { }
+
+        @Override
+        public void revive() { }
+
+        @Override
+        public void prepareRecycle() { }
+
+        @Override
+        public void addRecords(TopicPartition partition,
+                               Iterable<org.apache.kafka.clients.consumer.ConsumerRecord<byte[], byte[]>> records) { }
+
+        @Override
+        public Map<TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> prepareCommit() {
+            return Map.of();
+        }
+
+        @Override
+        public void postCommit(boolean enforce) { }
+
+        @Override
+        public void maybeInitTaskTimeoutOrThrow(long wallClockTime, Exception cause) { }
+
+        @Override
+        public void clearTaskTimeout() { }
+
+        @Override
+        public void recordRestoration(Time time, long numRecords, boolean endOfRestore) { }
+
+        @Override
+        public TaskId id() {
+            return TASK_ID;
+        }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
+        public Set<TopicPartition> inputPartitions() {
+            return Set.of(INPUT);
+        }
+
+        @Override
+        public Set<TopicPartition> changelogPartitions() {
+            return Set.of(INPUT);
+        }
+
+        @Override
+        public State state() {
+            return State.RUNNING;
+        }
+
+        @Override
+        public ProcessorStateManager stateManager() {
+            return null;
+        }
+
+        @Override
+        public boolean commitNeeded() {
+            return true;
+        }
+
+        @Override
+        public boolean commitRequested() {
+            return true;
+        }
+
+        @Override
+        public StateStore getStore(String name) {
+            return null;
+        }
+
+        @Override
+        public Map<TopicPartition, Long> changelogOffsets() {
+            return Map.of(INPUT, 7L);
+        }
+
+        @Override
+        public Map<TopicPartition, Long> committedOffsets() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<TopicPartition, Long> highWaterMark() {
+            return Map.of();
+        }
+
+        @Override
+        public Optional<Long> timeCurrentIdlingStarted() {
+            return Optional.empty();
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/RecordCollectorDeepCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/RecordCollectorDeepCoverageTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
+import org.apache.kafka.streams.processor.internals.StreamsProducer;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Drives dirty record-collector shutdown through the producer abstraction. */
+public class RecordCollectorDeepCoverageTest {
+    @Test
+    void shouldAbortTheProducerThroughDirtyClose() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(
+                true, new ByteArraySerializer(), new ByteArraySerializer());
+        KafkaClientSupplier clients = new KafkaClientSupplier() {
+            @Override
+            public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+                return producer;
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getConsumer(Map<String, Object> config) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getRestoreConsumer(Map<String, Object> config) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Consumer<byte[], byte[]> getGlobalConsumer(Map<String, Object> config) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        StreamsProducer streamsProducer = new StreamsProducer(streamsConfig(), "coverage-StreamThread-1", clients,
+                new TaskId(0, 0), UUID.randomUUID(), new LogContext(), Time.SYSTEM);
+        Metrics metrics = new Metrics();
+        StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "collector-client", "coverage-StreamThread-1",
+                Time.SYSTEM);
+        ProcessorTopology topology = new ProcessorTopology(List.of(), Map.of(), Map.of(), List.of(), List.of(),
+                Map.of(), Set.of());
+        ProductionExceptionHandler handler = new ProductionExceptionHandler() {
+            @Override
+            public ProductionExceptionHandlerResponse handle(
+                    org.apache.kafka.clients.producer.ProducerRecord<byte[], byte[]> record, Exception exception) {
+                return ProductionExceptionHandlerResponse.CONTINUE;
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs) {
+            }
+        };
+        RecordCollectorImpl collector = new RecordCollectorImpl(new LogContext(), new TaskId(0, 0), streamsProducer,
+                handler, streamsMetrics, topology);
+
+        collector.closeDirty();
+        assertThat(collector.offsets()).isEmpty();
+        metrics.close();
+    }
+
+    private static StreamsConfig streamsConfig() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "collector-coverage");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        return new StreamsConfig(properties);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/RemainingConfigurationApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/RemainingConfigurationApiCoverageTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
+import org.apache.kafka.streams.kstream.EmitStrategy;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.internals.suppress.BufferFullStrategy;
+import org.apache.kafka.streams.kstream.internals.suppress.EagerBufferConfigImpl;
+import org.apache.kafka.streams.kstream.internals.suppress.StrictBufferConfigImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises configuration variants and public enum contracts. */
+public class RemainingConfigurationApiCoverageTest {
+    @Test
+    void shouldConfigureBothSuppressionBufferPolicies() {
+        EagerBufferConfigImpl eager = new EagerBufferConfigImpl(10L, 100L, Map.of("x", "y"));
+        eager = (EagerBufferConfigImpl) eager.withMaxRecords(3).withMaxBytes(30).withLoggingDisabled();
+        eager = (EagerBufferConfigImpl) eager.withLoggingEnabled(Map.of("compression.type", "lz4"));
+        assertThat(eager.isLoggingEnabled()).isTrue();
+        assertThat(eager.maxRecords()).isEqualTo(3L);
+        assertThat(eager.maxBytes()).isEqualTo(30L);
+
+        StrictBufferConfigImpl strict = new StrictBufferConfigImpl();
+        strict = (StrictBufferConfigImpl) strict.withMaxRecords(4).withMaxBytes(40).withLoggingDisabled();
+        strict = (StrictBufferConfigImpl) strict.withLoggingEnabled(new HashMap<>(Map.of("retention.ms", "1000")));
+        assertThat(strict.isLoggingEnabled()).isTrue();
+        assertThat(strict.bufferFullStrategy()).isEqualTo(BufferFullStrategy.SHUT_DOWN);
+        assertThat(strict.maxRecords()).isEqualTo(4L);
+        assertThat(strict.maxBytes()).isEqualTo(40L);
+        assertThat(Suppressed.BufferConfig.unbounded()).isNotNull();
+        assertThat(EmitStrategy.StrategyType.values()).contains(EmitStrategy.StrategyType.ON_WINDOW_CLOSE);
+    }
+
+    @Test
+    void shouldExposeQueryParameterValueSemantics() {
+        StoreQueryParameters<?> left = StoreQueryParameters.fromNameAndType("store",
+                org.apache.kafka.streams.state.QueryableStoreTypes.keyValueStore());
+        StoreQueryParameters<?> right = left.withPartition(null);
+        assertThat(left).isEqualTo(right);
+        assertThat(left.hashCode()).isEqualTo(right.hashCode());
+    }
+
+    @Test
+    void shouldExposeEnumAndInternalConfigurationNames() {
+        assertThat(Topology.AutoOffsetReset.values()).contains(Topology.AutoOffsetReset.EARLIEST);
+        assertThat(Topology.AutoOffsetReset.valueOf("LATEST")).isEqualTo(Topology.AutoOffsetReset.LATEST);
+        assertThat(DeserializationExceptionHandler.DeserializationHandlerResponse.values()).isNotEmpty();
+        assertThat(ProductionExceptionHandler.ProductionExceptionHandlerResponse.values()).isNotEmpty();
+        assertThat(StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.values()).isNotEmpty();
+        assertThat(StreamsConfigUtils.ProcessingMode.values()).isNotEmpty();
+        assertThat(StreamsConfigUtils.processingModeString(StreamsConfigUtils.ProcessingMode.EXACTLY_ONCE_V2)).isNotEmpty();
+        assertThat(Materialized.StoreType.valueOf("IN_MEMORY")).isEqualTo(Materialized.StoreType.IN_MEMORY);
+
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "internal-config-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        assertThat(new StreamsConfig.InternalConfig()).isNotNull();
+        assertThat(StreamsConfig.InternalConfig.getLong(Map.of("value", 12L), "value", 0L)).isEqualTo(12L);
+        assertThat(StreamsConfig.InternalConfig.getLong(Map.of(), "missing", 7L)).isEqualTo(7L);
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StandbyTaskApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StandbyTaskApiCoverageTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises standby-task lifecycle behavior through the public {@link Task} contract. */
+public class StandbyTaskApiCoverageTest {
+    private static final TopicPartition INPUT = new TopicPartition("standby-input", 0);
+
+    @Test
+    void shouldInitializeRestoreInspectAndRecycleStandbyTask() {
+        TestTaskResources resources = new TestTaskResources();
+        Task task = resources.newTask();
+
+        assertThat(task.isActive()).isFalse();
+        assertThat(task.state()).isEqualTo(Task.State.CREATED);
+        task.initializeIfNeeded();
+        assertThat(task.state()).isEqualTo(Task.State.RUNNING);
+
+        task.recordRestoration(Time.SYSTEM, 3L, false);
+        assertThatThrownBy(() -> task.recordRestoration(Time.SYSTEM, 1L, true))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(task.prepareCommit()).isEmpty();
+        task.postCommit(false);
+        assertThat(task.commitNeeded()).isFalse();
+        assertThat(task.changelogOffsets()).isEmpty();
+        assertThat(task.committedOffsets()).isEmpty();
+        assertThat(task.highWaterMark()).isEmpty();
+        assertThat(task.timeCurrentIdlingStarted()).isEmpty();
+        assertThatThrownBy(() -> task.addRecords(new TopicPartition("other", 0), List.of()))
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> task.completeRestoration(ignored -> { }))
+                .isInstanceOf(IllegalStateException.class);
+
+        task.suspend();
+        assertThat(task.state()).isEqualTo(Task.State.SUSPENDED);
+        task.resume();
+        assertThat(task.state()).isEqualTo(Task.State.SUSPENDED);
+        task.prepareRecycle();
+        assertThat(task.state()).isEqualTo(Task.State.CLOSED);
+        resources.close();
+    }
+
+    @Test
+    void shouldCloseInitializedStandbyTaskUsingBothClosePolicies() {
+        TestTaskResources cleanResources = new TestTaskResources();
+        Task cleanTask = cleanResources.newTask();
+        cleanTask.initializeIfNeeded();
+        cleanTask.suspend();
+        cleanTask.closeClean();
+        assertThat(cleanTask.state()).isEqualTo(Task.State.CLOSED);
+        cleanResources.close();
+
+        TestTaskResources dirtyResources = new TestTaskResources();
+        Task dirtyTask = dirtyResources.newTask();
+        dirtyTask.initializeIfNeeded();
+        dirtyTask.suspend();
+        dirtyTask.closeDirty();
+        assertThat(dirtyTask.state()).isEqualTo(Task.State.CLOSED);
+        dirtyResources.close();
+    }
+
+    private static final class TestTaskResources {
+        private final StreamsConfig config;
+        private final Metrics metrics = new Metrics();
+        private final StreamsMetricsImpl streamsMetrics;
+        private final StateDirectory stateDirectory;
+        private final ThreadCache cache;
+        private final InternalMockProcessorContext<?, ?> context;
+        private final ProcessorStateManager stateManager;
+
+        TestTaskResources() {
+            Properties properties = new Properties();
+            properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "standby-api");
+            properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+            properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
+                    "org.apache.kafka.common.serialization.Serdes$ByteArraySerde");
+            properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
+                    "org.apache.kafka.common.serialization.Serdes$ByteArraySerde");
+            config = new StreamsConfig(properties);
+            streamsMetrics = new StreamsMetricsImpl(metrics, "standby-api", "standby-thread", Time.SYSTEM);
+            stateDirectory = new StateDirectory(config, Time.SYSTEM, false, false);
+            cache = new ThreadCache(new LogContext("standby "), 1024L, streamsMetrics);
+            context = new InternalMockProcessorContext<>(new File("build/standby-api"),
+                    Serdes.ByteArray(), Serdes.ByteArray(), config);
+            context.initialize();
+            stateManager = new ProcessorStateManager(new TaskId(0, 0), Task.TaskType.STANDBY, false,
+                    new LogContext("standby "), stateDirectory, new EmptyChangelogRegister(), Map.of(), Set.of(INPUT), false);
+        }
+
+        Task newTask() {
+            TopologyConfig.TaskConfig taskConfig = new TopologyConfig(config).getTaskConfig();
+            ProcessorTopology topology = new ProcessorTopology(
+                    List.of(), Map.of(), Map.of(), List.of(), List.of(), Map.of(), Set.of());
+            return new StandbyTask(new TaskId(0, 0), Set.of(INPUT), topology, taskConfig,
+                    streamsMetrics, stateManager, stateDirectory, cache, context);
+        }
+
+        void close() {
+            stateManager.close();
+            stateDirectory.close();
+            metrics.close();
+        }
+    }
+
+    private static final class EmptyChangelogRegister implements ChangelogRegister {
+        @Override public void register(TopicPartition partition, ProcessorStateManager stateManager) { }
+        @Override public void register(Set<TopicPartition> partitions, ProcessorStateManager stateManager) { }
+        @Override public void unregister(java.util.Collection<TopicPartition> partitions) { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StateStoreBuilderApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StateStoreBuilderApiCoverageTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.TimestampedWindowStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer;
+import org.apache.kafka.test.InternalMockProcessorContext;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.ListValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.RocksDBTimeOrderedKeyValueBuffer;
+import org.apache.kafka.streams.state.internals.SessionStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.TimestampedWindowStoreBuilder;
+import org.apache.kafka.streams.state.internals.VersionedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.WindowStoreBuilder;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Builds and uses the state-store families that back the public window and query APIs. */
+public class StateStoreBuilderApiCoverageTest {
+    @Test
+    void shouldBuildKeyValueSessionWindowAndVersionedStores() {
+        KeyValueStoreBuilder<String, String> keyValueBuilder = new KeyValueStoreBuilder<>(
+                Stores.inMemoryKeyValueStore("builder-kv"), Serdes.String(), Serdes.String(), Time.SYSTEM);
+        KeyValueStore<String, String> keyValue = keyValueBuilder.build();
+        assertThat(keyValue.name()).isEqualTo("builder-kv");
+        InternalMockProcessorContext<?, ?> keyValueContext = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("context", String.class, String.class), NativeCoverageFixtures.recordCollector());
+        keyValueContext.initialize();
+        keyValueContext.setTime(1L);
+        keyValue.init((ProcessorContext) keyValueContext, keyValue);
+        keyValue.put("one", "1");
+        keyValue.putAll(java.util.List.of(org.apache.kafka.streams.KeyValue.pair("two", "2")));
+        assertThat(keyValue.get("one")).isEqualTo("1");
+        assertThat(keyValue.delete("two")).isEqualTo("2");
+        assertThat(keyValue.approximateNumEntries()).isEqualTo(1);
+        assertThat(keyValue.all().hasNext()).isTrue();
+        assertThat(keyValue.range("one", "two").hasNext()).isTrue();
+        assertThat(keyValue.reverseRange("one", "two").hasNext()).isTrue();
+        assertThat(keyValue.reverseAll().hasNext()).isTrue();
+        assertThat(keyValue.prefixScan("o", Serdes.String().serializer()).hasNext()).isTrue();
+
+        ListValueStoreBuilder<String, String> listBuilder = new ListValueStoreBuilder<>(
+                Stores.inMemoryKeyValueStore("builder-list"), Serdes.String(), Serdes.String(), Time.SYSTEM);
+        assertThat(listBuilder.build().name()).isEqualTo("builder-list");
+
+        TimestampedKeyValueStoreBuilder<String, String> timestampedBuilder = new TimestampedKeyValueStoreBuilder<>(
+                Stores.inMemoryKeyValueStore("builder-timestamped-kv"), Serdes.String(), Serdes.String(), Time.SYSTEM);
+        TimestampedKeyValueStore<String, String> timestamped = timestampedBuilder.build();
+        assertThat(timestamped.name()).isEqualTo("builder-timestamped-kv");
+
+        SessionStoreBuilder<String, String> sessionBuilder = new SessionStoreBuilder<>(
+                Stores.inMemorySessionStore("builder-session", Duration.ofMinutes(1)), Serdes.String(), Serdes.String(), Time.SYSTEM);
+        SessionStore<String, String> session = sessionBuilder.build();
+        assertThat(session.name()).isEqualTo("builder-session");
+        InternalMockProcessorContext<?, ?> sessionContext = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("context", String.class, String.class), NativeCoverageFixtures.recordCollector());
+        sessionContext.initialize();
+        sessionContext.setTime(1L);
+        session.init((ProcessorContext) sessionContext, session);
+        session.put(new Windowed<>("key", new org.apache.kafka.streams.kstream.internals.SessionWindow(10L, 20L)), "value");
+        assertThat(session.fetch("key").hasNext()).isTrue();
+        assertThat(session.backwardFetch("key").hasNext()).isTrue();
+        assertThat(session.fetch("key", "key").hasNext()).isTrue();
+        assertThat(session.backwardFetch("key", "key").hasNext()).isTrue();
+        assertThat(session.findSessions("key", 0L, 30L).hasNext()).isTrue();
+        assertThat(session.backwardFindSessions("key", 0L, 30L).hasNext()).isTrue();
+        assertThat(sessionBuilder.retentionPeriod()).isEqualTo(Duration.ofMinutes(1).toMillis());
+
+        VersionedKeyValueStoreBuilder<String, String> versionedBuilder = new VersionedKeyValueStoreBuilder<>(
+                Stores.persistentVersionedKeyValueStore("builder-versioned", Duration.ofMinutes(1)),
+                Serdes.String(), Serdes.String(), Time.SYSTEM);
+        VersionedKeyValueStore<String, String> versioned = versionedBuilder.build();
+        assertThat(versioned.name()).isEqualTo("builder-versioned");
+    }
+
+    @Test
+    void shouldExerciseCachingAndChangeLoggingStoreWrappers() {
+        org.apache.kafka.streams.state.StoreBuilder<KeyValueStore<org.apache.kafka.common.utils.Bytes, byte[]>> cachedBuilder =
+                new KeyValueStoreBuilder<>(Stores.inMemoryKeyValueStore("builder-cached"),
+                        Serdes.Bytes(), Serdes.ByteArray(), Time.SYSTEM).withCachingEnabled();
+        KeyValueStore<org.apache.kafka.common.utils.Bytes, byte[]> cached = cachedBuilder.build();
+
+        StreamsMetricsImpl metrics = new StreamsMetricsImpl(new org.apache.kafka.common.metrics.Metrics(),
+                "cached-client", "cached-thread", Time.SYSTEM);
+        ThreadCache threadCache = new ThreadCache(new LogContext("cached "), 1024L, metrics);
+        InternalMockProcessorContext<?, ?> context = new InternalMockProcessorContext<>(
+                new java.io.File("build/api-cached"), Serdes.Bytes(), Serdes.ByteArray(),
+                NativeCoverageFixtures.recordCollector(), threadCache);
+        context.initialize();
+        context.setTime(1L);
+        cached.init((StateStoreContext) context, cached);
+        assertThat(cached.approximateNumEntries()).isZero();
+        org.apache.kafka.common.utils.Bytes key = org.apache.kafka.common.utils.Bytes.wrap(new byte[] {1});
+        cached.put(key, new byte[] {2});
+        Bytes secondKey = Bytes.wrap(new byte[] {2});
+        cached.put(secondKey, new byte[] {3});
+        assertThat(cached.get(key)).containsExactly(2);
+        assertThat(cached.all().hasNext()).isTrue();
+        assertThat(cached.range(key, secondKey).hasNext()).isTrue();
+        assertThat(cached.reverseRange(key, secondKey).hasNext()).isTrue();
+        assertThat(cached.reverseAll().hasNext()).isTrue();
+        assertThat(cached.prefixScan(new byte[] {1}, Serdes.ByteArray().serializer()).hasNext()).isTrue();
+        cached.flush();
+        assertThat(cached.approximateNumEntries()).isEqualTo(2);
+        assertThat(cached.delete(key)).containsExactly(2);
+
+        org.apache.kafka.streams.state.StoreBuilder<SessionStore<String, byte[]>> loggingSessionBuilder = new SessionStoreBuilder<>(
+                Stores.inMemorySessionStore("builder-logging-session", Duration.ofMinutes(1)),
+                Serdes.String(), Serdes.ByteArray(), Time.SYSTEM).withLoggingEnabled(Map.of());
+        SessionStore<String, byte[]> loggingSession = loggingSessionBuilder.build();
+        assertThat(loggingSession.name()).isEqualTo("builder-logging-session");
+
+        org.apache.kafka.streams.state.StoreBuilder<TimestampedKeyValueStore<String, String>> loggingTimestampedBuilder =
+                new TimestampedKeyValueStoreBuilder<>(Stores.inMemoryKeyValueStore("builder-logging-timestamped"),
+                        Serdes.String(), Serdes.String(), Time.SYSTEM).withLoggingEnabled(Map.of());
+        assertThat(loggingTimestampedBuilder.build().name()).isEqualTo("builder-logging-timestamped");
+    }
+
+    @Test
+    void shouldUseWindowStoreInstantFetchOverloads() {
+        WindowStoreBuilder<String, String> windowBuilder = new WindowStoreBuilder<>(
+                Stores.inMemoryWindowStore("builder-window", Duration.ofMinutes(2), Duration.ofSeconds(10), false),
+                Serdes.String(), Serdes.String(), Time.SYSTEM);
+        WindowStore<String, String> window = windowBuilder.build();
+        assertThat(window.name()).isEqualTo("builder-window");
+        InternalMockProcessorContext<?, ?> windowContext = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("context", String.class, String.class), NativeCoverageFixtures.recordCollector());
+        windowContext.initialize();
+        windowContext.setTime(1L);
+        window.init((ProcessorContext) windowContext, window);
+        window.put("key", "value", 100L);
+        assertThat(window.fetch("key", 100L)).isEqualTo("value");
+        assertThat(window.backwardFetch("key", 50L, 150L).hasNext()).isTrue();
+        assertThat(window.fetch("key", "key", 50L, 150L).hasNext()).isTrue();
+        assertThat(window.backwardFetch("key", "key", 50L, 150L).hasNext()).isTrue();
+        assertThat(window.fetchAll(50L, 150L).hasNext()).isTrue();
+        assertThat(window.backwardFetchAll(50L, 150L).hasNext()).isTrue();
+        assertThat(window.all().hasNext()).isTrue();
+        assertThat(window.backwardAll().hasNext()).isTrue();
+        RecordingWindowStore recording = new RecordingWindowStore();
+        recording.fetch("key", 100L, 200L);
+        assertThat(recording.fetch("key", Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+        assertThat(recording.lastStart).isEqualTo(50L);
+        assertThat(recording.backwardFetch("key", Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+        assertThat(recording.lastEnd).isEqualTo(250L);
+        assertThat(recording.fetch("key", "key", Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+        assertThat(recording.backwardFetch("key", "key", Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+        assertThat(recording.fetchAll(Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+        assertThat(recording.backwardFetchAll(Instant.ofEpochMilli(50), Instant.ofEpochMilli(250))).isNull();
+
+        TimestampedWindowStoreBuilder<String, String> timestampedBuilder = new TimestampedWindowStoreBuilder<>(
+                Stores.inMemoryWindowStore("builder-timestamped-window", Duration.ofMinutes(1), Duration.ofSeconds(5), false),
+                Serdes.String(), Serdes.String(), Time.SYSTEM);
+        TimestampedWindowStore<String, String> timestamped = timestampedBuilder.build();
+        assertThat(timestamped.name()).isEqualTo("builder-timestamped-window");
+        InternalMockProcessorContext<?, ?> timestampedContext = new InternalMockProcessorContext<>(
+                StateSerdes.withBuiltinTypes("context", String.class, String.class), NativeCoverageFixtures.recordCollector());
+        timestampedContext.initialize();
+        timestampedContext.setTime(1L);
+        timestamped.init((ProcessorContext) timestampedContext, timestamped);
+        timestamped.put("key", org.apache.kafka.streams.state.ValueAndTimestamp.make("value", 100L), 100L);
+        assertThat(timestamped.fetch("key", 100L)).isNotNull();
+        assertThat(timestamped.backwardFetch("key", 50L, 150L).hasNext()).isTrue();
+        assertThat(timestamped.fetchAll(50L, 150L).hasNext()).isTrue();
+        assertThat(windowBuilder.retentionPeriod()).isEqualTo(Duration.ofMinutes(2).toMillis());
+
+        WindowStoreBuilder<String, String> persistentBuilder = new WindowStoreBuilder<>(
+                Stores.persistentWindowStore("builder-rocks-window", Duration.ofMinutes(2), Duration.ofSeconds(10), false),
+                Serdes.String(), Serdes.String(), Time.SYSTEM);
+        WindowStore<String, String> persistent = persistentBuilder.build();
+        assertThat(persistent.name()).isEqualTo("builder-rocks-window");
+        InternalMockProcessorContext<?, ?> persistentContext = new InternalMockProcessorContext<>(
+                new java.io.File("build/api-rocks"), Serdes.String(), Serdes.String(),
+                NativeCoverageFixtures.recordCollector(), null);
+        persistentContext.initialize();
+        persistentContext.setTime(1L);
+        persistent.init((StateStoreContext) persistentContext, persistent);
+        persistent.put("key", "value", 100L);
+        assertThat(persistent.fetch("key", 100L)).isEqualTo("value");
+        assertThat(persistent.backwardFetch("key", 50L, 150L).hasNext()).isTrue();
+        assertThat(persistent.fetch("key", "key", 50L, 150L).hasNext()).isTrue();
+        assertThat(persistent.backwardFetch("key", "key", 50L, 150L).hasNext()).isTrue();
+        assertThat(persistent.fetchAll(50L, 150L).hasNext()).isTrue();
+        assertThat(persistent.backwardFetchAll(50L, 150L).hasNext()).isTrue();
+        assertThat(persistent.all().hasNext()).isTrue();
+        assertThat(persistent.backwardAll().hasNext()).isTrue();
+
+        TimestampedWindowStoreBuilder<String, String> persistentTimestampedBuilder = new TimestampedWindowStoreBuilder<>(
+                Stores.persistentWindowStore("builder-rocks-timestamped", Duration.ofMinutes(1), Duration.ofSeconds(5), false),
+                Serdes.String(), Serdes.String(), Time.SYSTEM);
+        assertThat(persistentTimestampedBuilder.build().name()).isEqualTo("builder-rocks-timestamped");
+    }
+
+    private static final class RecordingWindowStore implements WindowStore<String, String> {
+        private long lastStart;
+        private long lastEnd;
+        @Override public String name() {
+            return "recording-window";
+        }
+        @Override public void init(ProcessorContext context, StateStore root) { }
+        @Override public void init(StateStoreContext context, StateStore root) { }
+        @Override public void flush() { }
+        @Override public void close() { }
+        @Override public boolean persistent() {
+            return false;
+        }
+        @Override public boolean isOpen() {
+            return true;
+        }
+        @Override public void put(String key, String value, long timestamp) { }
+        @Override public String fetch(String key, long timestamp) {
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.WindowStoreIterator<String> fetch(String key, long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> fetch(
+                String fromKey, String toKey, long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> fetchAll(long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.WindowStoreIterator<String> backwardFetch(String key, long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> backwardFetch(
+                String fromKey, String toKey, long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> backwardFetchAll(long from, long to) {
+            lastStart = from;
+            lastEnd = to;
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> all() {
+            return null;
+        }
+        @Override public org.apache.kafka.streams.state.KeyValueIterator<Windowed<String>, String> backwardAll() {
+            return null;
+        }
+    }
+
+    @Test
+    void shouldBuildTimeOrderedBufferBuildersWithConfiguration() {
+        InMemoryTimeOrderedKeyValueChangeBuffer.Builder<String, String> changeBuilder =
+                new InMemoryTimeOrderedKeyValueChangeBuffer.Builder<>("change-buffer", Serdes.String(), Serdes.String());
+        assertThat(changeBuilder.withCachingEnabled().withCachingDisabled().withLoggingEnabled(Map.of("retention.ms", "1"))
+                .withLoggingDisabled().build().name()).isEqualTo("change-buffer");
+
+        RocksDBTimeOrderedKeyValueBuffer.Builder<String, String> rocksBuilder =
+                new RocksDBTimeOrderedKeyValueBuffer.Builder<>("rocks-buffer", Duration.ofMinutes(1), "api-task");
+        assertThat(rocksBuilder.withCachingEnabled().withCachingDisabled().withLoggingEnabled(Map.of()).withLoggingDisabled()
+                .build().name()).isEqualTo("rocks-buffer");
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StateUpdaterApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StateUpdaterApiCoverageTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ChangelogReader;
+import org.apache.kafka.streams.processor.internals.DefaultStateUpdater;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.StateUpdater;
+import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises the empty state-updater lifecycle and its value object contract. */
+public class StateUpdaterApiCoverageTest {
+    @Test
+    void shouldStartStopAndExposeEmptyUpdaterQueues() {
+        StreamsConfig config = streamsConfig();
+        ChangelogReader changelogReader = new EmptyChangelogReader();
+        TopologyMetadata topologyMetadata = new TopologyMetadata(new InternalTopologyBuilder(), config);
+        Metrics metrics = new Metrics();
+        DefaultStateUpdater updater = new DefaultStateUpdater(
+                "coverage-updater", metrics, config, changelogReader, topologyMetadata, Time.SYSTEM);
+
+        try {
+            assertThat(updater.getTasks()).isEmpty();
+            assertThat(updater.getActiveTasks()).isEmpty();
+            assertThat(updater.getStandbyTasks()).isEmpty();
+            assertThat(updater.getUpdatingTasks()).isEmpty();
+            assertThat(updater.getUpdatingStandbyTasks()).isEmpty();
+            assertThat(updater.getRestoredActiveTasks()).isEmpty();
+            assertThat(updater.getPausedTasks()).isEmpty();
+            assertThat(updater.getRemovedTasks()).isEmpty();
+            assertThat(updater.getExceptionsAndFailedTasks()).isEmpty();
+            assertThat(updater.restoresActiveTasks()).isFalse();
+            assertThat(updater.hasRemovedTasks()).isFalse();
+            assertThat(updater.hasExceptionsAndFailedTasks()).isFalse();
+            assertThat(updater.drainRestoredActiveTasks(Duration.ZERO)).isEmpty();
+            assertThat(updater.drainRemovedTasks()).isEmpty();
+            assertThat(updater.drainExceptionsAndFailedTasks()).isEmpty();
+
+            updater.signalResume();
+            updater.start();
+            updater.start();
+            updater.shutdown(Duration.ofSeconds(2));
+            updater.shutdown(Duration.ZERO);
+        } finally {
+            updater.shutdown(Duration.ofSeconds(2));
+            metrics.close();
+        }
+    }
+
+    @Test
+    void shouldRetainAndDrainAQueuedTaskRemoval() {
+        StreamsConfig config = streamsConfig();
+        TopologyMetadata topologyMetadata = new TopologyMetadata(new InternalTopologyBuilder(), config);
+        Metrics metrics = new Metrics();
+        DefaultStateUpdater updater = new DefaultStateUpdater(
+                "coverage-updater-removal", metrics, config, new EmptyChangelogReader(), topologyMetadata, Time.SYSTEM);
+        Task task = new SimpleTask(new TaskId(4, 1));
+
+        try {
+            updater.add(task);
+            assertThat(updater.getTasks()).hasSize(1);
+            updater.shutdown(Duration.ZERO);
+            assertThat(updater.hasRemovedTasks()).isTrue();
+            assertThat(updater.drainRemovedTasks()).containsExactly(task);
+            assertThat(updater.hasRemovedTasks()).isFalse();
+            updater.remove(task.id());
+            updater.signalResume();
+        } finally {
+            updater.shutdown(Duration.ZERO);
+            metrics.close();
+        }
+    }
+
+    @Test
+    void shouldCompareExceptionAndTasksByValue() {
+        RuntimeException exception = new RuntimeException("restore failed");
+        Set<Task> tasks = Set.of(new SimpleTask(new TaskId(4, 1)));
+        StateUpdater.ExceptionAndTasks first = new StateUpdater.ExceptionAndTasks(tasks, exception);
+        StateUpdater.ExceptionAndTasks same = new StateUpdater.ExceptionAndTasks(tasks, exception);
+
+        assertThat(first.getTasks()).containsExactlyElementsOf(tasks);
+        assertThat(first.exception()).isSameAs(exception);
+        assertThat(first).isEqualTo(same);
+        assertThat(first.hashCode()).isEqualTo(same.hashCode());
+    }
+
+    private static StreamsConfig streamsConfig() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "state-updater-coverage");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "1");
+        properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE);
+        return new StreamsConfig(properties);
+    }
+
+    private static final class EmptyChangelogReader implements ChangelogReader {
+        @Override public void register(TopicPartition partition, ProcessorStateManager stateManager) { }
+        @Override public void register(Set<TopicPartition> partitions, ProcessorStateManager stateManager) { }
+        @Override public void unregister(Collection<TopicPartition> partitions) { }
+        @Override public long restore(Map<TaskId, Task> restoringTasks) {
+            return 0L;
+        }
+        @Override public void enforceRestoreActive() { }
+        @Override public void transitToUpdateStandby() { }
+        @Override public boolean isRestoringActive() {
+            return false;
+        }
+        @Override public Set<TopicPartition> completedChangelogs() {
+            return Set.of();
+        }
+        @Override public boolean allChangelogsCompleted() {
+            return true;
+        }
+        @Override public void clear() { }
+        @Override public boolean isEmpty() {
+            return true;
+        }
+    }
+
+    private static final class SimpleTask implements Task {
+        private final TaskId id;
+        private State state = State.RUNNING;
+
+        SimpleTask(TaskId id) {
+            this.id = id;
+        }
+
+        @Override public void initializeIfNeeded() {
+            state = State.RUNNING;
+        }
+        @Override public void completeRestoration(Consumer<Set<TopicPartition>> callback) { }
+        @Override public void suspend() {
+            state = State.SUSPENDED;
+        }
+        @Override public void resume() {
+            state = State.RUNNING;
+        }
+        @Override public void closeDirty() {
+            state = State.CLOSED;
+        }
+        @Override public void closeClean() {
+            state = State.CLOSED;
+        }
+        @Override public void updateInputPartitions(Set<TopicPartition> partitions, Map<String, List<String>> nodeToSourceTopics) { }
+        @Override public void maybeCheckpoint(boolean enforceCheckpoint) { }
+        @Override public void markChangelogAsCorrupted(Collection<TopicPartition> partitions) { }
+        @Override public void revive() {
+            state = State.CREATED;
+        }
+        @Override public void prepareRecycle() {
+            state = State.CLOSED;
+        }
+        @Override public void addRecords(TopicPartition partition, Iterable<ConsumerRecord<byte[], byte[]>> records) { }
+        @Override public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
+            return Map.of();
+        }
+        @Override public void postCommit(boolean enforceCheckpoint) { }
+        @Override public void maybeInitTaskTimeoutOrThrow(long wallClockTime, Exception cause) { }
+        @Override public void clearTaskTimeout() { }
+        @Override public void recordRestoration(Time time, long numRestored, boolean end) { }
+        @Override public TaskId id() {
+            return id;
+        }
+        @Override public boolean isActive() {
+            return false;
+        }
+        @Override public Set<TopicPartition> inputPartitions() {
+            return Set.of();
+        }
+        @Override public Set<TopicPartition> changelogPartitions() {
+            return Set.of();
+        }
+        @Override public State state() {
+            return state;
+        }
+        @Override public ProcessorStateManager stateManager() {
+            return null;
+        }
+        @Override public boolean commitNeeded() {
+            return false;
+        }
+        @Override public StateStore getStore(String name) {
+            return null;
+        }
+        @Override public Map<TopicPartition, Long> changelogOffsets() {
+            return Map.of();
+        }
+        @Override public Map<TopicPartition, Long> committedOffsets() {
+            return Map.of();
+        }
+        @Override public Map<TopicPartition, Long> highWaterMark() {
+            return Map.of();
+        }
+        @Override public Optional<Long> timeCurrentIdlingStarted() {
+            return Optional.empty();
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StreamsBuilderApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/StreamsBuilderApiCoverageTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises source, table, global-table, and global-store builder entry points. */
+public class StreamsBuilderApiCoverageTest {
+    @Test
+    void shouldBuildPatternSourcesAndGlobalTables() {
+        StreamsBuilder builder = new StreamsBuilder(new TopologyConfig("builder-api", config(), new Properties()));
+        assertThat(builder.stream(Pattern.compile("builder-input-.*"))).isNotNull();
+        assertThat(builder.stream(Pattern.compile("builder-consumed-.*"), Consumed.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(builder.table("builder-table", org.apache.kafka.streams.kstream.Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(builder.globalTable("builder-global-default")).isNotNull();
+        assertThat(builder.globalTable("builder-global-consumed", Consumed.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(builder.globalTable("builder-global-materialized", org.apache.kafka.streams.kstream.Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        assertThat(builder.globalTable("builder-global-both", Consumed.with(Serdes.String(), Serdes.String()),
+                org.apache.kafka.streams.kstream.Materialized.with(Serdes.String(), Serdes.String()))).isNotNull();
+        builder.addStateStore(store("builder-state"));
+        builder.addGlobalStore(store("builder-global-store"), "builder-global-source", Consumed.with(Serdes.String(), Serdes.String()),
+                () -> new NoopProcessor());
+        assertThat(builder.build().describe().toString()).contains("builder-global");
+    }
+
+    @Test
+    void shouldUseProcessorApiGlobalStoreRegistration() {
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.addGlobalStore(store("builder-api-global-store"), "builder-api-global-source",
+                Consumed.with(Serdes.String(), Serdes.String()),
+                () -> new org.apache.kafka.streams.processor.api.Processor<String, String, Void, Void>() {
+                    @Override public void init(org.apache.kafka.streams.processor.api.ProcessorContext<Void, Void> context) { }
+                    @Override public void process(org.apache.kafka.streams.processor.api.Record<String, String> record) { }
+                });
+        assertThat(builder.build()).isNotNull();
+    }
+
+    private static StreamsConfig config() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "builder-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        return new StreamsConfig(properties);
+    }
+
+    private static StoreBuilder<?> store(String name) {
+        return Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore(name), Serdes.String(), Serdes.String()).withLoggingDisabled();
+    }
+
+    private static final class NoopProcessor implements Processor<String, String> {
+        @Override public void init(ProcessorContext context) { }
+        @Override public void process(String key, String value) { }
+        @Override public void close() { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TaskManagerApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TaskManagerApiCoverageTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ReadOnlyTask;
+import org.apache.kafka.streams.processor.internals.StandbyTask;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.TaskExecutionMetadata;
+import org.apache.kafka.streams.processor.internals.TasksRegistry;
+import org.apache.kafka.streams.processor.internals.tasks.DefaultTaskManager;
+import org.apache.kafka.streams.processor.internals.tasks.TaskExecutor;
+import org.apache.kafka.streams.processor.internals.tasks.TaskExecutorCreator;
+import org.apache.kafka.streams.internals.StreamsConfigUtils;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Exercises an empty task manager through its public coordination operations. */
+public class TaskManagerApiCoverageTest {
+    @Test
+    void shouldCoordinateAnEmptyTaskSetAndDrainFailures() {
+        StreamsConfig config = streamsConfig();
+        TaskExecutor executor = new EmptyTaskExecutor();
+        TaskExecutorCreator creator = (manager, name, time, metadata) -> executor;
+        TaskExecutionMetadata metadata = new TaskExecutionMetadata(
+                Set.of(), Set.of(), StreamsConfigUtils.ProcessingMode.AT_LEAST_ONCE);
+        DefaultTaskManager manager = new DefaultTaskManager(
+                Time.SYSTEM, "coverage-manager", new EmptyTasksRegistry(), config, creator, metadata);
+        TaskId taskId = new TaskId(5, 2);
+        StreamsException failure = new StreamsException("task failed");
+
+        assertThat(manager.getTasks()).isEmpty();
+        assertThat(manager.assignNextTask(executor)).isNull();
+        assertThat(manager.lockTasks(Set.of())).isNotNull();
+        KafkaFuture<Void> allLocked = manager.lockAllTasks();
+        assertThat(allLocked).isNotNull();
+        manager.unlockTasks(Set.of(taskId));
+        manager.unlockAllTasks();
+        manager.add(Set.of());
+        assertThatThrownBy(() -> manager.remove(taskId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not locked");
+        assertThatThrownBy(() -> manager.setUncaughtException(failure, taskId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only be set");
+        assertThat(manager.drainUncaughtExceptions()).isEmpty();
+    }
+
+    private static StreamsConfig streamsConfig() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "task-manager-coverage");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, "org.apache.kafka.common.serialization.Serdes$StringSerde");
+        properties.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "1");
+        return new StreamsConfig(properties);
+    }
+
+    private static final class EmptyTaskExecutor implements TaskExecutor {
+        @Override public String name() {
+            return "empty";
+        }
+        @Override public void start() { }
+        @Override public void shutdown(Duration timeout) { }
+        @Override public ReadOnlyTask currentTask() {
+            return null;
+        }
+        @Override public KafkaFuture<StreamTask> unassign() {
+            return KafkaFuture.completedFuture(null);
+        }
+    }
+
+    private static final class EmptyTasksRegistry implements TasksRegistry {
+        @Override public Map<TaskId, Set<TopicPartition>> drainPendingActiveTasksForTopologies(Set<String> topologies) {
+            return Map.of();
+        }
+        @Override public Map<TaskId, Set<TopicPartition>> drainPendingStandbyTasksForTopologies(Set<String> topologies) {
+            return Map.of();
+        }
+        @Override public void addPendingActiveTasksToCreate(Map<TaskId, Set<TopicPartition>> tasks) { }
+        @Override public void addPendingStandbyTasksToCreate(Map<TaskId, Set<TopicPartition>> tasks) { }
+        @Override public void clearPendingTasksToCreate() { }
+        @Override public Set<TopicPartition> removePendingTaskToRecycle(TaskId taskId) {
+            return Set.of();
+        }
+        @Override public boolean hasPendingTasksToRecycle() {
+            return false;
+        }
+        @Override public void addPendingTaskToRecycle(TaskId taskId, Set<TopicPartition> partitions) { }
+        @Override public Set<TopicPartition> removePendingTaskToUpdateInputPartitions(TaskId taskId) {
+            return Set.of();
+        }
+        @Override public void addPendingTaskToUpdateInputPartitions(TaskId taskId, Set<TopicPartition> partitions) { }
+        @Override public boolean removePendingTaskToCloseDirty(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingTaskToCloseDirty(TaskId taskId) { }
+        @Override public boolean removePendingTaskToCloseClean(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingTaskToCloseClean(TaskId taskId) { }
+        @Override public Set<Task> drainPendingTasksToInit() {
+            return Set.of();
+        }
+        @Override public void addPendingTasksToInit(Collection<Task> tasks) { }
+        @Override public boolean hasPendingTasksToInit() {
+            return false;
+        }
+        @Override public boolean removePendingActiveTaskToSuspend(TaskId taskId) {
+            return false;
+        }
+        @Override public void addPendingActiveTaskToSuspend(TaskId taskId) { }
+        @Override public void addActiveTasks(Collection<Task> tasks) { }
+        @Override public void addStandbyTasks(Collection<Task> tasks) { }
+        @Override public void addTask(Task task) { }
+        @Override public void removeTask(Task task) { }
+        @Override public void replaceActiveWithStandby(StandbyTask task) { }
+        @Override public void replaceStandbyWithActive(StreamTask task) { }
+        @Override public boolean updateActiveTaskInputPartitions(Task task, Set<TopicPartition> partitions) {
+            return false;
+        }
+        @Override public void clear() { }
+        @Override public Task activeTasksForInputPartition(TopicPartition partition) {
+            return null;
+        }
+        @Override public Task task(TaskId taskId) {
+            return null;
+        }
+        @Override public Collection<Task> tasks(Collection<TaskId> taskIds) {
+            return Collections.emptyList();
+        }
+        @Override public Collection<Task> activeTasks() {
+            return Collections.emptyList();
+        }
+        @Override public Set<Task> allTasks() {
+            return Set.of();
+        }
+        @Override public Map<TaskId, Task> allTasksPerId() {
+            return Map.of();
+        }
+        @Override public Set<TaskId> allTaskIds() {
+            return Set.of();
+        }
+        @Override public boolean contains(TaskId taskId) {
+            return false;
+        }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TopologyApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/TopologyApiCoverageTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.streams.processor.TopicNameExtractor;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.regex.Pattern;
+import org.apache.kafka.streams.StreamsConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises the low-level topology construction API with real node wiring. */
+public class TopologyApiCoverageTest {
+    private static final Serde<String> SERDE = Serdes.String();
+    private static final TimestampExtractor TIMESTAMP = (record, partitionTime) -> record.timestamp();
+    private static final ProcessorSupplier<String, String> PROCESSOR = () -> new NoopProcessor();
+    private static final StreamPartitioner<String, String> PARTITIONER = (topic, key, value, partitions) -> 0;
+    private static final TopicNameExtractor<String, String> TOPIC = (key, value, context) -> "api-dynamic-output";
+
+    @Test
+    void shouldBuildSourcesProcessorsSinksAndStores() {
+        Topology topology = new Topology(new TopologyConfig("api-topology", streamsConfig(), new Properties()));
+        topology.addSource("source-topics", "api-input");
+        topology.addSource("source-pattern", Pattern.compile("pattern-.*"));
+        topology.addSource("source-deserialized", SERDE.deserializer(), SERDE.deserializer(), "api-deserialized");
+        topology.addSource("source-pattern-deserialized", SERDE.deserializer(), SERDE.deserializer(), Pattern.compile("api-deserialized-.*"));
+        topology.addSource(Topology.AutoOffsetReset.EARLIEST, "source-earliest", "api-earliest");
+        topology.addSource(Topology.AutoOffsetReset.LATEST, "source-latest-pattern", Pattern.compile("pat-latest-.*"));
+        topology.addSource(Topology.AutoOffsetReset.EARLIEST, "source-earliest-deserialized", SERDE.deserializer(), SERDE.deserializer(), "api-earliest-deserialized");
+        topology.addSource(Topology.AutoOffsetReset.LATEST, "source-latest-pattern-deserialized", SERDE.deserializer(), SERDE.deserializer(), Pattern.compile("pat-latest-deserialized-.*"));
+        topology.addSource(Topology.AutoOffsetReset.EARLIEST, TIMESTAMP, "source-timestamp", "api-timestamp");
+        topology.addSource(Topology.AutoOffsetReset.LATEST, TIMESTAMP, "source-timestamp-pattern", Pattern.compile("pat-timestamp-.*"));
+        topology.addSource(Topology.AutoOffsetReset.EARLIEST, "source-timestamp-deserialized", TIMESTAMP, SERDE.deserializer(), SERDE.deserializer(), "api-timestamp-deserialized");
+        topology.addSource(Topology.AutoOffsetReset.LATEST, "source-timestamp-pattern-deserialized", TIMESTAMP, SERDE.deserializer(), SERDE.deserializer(), Pattern.compile("pat-timestamp-deserialized-.*"));
+        topology.addSource(TIMESTAMP, "source-no-reset", "api-no-reset");
+        topology.addSource(TIMESTAMP, "source-no-reset-pattern", Pattern.compile("pat-no-reset-.*"));
+
+        topology.addProcessor("processor-old", PROCESSOR, "source-topics");
+        topology.addProcessor("processor-old-second", PROCESSOR, "source-pattern");
+        topology.addProcessor("processor-api", (org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, Void, Void>) new ApiProcessorSupplier(), "source-deserialized");
+
+        topology.addStateStore(store("state-one"), "processor-old");
+        topology.connectProcessorAndStateStores("processor-old", "state-one");
+
+        topology.addSink("sink-topic", "api-sink", "processor-old");
+        topology.addSink("sink-topic-serde", "api-sink-serde", SERDE.serializer(), SERDE.serializer(), "processor-old-second");
+        topology.addSink("sink-topic-partitioner", "api-sink-partitioner", SERDE.serializer(), SERDE.serializer(), PARTITIONER, "processor-old-second");
+        topology.addSink("sink-partitioner", "api-sink-partitioner-2", PARTITIONER, "processor-old-second");
+        topology.addSink("sink-extractor", TOPIC, "processor-old-second");
+        topology.addSink("sink-extractor-serde", TOPIC, SERDE.serializer(), SERDE.serializer(), "processor-old-second");
+        topology.addSink("sink-extractor-partitioner", TOPIC, SERDE.serializer(), SERDE.serializer(), PARTITIONER, "processor-old-second");
+        topology.addSink("sink-extractor-partitioner-2", TOPIC, PARTITIONER, "processor-old-second");
+
+        assertThat(topology.describe().toString()).contains("source-topics", "processor-old", "api-sink");
+    }
+
+    @Test
+    void shouldBuildGlobalStoresAndUseConfigFactories() {
+        Topology topology = new Topology();
+        topology.addGlobalStore(store("global-one"), "global-source-one", SERDE.deserializer(), SERDE.deserializer(), "api-global-one", "api-global-processor-one", PROCESSOR);
+        topology.addGlobalStore(store("global-two"), "global-source-two", TIMESTAMP, SERDE.deserializer(), SERDE.deserializer(), "api-global-two", "api-global-processor-two", PROCESSOR);
+        topology.addGlobalStore(
+                store("global-three"),
+                "global-source-three",
+                SERDE.deserializer(),
+                SERDE.deserializer(),
+                "api-global-three",
+                "api-global-processor-three",
+                (org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, Void, Void>) new ApiProcessorSupplier());
+        topology.addGlobalStore(
+                store("global-four"),
+                "global-source-four",
+                TIMESTAMP,
+                SERDE.deserializer(),
+                SERDE.deserializer(),
+                "api-global-four",
+                "api-global-processor-four",
+                (org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, Void, Void>) new ApiProcessorSupplier());
+        assertThat(topology.describe().toString()).contains("global-one", "global-four");
+        assertThat(new TopologyConfig("named", streamsConfig(), new Properties()).isNamedTopology()).isTrue();
+        assertThat(new TopologyConfig("plain", streamsConfig(), new Properties()).parseStoreType()).isEqualTo(Materialized.StoreType.ROCKS_DB);
+    }
+
+    private static StreamsConfig streamsConfig() {
+        Properties properties = new Properties();
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "topology-api");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        return new StreamsConfig(properties);
+    }
+
+    private static StoreBuilder<?> store(String name) {
+        return Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore(name), SERDE, SERDE).withLoggingDisabled();
+    }
+
+    private static final class ApiProcessorSupplier implements org.apache.kafka.streams.processor.api.ProcessorSupplier<String, String, Void, Void> {
+        @Override public org.apache.kafka.streams.processor.api.Processor<String, String, Void, Void> get() {
+            return new ApiProcessor();
+        }
+    }
+
+    private static final class ApiProcessor implements org.apache.kafka.streams.processor.api.Processor<String, String, Void, Void> {
+        @Override public void init(org.apache.kafka.streams.processor.api.ProcessorContext<Void, Void> context) { }
+        @Override public void process(org.apache.kafka.streams.processor.api.Record<String, String> record) { }
+    }
+
+    private static final class NoopProcessor implements Processor<String, String> {
+        @Override public void init(org.apache.kafka.streams.processor.ProcessorContext context) { }
+        @Override public void process(String key, String value) { }
+        @Override public void close() { }
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/WindowAndSerdeApiCoverageTest.java
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/src/test/java/org_apache_kafka/kafka_streams/WindowAndSerdeApiCoverageTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org_apache_kafka.kafka_streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
+import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.WindowedSerdes;
+import org.apache.kafka.streams.kstream.internals.Change;
+import org.apache.kafka.streams.kstream.internals.ChangedDeserializer;
+import org.apache.kafka.streams.kstream.internals.ChangedSerializer;
+import org.apache.kafka.streams.kstream.internals.FullChangeSerde;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Exercises window value objects and the serde adapters used by state stores. */
+public class WindowAndSerdeApiCoverageTest {
+    @Test
+    void shouldRoundTripTimeAndSessionWindowedKeys() {
+        Windowed<String> timeKey = new Windowed<>("key", new TimeWindow(100, 200));
+        TimeWindowedSerializer<String> timeSerializer = new TimeWindowedSerializer<>(Serdes.String().serializer());
+        timeSerializer.configure(Map.of(), false);
+        byte[] encoded = timeSerializer.serialize("topic", timeKey);
+        assertThat(timeSerializer.serializeBaseKey("topic", timeKey)).isNotEmpty();
+        TimeWindowedDeserializer<String> timeDeserializer = new TimeWindowedDeserializer<>(Serdes.String().deserializer(), 100L);
+        timeDeserializer.configure(Map.of(), false);
+        assertThat(timeDeserializer.getWindowSize()).isEqualTo(100L);
+        assertThat(timeDeserializer.deserialize("topic", encoded)).isEqualTo(timeKey);
+        timeDeserializer.setIsChangelogTopic(true);
+        timeSerializer.close();
+        timeDeserializer.close();
+
+        Windowed<String> sessionKey = new Windowed<>("key", new SessionWindow(100, 200));
+        SessionWindowedSerializer<String> sessionSerializer = new SessionWindowedSerializer<>(Serdes.String().serializer());
+        SessionWindowedDeserializer<String> sessionDeserializer = new SessionWindowedDeserializer<>(Serdes.String().deserializer());
+        byte[] sessionBytes = sessionSerializer.serialize("topic", sessionKey);
+        assertThat(sessionSerializer.serializeBaseKey("topic", sessionKey)).isNotEmpty();
+        assertThat(sessionDeserializer.deserialize("topic", sessionBytes)).isEqualTo(sessionKey);
+        sessionSerializer.close();
+        sessionDeserializer.close();
+        assertThat(new WindowedSerdes()).isNotNull();
+        assertThat(WindowedSerdes.sessionWindowedSerdeFrom(String.class)).isNotNull();
+    }
+
+    @Test
+    void shouldSerializeChangesAndPreserveChangeValueSemantics() {
+        Change<String> change = new Change<>("new", "old", true);
+        ChangedSerializer<String> serializer = new ChangedSerializer<>(Serdes.String().serializer());
+        ChangedDeserializer<String> deserializer = new ChangedDeserializer<>(Serdes.String().deserializer());
+        serializer.configure(Map.of(), false);
+        deserializer.configure(Map.of(), false);
+        byte[] bytes = serializer.serialize("topic", change);
+        assertThat(deserializer.deserialize("topic", bytes)).isEqualTo(change);
+        ChangedSerializer rawSerializer = serializer;
+        assertThat(rawSerializer.serialize("topic", (Object) change)).isNotEmpty();
+        assertThat(deserializer.deserialize("topic", bytes)).isEqualTo(change);
+        assertThat(serializer.inner()).isNotNull();
+        assertThat(deserializer.inner()).isNotNull();
+        serializer.close();
+        deserializer.close();
+
+        FullChangeSerde<String> full = FullChangeSerde.wrap(Serdes.String());
+        Change<byte[]> parts = full.serializeParts("topic", change);
+        assertThat(parts.newValue).isNotEmpty();
+        assertThat(full.deserializeParts("topic", parts)).isEqualTo(change);
+        java.nio.ByteBuffer legacy = java.nio.ByteBuffer.allocate(12);
+        legacy.putInt(2).put(new byte[] {1, 2}).putInt(2).put(new byte[] {3, 4});
+        assertThat(FullChangeSerde.decomposeLegacyFormattedArrayIntoChangeArrays(legacy.array())).isNotNull();
+        assertThat(full.innerSerde()).isNotNull();
+        assertThat(change.toString()).contains("new");
+        assertThat(change.hashCode()).isEqualTo(new Change<>("new", "old", true).hashCode());
+    }
+
+    @Test
+    void shouldDescribeWindowBoundariesAndWindowPolicies() {
+        Window time = new TimeWindow(10, 20);
+        assertThat(time.startTime()).isEqualTo(Instant.ofEpochMilli(10));
+        assertThat(time.endTime()).isEqualTo(Instant.ofEpochMilli(20));
+        assertThat(time.toString()).contains("10", "20");
+        assertThat(time.overlap(new TimeWindow(15, 25))).isTrue();
+        assertThat(time.overlap(new TimeWindow(20, 30))).isFalse();
+        Window session = new SessionWindow(10, 20);
+        assertThat(session.overlap(new SessionWindow(15, 25))).isTrue();
+
+        TimeWindows timeWindows = TimeWindows.of(Duration.ofSeconds(10)).advanceBy(Duration.ofSeconds(5)).grace(Duration.ofSeconds(2));
+        assertThat(timeWindows.windowsFor(12_000L)).isNotEmpty();
+        assertThat(timeWindows.toString()).contains("sizeMs");
+        assertThat(timeWindows.equals(TimeWindows.of(Duration.ofSeconds(10)).advanceBy(Duration.ofSeconds(5)).grace(Duration.ofSeconds(2)))).isTrue();
+        assertThat(timeWindows.hashCode()).isEqualTo(timeWindows.hashCode());
+        SessionWindows sessions = SessionWindows.with(Duration.ofSeconds(4)).grace(Duration.ofSeconds(1));
+        assertThat(sessions.toString()).contains("gapMs");
+        assertThat(sessions.equals(SessionWindows.with(Duration.ofSeconds(4)).grace(Duration.ofSeconds(1)))).isTrue();
+        assertThat(sessions.hashCode()).isEqualTo(sessions.hashCode());
+        SlidingWindows sliding = SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1));
+        assertThat(sliding.toString()).contains("sizeMs");
+        assertThat(sliding.equals(SlidingWindows.withTimeDifferenceAndGrace(Duration.ofSeconds(3), Duration.ofSeconds(1)))).isTrue();
+        assertThat(sliding.hashCode()).isEqualTo(sliding.hashCode());
+
+        UnlimitedWindows unlimited = UnlimitedWindows.of().startOn(Instant.ofEpochMilli(100));
+        assertThat(unlimited.size()).isEqualTo(Long.MAX_VALUE);
+        assertThat(unlimited.gracePeriodMs()).isZero();
+        assertThat(unlimited.windowsFor(200)).isNotEmpty();
+        assertThat(unlimited.toString()).contains("startMs");
+        assertThat(unlimited.equals(UnlimitedWindows.of().startOn(Instant.ofEpochMilli(100)))).isTrue();
+    }
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement/suite.json
@@ -1,0 +1,3 @@
+{
+  "coordinates": "org.apache.kafka:kafka-streams:3.6.2"
+}

--- a/tests/src/org.apache.kafka/kafka-streams/3.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
+++ b/tests/src/org.apache.kafka/kafka-streams/3.6.0/src/test/resources/META-INF/native-image/reachability-metadata.json
@@ -57,6 +57,39 @@
         }
       ],
       "type": "org.apache.kafka.coordinator.group.assignor.RangeAssignor"
+    },
+    {
+      "condition": {
+        "typeReached": "org_apache_kafka.kafka_streams.DeepMetricsCoverageTest"
+      },
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "double",
+            "double",
+            "double",
+            "double",
+            "double"
+          ]
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "double",
+            "double",
+            "double",
+            "double",
+            "double",
+            "double",
+            "long",
+            "long",
+            "double"
+          ]
+        }
+      ],
+      "type": "org.rocksdb.HistogramData",
+      "jniAccessible": true
     }
   ],
   "resources": [


### PR DESCRIPTION
## Code coverage improvement

- Source issue: #9055
- Coordinate: `org.apache.kafka:kafka-streams:3.6.2`
- Coverage suite path: `tests/src/org.apache.kafka/kafka-streams/3.6.0/code-coverage-improvement`
- Needs human intervention: no

## JaCoCo coverage

Every figure divides by the same denominator: the 7065 library methods JaCoCo
can rule on, made up of 3923 public API methods and 3142 internal methods, which
are disjoint by construction. Each checkpoint is counted over that one frozen set
of method ids from a single JaCoCo report, so every phase starts where the
previous phase ended.

| Checkpoint | Covered | Share |
|---|--:|--:|
| Run start | 1790/7065 | 25.34% |
| After Simple Jacoco guidance phase | 4163/7065 | 58.92% |
| After PGO guidance phase (final) | 4606/7065 | 65.19% |

- Simple Jacoco guidance phase: +2373 methods, +33.58pp
- PGO guidance phase: +443 methods, +6.27pp
- Run total: +2816 methods, +39.85pp
- Remaining uncovered: 2459 of 7065

Where the coverage and the remaining headroom sit:

| Method universe | Run start | Final | Still uncovered |
|---|--:|--:|--:|
| Public API | 994/3923 | 2838/3923 | 1085 |
| Internal | 796/3142 | 1768/3142 | 1374 |


## Token usage

| Phase | Input | Input (cached) | Output |
|---|--:|--:|--:|
| convert | 73,983 | 635,392 | 8,985 |
| prepare | 85,499 | 1,025,536 | 8,938 |
| api-inventory | 55,748 | 390,656 | 4,838 |
| api-coverage | 1,898,181 | 59,704,832 | 232,260 |
| prepare-native-metadata | 26,456 | 174,080 | 3,939 |
| deep-coverage | 2,570,282 | 50,880,512 | 199,402 |
| finalization | 170,312 | 2,531,840 | 7,233 |
| **Total** | **4,880,461** | **115,342,848** | **465,595** |

Input is uncached input tokens; Input (cached) is cache reads.

Refs #9055.

