### PR TITLE
Condition Hibernate Validator's Joda-Time validators on Joda-Time types

### DIFF
--- a/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reachability-metadata.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/7.0.4.Final/reachability-metadata.json
@@ -2544,7 +2544,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadableInstant"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadableInstant",
       "methods": [
@@ -2556,7 +2556,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadablePartial"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadablePartial",
       "methods": [
@@ -2760,7 +2760,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadableInstant"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadableInstant",
       "methods": [
@@ -2772,7 +2772,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadablePartial"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadablePartial",
       "methods": [
@@ -2976,7 +2976,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadableInstant"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadableInstant",
       "methods": [
@@ -2988,7 +2988,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadablePartial"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadablePartial",
       "methods": [
@@ -3192,7 +3192,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadableInstant"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadableInstant",
       "methods": [
@@ -3204,7 +3204,7 @@
     },
     {
       "condition": {
-        "typeReached": "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached": "org.joda.time.ReadablePartial"
       },
       "type": "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadablePartial",
       "methods": [

--- a/metadata/org.hibernate.validator/hibernate-validator/9.1.0.Final/reachability-metadata.json
+++ b/metadata/org.hibernate.validator/hibernate-validator/9.1.0.Final/reachability-metadata.json
@@ -3445,7 +3445,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadableInstant"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadableInstant",
       "methods" : [
@@ -3457,7 +3457,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadablePartial"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.future.FutureValidatorForReadablePartial",
       "methods" : [
@@ -3673,7 +3673,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadableInstant"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadableInstant",
       "methods" : [
@@ -3685,7 +3685,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadablePartial"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForReadablePartial",
       "methods" : [
@@ -3901,7 +3901,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadableInstant"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadableInstant",
       "methods" : [
@@ -3913,7 +3913,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadablePartial"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.past.PastValidatorForReadablePartial",
       "methods" : [
@@ -4129,7 +4129,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadableInstant"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadableInstant",
       "methods" : [
@@ -4141,7 +4141,7 @@
     },
     {
       "condition" : {
-        "typeReached" : "org.hibernate.validator.internal.engine.ValidatorImpl"
+        "typeReached" : "org.joda.time.ReadablePartial"
       },
       "type" : "org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForReadablePartial",
       "methods" : [


### PR DESCRIPTION
## What does this PR do?

Fixes GraalVM Native Image builds that use Hibernate Validator **without** the optional `joda-time` dependency.

### Problem

`joda-time` is declared `<optional>true</optional>` by Hibernate Validator (verified in both `7.0.4.Final` and `9.1.0.Final` POMs), so it is absent from most consumer classpaths.

Eight validator classes ship in the `hibernate-validator` jar but extend `org.joda.time` types:

```
Future/FutureOrPresent/Past/PastOrPresent ValidatorForReadableInstant
Future/FutureOrPresent/Past/PastOrPresent ValidatorForReadablePartial
```

For example:

```
public class FutureOrPresentValidatorForReadablePartial
    extends AbstractFutureOrPresentEpochBasedValidator<org.joda.time.ReadablePartial>
```

The metadata registered all eight under the condition `org.hibernate.validator.internal.engine.ValidatorImpl`, which is reached by essentially any application that performs Bean Validation. When that condition is satisfied and `joda-time` is not on the classpath, the classes are present but unresolvable, and the build fails:

```
Error: Type not found during analysis: HotSpotType<Lorg/hibernate/validator/internal/
constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForReadablePartial;, resolved>
```

Reproduced with a Spring Boot 4.1 / GraalVM 25.0.4 application using `spring-boot-starter-validation` and no `joda-time` dependency. Each build surfaces one such type at a time, so all eight are affected.

### Fix

Condition each entry on the Joda-Time type it actually requires (`org.joda.time.ReadableInstant` / `org.joda.time.ReadablePartial`) instead of `ValidatorImpl`. When `joda-time` is absent, the condition type is absent and the entries are simply not applied; when it is present, behaviour is unchanged.

This also tightens the metadata scope, per the "use Conditional Configuration to precisely define the metadata scope" requirement in `docs/CONTRIBUTING.md`.

The change is limited to `"condition".typeReached` values — 8 lines per file, no entries added or removed.

### Validation

Local, on GraalVM/Liberica NIK 25.0.4:

- `./gradlew test -Pcoordinates=org.hibernate.validator:hibernate-validator:9.1.0.Final` → **22 tests successful, 0 failed** (this TCK has `joda-time` on the test classpath, so it covers the "Joda present" path).
- `./gradlew test -Pcoordinates=org.hibernate.validator:hibernate-validator:7.0.4.Final` → **2 tests successful, 0 failed**.
- The real Spring Boot application above, pointed at this branch via `<metadataRepository><localPath>`, previously failed with the error above and now builds successfully.

Note: the existing TCK tests pass both before and after this change, so they do not currently cover the failing configuration (Bean Validation reached with `joda-time` absent). I am happy to add a test variant for that case if you would like it in this PR.

## Code sections where the PR accesses files, network, docker or some external service

- None. This PR only edits JSON metadata; no test, build, or harness code is touched.
