### PR TITLE
Make gpt-5.6-luna|high default model

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/.example-values.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/.example-values.yaml
@@ -12,6 +12,6 @@ in_progress_status: In Progress
 pr_push_remote: ""
 pr_head_owner: ""
 pr_base_branch: master
-worker_agent: pi:openai-codex/gpt-5.6-sol
+worker_agent: pi[high]:openai-codex/gpt-5.6-luna
 
 fix_passes: 2

--- a/forge/.agents/rhei/templates/code-coverage-improvement/settings.json
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/settings.json
@@ -1,5 +1,23 @@
 {
   "defaults": {
     "agent_timeout": "2h"
+  },
+  "agents": {
+    "pi": {
+      "command": ["pi"],
+      "prompt_flag": "-p",
+      "model_flag": "--model",
+      "session": {
+        "session_dir_flag": "--session-dir",
+        "layout": {
+          "kind": "FlatById",
+          "ext": "jsonl"
+        }
+      },
+      "modes": {
+        "high": ["--thinking", "high"],
+        "xhigh": ["--thinking", "xhigh"]
+      }
+    }
   }
 }

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -242,6 +242,7 @@
 - PR push remote: `{{pr_push_remote}}`
 - PR head owner: `{{pr_head_owner}}`
 - PR base branch: `{{pr_base_branch}}`
+- Worker agent: `{{worker_agent}}`
 - Branch suffix: `{{branch_suffix}}`
 - Purpose: publish the verified code coverage improvement as a pull request.
 - Required work:
@@ -250,10 +251,13 @@
   - Confirm the issue worktree branch is the expected issue branch.
   - Create a focused commit if verified changes are uncommitted.
   - Push to the configured fork remote or infer a writable fork remote.
+  - Pass `--worker-agent {{worker_agent}}`. The helper names the head branch
+    after that target's model, so a run of this coordinate on another model
+    owns a different branch.
   - Pass `--branch-suffix {{branch_suffix}}` when that value is non-empty. The
     helper force-replaces the remote head branch, so omitting a configured
     suffix deletes the head branch of an earlier run's pull request for this
-    same coordinate and takes its place.
+    same coordinate and model, and takes its place.
   - Open a pull request against `{{repo}}` base `{{pr_base_branch}}`.
   - Include source issue, coordinate, coverage suite path, separate baseline and
     final API/deep JaCoCo coverage, the two phases combined, coverage deltas,

--- a/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
@@ -99,9 +99,13 @@ inputs:
     default: ""
 
   - name: worker_agent
-    description: Agent used for execution and fix states.
+    description: >-
+      Rhei target used for execution and fix states, as
+      <agent>[<mode>]:<provider>/<model>. Its model names the publication head
+      branch, and its mode selects the reasoning level from the agent profile in
+      this template's settings.json.
     type: string
-    default: pi:openai-codex/gpt-5.6-sol
+    default: pi[high]:openai-codex/gpt-5.6-luna
 
   - name: fix_passes
     description: Maximum automated fix passes when finalization verification fails.

--- a/forge/docs/workflows/code-coverage-improvement.md
+++ b/forge/docs/workflows/code-coverage-improvement.md
@@ -52,7 +52,8 @@ directory name makes the two disagree: the agent is told one path and the
 output-existence check reads another, and the task stalls in a non-terminal
 state after an agent that exited zero. Runs that must not collide — a second
 model, agent, or pass budget on one library — separate themselves by parent
-directory and by `branch_suffix`, never by renaming the workspace. A workspace
+directory, and their published branches by the model the head branch already
+names and by `branch_suffix`, never by renaming the workspace. A workspace
 under a parent directory must also set `workspace_path`, since the cover states
 tell the agent where to resolve artifacts from and that path is no longer
 derivable from `work_subdir` alone.
@@ -456,13 +457,17 @@ The Rhei template should decompose the workflow into these phases:
    since its own invocations are still running when the body is built. Sampled
    PGO evidence stays in the local finalization summary and is not published in
    the PR body. The head branch is
