### PR TITLE
Publish Forge PRs as graalvmbot without a pusher allowlist

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -87,7 +87,6 @@ def validate_publication(
         branch: str,
         actor: str,
         repository: str,
-        authorized_pushers: str,
 ) -> ValidatedPublication:
     """Validate a feature tree as inert data (§GIT-actions-publication)."""
     if repository != REPOSITORY:
@@ -147,9 +146,6 @@ def validate_publication(
     producer = str(descriptor["producer"])
     if actor != producer:
         raise ValueError(f"Triggering actor {actor!r} does not match descriptor producer {producer!r}")
-    authorized = {value.strip() for value in authorized_pushers.split(",") if value.strip()}
-    if actor not in authorized:
-        raise ValueError(f"Triggering actor {actor!r} is not in FORGE_AUTHORIZED_PUSHERS")
     if branch != descriptor["branch"] or not branch.startswith(f"ai/{producer}/"):
         raise ValueError("Event branch does not match the descriptor producer branch")
     if not branch.endswith(f"-{descriptor['publication_id']}"):
@@ -658,7 +654,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--branch", required=True)
     parser.add_argument("--actor", required=True)
     parser.add_argument("--repository", required=True)
-    parser.add_argument("--authorized-pushers", required=True)
     parser.add_argument("--mode", default="shadow")
     parser.add_argument("--reviewers", default="")
     return parser
@@ -672,7 +667,6 @@ def main() -> int:
             branch=args.branch,
             actor=args.actor,
             repository=args.repository,
-            authorized_pushers=args.authorized_pushers,
         )
         if args.command == "publish":
             title, body, pr_url = publish(validated, args.mode, args.reviewers)

--- a/.github/workflows/forge-branch-ready.yml
+++ b/.github/workflows/forge-branch-ready.yml
@@ -37,14 +37,12 @@ jobs:
           HEAD_BRANCH: ${{ github.ref_name }}
           HEAD_ACTOR: ${{ github.actor }}
           HEAD_REPOSITORY: ${{ github.repository }}
-          AUTHORIZED_PUSHERS: ${{ vars.FORGE_AUTHORIZED_PUSHERS }}
         run: >-
           python3 .github/scripts/forge_pr_publisher/publisher.py validate
           --sha "$HEAD_SHA"
           --branch "$HEAD_BRANCH"
           --actor "$HEAD_ACTOR"
           --repository "$HEAD_REPOSITORY"
-          --authorized-pushers "$AUTHORIZED_PUSHERS"
 
       - name: Upload trusted publication preview
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/forge-open-pr.yml
+++ b/.github/workflows/forge-open-pr.yml
@@ -38,26 +38,15 @@ jobs:
       - name: Install publisher schema validator
         run: python3 -m pip install --disable-pip-version-check jsonschema==4.25.1
 
