### PR TITLE
Review Forge branches before they are pushed

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -291,6 +291,62 @@ def _path_changed(head_sha: str, path: str) -> bool:
     ).returncode != 0
 
 
+def _render_local_review(descriptor: dict[str, Any]) -> str:
+    """Render reviewer-owned words and Forge-owned tree facts separately."""
+    review: Any = descriptor.get("local_review")
+    if not isinstance(review, dict):
+        return ""
+    lines: list[str] = ["", "## Local Agent Review", ""]
+    if review["status"] == "unavailable":
+        lines.extend([
+            "The local reviewer was unavailable, so this branch carries no reviewer verdict or finding.",
+            "",
+            f"- Model: `{review['model']}`",
+            f"- Session log: `{review['session_log_path']}`",
+            "- Published tree: the verified pre-review tree",
+        ])
+        return "\n".join(lines) + "\n"
+
+    lines.extend([
+        f"- Decision: `{review['decision']}`",
+        f"- Model: `{review['model']}`",
+        f"- Session log: `{review['session_log_path']}`",
+        f"- Published tree: `{review['published_tree']}`",
+        "",
+        review["review_comment"],
+    ])
+    finding_title: str = review["finding_title"]
+    if finding_title:
+        lines.extend([
+            "",
+            f"**Finding — {finding_title}**",
+            "",
+            review["finding_body"],
+        ])
+    fix_note: str = review["fix_note"]
+    if fix_note:
+        lines.extend(["", "**Reviewer fix note**", "", fix_note])
+    if review["repair_reverted"]:
+        lines.extend([
+            "",
+            "**Forge verification fact:** the reviewer repair was reverted after "
+            f"`{review['failed_step']}` failed; the verified pre-review tree is published.",
+        ])
+    return "\n".join(lines) + "\n"
+
+
+def _local_review_requires_human_intervention(descriptor: dict[str, Any]) -> bool:
+    """Use only reviewer non-approval or Forge's reset fact as the review signal."""
+    review: Any = descriptor.get("local_review")
+    if not isinstance(review, dict):
+        return False
+    return (
+        review["status"] != "completed"
+        or review.get("decision") != "approved"
+        or bool(review["repair_reverted"])
+    )
+
+
 def render_publication(
         descriptor: dict[str, Any],
         validated: ValidatedPublication | None = None,
@@ -309,6 +365,7 @@ def render_publication(
     if builder is None:
         raise ValueError(f"Unsupported template type: {template}")
     title, body = builder(descriptor, validated)
+    body += _render_local_review(descriptor)
     body += f"\nForge-Publication-ID: {descriptor['publication_id']}\n"
     return title, _bound_body(body)
 
@@ -1311,7 +1368,11 @@ def _ensure_pull_request_metadata(
     modifiers = descriptor["modifiers"]
     if modifiers["chunked_dynamic_access"]:
         labels.append("chunked-dynamic-access")
-    if modifiers["human_intervention"] or _has_severe_metadata_drop(descriptor):
+    if (
+            modifiers["human_intervention"]
+            or _has_severe_metadata_drop(descriptor)
+            or _local_review_requires_human_intervention(descriptor)
+    ):
         labels.append("human-intervention")
     run(
         [

--- a/.github/scripts/forge_pr_publisher/schema.json
+++ b/.github/scripts/forge_pr_publisher/schema.json
@@ -144,6 +144,178 @@
         }
       }
     },
+    "local_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "model",
+        "session_log_path",
+        "changed_paths",
+        "repair_reverted",
+        "failed_step",
+        "published_tree"
+      ],
+      "properties": {
+        "status": {
+          "enum": ["completed", "unavailable"]
+        },
+        "decision": {
+          "enum": ["approved", "changes_requested"]
+        },
+        "review_comment": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30000
+        },
+        "finding_title": {
+          "type": "string",
+          "maxLength": 30000
+        },
+        "finding_body": {
+          "type": "string",
+          "maxLength": 30000
+        },
+        "fix_note": {
+          "type": "string",
+          "maxLength": 30000
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "session_log_path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "changed_paths": {
+          "type": "array",
+          "maxItems": 200,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          }
+        },
+        "repair_reverted": {
+          "type": "boolean"
+        },
+        "failed_step": {
+          "oneOf": [
+            {"type": "null"},
+            {"type": "string", "maxLength": 1000}
+          ]
+        },
+        "published_tree": {
+          "enum": ["verified", "repaired"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"status": {"const": "completed"}},
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "decision",
+              "review_comment",
+              "finding_title",
+              "finding_body",
+              "fix_note"
+            ]
+          },
+          "else": {
+            "not": {
+              "anyOf": [
+                {"required": ["decision"]},
+                {"required": ["review_comment"]},
+                {"required": ["finding_title"]},
+                {"required": ["finding_body"]},
+                {"required": ["fix_note"]}
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"repair_reverted": {"const": true}},
+            "required": ["repair_reverted"]
+          },
+          "then": {
+            "properties": {
+              "failed_step": {"type": "string", "minLength": 1},
+              "published_tree": {"const": "verified"}
+            }
+          },
+          "else": {
+            "properties": {
+              "failed_step": {"type": "null"}
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {"changed_paths": {"minItems": 1}},
+                  "required": ["changed_paths"]
+                },
+                "then": {
+                  "properties": {
+                    "published_tree": {"const": "repaired"}
+                  }
+                },
+                "else": {
+                  "properties": {
+                    "published_tree": {"const": "verified"}
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {"decision": {"const": "changes_requested"}},
+            "required": ["decision"]
+          },
+          "then": {
+            "properties": {
+              "finding_title": {"type": "string", "minLength": 1},
+              "finding_body": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"status": {"const": "unavailable"}},
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "changed_paths": {"maxItems": 0},
+              "repair_reverted": {"const": false},
+              "failed_step": {"type": "null"},
+              "published_tree": {"const": "verified"}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"changed_paths": {"minItems": 1}},
+            "required": ["changed_paths"]
+          },
+          "then": {
+            "properties": {
+              "status": {"const": "completed"},
+              "finding_title": {"type": "string", "minLength": 1},
+              "finding_body": {"type": "string", "minLength": 1},
+              "fix_note": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      ]
+    },
     "forge": {
       "type": "object",
       "additionalProperties": false,
@@ -205,6 +377,20 @@
     }
   },
   "allOf": [
+    {
+      "if": {
+        "properties": {
+          "task_type": {"const": "code-coverage-improvement"}
+        },
+        "required": ["task_type"]
+      },
+      "then": {
+        "not": {"required": ["local_review"]}
+      },
+      "else": {
+        "required": ["local_review"]
+      }
+    },
     {
       "if": {
         "properties": {

--- a/forge/FINDINGS.md
+++ b/forge/FINDINGS.md
@@ -1,0 +1,4 @@
+# Forge pre-push review findings
+
+Rendered by Forge from the pre-push branch review of §FS-local-branch-review.
+Newest entry first; every non-approval is recorded, including one a repair later cleared.

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -748,9 +748,9 @@ human-intervention handoff that happens today (§FS-human-intervention-policy).
 **Neural.** Judging whether a diff satisfies the review rules is what no gate can
 decide, and neither is the edit that answers a finding.
 
-Specified by §FS-local-branch-review; planned, not implemented
-(§ROADMAP-forge-local-branch-review). A second review of the branch before it is
-pushed, run cold — a detached worktree at the verified commit, no shared session
+Specified by §FS-local-branch-review. Except for the temporarily excluded
+`code-coverage-improvement` route, a second review of the branch before it is
+pushed runs cold — a detached worktree at the verified commit, no shared session
 with the run that produced it — over `base_ref..HEAD`, under the same
 `skills/review-*/SKILL.md` rules the post-push reviewer applies
 (§FS-automated-pr-review), selected by the same `task_type`, with the local

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -287,12 +287,16 @@ intervention lane, so that every caller gets identical behavior.
 
 ## FS-local-branch-review: Local pre-push branch review
 
-Every generated branch must be reviewed before it is pushed, and not only after
-it has become a pull request (§FS-automated-pr-review). The pre-push review is
-the cheaper of the two: the working tree that generation verified is still on
-disk, the local gate records still exist, and the branch can still be corrected
-without a maintainer's queue being involved. Planned, not implemented
-(§ROADMAP-forge-local-branch-review).
+Every generated branch except a `code-coverage-improvement` branch must be reviewed
+before it is pushed, and not only after it has become a pull request
+(§FS-automated-pr-review). The pre-push review is the cheaper of the two: the
+working tree that generation verified is still on disk, the local gate records
+still exist, and the branch can still be corrected without a maintainer's queue
+being involved. The shared publication pipeline implements this phase before it
+writes the descriptor. Code-coverage publication is temporarily excluded: its
+phase-boundary coverage evidence cannot yet be reconstructed after reviewer
+edits to tests, so it must not emit a review verdict until that workflow owns
+durable phase snapshots.
 
 **Placement.** The review runs inside publication, after the pre-publication
 gate of §FS-local-ci-equivalent-verification.2 has passed and the descriptor
@@ -305,7 +309,11 @@ the resolved render statistics.
 verified commit, in a session carrying no part of the generation transcript. A
 review that shares context with the run that produced the branch inherits the
 justifications that run already accepted, and its verdict then carries no
-information. It applies the same review rules the post-push reviewer applies,
+information. Forge invokes it through the worker-configured analysis role
+rather than selecting an agent backend, model, or provider locally
+(§FS-forge-agent-runtime-selection). The caller supplies the review prompt and
+detached worktree while the centralized runtime owns execution and logging.
+The reviewer applies the same review rules the post-push reviewer applies,
 selected by the run's `task_type` so that one rule set governs both reviews, and
 the same blocking discipline: a finding is a concrete violation of an enumerated
 rule, never a self-formed judgment about test quality.

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -217,14 +217,20 @@ re-attempted silently (§AR-forge-orchestration).
 
 # ROADMAP-forge-local-branch-review: Pre-push local branch review
 
+Status: implemented for every publication route except
+`code-coverage-improvement`, which is deferred until its phase evidence is
+snapshot-backed.
+
 Priority: fifth (part of §ROADMAP-forge-implementation).
 
-A generated branch is reviewed once today, and only after it is already a pull
-request. Everything the run held — the verified worktree, the local CI gate
-records, the resolved descriptor statistics — is discarded at push time, so the
-cheapest moment to fix a finding has passed before any reviewer looks.
+Before this item, a generated branch was reviewed once and only after it was
+already a pull request. Everything the run held — the verified worktree, the
+local CI gate records, the resolved descriptor statistics — was discarded at
+push time, so the cheapest moment to fix a finding passed before any reviewer
+looked.
 
-This item adds `local_review()` as a phase of `publish_branch()`
+The implementation adds `local_review()` as a phase of `publish_branch()` for
+every route except `code-coverage-improvement`
 (§AR-forge-workflow-pipeline), in the one slot the existing ordering allows:
 after the pre-publication gate (§FS-local-ci-equivalent-verification.2) and
 after descriptor input resolution, because the review rules dereference render

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -329,6 +329,7 @@ PUBLICATION_METRICS_EXTRA_KEYS: tuple[str, ...] = (
     "post_generation_intervention",
     "local_ci_verification",
     "library_update_alias_split",
+    "local_review",
 )
 # A workflow failure is logical (driver/core/CI-check) and gets `human-intervention`
 # by default. The only exception is an external dependency failure, which surfaces

--- a/forge/git_scripts/branch_publication.py
+++ b/forge/git_scripts/branch_publication.py
@@ -25,13 +25,17 @@ from git_scripts.common_git import (
     run_git_transport,
     stage_and_commit as stage_and_commit_common,
 )
+from git_scripts.local_branch_review import run_local_branch_review
 from git_scripts.publication_descriptor import (
     PublicationDescriptorInput,
     build_publication_branch,
     build_publication_id,
     write_publication_descriptor,
 )
+from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.library_finalization import run_library_finalization
 from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.metadata_index import resolve_metadata_version
 from utility_scripts.local_ci_verification import (
     LocalCIVerificationResult,
     fetch_pr_base_ref,
@@ -63,6 +67,9 @@ PRESERVATION_ONLY_DIRECTORIES: tuple[str, ...] = (
 MAX_PR_BODY_CHARS: int = 60_000
 MAX_INLINE_TEST_DIFF_CHARS: int = 12_000
 PR_BODY_REQUIRED_TAIL_CHARS: int = 12_000
+LOCAL_REVIEW_EXCLUDED_TASK_TYPES: frozenset[str] = frozenset({
+    "code-coverage-improvement",
+})
 
 
 def _publication_resume_marker(repo_path: str) -> ContinuationMarker | None:
@@ -185,6 +192,76 @@ def _prepare_unpushed_publication_resume_branch(
     _record_publication_branch(repo_path, branch, marker)
 
 
+def _run_post_review_gradle_test(
+        repo_path: str,
+        coordinates: str,
+        environment: dict[str, str],
+) -> bool:
+    """Run one deterministic native test lane after a reviewer edit."""
+    result = subprocess.run(
+        ["./gradlew", "test", f"-Pcoordinates={coordinates}"],
+        cwd=repo_path,
+        env=gradle_command_environment(repo_path, environment),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        return False
+    return True
+
+
+def _run_standard_post_review_finalization(
+        repo_path: str,
+        coordinates: str,
+        base_commit: str,
+) -> bool:
+    """Replay the standard generation/finalization tier over reviewer edits.
+
+    The outer local-review phase owns the bounded repair and deterministic
+    rerun; this callback only reports whether the tier passed.
+    §FS-local-branch-review
+    """
+    current_environment: dict[str, str] = dict(os.environ)
+    future_defaults_environment: dict[str, str] = dict(os.environ)
+    future_defaults_environment["GVM_TCK_NATIVE_IMAGE_MODE"] = "future-defaults-all"
+    graalvm_25_home: str | None = os.environ.get("GRAALVM_HOME_25_0")
+    if not graalvm_25_home:
+        return False
+    graalvm_25_environment: dict[str, str] = dict(os.environ)
+    graalvm_25_environment["GRAALVM_HOME"] = graalvm_25_home
+    graalvm_25_environment["JAVA_HOME"] = graalvm_25_home
+    graalvm_25_environment.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
+    for environment in (
+            current_environment,
+            future_defaults_environment,
+            graalvm_25_environment,
+    ):
+        if not _run_post_review_gradle_test(repo_path, coordinates, environment):
+            return False
+
+    group, artifact, version = coordinates.split(":")
+    libraries: list[str] = [coordinates]
+    metadata_version: str = resolve_metadata_version(repo_path, group, artifact, version)
+    metadata_coordinates: str = f"{group}:{artifact}:{metadata_version}"
+    if metadata_coordinates not in libraries:
+        libraries.append(metadata_coordinates)
+    for library in libraries:
+        library_version: str = library.rsplit(":", 1)[-1]
+        if not run_library_finalization(
+                repo_path=repo_path,
+                library=library,
+                group=group,
+                artifact=artifact,
+                library_version=library_version,
+                base_commit=base_commit,
+        ):
+            return False
+    return True
+
+
 def publish_branch(
         repo_path: str,
         branch_suffix: str,
@@ -195,6 +272,7 @@ def publish_branch(
         before_verification: Callable[[str], None] | None = None,
         descriptor_input: PublicationDescriptorInput | Callable[[], PublicationDescriptorInput] | None = None,
         before_stage: Callable[[str, str], None] | None = None,
+        post_review_finalization: Callable[[], bool] | None = None,
 ) -> tuple[str, LocalCIVerificationResult]:
     """Create, stage, rebase, verify, and push the publication branch.
 
@@ -270,7 +348,54 @@ def publish_branch(
     if resolved_descriptor_input is not None:
         if publication_id is None:
             raise ValueError("Publication descriptor requires a publication ID")
-        final_descriptor_input = descriptor_input() if callable(descriptor_input) else resolved_descriptor_input
+        review_descriptor_input = (
+            descriptor_input() if callable(descriptor_input) else resolved_descriptor_input
+        )
+        if review_descriptor_input.timestamp != resolved_descriptor_input.timestamp:
+            review_descriptor_input = replace(
+                review_descriptor_input, timestamp=resolved_descriptor_input.timestamp,
+            )
+        review_publication_id = build_publication_id(
+            review_descriptor_input.issue_number,
+            review_descriptor_input.timestamp,
+            coordinates,
+            review_descriptor_input.task_type,
+        )
+        if review_publication_id != publication_id:
+            raise ValueError("Publication descriptor identity changed during finalization")
+
+        local_review_payload: dict | None = None
+        if review_descriptor_input.task_type not in LOCAL_REVIEW_EXCLUDED_TASK_TYPES:
+            # Code-coverage runs retain phase-boundary reports that cannot yet be
+            # regenerated correctly after reviewer test edits, so that route is
+            # excluded until it has phase snapshots. §FS-local-branch-review
+            review_outcome = run_local_branch_review(
+                repo_path=repo_path,
+                coordinates=coordinates,
+                base_commit=base_ref,
+                task_type=review_descriptor_input.task_type,
+                local_ci_verification=local_ci_verification,
+                descriptor_input=review_descriptor_input,
+                metrics_repo_path=metrics_repo_path,
+                post_review_finalization=(
+                    post_review_finalization
+                    if post_review_finalization is not None
+                    else (
+                        (lambda: True)
+                        if review_descriptor_input.task_type == "not-for-native-image"
+                        else lambda: _run_standard_post_review_finalization(
+                            repo_path, coordinates, base_ref,
+                        )
+                    )
+                ),
+                stage_publication_changes=stage,
+            )
+            local_ci_verification = review_outcome.local_ci_verification
+            local_review_payload = review_outcome.to_descriptor_payload()
+
+        final_descriptor_input = (
+            descriptor_input() if callable(descriptor_input) else review_descriptor_input
+        )
         if final_descriptor_input.timestamp != resolved_descriptor_input.timestamp:
             final_descriptor_input = replace(
                 final_descriptor_input, timestamp=resolved_descriptor_input.timestamp,
@@ -282,7 +407,7 @@ def publish_branch(
             final_descriptor_input.task_type,
         )
         if final_publication_id != publication_id:
-            raise ValueError("Publication descriptor identity changed during finalization")
+            raise ValueError("Publication descriptor identity changed after local review")
         descriptor_path = write_publication_descriptor(
             repo_path=repo_path,
             coordinates=coordinates,
@@ -292,6 +417,7 @@ def publish_branch(
             base_commit=base_ref,
             descriptor_input=final_descriptor_input,
             local_ci_verification=local_ci_verification,
+            local_review=local_review_payload,
         )
         descriptor_relative_path = os.path.relpath(descriptor_path, repo_path)
         stage_and_commit_common(

--- a/forge/git_scripts/local_branch_review.py
+++ b/forge/git_scripts/local_branch_review.py
@@ -1,0 +1,787 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cold pre-push review of a verified publication branch (§FS-local-branch-review)."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shutil
+import subprocess
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from ai_workflows.agents.agent_runtime import (
+    AgentRunResult,
+    AgentSelection,
+    analysis_agent_run,
+    get_analysis_agent,
+)
+from git_scripts.common_git import parse_coordinate_parts, stage_and_commit
+from utility_scripts.local_ci_verification import (
+    FINDINGS_RELATIVE_PATH,
+    LocalCIVerificationError,
+    LocalCIVerificationResult,
+    run_local_ci_verification,
+    run_repair_agent,
+    write_verification_metrics,
+)
+from utility_scripts.metrics_writer import read_pending_metrics, write_pending_metrics
+from utility_scripts.stage_logger import log_stage
+from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+
+LOCAL_REVIEW_TIMEOUT_SECONDS: int = 900
+LOCAL_REVIEW_METRICS_KEY: str = "local_review"
+REVIEW_WORKTREE_DIRNAME: str = "forge_prepublication_review_worktrees"
+FINDINGS_TITLE: str = "# Forge pre-push review findings"
+FINDINGS_PREAMBLE: str = (
+    "Rendered by Forge from the pre-push branch review of §FS-local-branch-review.\n"
+    "Newest entry first; every finding is recorded, including one the reviewer repaired."
+)
+UNAVAILABLE_FINDING_TITLE: str = "Pre-push review unavailable"
+UNAVAILABLE_FINDING_BODY: str = (
+    "Forge could not obtain a readable pre-push review verdict. This records a review "
+    "availability problem, not a reviewer finding against the branch."
+)
+MAX_REVIEW_TEXT_CHARS: int = 20_000
+
+REVIEW_SKILLS_BY_TASK_TYPE: dict[str, str] = {
+    "library-new-request": "review-library-new-request",
+    "library-update-request": "review-library-update-request",
+    "fixes-javac-fail": "review-fixes-javac-fail",
+    "fixes-java-run-fail": "review-fixes-java-run-fail",
+    "fixes-native-image-run-fail": "review-fixes-native-image-run-fail",
+    "not-for-native-image": "review-library-new-request",
+}
+
+PostReviewFinalization = Callable[[], bool]
+StagePublicationChanges = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class LocalReviewVerdict:
+    """The reviewer's structured output, preserved without reinterpretation."""
+
+    decision: str
+    review_comment: str
+    finding_title: str
+    finding_body: str
+    fix_note: str
+
+
+@dataclass(frozen=True)
+class ReviewExecution:
+    """The observable result of the isolated reviewer process."""
+
+    verdict: LocalReviewVerdict | None
+    session_log_path: str
+    changed_paths: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LocalBranchReviewOutcome:
+    """Reviewer-owned verdict plus the downstream facts Forge derives."""
+
+    status: str
+    model: str
+    session_log_path: str
+    local_ci_verification: LocalCIVerificationResult
+    verdict: LocalReviewVerdict | None = None
+    changed_paths: list[str] = field(default_factory=list)
+    repair_reverted: bool = False
+    failed_step: str | None = None
+
+    @property
+    def is_approved(self) -> bool:
+        """Return only the reviewer's decision; reset state is a separate Forge fact."""
+        return self.verdict is not None and self.verdict.decision == "approved"
+
+    @property
+    def review_comment(self) -> str:
+        """Expose the reviewer's comment without synthesizing one for outages."""
+        return "" if self.verdict is None else self.verdict.review_comment
+
+    def to_descriptor_payload(self) -> dict[str, Any]:
+        """Return the descriptor object consumed by the trusted publisher."""
+        payload: dict[str, Any] = {
+            "status": self.status,
+            "model": self.model,
+            "session_log_path": self.session_log_path,
+            "changed_paths": list(self.changed_paths[:200]),
+            "repair_reverted": self.repair_reverted,
+            "failed_step": self.failed_step,
+            "published_tree": (
+                "verified" if self.repair_reverted or not self.changed_paths else "repaired"
+            ),
+        }
+        if self.verdict is not None:
+            payload.update({
+                "decision": self.verdict.decision,
+                "review_comment": self.verdict.review_comment,
+                "finding_title": self.verdict.finding_title,
+                "finding_body": self.verdict.finding_body,
+                "fix_note": self.verdict.fix_note,
+            })
+        return payload
+
+    @classmethod
+    def from_descriptor_payload(
+            cls,
+            payload: dict[str, Any],
+            local_ci_verification: LocalCIVerificationResult,
+    ) -> LocalBranchReviewOutcome:
+        """Reconstruct a persisted verdict without re-running the reviewer."""
+        status: str = str(payload["status"])
+        verdict: LocalReviewVerdict | None = None
+        if status == "completed":
+            verdict = LocalReviewVerdict(
+                decision=str(payload["decision"]),
+                review_comment=str(payload["review_comment"]),
+                finding_title=str(payload["finding_title"]),
+                finding_body=str(payload["finding_body"]),
+                fix_note=str(payload["fix_note"]),
+            )
+        return cls(
+            status=status,
+            model=str(payload["model"]),
+            session_log_path=str(payload["session_log_path"]),
+            local_ci_verification=local_ci_verification,
+            verdict=verdict,
+            changed_paths=[str(path) for path in payload.get("changed_paths", [])],
+            repair_reverted=bool(payload.get("repair_reverted")),
+            failed_step=(
+                str(payload["failed_step"])
+                if isinstance(payload.get("failed_step"), str)
+                else None
+            ),
+        )
+
+
+def _log_review(message: str, indent_level: int = 0) -> None:
+    log_stage("local-review", message, indent_level=indent_level)
+
+
+def _git_stdout(repo_path: str, args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo_path, text=True).strip()
+
+
+def review_model_name(model: str | None = None) -> str:
+    """Return the effective centralized analysis model used for local review."""
+    selection: AgentSelection = get_analysis_agent()
+    if model and not os.environ.get("FORGE_ANALYSIS_MODEL"):
+        return model
+    return selection.model
+
+
+def run_local_branch_review(
+        *,
+        repo_path: str,
+        coordinates: str,
+        base_commit: str,
+        task_type: str,
+        local_ci_verification: LocalCIVerificationResult,
+        descriptor_input: Any,
+        metrics_repo_path: str | None = None,
+        model: str | None = None,
+        post_review_finalization: PostReviewFinalization | None = None,
+        stage_publication_changes: StagePublicationChanges | None = None,
+) -> LocalBranchReviewOutcome:
+    """Review once, verify actual edits, and always return a publishable outcome.
+
+    Reviewer findings never reach the deterministic repair agent. The reviewer
+    reports and edits in one cold pass; Git alone decides whether finalization
+    and the gate run again. §FS-local-branch-review
+    """
+    persisted: LocalBranchReviewOutcome | None = _load_persisted_outcome(
+        metrics_repo_path,
+        local_ci_verification,
+        descriptor_input,
+    )
+    if persisted is not None:
+        _log_review("Reusing the persisted pre-push review verdict", indent_level=1)
+        return persisted
+
+    review_model: str = review_model_name(model)
+    base_sha: str = _git_stdout(repo_path, ["rev-parse", f"{base_commit}^{{commit}}"])
+    verified_sha: str = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+    _log_review(
+        f"Reviewing {coordinates} at {verified_sha[:12]} against {base_sha[:12]} "
+        f"with {review_model}"
+    )
+
+    execution: ReviewExecution = _request_review(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        base_sha=base_sha,
+        verified_sha=verified_sha,
+        task_type=task_type,
+        review_model=review_model,
+        local_ci_verification=local_ci_verification,
+        descriptor_input=descriptor_input,
+    )
+    outcome = LocalBranchReviewOutcome(
+        status="unavailable" if execution.verdict is None else "completed",
+        model=review_model,
+        session_log_path=execution.session_log_path,
+        local_ci_verification=local_ci_verification,
+        verdict=execution.verdict,
+        changed_paths=list(execution.changed_paths),
+    )
+
+    if execution.changed_paths:
+        _log_review(
+            f"Reviewer changed {len(execution.changed_paths)} path(s); "
+            "re-running finalization and the pre-publication gate",
+            indent_level=1,
+        )
+        _verify_reviewer_edits(
+            repo_path=repo_path,
+            coordinates=coordinates,
+            base_commit=base_commit,
+            verified_sha=verified_sha,
+            metrics_repo_path=metrics_repo_path,
+            original_verification=local_ci_verification,
+            outcome=outcome,
+            post_review_finalization=post_review_finalization,
+            stage_publication_changes=stage_publication_changes,
+        )
+    else:
+        _log_review("Reviewer made no branch edits; verification is not repeated", indent_level=1)
+
+    _record_outcome_finding(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        descriptor_input=descriptor_input,
+        outcome=outcome,
+    )
+    _persist_outcome(
+        metrics_repo_path,
+        descriptor_input,
+        outcome,
+    )
+    return outcome
+
+
+def _verify_reviewer_edits(
+        *,
+        repo_path: str,
+        coordinates: str,
+        base_commit: str,
+        verified_sha: str,
+        metrics_repo_path: str | None,
+        original_verification: LocalCIVerificationResult,
+        outcome: LocalBranchReviewOutcome,
+        post_review_finalization: PostReviewFinalization | None,
+        stage_publication_changes: StagePublicationChanges | None,
+) -> None:
+    """Re-run both deterministic tiers and reset only reviewer-covered edits on failure."""
+    failed_step: str | None = _run_finalization(post_review_finalization)
+    if failed_step is not None:
+        if stage_publication_changes is not None:
+            stage_publication_changes()
+        run_repair_agent(
+            repo_path=repo_path,
+            prompt=_build_deterministic_repair_prompt(coordinates, failed_step),
+            task_type="local-review-check-repair",
+            library=coordinates,
+            commit_message="Repair post-review finalization failure",
+        )
+        failed_step = _run_finalization(post_review_finalization)
+        if failed_step is not None:
+            _reset_reviewer_edits(
+                repo_path, verified_sha, metrics_repo_path, original_verification,
+            )
+            outcome.repair_reverted = True
+            outcome.failed_step = failed_step
+            return
+
+    if stage_publication_changes is not None:
+        stage_publication_changes()
+
+    try:
+        outcome.local_ci_verification = run_local_ci_verification(
+            repo_path=repo_path,
+            coordinates=coordinates,
+            base_commit=base_commit,
+            metrics_repo_path=metrics_repo_path,
+        )
+    except LocalCIVerificationError as error:
+        _reset_reviewer_edits(
+            repo_path, verified_sha, metrics_repo_path, original_verification,
+        )
+        outcome.local_ci_verification = original_verification
+        outcome.repair_reverted = True
+        outcome.failed_step = error.result.failure_gate or "pre-publication-gate"
+
+
+def _run_finalization(finalization: PostReviewFinalization | None) -> str | None:
+    """Run route-owned finalization and return the failing step, if any."""
+    if finalization is None:
+        return "post-review-finalization-not-configured"
+    try:
+        if finalization():
+            return None
+    except Exception as error:  # The review phase degrades instead of failing publication. §FS-local-branch-review
+        step = getattr(error, "step", None)
+        return str(step or type(error).__name__)
+    return "post-review-finalization"
+
+
+def _reset_reviewer_edits(
+        repo_path: str,
+        verified_sha: str,
+        metrics_repo_path: str | None,
+        original_verification: LocalCIVerificationResult,
+) -> None:
+    """Restore the tree the gate verified and its matching verification record."""
+    subprocess.run(["git", "reset", "--hard", verified_sha], cwd=repo_path, check=True)
+    write_verification_metrics(metrics_repo_path, original_verification)
+    _log_review(
+        f"Post-review checks did not pass; restored verified commit {verified_sha[:12]}",
+        indent_level=1,
+    )
+
+
+def _build_deterministic_repair_prompt(coordinates: str, failed_step: str) -> str:
+    return "\n".join([
+        "A deterministic check failed after the pre-push reviewer edited the branch.",
+        "Fix only that check's failure, keep the reviewer's intended repair intact when possible,",
+        "and do not edit forge/FINDINGS.md. The deterministic rerun will decide the outcome.",
+        "",
+        f"Library: {coordinates}",
+        f"Failed step: {failed_step}",
+    ])
+
+
+def _request_review(
+        *,
+        repo_path: str,
+        coordinates: str,
+        base_sha: str,
+        verified_sha: str,
+        task_type: str,
+        review_model: str,
+        local_ci_verification: LocalCIVerificationResult,
+        descriptor_input: Any,
+) -> ReviewExecution:
+    """Run the isolated reviewer, transfer its Git edits, and return its verdict."""
+    unavailable_log_path: str = build_timestamped_task_log_path(
+        "local-review", coordinates, "local_branch_review"
+    )
+    worktree_path: str | None = _create_review_worktree(repo_path, verified_sha)
+    if worktree_path is None:
+        _write_unavailable_log(
+            unavailable_log_path, "Could not create detached review worktree.",
+        )
+        return ReviewExecution(None, display_log_path(unavailable_log_path))
+
+    try:
+        evidence_dir: str = os.path.join(
+            worktree_path, f".forge-local-review-{uuid.uuid4().hex[:8]}"
+        )
+        os.makedirs(evidence_dir)
+        evidence_path: str = os.path.join(evidence_dir, "review-evidence.json")
+        verdict_path: str = os.path.join(evidence_dir, "verdict.json")
+        _write_evidence(
+            evidence_path,
+            coordinates,
+            task_type,
+            local_ci_verification,
+            descriptor_input,
+        )
+        prompt: str = _build_review_prompt(
+            coordinates=coordinates,
+            base_sha=base_sha,
+            verified_sha=verified_sha,
+            task_type=task_type,
+            evidence_path=evidence_path,
+            verdict_path=verdict_path,
+        )
+        selection: AgentSelection = get_analysis_agent()
+        result: AgentRunResult = analysis_agent_run(
+            working_dir=worktree_path,
+            context=prompt,
+            task_type="local-branch-review",
+            library=coordinates,
+            timeout=LOCAL_REVIEW_TIMEOUT_SECONDS,
+            model=review_model,
+            thinking_level="medium",
+        )
+        displayed_log_path: str = display_log_path(result.log_path)
+        _log_review(
+            f"{selection.backend} review log: {displayed_log_path}",
+            indent_level=1,
+        )
+        if result.return_code != 0:
+            if result.timed_out:
+                detail: str = (
+                    f"timed out after {LOCAL_REVIEW_TIMEOUT_SECONDS} seconds"
+                )
+            else:
+                detail = f"exited with code {result.return_code}"
+            _log_review(
+                f"Review {detail}",
+                indent_level=1,
+            )
+            return ReviewExecution(None, displayed_log_path)
+
+        verdict: LocalReviewVerdict | None = _read_verdict(verdict_path)
+        if verdict is None:
+            return ReviewExecution(None, displayed_log_path)
+        shutil.rmtree(evidence_dir, ignore_errors=True)
+        changed_paths: list[str] = _commit_reviewer_edits(worktree_path, verified_sha)
+        if changed_paths and (
+                not verdict.finding_title.strip() or not verdict.fix_note.strip()
+        ):
+            _log_review(
+                "Reviewer edited the tree without a complete finding and fix note",
+                indent_level=1,
+            )
+            return ReviewExecution(None, displayed_log_path)
+        if changed_paths:
+            review_commit: str = _git_stdout(worktree_path, ["rev-parse", "HEAD"])
+            subprocess.run(["git", "cherry-pick", review_commit], cwd=repo_path, check=True)
+        return ReviewExecution(verdict, displayed_log_path, changed_paths)
+    finally:
+        _remove_review_worktree(repo_path, worktree_path)
+
+
+def _commit_reviewer_edits(worktree_path: str, verified_sha: str) -> list[str]:
+    """Stage and commit actual review-worktree edits, excluding the findings record."""
+    reviewer_head: str = _git_stdout(worktree_path, ["rev-parse", "HEAD"])
+    if reviewer_head != verified_sha:
+        # Normalize an accidental reviewer commit back to worktree edits so
+        # Forge remains the only party that stages and commits the repair.
+        subprocess.run(["git", "reset", "--mixed", verified_sha], cwd=worktree_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True)
+    findings_path: str = os.path.join(worktree_path, FINDINGS_RELATIVE_PATH)
+    tracked_finding = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", FINDINGS_RELATIVE_PATH],
+        cwd=worktree_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).returncode == 0
+    if tracked_finding:
+        subprocess.run(
+            [
+                "git", "restore", "--source=HEAD", "--staged", "--worktree", "--",
+                FINDINGS_RELATIVE_PATH,
+            ],
+            cwd=worktree_path,
+            check=True,
+        )
+    elif os.path.isfile(findings_path):
+        os.remove(findings_path)
+        subprocess.run(
+            ["git", "restore", "--staged", "--", FINDINGS_RELATIVE_PATH],
+            cwd=worktree_path,
+            check=False,
+        )
+
+    changed_output: str = subprocess.check_output(
+        ["git", "diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRTD"],
+        cwd=worktree_path,
+        text=True,
+    )
+    changed_paths: list[str] = [path for path in changed_output.split("\0") if path]
+    if changed_paths:
+        subprocess.run(
+            ["git", "commit", "-m", "Apply pre-push reviewer edits"],
+            cwd=worktree_path,
+            check=True,
+        )
+    return changed_paths
+
+
+def _create_review_worktree(repo_path: str, head_sha: str) -> str | None:
+    """Detach a cold worktree at the verified commit from the shared object store."""
+    worktree_root: str = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "local_repositories",
+        REVIEW_WORKTREE_DIRNAME,
+    )
+    os.makedirs(worktree_root, exist_ok=True)
+    worktree_path: str = os.path.join(worktree_root, f"review-{uuid.uuid4().hex[:8]}")
+    result = subprocess.run(
+        ["git", "worktree", "add", "--detach", worktree_path, head_sha],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        _log_review(
+            f"Failed to create the isolated review worktree: {result.stdout.strip()}",
+            indent_level=1,
+        )
+        return None
+    return worktree_path
+
+
+def _remove_review_worktree(repo_path: str, worktree_path: str) -> None:
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", worktree_path],
+        cwd=repo_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if os.path.isdir(worktree_path):
+        shutil.rmtree(worktree_path, ignore_errors=True)
+
+
+def _write_evidence(
+        evidence_path: str,
+        coordinates: str,
+        task_type: str,
+        local_ci_verification: LocalCIVerificationResult,
+        descriptor_input: Any,
+) -> None:
+    """Write local gate records and resolved descriptor statistics for the reviewer."""
+    evidence: dict[str, Any] = {
+        "coordinates": coordinates,
+        "task_type": task_type,
+        "local_ci_verification": local_ci_verification.to_metrics(),
+    }
+    render = getattr(descriptor_input, "render", None)
+    if isinstance(render, dict):
+        evidence["render"] = copy.deepcopy(render)
+    run_metrics = getattr(descriptor_input, "run_metrics", None)
+    if isinstance(run_metrics, dict):
+        evidence_run_metrics: dict[str, Any] = copy.deepcopy(run_metrics)
+        evidence_run_metrics.pop(LOCAL_REVIEW_METRICS_KEY, None)
+        evidence["run_metrics"] = evidence_run_metrics
+    for attribute in ("issue_number", "template_type", "status", "previous_coordinates"):
+        evidence[attribute] = getattr(descriptor_input, attribute, None)
+    with open(evidence_path, "w", encoding="utf-8") as evidence_file:
+        json.dump(evidence, evidence_file, indent=2, sort_keys=True, default=str)
+        evidence_file.write("\n")
+
+
+def _read_verdict(verdict_path: str) -> LocalReviewVerdict | None:
+    """Read one complete verdict, treating any malformed output as unavailable."""
+    if not os.path.isfile(verdict_path):
+        _log_review("Review wrote no verdict file", indent_level=1)
+        return None
+    try:
+        with open(verdict_path, "r", encoding="utf-8") as verdict_file:
+            payload = json.load(verdict_file)
+    except (OSError, json.JSONDecodeError) as error:
+        _log_review(f"Review verdict could not be read: {error}", indent_level=1)
+        return None
+    if not isinstance(payload, dict) or payload.get("decision") not in {
+        "approved", "changes_requested",
+    }:
+        _log_review("Review verdict did not carry a valid decision", indent_level=1)
+        return None
+
+    values: dict[str, str] = {}
+    for key in ("review_comment", "finding_title", "finding_body", "fix_note"):
+        value = payload.get(key)
+        if not isinstance(value, str) or len(value) > MAX_REVIEW_TEXT_CHARS:
+            _log_review(f"Review verdict carried an invalid {key}", indent_level=1)
+            return None
+        values[key] = value
+    if not values["review_comment"].strip():
+        _log_review("Review verdict carried no review comment", indent_level=1)
+        return None
+    if bool(values["finding_title"].strip()) != bool(values["finding_body"].strip()):
+        _log_review("Review verdict carried an incomplete finding", indent_level=1)
+        return None
+    if payload["decision"] == "changes_requested" and not values["finding_title"].strip():
+        _log_review("Review requested changes without a finding", indent_level=1)
+        return None
+    return LocalReviewVerdict(
+        decision=str(payload["decision"]),
+        review_comment=values["review_comment"],
+        finding_title=values["finding_title"],
+        finding_body=values["finding_body"],
+        fix_note=values["fix_note"],
+    )
+
+
+def _build_review_prompt(
+        *,
+        coordinates: str,
+        base_sha: str,
+        verified_sha: str,
+        task_type: str,
+        evidence_path: str,
+        verdict_path: str,
+) -> str:
+    """Build the cold review-and-repair prompt from local evidence."""
+    skill: str = REVIEW_SKILLS_BY_TASK_TYPE[task_type]
+    return "\n".join([
+        f"Review the branch Forge is about to push for {coordinates}.",
+        "There is no pull request yet. Use these local equivalents:",
+        f"- Review `git diff {base_sha} {verified_sha}`; it is the eventual PR diff minus the descriptor.",
+        f"- Apply every relevant enumerated rule in `skills/{skill}/SKILL.md`.",
+        f"- Read local gate records and resolved render statistics from `{evidence_path}`.",
+        "- Ignore skill steps about `gh`, PR labels, reviews, merges, and remote CI status.",
+        "",
+        "This is a detached worktree and a cold session. Do not run `gh`, push, commit, or edit "
+        "forge/FINDINGS.md. Request changes only for a concrete violation of an enumerated rule.",
+        "",
+        "When you find a violation, report it and make the smallest safe correction in this worktree "
+        "in this same pass. If you can correct it, approve the resulting tree. If you cannot, leave "
+        "the tree unchanged (or retain only useful partial edits) and request changes. Forge, not your "
+        "verdict text, will use Git to determine whether any path changed and which checks must rerun.",
+        "",
+        f"Write exactly one JSON verdict to `{verdict_path}`. This is the only judgment Forge reads:",
+        json.dumps({
+            "decision": "approved",
+            "review_comment": "What you checked and concluded.",
+            "finding_title": "Reusable defect title, or empty when no finding.",
+            "finding_body": "Rule violation and location, or empty when no finding.",
+            "fix_note": "What you changed and why, or empty when you made no correction.",
+        }, indent=2),
+        "",
+        "Keep a repaired finding's title and body in the verdict even when the repaired tree is "
+        "approved. The decision and fix note must state your judgment and your edits; Forge records "
+        "them as returned and will not rewrite them.",
+    ])
+
+
+def _record_outcome_finding(
+        *,
+        repo_path: str,
+        coordinates: str,
+        descriptor_input: Any,
+        outcome: LocalBranchReviewOutcome,
+) -> None:
+    """Record reviewer findings and the fixed outage finding after any checkpoint reset."""
+    if outcome.verdict is None:
+        title: str = UNAVAILABLE_FINDING_TITLE
+        body: str = UNAVAILABLE_FINDING_BODY
+    elif outcome.verdict.finding_title:
+        title = outcome.verdict.finding_title
+        body = outcome.verdict.finding_body
+    else:
+        return
+    _record_finding(
+        repo_path=repo_path,
+        coordinates=coordinates,
+        descriptor_input=descriptor_input,
+        title=title,
+        body=body,
+    )
+
+
+def _record_finding(
+        *,
+        repo_path: str,
+        coordinates: str,
+        descriptor_input: Any,
+        title: str,
+        body: str,
+) -> None:
+    """Render a stable newest-first finding entry and commit it."""
+    findings_path: str = os.path.join(repo_path, FINDINGS_RELATIVE_PATH)
+    entry: str = _render_finding_entry(coordinates, descriptor_input, title, body)
+    existing: str = ""
+    if os.path.isfile(findings_path):
+        with open(findings_path, "r", encoding="utf-8") as findings_file:
+            existing = findings_file.read()
+    if existing.startswith(FINDINGS_TITLE):
+        header, _, entries = existing.partition("\n## ")
+        header_block: str = header.rstrip("\n")
+        remaining: str = f"## {entries}" if entries else ""
+    else:
+        header_block = f"{FINDINGS_TITLE}\n\n{FINDINGS_PREAMBLE}"
+        remaining = existing.strip()
+    updated: str = f"{header_block}\n\n{entry}"
+    if remaining:
+        updated += f"\n{remaining.rstrip()}\n"
+    os.makedirs(os.path.dirname(findings_path), exist_ok=True)
+    with open(findings_path, "w", encoding="utf-8") as findings_file:
+        findings_file.write(updated)
+    stage_and_commit(
+        [FINDINGS_RELATIVE_PATH],
+        f"Record pre-push review finding for {coordinates}",
+        cwd=repo_path,
+    )
+    _log_review(f"Recorded '{title}' in {FINDINGS_RELATIVE_PATH}", indent_level=1)
+
+
+def _render_finding_entry(
+        coordinates: str,
+        descriptor_input: Any,
+        title: str,
+        body: str,
+) -> str:
+    """Render one finding only from its reviewer-supplied title and body."""
+    group, artifact, version = parse_coordinate_parts(coordinates)
+    issue_number = getattr(descriptor_input, "issue_number", None)
+    issue_reference: str = f" (#{issue_number})" if issue_number else ""
+    date: str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return "\n".join([
+        f"## {date} — {group}:{artifact}:{version}{issue_reference}",
+        "",
+        f"**{title}**",
+        "",
+        body,
+        "",
+    ])
+
+
+def _load_persisted_outcome(
+        metrics_repo_path: str | None,
+        local_ci_verification: LocalCIVerificationResult,
+        descriptor_input: Any,
+) -> LocalBranchReviewOutcome | None:
+    if metrics_repo_path is None:
+        return None
+    try:
+        metrics: dict[str, Any] = read_pending_metrics(metrics_repo_path)
+    except (OSError, ValueError, TypeError):
+        return None
+    state = metrics.get(LOCAL_REVIEW_METRICS_KEY)
+    if not isinstance(state, dict):
+        return None
+    expected_timestamp = getattr(descriptor_input, "timestamp", None)
+    if state.get("timestamp") != expected_timestamp:
+        return None
+    payload = state.get("outcome")
+    if not isinstance(payload, dict):
+        return None
+    try:
+        return LocalBranchReviewOutcome.from_descriptor_payload(
+            payload, local_ci_verification,
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _persist_outcome(
+        metrics_repo_path: str | None,
+        descriptor_input: Any,
+        outcome: LocalBranchReviewOutcome,
+) -> None:
+    """Stage the verdict with the run's durable in-flight publication data."""
+    if metrics_repo_path is None:
+        return
+    try:
+        metrics: dict[str, Any] = read_pending_metrics(metrics_repo_path)
+    except (OSError, ValueError, TypeError):
+        metrics = {}
+    metrics[LOCAL_REVIEW_METRICS_KEY] = {
+        "timestamp": getattr(descriptor_input, "timestamp", None),
+        "outcome": outcome.to_descriptor_payload(),
+    }
+    write_pending_metrics(metrics_repo_path, metrics)
+
+
+def _write_unavailable_log(log_path: str, detail: str) -> None:
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(f"# Pre-push local review unavailable\n\n{detail}\n")

--- a/forge/git_scripts/publication_descriptor.py
+++ b/forge/git_scripts/publication_descriptor.py
@@ -165,6 +165,7 @@ def write_publication_descriptor(
         base_commit: str,
         descriptor_input: PublicationDescriptorInput,
         local_ci_verification: LocalCIVerificationResult,
+        local_review: dict[str, Any] | None,
 ) -> str:
     """Write and validate the descriptor that Actions will treat as data."""
     if descriptor_input.status not in ELIGIBLE_STATUSES:
@@ -197,6 +198,8 @@ def write_publication_descriptor(
         "follow_ups": copy.deepcopy(descriptor_input.follow_ups),
         "render": copy.deepcopy(descriptor_input.render),
     }
+    if local_review is not None:
+        descriptor["local_review"] = copy.deepcopy(local_review)
     if descriptor_input.previous_coordinates:
         previous_group, previous_artifact, previous_version = parse_coordinate_parts(
             descriptor_input.previous_coordinates,

--- a/forge/tests/test_branch_publication.py
+++ b/forge/tests/test_branch_publication.py
@@ -27,6 +27,16 @@ def _git(repo_path: str, *args: str) -> str:
 
 
 class BranchPublicationTests(unittest.TestCase):
+    def test_code_coverage_is_excluded_from_local_review(self) -> None:
+        self.assertIn(
+            "code-coverage-improvement",
+            branch_publication.LOCAL_REVIEW_EXCLUDED_TASK_TYPES,
+        )
+        self.assertNotIn(
+            "library-new-request",
+            branch_publication.LOCAL_REVIEW_EXCLUDED_TASK_TYPES,
+        )
+
     def test_format_bounded_test_diff_section_truncates_large_diff(self) -> None:
         diff_text = "Q" * (branch_publication.MAX_INLINE_TEST_DIFF_CHARS + 1)
         with patch.object(

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from typing import Any
 
-from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
 
 REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PUBLISHER_PATH = os.path.join(
@@ -109,6 +109,23 @@ def _descriptor(**render_overrides: Any) -> dict[str, Any]:
     }
 
 
+def _local_review() -> dict[str, Any]:
+    return {
+        "status": "completed",
+        "decision": "approved",
+        "review_comment": "Checked the publication rules; no blocking issue remains.",
+        "finding_title": "",
+        "finding_body": "",
+        "fix_note": "",
+        "model": "gpt-5.6-terra",
+        "session_log_path": "task-logs/review.log",
+        "changed_paths": [],
+        "repair_reverted": False,
+        "failed_step": None,
+        "published_tree": "verified",
+    }
+
+
 class CoveragePublisherTemplateTests(unittest.TestCase):
 
     def test_descriptor_is_schema_valid(self) -> None:
@@ -116,6 +133,45 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
             schema = json.load(schema_file)
 
         Draft202012Validator(schema, format_checker=FormatChecker()).validate(_descriptor())
+
+    def test_unavailable_review_has_no_reviewer_words(self) -> None:
+        review = _local_review()
+        review["status"] = "unavailable"
+        for field in (
+                "decision", "review_comment", "finding_title", "finding_body", "fix_note",
+        ):
+            review.pop(field)
+        with open(SCHEMA_PATH, encoding="utf-8") as schema_file:
+            schema = json.load(schema_file)
+
+        Draft202012Validator(
+            schema["properties"]["local_review"], format_checker=FormatChecker(),
+        ).validate(review)
+        body = publisher._render_local_review({"local_review": review})
+
+        self.assertIn("reviewer was unavailable", body)
+        self.assertIn("no reviewer verdict or finding", body)
+        self.assertNotIn("Checked the publication rules", body)
+
+    def test_nonapproval_requires_a_complete_finding(self) -> None:
+        review = _local_review()
+        review["decision"] = "changes_requested"
+        with open(SCHEMA_PATH, encoding="utf-8") as schema_file:
+            schema = json.load(schema_file)
+
+        with self.assertRaises(ValidationError):
+            Draft202012Validator(
+                schema["properties"]["local_review"], format_checker=FormatChecker(),
+            ).validate(review)
+
+    def test_code_coverage_descriptor_rejects_local_review(self) -> None:
+        descriptor = _descriptor()
+        descriptor["local_review"] = _local_review()
+        with open(SCHEMA_PATH, encoding="utf-8") as schema_file:
+            schema = json.load(schema_file)
+
+        with self.assertRaises(ValidationError):
+            Draft202012Validator(schema, format_checker=FormatChecker()).validate(descriptor)
 
     def test_title_names_the_coordinate_and_the_model(self) -> None:
         title, _ = publisher.render_publication(_descriptor())
@@ -195,6 +251,21 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
         self.assertIn("Needs human intervention: yes", body)
         self.assertIn("### Local CI Verification", body)
         self.assertIn("Forge-Publication-ID: forge-8380-20260820101530-0123456789ab", body)
+
+    def test_body_omits_the_local_agent_review(self) -> None:
+        _, body = publisher.render_publication(_descriptor())
+
+        self.assertNotIn("## Local Agent Review", body)
+
+    def test_review_nonapproval_or_reverted_repair_requires_intervention(self) -> None:
+        descriptor = {"local_review": _local_review()}
+        self.assertFalse(publisher._local_review_requires_human_intervention(descriptor))
+        descriptor["local_review"]["decision"] = "changes_requested"
+        self.assertTrue(publisher._local_review_requires_human_intervention(descriptor))
+        descriptor["local_review"]["decision"] = "approved"
+        descriptor["local_review"]["repair_reverted"] = True
+        descriptor["local_review"]["failed_step"] = "checkMetadataFiles"
+        self.assertTrue(publisher._local_review_requires_human_intervention(descriptor))
 
     def test_body_omits_the_forge_revision_block(self) -> None:
         """A Rhei-template workflow has no Forge strategy revision to report."""

--- a/forge/tests/test_local_branch_review.py
+++ b/forge/tests/test_local_branch_review.py
@@ -1,0 +1,335 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from git_scripts import local_branch_review as module
+from utility_scripts.local_ci_verification import LocalCIVerificationResult
+from utility_scripts.metrics_writer import read_pending_metrics, write_pending_metrics
+
+
+def _git(repo_path: str, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo_path, text=True).strip()
+
+
+def _verdict() -> module.LocalReviewVerdict:
+    return module.LocalReviewVerdict(
+        decision="approved",
+        review_comment="Checked every applicable rule.",
+        finding_title="Unsafe test shortcut",
+        finding_body="The test called an internal method directly.",
+        fix_note="Replaced the shortcut with the supported public API.",
+    )
+
+
+class LocalBranchReviewTests(unittest.TestCase):
+    def test_verdict_reader_preserves_every_reviewer_field(self) -> None:
+        payload = {
+            "decision": "approved",
+            "review_comment": "Checked every rule.\n",
+            "finding_title": "Reusable title",
+            "finding_body": "Concrete body.\n",
+            "fix_note": "Changed the public call path.\n",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            verdict_path = os.path.join(directory, "verdict.json")
+            with open(verdict_path, "w", encoding="utf-8") as verdict_file:
+                json.dump(payload, verdict_file)
+
+            verdict = module._read_verdict(verdict_path)
+
+        self.assertIsNotNone(verdict)
+        self.assertEqual(verdict.decision, payload["decision"])
+        self.assertEqual(verdict.review_comment, payload["review_comment"])
+        self.assertEqual(verdict.finding_title, payload["finding_title"])
+        self.assertEqual(verdict.finding_body, payload["finding_body"])
+        self.assertEqual(verdict.fix_note, payload["fix_note"])
+
+    def test_git_detects_reviewer_edits_and_ignores_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            subprocess.run(["git", "init", "-q"], cwd=repo_path, check=True)
+            subprocess.run(["git", "config", "user.name", "Forge Test"], cwd=repo_path, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "forge-test@example.invalid"],
+                cwd=repo_path,
+                check=True,
+            )
+            os.makedirs(os.path.join(repo_path, "forge"))
+            source_path = os.path.join(repo_path, "source.txt")
+            findings_path = os.path.join(repo_path, module.FINDINGS_RELATIVE_PATH)
+            with open(source_path, "w", encoding="utf-8") as source_file:
+                source_file.write("before\n")
+            with open(findings_path, "w", encoding="utf-8") as findings_file:
+                findings_file.write("original findings\n")
+            subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+            subprocess.run(["git", "commit", "-qm", "Initial"], cwd=repo_path, check=True)
+            original_commit = _git(repo_path, "rev-parse", "HEAD")
+
+            with open(source_path, "w", encoding="utf-8") as source_file:
+                source_file.write("reviewer edit\n")
+            with open(findings_path, "w", encoding="utf-8") as findings_file:
+                findings_file.write("reviewer must not own this file\n")
+
+            changed_paths = module._commit_reviewer_edits(repo_path, original_commit)
+
+            self.assertEqual(changed_paths, ["source.txt"])
+            self.assertNotEqual(_git(repo_path, "rev-parse", "HEAD"), original_commit)
+            with open(findings_path, encoding="utf-8") as findings_file:
+                self.assertEqual(findings_file.read(), "original findings\n")
+
+    def test_unchanged_tree_does_not_rerun_checks(self) -> None:
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        finalization = Mock(return_value=True)
+        stage = Mock()
+        descriptor_input = SimpleNamespace(timestamp="2026-08-25T10:00:00Z")
+        execution = module.ReviewExecution(_verdict(), "task-logs/review.log", [])
+
+        with patch.object(module, "_load_persisted_outcome", return_value=None), \
+                patch.object(module, "_git_stdout", side_effect=["base", "head"]), \
+                patch.object(module, "_request_review", return_value=execution), \
+                patch.object(module, "_record_outcome_finding"), \
+                patch.object(module, "_persist_outcome"), \
+                patch.object(module, "run_local_ci_verification") as local_ci:
+            outcome = module.run_local_branch_review(
+                repo_path="/repo",
+                coordinates="org.example:demo:1.0.0",
+                base_commit="base",
+                task_type="library-new-request",
+                local_ci_verification=verification,
+                descriptor_input=descriptor_input,
+                post_review_finalization=finalization,
+                stage_publication_changes=stage,
+            )
+
+        self.assertIs(outcome.local_ci_verification, verification)
+        finalization.assert_not_called()
+        stage.assert_not_called()
+        local_ci.assert_not_called()
+
+    def test_changed_tree_reruns_finalization_and_gate(self) -> None:
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        reverified = LocalCIVerificationResult(status="success", base_commit="base")
+        finalization = Mock(return_value=True)
+        stage = Mock()
+        descriptor_input = SimpleNamespace(timestamp="2026-08-25T10:00:00Z")
+        execution = module.ReviewExecution(_verdict(), "task-logs/review.log", ["source.txt"])
+
+        with patch.object(module, "_load_persisted_outcome", return_value=None), \
+                patch.object(module, "_git_stdout", side_effect=["base", "head"]), \
+                patch.object(module, "_request_review", return_value=execution), \
+                patch.object(module, "_record_outcome_finding"), \
+                patch.object(module, "_persist_outcome"), \
+                patch.object(module, "run_local_ci_verification", return_value=reverified) as local_ci:
+            outcome = module.run_local_branch_review(
+                repo_path="/repo",
+                coordinates="org.example:demo:1.0.0",
+                base_commit="base",
+                task_type="library-new-request",
+                local_ci_verification=verification,
+                descriptor_input=descriptor_input,
+                post_review_finalization=finalization,
+                stage_publication_changes=stage,
+            )
+
+        self.assertIs(outcome.local_ci_verification, reverified)
+        finalization.assert_called_once_with()
+        stage.assert_called_once_with()
+        local_ci.assert_called_once()
+
+    def test_failed_finalization_gets_one_repair_then_resets(self) -> None:
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        verdict = _verdict()
+        outcome = module.LocalBranchReviewOutcome(
+            status="completed",
+            model="gpt-test",
+            session_log_path="task-logs/review.log",
+            local_ci_verification=verification,
+            verdict=verdict,
+            changed_paths=["source.txt"],
+        )
+        finalization = Mock(side_effect=[False, False])
+        stage = Mock()
+
+        with patch.object(module, "run_repair_agent") as repair, \
+                patch.object(module, "_reset_reviewer_edits") as reset, \
+                patch.object(module, "run_local_ci_verification") as local_ci:
+            module._verify_reviewer_edits(
+                repo_path="/repo",
+                coordinates="org.example:demo:1.0.0",
+                base_commit="base",
+                verified_sha="verified",
+                metrics_repo_path="/metrics",
+                original_verification=verification,
+                outcome=outcome,
+                post_review_finalization=finalization,
+                stage_publication_changes=stage,
+            )
+
+        self.assertIs(outcome.verdict, verdict)
+        self.assertTrue(outcome.repair_reverted)
+        self.assertEqual(outcome.failed_step, "post-review-finalization")
+        self.assertIs(outcome.local_ci_verification, verification)
+        self.assertEqual(finalization.call_count, 2)
+        repair.assert_called_once()
+        stage.assert_called_once_with()
+        reset.assert_called_once_with("/repo", "verified", "/metrics", verification)
+        local_ci.assert_not_called()
+
+    def test_failed_gate_resets_and_restores_the_verified_record(self) -> None:
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        failed = LocalCIVerificationResult(
+            status="failure",
+            base_commit="base",
+            failure_gate="validate-index-files",
+        )
+        verdict = _verdict()
+        outcome = module.LocalBranchReviewOutcome(
+            status="completed",
+            model="gpt-test",
+            session_log_path="task-logs/review.log",
+            local_ci_verification=verification,
+            verdict=verdict,
+            changed_paths=["source.txt"],
+        )
+
+        with patch.object(
+                module,
+                "run_local_ci_verification",
+                side_effect=module.LocalCIVerificationError(failed),
+            ), patch.object(module, "_reset_reviewer_edits") as reset:
+            module._verify_reviewer_edits(
+                repo_path="/repo",
+                coordinates="org.example:demo:1.0.0",
+                base_commit="base",
+                verified_sha="verified",
+                metrics_repo_path="/metrics",
+                original_verification=verification,
+                outcome=outcome,
+                post_review_finalization=lambda: True,
+                stage_publication_changes=Mock(),
+            )
+
+        self.assertIs(outcome.verdict, verdict)
+        self.assertIs(outcome.local_ci_verification, verification)
+        self.assertTrue(outcome.repair_reverted)
+        self.assertEqual(outcome.failed_step, "validate-index-files")
+        reset.assert_called_once_with("/repo", "verified", "/metrics", verification)
+
+    def test_persisted_verdict_is_scoped_to_publication_timestamp(self) -> None:
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        descriptor_input = SimpleNamespace(timestamp="2026-08-25T10:00:00Z")
+        outcome = module.LocalBranchReviewOutcome(
+            status="completed",
+            model="gpt-test",
+            session_log_path="task-logs/review.log",
+            local_ci_verification=verification,
+            verdict=_verdict(),
+        )
+        with tempfile.TemporaryDirectory() as metrics_path:
+            write_pending_metrics(metrics_path, {"status": "success"})
+            module._persist_outcome(
+                metrics_path,
+                descriptor_input,
+                outcome,
+            )
+
+            loaded = module._load_persisted_outcome(
+                metrics_path,
+                verification,
+                descriptor_input,
+            )
+            stale = module._load_persisted_outcome(
+                metrics_path,
+                verification,
+                SimpleNamespace(timestamp="2026-08-25T10:00:01Z"),
+            )
+            state = read_pending_metrics(metrics_path)[module.LOCAL_REVIEW_METRICS_KEY]
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.verdict, outcome.verdict)
+        self.assertIsNone(stale)
+        self.assertEqual(set(state), {"timestamp", "outcome"})
+        self.assertEqual(state["outcome"]["decision"], "approved")
+
+    def test_request_review_uses_centralized_analysis_agent(self) -> None:
+        verdict = _verdict()
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        descriptor_input = SimpleNamespace(render={})
+        result = SimpleNamespace(
+            return_code=0,
+            log_path="/task-logs/local-review/codex.log",
+            timed_out=False,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            review_worktree = os.path.join(directory, "review-worktree")
+            os.makedirs(review_worktree)
+            with patch.object(
+                    module,
+                    "build_timestamped_task_log_path",
+                    return_value=os.path.join(directory, "unavailable.log"),
+                ), patch.object(
+                    module, "_create_review_worktree", return_value=review_worktree,
+                ), patch.object(module, "_write_evidence"), \
+                patch.object(module, "_build_review_prompt", return_value="same prompt"), \
+                patch.object(
+                    module,
+                    "get_analysis_agent",
+                    return_value=SimpleNamespace(backend="codex", model="central-model"),
+                ), patch.object(
+                    module, "analysis_agent_run", return_value=result,
+                ) as run_agent, patch.object(
+                    module, "_read_verdict", return_value=verdict,
+                ), patch.object(
+                    module, "_commit_reviewer_edits", return_value=[],
+                ), patch.object(module, "_remove_review_worktree") as remove_worktree:
+                execution = module._request_review(
+                    repo_path="/repo",
+                    coordinates="org.example:demo:1.0.0",
+                    base_sha="base",
+                    verified_sha="verified",
+                    task_type="library-new-request",
+                    review_model="central-model",
+                    local_ci_verification=verification,
+                    descriptor_input=descriptor_input,
+                )
+
+        run_agent.assert_called_once_with(
+            working_dir=review_worktree,
+            context="same prompt",
+            task_type="local-branch-review",
+            library="org.example:demo:1.0.0",
+            timeout=module.LOCAL_REVIEW_TIMEOUT_SECONDS,
+            model="central-model",
+            thinking_level="medium",
+        )
+        self.assertEqual(execution.verdict, verdict)
+        self.assertEqual(
+            execution.session_log_path, module.display_log_path(result.log_path),
+        )
+        remove_worktree.assert_called_once_with("/repo", review_worktree)
+
+    def test_review_model_uses_centralized_analysis_selection(self) -> None:
+        selection = SimpleNamespace(model="central-model")
+        with patch.object(module, "get_analysis_agent", return_value=selection):
+            self.assertEqual(module.review_model_name(), "central-model")
+
+    def test_explicit_analysis_model_wins_over_caller_preference(self) -> None:
+        selection = SimpleNamespace(model="operator-model")
+        with patch.dict(os.environ, {"FORGE_ANALYSIS_MODEL": "operator-model"}), \
+                patch.object(module, "get_analysis_agent", return_value=selection):
+            self.assertEqual(
+                module.review_model_name("caller-model"), "operator-model",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_publish_not_for_native_image.py
+++ b/forge/tests/test_publish_not_for_native_image.py
@@ -8,6 +8,10 @@ import unittest
 from unittest.mock import patch
 
 from git_scripts import publish_not_for_native_image, branch_publication
+from git_scripts.local_branch_review import (
+    LocalBranchReviewOutcome,
+    LocalReviewVerdict,
+)
 from utility_scripts.local_ci_verification import LocalCIVerificationResult
 
 
@@ -38,6 +42,24 @@ class PublishNotForNativeImageTests(unittest.TestCase):
             self.assertEqual(kwargs["base_commit"], "FETCH_HEAD")
             return result
 
+        def fake_run_local_branch_review(**kwargs):
+            events.append("local-review")
+            self.assertEqual(kwargs["task_type"], "not-for-native-image")
+            self.assertIs(kwargs["local_ci_verification"], result)
+            return LocalBranchReviewOutcome(
+                status="completed",
+                model="test-model",
+                session_log_path="task-logs/review.log",
+                local_ci_verification=result,
+                verdict=LocalReviewVerdict(
+                    decision="approved",
+                    review_comment="No blocking issues.",
+                    finding_title="",
+                    finding_body="",
+                    fix_note="",
+                ),
+            )
+
         with patch.object(
                     publish_not_for_native_image,
                     "get_not_for_native_image_marker",
@@ -59,6 +81,11 @@ class PublishNotForNativeImageTests(unittest.TestCase):
                     "run_local_ci_verification",
                     side_effect=fake_run_local_ci_verification,
                 ), \
+                patch.object(
+                    branch_publication,
+                    "run_local_branch_review",
+                    side_effect=fake_run_local_branch_review,
+                ), \
                 patch.object(branch_publication, "run_git_transport", side_effect=fake_run_git_transport), \
                 patch.object(branch_publication.subprocess, "run", side_effect=fake_subprocess_run):
             branch, local_ci_verification = publish_not_for_native_image.push_marker_branch(
@@ -73,5 +100,5 @@ class PublishNotForNativeImageTests(unittest.TestCase):
             branch,
         )
         self.assertIs(local_ci_verification, result)
-        self.assertEqual(events, ["rebase", "local-ci", "push"])
+        self.assertEqual(events, ["rebase", "local-ci", "local-review", "push"])
 

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -35,6 +35,8 @@ from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 LOCAL_CI_VERIFICATION_KEY = "local_ci_verification"
+FINDINGS_RELATIVE_PATH = "forge/FINDINGS.md"
+EXPECTED_PUBLICATION_PATHS = frozenset({FINDINGS_RELATIVE_PATH})
 HUMAN_INTERVENTION_LABEL = "human-intervention"
 MAX_OUTPUT_CHARS = 12000
 MAX_FIXUP_ATTEMPTS = 2
@@ -70,6 +72,17 @@ class FixupRecord:
     commit: str | None
     changed_paths: list[str]
     log_path: str | None = None
+
+
+@dataclass(frozen=True)
+class RepairAttempt:
+    """Outcome of one bounded centralized analysis-agent repair."""
+
+    command: list[str]
+    commit: str | None
+    changed_paths: list[str]
+    log_path: str | None
+    failure_reason: str | None = None
 
 
 @dataclass
@@ -147,7 +160,7 @@ def run_local_ci_verification(
             result.repo_fix_paths = classify_repo_fix_paths(repo_path, base_commit, coordinates)
             result.human_intervention_required = bool(result.repo_fix_paths)
             _log_local_ci(f"Verification passed for {coordinates}", indent_level=1)
-            _write_verification_metrics(metrics_repo_path, result)
+            write_verification_metrics(metrics_repo_path, result)
             return result
 
         result.failure_gate = failed_command.gate
@@ -156,7 +169,7 @@ def run_local_ci_verification(
         if attempt >= max_fixup_attempts:
             result.status = "failure"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
-            _write_verification_metrics(metrics_repo_path, result)
+            write_verification_metrics(metrics_repo_path, result)
             raise LocalCIVerificationError(result)
 
         _log_local_ci(f"Running fixup after {failed_command.gate}", indent_level=1)
@@ -165,11 +178,11 @@ def run_local_ci_verification(
         if fixup.commit is None:
             result.status = "failure"
             result.final_commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
-            _write_verification_metrics(metrics_repo_path, result)
+            write_verification_metrics(metrics_repo_path, result)
             raise LocalCIVerificationError(result)
 
     result.status = "failure"
-    _write_verification_metrics(metrics_repo_path, result)
+    write_verification_metrics(metrics_repo_path, result)
     raise LocalCIVerificationError(result)
 
 
@@ -248,7 +261,7 @@ def classify_repo_fix_paths(repo_path: str, base_commit: str, coordinates: str) 
     )
     repo_fix_paths: list[str] = []
     for path in _changed_files(repo_path, base_commit, "HEAD", diff_filter="ACMRTD"):
-        if path.startswith(allowed_prefixes):
+        if path.startswith(allowed_prefixes) or path in EXPECTED_PUBLICATION_PATHS:
             continue
         repo_fix_paths.append(path)
     return sorted(repo_fix_paths)
@@ -585,56 +598,68 @@ def _script_sudo_line(script_path: str) -> str | None:
     return None
 
 
-def _run_fixup(repo_path: str, coordinates: str, failed_command: CommandRecord) -> FixupRecord:
+def run_repair_agent(
+        *,
+        repo_path: str,
+        prompt: str,
+        task_type: str,
+        library: str,
+        commit_message: str,
+        timeout_seconds: int = LOCAL_CI_FIXUP_TIMEOUT_SECONDS,
+) -> RepairAttempt:
+    """Run one centralized analysis-agent repair and commit only its edits."""
     before_paths = _worktree_changed_paths(repo_path)
-    prompt = _build_fixup_prompt(coordinates, failed_command)
     selection = get_analysis_agent()
     command = [selection.backend, selection.model]
     result = analysis_agent_run(
         working_dir=repo_path,
         context=prompt,
-        task_type="local-ci-fixup",
-        library=coordinates,
-        timeout=LOCAL_CI_FIXUP_TIMEOUT_SECONDS,
+        task_type=task_type,
+        library=library,
+        timeout=timeout_seconds,
     )
+    displayed_log_path = display_log_path(result.log_path)
     if result.return_code != 0:
-        return FixupRecord(
-            gate=failed_command.gate,
-            command=command,
-            commit=None,
-            changed_paths=[],
-            log_path=display_log_path(result.log_path),
+        failure_reason = (
+            "timed out" if result.timed_out
+            else f"exited with code {result.return_code}"
         )
+        return RepairAttempt(command, None, [], displayed_log_path, failure_reason)
 
-    after_paths = _worktree_changed_paths(repo_path)
-    changed_paths = sorted(after_paths - before_paths)
+    changed_paths = sorted(_worktree_changed_paths(repo_path) - before_paths)
     if not changed_paths:
-        return FixupRecord(
-            gate=failed_command.gate,
-            command=command,
-            commit=None,
-            changed_paths=[],
-            log_path=display_log_path(result.log_path),
-        )
+        return RepairAttempt(command, None, [], displayed_log_path, "changed no files")
 
     subprocess.run(["git", "add", "-A", "--", *changed_paths], cwd=repo_path, check=True)
     staged = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, check=False)
     if staged.returncode == 0:
-        return FixupRecord(
-            gate=failed_command.gate,
-            command=command,
-            commit=None,
-            changed_paths=changed_paths,
-            log_path=display_log_path(result.log_path),
+        return RepairAttempt(
+            command, None, changed_paths, displayed_log_path, "left nothing to commit",
         )
-    subprocess.run(["git", "commit", "-m", "Apply local CI verification fixes"], cwd=repo_path, check=True)
-    commit = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+    subprocess.run(["git", "commit", "-m", commit_message], cwd=repo_path, check=True)
+    return RepairAttempt(
+        command,
+        _git_stdout(repo_path, ["rev-parse", "HEAD"]),
+        changed_paths,
+        displayed_log_path,
+        None,
+    )
+
+
+def _run_fixup(repo_path: str, coordinates: str, failed_command: CommandRecord) -> FixupRecord:
+    attempt = run_repair_agent(
+        repo_path=repo_path,
+        prompt=_build_fixup_prompt(coordinates, failed_command),
+        task_type="local-ci-fixup",
+        library=coordinates,
+        commit_message="Apply local CI verification fixes",
+    )
     return FixupRecord(
         gate=failed_command.gate,
-        command=command,
-        commit=commit,
-        changed_paths=changed_paths,
-        log_path=display_log_path(result.log_path),
+        command=attempt.command,
+        commit=attempt.commit,
+        changed_paths=attempt.changed_paths,
+        log_path=attempt.log_path,
     )
 
 
@@ -659,7 +684,7 @@ def _build_fixup_prompt(coordinates: str, failed_command: CommandRecord) -> str:
     ])
 
 
-def _write_verification_metrics(metrics_repo_path: str | None, result: LocalCIVerificationResult) -> None:
+def write_verification_metrics(metrics_repo_path: str | None, result: LocalCIVerificationResult) -> None:
     if metrics_repo_path is None:
         return
     pending_path = os.path.join(metrics_repo_path, PENDING_METRICS_FILENAME)


### PR DESCRIPTION
Closes #9413

## What this does

A generated branch is reviewed once today, and only after it is already a pull request: `--review-pr` reads `gh pr diff` and nothing else. The run that produced that branch held far more — the verified working tree, the local CI gate records, the fixup history, the resolved render statistics — and discarded all of it at push time. By the time any reviewer looks, the cheapest moment to fix something has passed and the branch is already a PR in someone's queue.

This adds a second review that runs **before** the push, in the same isolation the PR reviewer uses, over `base_ref..HEAD` — the eventual PR diff minus the descriptor commit — plus the local evidence the PR reviewer never gets. The verdict travels in the publication descriptor, so the PR carries the right label the moment it opens, and every non-approval is recorded in a tracked `forge/FINDINGS.md`. The behaviour is specified in a new [§forge/FS-local-branch-review](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/forge-pre-push-branch-review/forge/docs/functional-spec/README.md), written before the code.

## Where the phase sits

`publish_branch` is the single path from a verified worktree to a pushed branch ([§forge/GIT-shared-publication-pipeline](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/forge-pre-push-branch-review/forge/docs/git-scripts.md)), and its existing ordering fixes where a review can go:

```
stage → rebase → pre-publication gate → [ review ] → write descriptor → push
```

After the gate and the descriptor-input resolution, because the review rules dereference render statistics that only exist once that input resolves. Before the descriptor is written, because the verdict has to be inside the descriptor the publisher reads. That is one slot, and it is the slot the phase takes.

## What the reviewer sees, and why it runs cold

`create_review_workspace` detaches a worktree and then calls `gh pr checkout`. There is no PR yet, so that step cannot apply, and detaching at the verified commit from the shared object store gives the same cold tree. What carries over unchanged is `--no-session`: a review that shares context with the run that generated the branch inherits every justification that run already talked itself into, and the verdict is worthless. Isolation is the mechanism here, not an implementation detail.

The review skills are written against `gh pr view/diff/checks`, none of which exist pre-push, so each is substituted by its local equivalent:

| What the skill reaches for | What the phase supplies |
|---|---|
| `gh pr diff` | `git diff <base_sha> <head_sha>` in the detached worktree |
| PR check runs | the local CI gate records, as JSON outside the tree |
| PR body entry counts | the resolved descriptor input's render statistics |
| rules for the PR's label | `skills/review-*/SKILL.md`, selected by `task_type` |

`task_type` is the selector rather than `template_type` so that both reviews judge the branch against one rule set — the post-push reviewer selects by PR label, and labels come from `ROUTE_LABELS[task_type]`.

The blocking discipline carries over verbatim from the PR reviewer: request changes only for a concrete violation of an enumerated rule, never for a self-formed test-quality judgment. That constraint binds harder here, because this reviewer can stop a branch from ever becoming a PR.

## Repair, and what happens when the repair goes wrong

A non-approval is not terminal. The finding goes back for one bounded repair, taking the same shape and the same bound as the fixup a failed CI gate already gets. Because the repair edits a tree that verification already passed, the gate runs again over the repaired tree — a push must never carry code no gate has seen.

If that re-run fails, the branch is reset to the verified pre-repair commit and published as it stood. A review finding must not be able to destroy an otherwise-publishable run.

`is_approved` records the **final** state, so a repair that lands and re-verifies clears the label and no PR carries `human-intervention` for a problem that no longer exists. The `FINDINGS.md` entry is written either way, because what was wrong is worth recording once it is fixed — that record is what makes a recurring defect visible.

An unavailable reviewer — failed authentication, non-zero exit, timeout, missing verdict — is recorded as a non-approval rather than raised. Halting publication on a review outage turns a review problem into a throughput outage; a labelled PR turns it into one person's inbox.

## The verdict in the descriptor

`modifiers.human_intervention` is already a disjunction of two causes: local CI touched paths outside the target library, ORed in the publisher with `_has_severe_metadata_drop`. Folding a third cause into the same boolean would leave the label unable to answer *why*, which is the question triage asks. So the verdict becomes a new optional `local_review` object and `not is_approved` joins the existing OR.

**This has to reach `master` before Forge runs with it.** The Actions publisher validates each descriptor against **its own** copy of `schema.json` from the default branch, and that schema is `additionalProperties: false`. A run from this branch against live GitHub would emit `local_review` and fail publication until the schema has landed.

## forge/FINDINGS.md

Tracked, appended newest-first, and rendered by Forge from a title and body the reviewer supplies. Compacting an error into two fields needs a model; deciding where the date and coordinates go does not, and letting the agent rewrite the file invites format drift across hundreds of runs.

Allowlisting the path in `classify_repo_fix_paths` is required rather than optional. It sits outside `metadata/`, `tests/src/`, and `stats/`, so any path that re-runs verification after writing it would flag the PR with the reason "repository-level files changed during verification" — which would be false.

Two ordering constraints hold it in place. The entry is committed **before** the descriptor commit, because the publisher requires the tip commit to be the descriptor commit (`Exactly one tip-committed forge-publication.json is required`). And the branch is rebased onto a fresh `base_ref` before verification, so entries never conflict with `master` drift — only with other in-flight Forge branches prepending at the same offset, which is accepted and repaired at review, exactly as `index.json` collisions are today.

## Decisions taken while implementing

1. **A repair that breaks re-verification reverts** instead of failing publication, so a review finding cannot cost a green run.
2. **Entries are chronological**, not deduplicated by recurring title.
3. **The publisher renders the verdict into the PR body**, because human-intervention triage reads the body before it reads `stats/`.
4. **No new tests.** Fixture mode returns before `build_publication_handoff`, so a hermetic run never enters `publish_branch` and cannot reach this phase at all.

## The E2E spec claimed a fixture artifact that no longer exists

Looking for a way to verify this phase led straight into a contradiction inside [§forge/E2E-forge-workflow-testing](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/forge-pre-push-branch-review/forge/docs/e2e.md). #9317 deleted `write_fixture_publication_handoff` and made `finalize_successful_issue` return early in fixture mode, and it added the statements that publication is out of scope for a hermetic run — but five older claims about a `publication.md` dry-run artifact survived alongside them, including a *requirement* that it "must be built from the same git-script PR title/body builder that live publication uses", pointing at a renderer the same section says a hermetic run cannot exercise.

The second commit removes those claims: the artifact-directory list, the build requirement, the acceptance-ritual mention, and the reporting-checklist entry. The `9107` and `9108` fixtures were each described *only* by the dry-run PR body they supposedly produced, so both now state the half they still cover — `.pending_metrics.json` reconstruction and the marker's recorded skip decision.

`FIXTURE_PUBLICATION_FILENAME = "publication.md"` is still defined at `forge_metadata.py:236` with no remaining reference; I left the dead constant alone to keep this diff to the spec.