### PR TITLE
Accept the Forge publication descriptor under stats

### DIFF
--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/stats/LibraryStatsSchemaValidator.java
@@ -178,6 +178,10 @@ public final class LibraryStatsSchemaValidator {
             return null;
         }
 
+        if (isForgePublicationFile(relative)) {
+            return null;
+        }
+
         if (relative.getNameCount() == 4 && "stats.json".equals(relative.getName(3).toString())) {
             return new StatsLocation(
                     relative.getName(0).toString(),
@@ -188,7 +192,8 @@ public final class LibraryStatsSchemaValidator {
 
         failures.add("Unexpected JSON file under stats root: " + file
                 + " (expected stats/<groupId>/<artifactId>/<metadataVersion>/stats.json, "
-                + "stats/<groupId>/<artifactId>/<metadataVersion>/execution-metrics.json, or stats/schemas/*.json)");
+                + "stats/<groupId>/<artifactId>/<metadataVersion>/execution-metrics.json, "
+                + "stats/<groupId>/<artifactId>/<metadataVersion>/forge-publication.json, or stats/schemas/*.json)");
         return null;
     }
 
@@ -199,6 +204,14 @@ public final class LibraryStatsSchemaValidator {
     private static boolean isExecutionMetricsFile(Path relativePath) {
         return relativePath.getNameCount() == 4
                 && "execution-metrics.json".equals(relativePath.getName(3).toString());
+    }
+
+    /// Forge commits its publication descriptor beside the stats it publishes. Both sides of the
+    /// publication handoff already schema-validate it, so this validator only has to recognize the
+    /// file instead of rejecting it as stray JSON (§forge/GIT-actions-publication).
+    private static boolean isForgePublicationFile(Path relativePath) {
+        return relativePath.getNameCount() == 4
+                && "forge-publication.json".equals(relativePath.getName(3).toString());
     }
 
     private static void validateExecutionMetricsFile(


### PR DESCRIPTION
## What this does

#9317 started committing a publication descriptor at
`stats/<groupId>/<artifactId>/<metadataVersion>/forge-publication.json`, but
`validateLibraryStats` keeps a closed allowlist of what may live under the stats
root and was never told about it. Every Forge publication PR therefore fails the
stats gate on a file the publisher itself requires — #9407 is the first one to hit
it:

```
Library stats repository validation failed:
  Unexpected JSON file under stats root:
  stats/org.jctools/jctools-core/4.0.3/forge-publication.json
  (expected stats/<groupId>/<artifactId>/<metadataVersion>/stats.json,
   stats/<groupId>/<artifactId>/<metadataVersion>/execution-metrics.json,
   or stats/schemas/*.json)
```

This adds the descriptor to the allowlist and names it in the failure message, so
the next unexpected file gets accurate guidance.