-   `ai/<login>/code-coverage-<artifact>-<version>`, extended with the
-   configured `branch_suffix` when one is set. Publication force-replaces the
-   remote head branch, so two runs of the same coordinate that share a branch
-   name delete each other's pull request head: a run that must coexist with an
-   earlier one — a different model, agent, or pass budget measured against the
-   same library — sets the suffix so each run owns its own branch and each pull
-   request survives the next run.
+   `ai/<login>/code-coverage-<artifact>-<version>-<model>`, extended with the
+   configured `branch_suffix` when one is set. The model segment is the model of
+   the run's `worker_agent` target — the trailing component of
+   `<agent>[<mode>]:<provider>/<model>` — so a coordinate measured on two models
+   publishes two branches without any operator action, and the branch names what
+   generated the pull request it carries. Publication force-replaces the remote
+   head branch, so two runs of the same coordinate that share a branch name
+   delete each other's pull request head: a run that must coexist with an
+   earlier one on the same model — another agent or pass budget measured against
+   the same library — sets the suffix so each run owns its own branch and each
+   pull request survives the next run.
 
 The pipeline tasks run unreviewed: deterministic helpers, schema-validated
 artifacts, and zero-exit validation gates decide their completion. The
@@ -617,6 +622,18 @@ engine:
   supplied schema-valid state files remain accepted at finalization.
 - **Workflow engine** — owns prompt/command cycles, retries, target selection,
   JaCoCo progress comparison, path refresh, and terminal status.
+- **Worker target** — the single `worker_agent` input drives every agent state,
+  defaulting to `pi[high]:openai-codex/gpt-5.6-luna`. Rhei's target grammar
+  carries the reasoning level in the mode bracket, not in the model string: a
+  model written as `<model>:<thinking>` is parsed as a provider/model pair and
+  silently resolves to a different model. The template therefore bundles a `pi`
+  agent profile in its `settings.json` whose `high` and `xhigh` modes add
+  `--thinking`, and publication reads the model back out of the same target to
+  name the head branch (§WF-code-coverage-improvement.4). That profile replaces
+  Rhei's built-in one outright rather than extending it, so it restates the
+  `session` block as well: without it Rhei passes no `--session-dir`, cannot
+  read back the agent's native transcript, and silently captures no per-state
+  snapshot for a workflow whose every agent state is otherwise snapshotted.
 - **Publication handoff** — publishes only PR-eligible runs after local
   CI-equivalent verification passes (§AR-forge-verification-publication-boundary).
   Implemented in `forge/git_scripts/make_pr_code_coverage_improvement.py`, which

--- a/forge/git_scripts/make_pr_code_coverage_improvement.py
+++ b/forge/git_scripts/make_pr_code_coverage_improvement.py
@@ -17,21 +17,21 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 from typing import Any
 
+from git_scripts.branch_publication import BASE_BRANCH, REPO
 from git_scripts.common_git import (
     build_ai_branch_name,
     delete_remote_branch_if_exists,
     gh,
-    get_configured_reviewers,
     get_origin_owner,
     run_git_transport,
     stage_and_commit,
 )
