### PR TITLE
Make grund check a pull-request gate

### DIFF
--- a/.github/workflows/grund-check.yml
+++ b/.github/workflows/grund-check.yml
@@ -1,0 +1,66 @@
+# Per-PR gate that runs `grund check` over both namespaces, so a citation that stops resolving,
+# or a managed AGENTS.md block that drifts from its grund.toml, fails the PR instead of rotting.
+# §CI-grund-check; enforces §FS-repository-functional-spec.5.6.
+name: "Validate grund citations"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+env:
+  # Pinned, not floating: a newer grund can render a newer managed AGENTS.md block, which would
+  # fail every PR until someone re-runs `grund init`. Bump this and the checksum together.
+  GRUND_VERSION: "0.10.0"
+  GRUND_SHA256: "ce6e3eac69ecf91da795c898e068530610fd0b9a2a9a7c9e9263b43564baf61a"
+
+jobs:
+  grund-check:
+    name: "🧭 Validate grund citations"
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 5
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: "🔎 Detect relevant file changes"
+        id: filter
+        uses: ./.github/actions/detect-file-changes
+        with:
+          # The union of both projects' `[scan] include` roots and their configs; a PR that
+          # touches none of them cannot break a citation.
+          file-patterns: |
+            - 'AGENTS.md'
+            - 'README.md'
+            - 'COVERAGE.md'
+            - 'build.gradle'
+            - 'grund.toml'
+            - 'docs/**'
+            - 'skills/**'
+            - '.github/workflows/**'
+            - '.github/actions/**'
+            - 'forge/AGENTS.md'
+            - 'forge/README.md'
+            - 'forge/DEVELOPING.md'
+            - 'forge/grund.toml'
+            - 'forge/docs/**'
+
+      - name: "🔧 Install grund"
+        if: steps.filter.outputs.changed == 'true'
+        run: |
+          archive="grund-${GRUND_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSfL -o "${RUNNER_TEMP}/${archive}" \
+            "https://github.com/vjovanov/grund/releases/download/v${GRUND_VERSION}/${archive}"
+          echo "${GRUND_SHA256}  ${RUNNER_TEMP}/${archive}" | sha256sum --check --strict
+          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}"
+          echo "${RUNNER_TEMP}/grund-${GRUND_VERSION}-x86_64-unknown-linux-gnu" >> "${GITHUB_PATH}"
+
+      - name: "🧭 Check citations"
+        if: steps.filter.outputs.changed == 'true'
+        # Run from the workspace root: it is the only place the alias table that resolves
+        # cross-namespace citations is in scope, so this one run covers Forge too.
+        run: |
+          grund check

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,6 +80,21 @@ Triggers on PRs touching `metadata/library-and-framework-list.json` or its
 schema. Validates and sorts the master supported-library list against its schema
 (§METADATA-suite).
 