-      - name: Create short-lived publisher App token
-        if: ${{ vars.FORGE_PR_PUBLISH_MODE == 'live' }}
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.FORGE_PUBLISHER_APP_ID }}
-          private-key: ${{ secrets.FORGE_PUBLISHER_PRIVATE_KEY }}
-          owner: oracle
-          repositories: graalvm-reachability-metadata
-          permission-contents: read
-          permission-pull-requests: write
-
       - name: Revalidate and publish exact SHA
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          # Publication runs as the graalvmbot machine account, the same identity
+          # the compatibility sweep already publishes with (§GIT-actions-publication).
+          GH_TOKEN: ${{ vars.FORGE_PR_PUBLISH_MODE == 'live' && secrets.GRAALBOT_PR_TOKEN || github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_ACTOR: ${{ github.event.workflow_run.actor.login }}
           HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
-          AUTHORIZED_PUSHERS: ${{ vars.FORGE_AUTHORIZED_PUSHERS }}
           PUBLISH_MODE: ${{ vars.FORGE_PR_PUBLISH_MODE || 'shadow' }}
           PR_REVIEWERS: ${{ vars.FORGE_PR_REVIEWERS }}
         run: >-
@@ -66,7 +55,6 @@ jobs:
           --branch "$HEAD_BRANCH"
           --actor "$HEAD_ACTOR"
           --repository "$HEAD_REPOSITORY"
-          --authorized-pushers "$AUTHORIZED_PUSHERS"
           --mode "$PUBLISH_MODE"
           --reviewers "$PR_REVIEWERS"
 

--- a/forge/docs/git-scripts.md
+++ b/forge/docs/git-scripts.md
@@ -122,8 +122,8 @@ Before mutation the publisher must verify all of the following:
 - the head repository is `oracle/graalvm-reachability-metadata`, the head branch
   is the descriptor branch under `ai/<producer>/`, and the workflow-run head SHA
   is the exact object being read;
-- the triggering actor equals the descriptor producer and is listed in the
-  trusted comma-separated repository variable `FORGE_AUTHORIZED_PUSHERS`;
+- the triggering actor equals the descriptor producer, which the branch
+  namespace `ai/<producer>/` must also name;
 - the base commit is an ancestor of the head SHA and of the trusted base branch,
   and exactly one descriptor changed in the publication diff;
 - the coordinates, descriptor path, and publication identity agree, and the
@@ -135,12 +135,20 @@ execution metrics, or the local verification evidence. Expected-path staging
 (§FS-local-ci-equivalent-verification), and re-deriving it from branch-supplied
 data proves nothing the branch could not also assert.
 
-The workflow creates a short-lived token from
-`FORGE_PUBLISHER_APP_ID` and `FORGE_PUBLISHER_PRIVATE_KEY`. The App is granted
-only the repository pull-request and content-read permissions needed to open and
-label the pull request. Reviewer requests come only from the trusted comma-separated
-repository variable `FORGE_PR_REVIEWERS`. The producer remains eligible to
-review the bot-authored PR.
+The workflow publishes as the `graalvmbot` machine account, using the
+`GRAALBOT_PR_TOKEN` secret that already authors the compatibility-sweep pull
+requests. The token reaches the publisher step only in `live` mode, so a shadow
+run renders evidence without a publication credential in its environment.
+Reviewer requests come only from the trusted comma-separated repository variable
+`FORGE_PR_REVIEWERS`. The producer remains eligible to review the bot-authored
+PR.
+
+No pusher allowlist gates publication. A `push` event fires only on the upstream
+repository, so the trigger population is already the set of accounts with write
+access, each of which can open a pull request directly. The gate that remains is
+structural: the descriptor producer must equal the pushing actor and must own the
+`ai/<producer>/` branch namespace, so a publication cannot be attributed to
+someone who did not push it.
 
 The publisher renders the PR, applies only the fixed primary label and trusted
 modifiers (`GenAI`, `chunked-dynamic-access`, and `human-intervention`),


### PR DESCRIPTION
## What this does

#9317 moved PR publication out of `forge_metadata.py` and into two workflows, but the first real run after it landed produced no pull request. The local run succeeded and pushed its descriptor; `Forge Branch Ready` then failed with `Triggering actor 'kimeta' is not in FORGE_AUTHORIZED_PUSHERS`, and because `Forge Open PR` is gated on that job succeeding, it was skipped. The allowlist variable had never been created, so every Forge branch push since the merge died at the same gate.

Rather than populate the allowlist, this removes it, and publishes as the `graalvmbot` machine account instead of the dedicated GitHub App the design called for.

## Why no allowlist

A `push` event fires only on the upstream repository — a fork cannot trigger these workflows, and the publisher already refuses any head repository other than `oracle/graalvm-reachability-metadata`. So the population the allowlist filtered was the set of accounts that already hold write access, every one of which can open a pull request by hand. It bought a second list to maintain and a failure mode where forgetting to maintain it silently disables publication, which is exactly what happened.

The structural half of the check stays, because it is what makes an `ai/**` branch *adequate* rather than merely present:

```python
if actor != producer:
    raise ValueError(...)
if branch != descriptor["branch"] or not branch.startswith(f"ai/{producer}/"):
    raise ValueError(...)
```

The pusher must be the descriptor's producer and must own the `ai/<producer>/` namespace, so a publication cannot be attributed to someone who did not push it.