-from git_scripts.pr_publication import BASE_BRANCH, REPO, parse_pr_number
 from utility_scripts.code_coverage_finalize import (
     FinalizationError,
     load_validated_final_metrics,
@@ -42,6 +42,7 @@ from utility_scripts.metadata_index import (
 )
 
 HUMAN_INTERVENTION_LABEL = "human-intervention"
+REVIEWERS_ENV = "METADATA_FORGE_PR_REVIEWERS"
 MAX_COMMIT_SUBJECT_LENGTH = 60
 
 #: Workflow order for the token-usage table; unknown phases sort after these.
@@ -310,9 +311,45 @@ def create_pull_request(
     return parse_pr_number(result.stdout)
 
 
+def model_slug(worker_agent: str) -> str:
+    """Return the branch segment naming the model a Rhei target generates with.
+
+    A Rhei target reads `<agent>[<mode>]:<provider>/<model>`, and only the model
+    identifies what produced the run (§WF-code-coverage-improvement.4).
+    """
+    target: str = worker_agent.split(":", 1)[-1]
+    model: str = re.split(r"[/:]", target)[-1]
+    slug: str = re.sub(r"[^A-Za-z0-9._-]+", "-", model).strip("-.")
+    if not slug:
+        print(
+            f"ERROR: worker agent '{worker_agent}' names no model.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return slug
+
+
+def parse_pr_number(output: str) -> int | None:
+    """Extract a PR number from `gh pr create` output."""
+    match: re.Match[str] | None = re.search(r"/pull/(\d+)", output)
+    return int(match.group(1)) if match else None
+
+
+def get_configured_reviewers() -> list[str]:
+    """Return PR reviewers configured via ``METADATA_FORGE_PR_REVIEWERS``.
+
+    This workflow still opens its own pull request, so it keeps the reviewer
+    lookup that publication through GitHub Actions took over for every other
+    template (§AR-forge-verification-publication-boundary).
+    """
+    raw_value: str = os.environ.get(REVIEWERS_ENV, "")
+    return [reviewer.strip() for reviewer in raw_value.split(",") if reviewer.strip()]
+
+
 def publish(
         repo_path: str,
         coordinate: str,
+        worker_agent: str,
         issue_number: int | None,
         finalization_dir: str,
         coverage_suite_path: str,
@@ -344,12 +381,14 @@ def publish(
         )
         raise SystemExit(1)
 
-    # Publication force-replaces the remote head branch, so runs that must
-    # coexist on the same coordinate discriminate their branch
-    # (§WF-code-coverage-improvement.4).
+    # Publication force-replaces the remote head branch. The branch names the
+    # model that generated the run, so runs of one coordinate on different
+    # models never collide, and `branch_suffix` discriminates the runs that
+    # still share a model (§WF-code-coverage-improvement.4).
+    model: str = model_slug(worker_agent)
     suffix: str = f"-{branch_suffix}" if branch_suffix else ""
     branch: str = build_ai_branch_name(
-        f"code-coverage-{artifact}-{version}{suffix}", cwd=repo_path
+        f"code-coverage-{artifact}-{version}-{model}{suffix}", cwd=repo_path
     )
     delete_remote_branch_if_exists(branch, remote=push_remote, cwd=repo_path)
     subprocess.run(["git", "switch", "-C", branch], check=True, cwd=repo_path)
@@ -386,6 +425,7 @@ def main(argv: list[str] | None = None) -> None:
             "Example:\n"
             "  python3 git_scripts/make_pr_code_coverage_improvement.py "
             "--repo-path <worktree> --coordinate group:artifact:version "
+            "--worker-agent pi[high]:openai-codex/gpt-5.6-luna "
             "--issue-number 8380 "
             "--finalization-dir runtime/code-coverage/finalization "
             "--coverage-suite-path tests/src/group/artifact/version/code-coverage-improvement"
@@ -410,6 +450,15 @@ def main(argv: list[str] | None = None) -> None:
         "--coverage-suite-path",
         required=True,
         help="Repository-relative dedicated coverage suite path.",
+    )
+    parser.add_argument(
+        "--worker-agent",
+        required=True,
+        help=(
+            "Rhei target the run generated with, as "
+            "<agent>[<mode>]:<provider>/<model>. Its model names the head "
+            "branch, so each model owns its own branch for a coordinate."
+        ),
     )
     parser.add_argument(
         "--push-remote", default="origin", help="Writable fork remote."
@@ -439,6 +488,7 @@ def main(argv: list[str] | None = None) -> None:
     pr_number: int | None = publish(
         args.repo_path,
         args.coordinate,
+        args.worker_agent,
         args.issue_number,
         args.finalization_dir,
         args.coverage_suite_path,

--- a/forge/tests/test_make_pr_code_coverage_improvement.py
+++ b/forge/tests/test_make_pr_code_coverage_improvement.py
@@ -269,7 +269,11 @@ class PublisherTests(unittest.TestCase):
         self.assertNotIn(requested_metadata_dir, staged_paths)
         self.assertEqual(stage_and_commit.call_args.kwargs["cwd"], repo_path)
 
-    def _publish_with_branch_suffix(self, branch_suffix: str | None) -> str:
+    def _publish_branch(
+            self,
+            branch_suffix: str | None = None,
+            worker_agent: str = "pi[high]:openai-codex/gpt-5.6-luna",
+    ) -> str:
         """Return the head branch suffix `publish` asked `build_ai_branch_name` for."""
         with tempfile.TemporaryDirectory(prefix="coverage-publish-") as repo_path:
             finalization = os.path.join(repo_path, "finalization")
@@ -295,6 +299,7 @@ class PublisherTests(unittest.TestCase):
                 module.publish(
                     repo_path,
                     "com.example:demo:1.0.0",
+                    worker_agent,
                     8380,
                     finalization,
                     coverage_suite,
@@ -307,25 +312,52 @@ class PublisherTests(unittest.TestCase):
 
         return build_branch.call_args.args[0]
 
-    def test_branch_keeps_the_plain_coordinate_without_a_suffix(self) -> None:
+    def test_branch_names_the_generating_model_without_a_suffix(self) -> None:
         self.assertEqual(
-            self._publish_with_branch_suffix(None), "code-coverage-demo-1.0.0"
+            self._publish_branch(None), "code-coverage-demo-1.0.0-gpt-5.6-luna"
         )
         self.assertEqual(
-            self._publish_with_branch_suffix(""), "code-coverage-demo-1.0.0"
+            self._publish_branch(""), "code-coverage-demo-1.0.0-gpt-5.6-luna"
+        )
+
+    def test_branch_model_separates_runs_of_one_coordinate(self) -> None:
+        # Publication force-replaces the remote head branch, so measuring one
+        # coordinate on a second model must not resolve to the first branch.
+        self.assertEqual(
+            self._publish_branch(worker_agent="pi:openai-codex/gpt-5.6-sol"),
+            "code-coverage-demo-1.0.0-gpt-5.6-sol",
+        )
+        self.assertNotEqual(
+            self._publish_branch(worker_agent="pi:openai-codex/gpt-5.6-sol"),
+            self._publish_branch(
+                worker_agent="pi[high]:openai-codex/gpt-5.6-luna"
+            ),
         )
 
     def test_branch_suffix_discriminates_coexisting_runs(self) -> None:
-        # Publication force-replaces the remote head branch, so a second run on
-        # the same coordinate must not resolve to the first run's branch.
+        # Two runs on one model still share the model segment, so the suffix
+        # remains the discriminator that keeps both pull request heads alive.
         self.assertEqual(
-            self._publish_with_branch_suffix("luna"),
-            "code-coverage-demo-1.0.0-luna",
+            self._publish_branch("cap400"),
+            "code-coverage-demo-1.0.0-gpt-5.6-luna-cap400",
         )
         self.assertNotEqual(
-            self._publish_with_branch_suffix("luna"),
-            self._publish_with_branch_suffix("sol"),
+            self._publish_branch("cap400"), self._publish_branch("cap200")
         )
+
+    def test_model_slug_reads_the_model_out_of_a_rhei_target(self) -> None:
+        self.assertEqual(
+            module.model_slug("pi[high]:openai-codex/gpt-5.6-luna"),
+            "gpt-5.6-luna",
+        )
+        self.assertEqual(
+            module.model_slug("codex[xhigh]:openai:gpt-5.5"), "gpt-5.5"
+        )
+        self.assertEqual(module.model_slug("gpt-5.6-sol"), "gpt-5.6-sol")
+
+    def test_model_slug_rejects_a_target_without_a_model(self) -> None:
+        with self.assertRaises(SystemExit):
+            module.model_slug("pi[high]:openai-codex/")
 
     def test_links_without_autoclose_by_default(self) -> None:
         body = module.build_pull_request_body(


### PR DESCRIPTION
Closes #9472.

## What this does

A code-coverage-improvement run published to `ai/<login>/code-coverage-<artifact>-<version>`, and publication force-replaces the remote head branch. Two runs of one coordinate on different models therefore deleted each other's pull request head, and the only defence was remembering to set `branch_suffix` by hand — a convention that lived in the operator's head, nowhere in the code. The head branch now ends in the model the run generated with, read out of the run's own `worker_agent` target, so the branch names what produced the pull request it carries and two models never collide (§forge/WF-code-coverage-improvement.4).

The default target moves to `gpt-5.6-luna` at high thinking. Until now the high thinking level came from `~/.pi/agent/settings.json` on one machine, so nothing in the repository said what the measured runs actually ran at.
