### PR TITLE
Remove Crema-specific Gradle assertion workaround

### DIFF
--- a/.github/workflows/test-all-metadata-crema.yml
+++ b/.github/workflows/test-all-metadata-crema.yml
@@ -31,15 +31,6 @@ on:
         description: "GraalVM version to build Crema from. Must ship the jvm-library macro."
         required: false
         default: "latest-ea"
-      disable-assertions:
-        description: "Clear Gradle's default -ea, which Crema rejects at VM startup. On by default, because with -ea every coordinate fails before any test runs. Set false to confirm that blocker is still present."
-        required: false
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
-
 permissions:
   contents: read
 
@@ -278,7 +269,6 @@ jobs:
         env:
           # §TCK-test-harness.3.1 — selects the test workers' interpreter, adds no flag.
           GVM_TCK_TEST_JAVA_HOME: ${{ steps.crema.outputs.crema-home }}
-          GVM_TCK_TEST_DISABLE_ASSERTIONS: ${{ inputs.disable-assertions || 'true' }}
           MATRIX_COORDINATES: ${{ matrix.coordinates }}
           MATRIX_VM: ${{ matrix.vm }}
         run: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -215,11 +215,11 @@ Sunday metadata sweep (§CI-test-all-metadata) and the Monday release
 (§CI-create-scheduled-release) so the three never compete for runners.
 
 The scheduled run takes every input's default — all coordinates over 85 shards on
-the `crema` lane with assertions cleared — because the `inputs` context is empty
-on a `schedule` event; the workflow restates each default rather than resolving
-an empty matrix. The weekly trigger is confined to the canonical repository so a
-fork does not sweep on its own schedule, while manual dispatch stays available
-everywhere.
+the `crema` lane with the normal test configuration — because the `inputs`
+context is empty on a `schedule` event; the workflow restates each default rather
+than resolving an empty matrix. The weekly trigger is confined to the canonical
+repository so a fork does not sweep on its own schedule, while manual dispatch
+stays available everywhere.
 
 The JDK is built once by a dedicated job via §CI-setup-crema-jdk and shared with
 every shard as an artifact, because the macro build takes about ten minutes and
@@ -276,17 +276,6 @@ attributed per coordinate and published as NDJSON plus log artifacts in the same
 shape as §CI-test-all-metadata, so the existing failure tooling applies. The
 matrix comes from `generateMatrixBatchedCoordinates` (§TCK-test-harness.7) via
 the `batches` input; `coordinates` narrows a run to one shard or one library.
-
-Crema currently rejects `-ea` at VM startup, and Gradle puts `-ea` on every test
-worker, so leaving it in place fails every coordinate identically before any test
-executes and the sweep returns one finding repeated per coordinate instead of a
-survey. The `disable-assertions` input therefore defaults to true, clearing
-Gradle's `enableAssertions` (§TCK-test-harness.3.1) so the sweep reaches the
-failures behind that blocker. Setting it false re-checks whether the blocker is
-still present. Because assertions do not fire under this default, tests that
-verify via `assert` pass vacuously: a green coordinate here means Crema ran the
-code, never that the library is supported.
-
 
 ## Event-triggered automation
 

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -147,15 +147,6 @@ case. Because the selected JDK is used unmodified, a failure under it is a
 property of that JDK and not of the harness, which is what makes the resulting
 run usable as a bug report.
 
-`GVM_TCK_TEST_DISABLE_ASSERTIONS=true` is the one exception, and it is opt-in and
-off by default. Gradle enables assertions on every test worker, so a JDK that
-rejects `-ea` outright fails all workers at VM startup and the run yields a
-single finding repeated once per coordinate instead of a survey. Setting this
-clears Gradle's `enableAssertions` so the sweep can reach the failures behind
-that one. It changes what the tests check: assertions no longer fire, so a test
-that verifies via `assert` passes vacuously. A run with this set is a
-bug-discovery run, never evidence that a library is supported.
-
 ## 4. Native-image metadata tracing
 
 Helpers for collecting metadata with the native-image tracing agent (see also

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -831,8 +831,6 @@ tasks.register("mergeNativeTraceMetadata", Exec) { Exec task ->
 // §TCK-test-harness.3.1: run the forked JVM test workers on a JDK that need not be able to host
 // Gradle. Selects an interpreter only — JVM arguments are left exactly as they would be otherwise.
 String testJavaHome = System.getenv("GVM_TCK_TEST_JAVA_HOME")
-// §TCK-test-harness.3.1: opt-in escape hatch for a JDK that rejects Gradle's default `-ea`.
-boolean disableTestAssertions = Boolean.parseBoolean(System.getenv("GVM_TCK_TEST_DISABLE_ASSERTIONS"))
 
 tasks.register("nativeTestPGOSampling") { task ->
     task.inputs.property("pgoSamplingPeriodMicros", pgoSamplingPeriodMicros)
@@ -880,9 +878,6 @@ tasks.withType(Test).configureEach { Test testTask ->
         // a configured javaLauncher and an executable, and the Kotlin/Scala coordinates pin one.
         testTask.javaLauncher.unset()
         testTask.executable = new File(new File(testJavaHome, "bin"), "java").absolutePath
-    }
-    if (disableTestAssertions) {
-        testTask.enableAssertions = false
     }
     systemProperty "junit.jupiter.execution.timeout.default", "${maxJUnitTestTimeoutSeconds} s"
     systemProperty "junit.jupiter.execution.timeout.mode", "enabled"


### PR DESCRIPTION
## Summary

- remove the Crema-only assertion toggle from the workflow
- restore the standard Gradle assertion configuration for test workers
- retain separate Crema test-JDK selection and update the TCK/CI documentation

## Validation

- ./gradlew :tck-build-logic:test --stacktrace
- grund check
- git diff --check

Fixes #9462