+### CI-grund-check: Validate grund citations
+
+Triggers on PRs touching either project's scanned roots — `docs/`, `skills/`,
+the workflows and composite actions, the top-level Markdown, or a `grund.toml`.
+Installs a pinned `grund` release and runs `grund check` once from the
+repository root, which is the only scope where the workspace alias table
+resolves `§forge/<ID>`, so the run covers both namespaces. It fails on a
+citation that no longer resolves, on an `AGENTS.md` managed block that has
+drifted from its `grund.toml`, and on a `must`-level citation direction that is
+not met (§FS-repository-functional-spec.5.6).
+
+The `grund` version is pinned in the workflow rather than floating: a newer
+release can render a newer managed block, which would fail every PR until
+someone re-runs `grund init`. Bump the version and its checksum together.
+
 ### CI-checkstyle: Checkstyle
 
 Triggers on PRs that change code (excluding `docs/**`, `**.md`, and the framework

--- a/docs/functional-spec/README.md
+++ b/docs/functional-spec/README.md
@@ -237,7 +237,7 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 
 ### 5.3 CI gates
 
-- **PR gates.** Every PR is gated on the relevant subset of: `checkstyle`, `spotlessCheck`, `validateIndexFiles`, `checkMetadataFiles`, `validateLibraryStats`, `library-and-framework-list-validation`, and the appropriate `test-*` workflow.
+- **PR gates.** Every PR is gated on the relevant subset of: `checkstyle`, `spotlessCheck`, `validateIndexFiles`, `checkMetadataFiles`, `validateLibraryStats`, `library-and-framework-list-validation`, `grund check`, and the appropriate `test-*` workflow.
 - **Docker isolation.** Docker images used in tests are pre-pulled from `allowed-docker-images`, after which the runner disables Docker networking for deterministic, isolated test runs.
 - **Release style gate.** The release workflow runs `spotlessCheck` before packaging.
 - **Spring AOT scope.** The Spring AOT smoke matrix runs only when `metadata/` changes affect a Spring AOT project.
@@ -254,6 +254,18 @@ All four elements are versioned through the schema `$id` URLs and the GitHub Rel
 
 Forge's requirements are specified in [forge/docs/functional-spec/README.md](../../forge/docs/functional-spec/README.md).
 §forge/FS-forge-functional-spec
+
+### 5.6 Documentation grounding
+
+- **Resolvable citations.** Every `§<ID>` citation in a scanned file must resolve
+  to a declared ID, in this namespace or in a workspace member's.
+- **Current agent instructions.** The managed block in each `AGENTS.md` must be
+  what `grund init` renders from that project's `grund.toml`, so the rules an
+  agent reads are the rules that are checked.
+- **Held citation directions.** The directions declared `must` in `[citations]`
+  hold; the ones declared `should` are a worklist rather than a gate.
+
+These are enforced on every PR that touches a scanned path (§CI-grund-check).
 
 ## 6. Operational Guarantees
 


### PR DESCRIPTION
Nothing in this repository runs `grund` — no workflow, no Gradle task. The citation directions that #9322 turned into checked config, and every `§<ID>` in the tree, therefore hold only as far as whoever happens to run the check locally. A citation can stop resolving, or a managed `AGENTS.md` block can drift from its `grund.toml`, and the first sign of it is an agent reading a rule that is no longer true.

## What is in this PR

**A PR gate.** `.github/workflows/grund-check.yml` installs a pinned `grund` release, verifies it against a committed SHA-256, and runs `grund check` **once from the repository root** — the only scope where the workspace alias table resolves `§forge/<ID>`, so a single run covers both namespaces.

It fails on three things:

- a `§<ID>` citation that no longer resolves,
- an `AGENTS.md` managed block that has drifted from its `grund.toml` (grund re-renders the block and byte-compares it),
- a `must`-level citation direction that is not met.

The `should`-level directions stay a worklist, not a gate — they never appear in `grund check`'s standing output, only under `--suggestions`.

**The version is pinned, not floating.** A newer grund release can render a newer managed block, which would fail *every* PR until someone re-runs `grund init`. `GRUND_VERSION` and `GRUND_SHA256` sit next to each other in the workflow and move together. Bumping grund becomes a deliberate two-line change plus a `grund init`, which is the intended workflow rather than an outage.

**Scoped so the common PR is a no-op.** The gate runs behind `detect-file-changes` (§CI-detect-file-changes) on the union of both projects' `[scan] include` roots and their configs:

`AGENTS.md`, `README.md`, `COVERAGE.md`, `build.gradle`, `grund.toml`, `docs/**`, `skills/**`, `.github/workflows/**`, `.github/actions/**`, and the `forge/` equivalents.

A metadata PR — most of the queue — touches none of them and skips. The check itself takes ~15 ms; the runner setup is the entire cost.

**Spec first.** The requirement did not exist anywhere, so this adds it rather than letting a workflow assert its own reason for existing:

- `FS-repository-functional-spec.5.6` — resolvable citations, current agent instructions, held `must` directions.
- `CI-grund-check` in `docs/ci.md`, alongside the other per-PR validators.
- `grund check` added to the PR-gate list in `FS-repository-functional-spec.5.3`.

## Validation

`grund check` from the repository root: exit 0. `grund check --suggestions`: still 27 findings — the new `CI-grund-check` declaration cites `§FS-repository-functional-spec.5.6`, so it adds no new debt to the worklist.

The install steps were run verbatim in a sandbox with `RUNNER_TEMP` and `GITHUB_PATH` set: download, `sha256sum --check --strict` OK, extract, PATH entry written, `grund --version` → `grund 0.10.0`.

The workflow parses as YAML, and the 14 file patterns were fed through the same `parsePatterns` / `globToRegex` shapes the composite action uses. This PR touches `docs/**` and `.github/workflows/**`, so the gate runs on its own PR rather than skipping itself.

### Follow-ups, not in this PR

- **The 27 `should` findings** are a standing worklist: 13 `WF`, 4 `CI`, 4 `STRAT`, 3 `ROADMAP`, 2 `GIT`, 1 `FS` declaration that cites nothing upward. Clearing a kind's findings is what lets it be promoted from `should` to `must`.
- **Forge's Python sources are not scanned.** `forge/grund.toml` sets `extensions = ["md", "html"]`, so the `§` citations in `forge_metadata.py` and its siblings are neither resolved nor checked. Widening that is a separate change with its own fallout to work through.
