### PR TITLE
Count coverage on one frozen method universe

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -622,6 +623,9 @@ def _signed(value: int | float) -> str:
     return f"{'+' if value > 0 else ''}{value}"
 
 
+#: Column width prose paragraphs in a rendered body wrap at.
+BODY_TEXT_WIDTH = 80
+
 #: Checkpoint name -> the row label a reader sees.
 CHECKPOINT_LABELS: dict[str, str] = {
     "runStart": "Run start",
@@ -652,12 +656,17 @@ def _coverage_universe_lines(run: dict[str, Any]) -> list[str]:
     deep_universe = int(run["deepUniverse"])
     checkpoints: list[dict[str, Any]] = run["checkpoints"]
     lines = [
-        f"Every figure divides by the same denominator: the {universe} library "
-        f"methods JaCoCo can rule on, made up of {api_universe} public API "
-        f"methods and {deep_universe} internal methods, which are disjoint "
-        "by construction. Each checkpoint is counted over that one frozen set of "
-        "method ids from a single JaCoCo report, so every phase starts where the "
-        "previous phase ended.",
+        # Wrapped, so that editing this sentence later shows as a sentence-sized
+        # diff rather than one rewritten 300-column line.
+        textwrap.fill(
+            f"Every figure divides by the same denominator: the {universe} library "
+            f"methods JaCoCo can rule on, made up of {api_universe} public API "
+            f"methods and {deep_universe} internal methods, which are disjoint "
+            "by construction. Each checkpoint is counted over that one frozen set of "
+            "method ids from a single JaCoCo report, so every phase starts where the "
+            "previous phase ended.",
+            BODY_TEXT_WIDTH,
+        ),
         "",
         "| Checkpoint | Covered | Share |",
         "|---|--:|--:|",

--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -213,9 +213,16 @@ def _validate_code_coverage_render(render: dict[str, Any]) -> None:
     metrics = render.get("code_coverage")
     if not isinstance(metrics, dict):
         raise ValueError("Code coverage publication requires render.code_coverage")
-    for key in ("coverageSuitePath", "needsHumanIntervention", "apiJacoco", "deepJacoco"):
+    for key in (
+        "coverageSuitePath",
+        "needsHumanIntervention",
+        "runCoverage",
+        "apiJacoco",
+        "deepJacoco",
+    ):
         if key not in metrics:
             raise ValueError(f"Code coverage evidence is missing {key!r}")
+    _validate_run_coverage(metrics["runCoverage"])
     for key in ("apiJacoco", "deepJacoco"):
         evidence = metrics[key]
         if not isinstance(evidence, dict) or not {"baseline", "final"} <= evidence.keys():
@@ -224,6 +231,46 @@ def _validate_code_coverage_render(render: dict[str, Any]) -> None:
             snapshot = evidence[phase]
             if not isinstance(snapshot, dict) or not {"total", "covered"} <= snapshot.keys():
                 raise ValueError(f"Code coverage {key!r} {phase} needs total and covered")
+
+
+def _validate_run_coverage(run: Any) -> None:
+    """The whole-run block the body renders every figure from.
+
+    The renderer divides nothing itself, so a descriptor missing a checkpoint or
+    a universe count cannot be rendered against a fallback denominator — it is
+    rejected here instead (§forge/WF-code-coverage-improvement.4.1).
+    """
+    if not isinstance(run, dict):
+        raise ValueError("Code coverage runCoverage must be an object")
+    for key in ("universe", "apiUniverse", "deepUniverse"):
+        if not isinstance(run.get(key), int):
+            raise ValueError(f"Code coverage runCoverage needs an integer {key!r}")
+    checkpoints = run.get("checkpoints")
+    if not isinstance(checkpoints, list) or len(checkpoints) != len(CHECKPOINT_LABELS):
+        raise ValueError(
+            f"Code coverage runCoverage needs {len(CHECKPOINT_LABELS)} checkpoints"
+        )
+    for point in checkpoints:
+        if not isinstance(point, dict) or point.get("name") not in CHECKPOINT_LABELS:
+            raise ValueError("Code coverage checkpoint names an unknown instant")
+        missing = {
+            "apiCovered", "deepCovered", "covered", "uncovered", "coveragePercent",
+        } - point.keys()
+        if missing:
+            raise ValueError(
+                f"Code coverage checkpoint {point['name']!r} is missing {sorted(missing)}"
+            )
+    phases = run.get("phases")
+    if not isinstance(phases, list) or len(phases) != len(PHASE_LABELS):
+        raise ValueError(f"Code coverage runCoverage needs {len(PHASE_LABELS)} phases")
+    for phase in phases:
+        if not isinstance(phase, dict) or phase.get("name") not in PHASE_LABELS:
+            raise ValueError("Code coverage phase gain names an unknown phase")
+        if not {"covered", "coveragePercentagePoints"} <= phase.keys():
+            raise ValueError(
+                f"Code coverage phase {phase['name']!r} needs covered and "
+                "coveragePercentagePoints"
+            )
 
 
 def _path_changed(head_sha: str, path: str) -> bool:
@@ -575,58 +622,76 @@ def _signed(value: int | float) -> str:
     return f"{'+' if value > 0 else ''}{value}"
 
 
-def _coverage_percent(covered: int, total: int) -> float:
-    return round(100 * covered / total, 2) if total else 0.0
+#: Checkpoint name -> the row label a reader sees.
+CHECKPOINT_LABELS: dict[str, str] = {
+    "runStart": "Run start",
+    "afterApiPhase": "After Simple Jacoco guidance phase",
+    "final": "After PGO guidance phase (final)",
+}
+
+#: Phase name -> the row label a reader sees.
+PHASE_LABELS: dict[str, str] = {
+    "api": "Simple Jacoco guidance phase",
+    "deep": "PGO guidance phase",
+}
 
 
-def _reportable_total(snapshot: dict[str, Any]) -> int:
-    """The denominator JaCoCo can actually rule on.
+def _coverage_universe_lines(run: dict[str, Any]) -> list[str]:
+    """The run as one timeline on one denominator.
 
-    The API inventory carries both `total`, every inventory entry, and
-    `measured`, the entries JaCoCo reports at all. The difference is methods no
-    run can ever cover, so dividing by `total` understates the phase and
-    contradicts the `coveragePercent` the same document records. The deep
-    snapshot has no such split and falls back to `total`.
+    Finalization froze the universe and counted every checkpoint over it, so this
+    renderer computes no denominator of its own: it reports the counting that
+    already happened where the JaCoCo reports are. Each phase's gain is the
+    distance from the checkpoint the previous phase ended on, and the phase gains
+    sum to the run's gain. Reporting each phase against its own roster instead
+    put two different instants of the run on two different scales
+    (§forge/WF-code-coverage-improvement.4.1).
     """
-    return int(snapshot.get("measured", snapshot["total"]))
-
-
-def _coverage_phase_lines(label: str, evidence: dict[str, Any]) -> list[str]:
-    baseline = evidence["baseline"]
-    final = evidence["final"]
-    total = _reportable_total(final)
-    baseline_percent = _coverage_percent(int(baseline["covered"]), total)
-    final_percent = _coverage_percent(int(final["covered"]), total)
-    return [
-        f"### {label}",
+    universe = int(run["universe"])
+    api_universe = int(run["apiUniverse"])
+    deep_universe = int(run["deepUniverse"])
+    checkpoints: list[dict[str, Any]] = run["checkpoints"]
+    lines = [
+        f"Every figure divides by the same denominator: the {universe} library "
+        f"methods JaCoCo can rule on, made up of {api_universe} public API "
+        f"methods and {deep_universe} internal methods, which are disjoint "
+        "by construction. Each checkpoint is counted over that one frozen set of "
+        "method ids from a single JaCoCo report, so every phase starts where the "
+        "previous phase ended.",
         "",
-        f"- Baseline: {baseline['covered']}/{total} ({baseline_percent}%)",
-        f"- Final: {final['covered']}/{total} ({final_percent}%)",
-        f"- Delta: {_signed(round(final_percent - baseline_percent, 2))}pp",
-        f"- Remaining uncovered: {total - int(final['covered'])}",
+        "| Checkpoint | Covered | Share |",
+        "|---|--:|--:|",
     ]
-
-
-def _coverage_combined_lines(api: dict[str, Any], deep: dict[str, Any]) -> list[str]:
-    """API and deep coverage as one number.
-
-    The two universes are disjoint by construction: the deep universe holds
-    exactly the library methods the API inventory does not, so their measured
-    counts and covered counts add without double counting.
-    """
-    total = _reportable_total(api["final"]) + _reportable_total(deep["final"])
-    baseline = int(api["baseline"]["covered"]) + int(deep["baseline"]["covered"])
-    final = int(api["final"]["covered"]) + int(deep["final"]["covered"])
-    baseline_percent = _coverage_percent(baseline, total)
-    final_percent = _coverage_percent(final, total)
-    return [
-        "### Both phases combined",
+    lines += [
+        f"| {CHECKPOINT_LABELS[point['name']]} | {point['covered']}/{universe} "
+        f"| {point['coveragePercent']}% |"
+        for point in checkpoints
+    ]
+    lines.append("")
+    lines += [
+        f"- {PHASE_LABELS[phase['name']]}: {_signed(phase['covered'])} methods, "
+        f"{_signed(phase['coveragePercentagePoints'])}pp"
+        for phase in run["phases"]
+    ]
+    first = checkpoints[0]
+    last = checkpoints[-1]
+    lines += [
+        f"- Run total: {_signed(int(last['covered']) - int(first['covered']))} methods, "
+        f"{_signed(round(last['coveragePercent'] - first['coveragePercent'], 2))}pp",
+        f"- Remaining uncovered: {last['uncovered']} of {universe}",
         "",
-        f"- Baseline: {baseline}/{total} ({baseline_percent}%)",
-        f"- Final: {final}/{total} ({final_percent}%)",
-        f"- Delta: {_signed(round(final_percent - baseline_percent, 2))}pp",
-        f"- Remaining uncovered: {total - final}",
+        "Where the coverage and the remaining headroom sit:",
+        "",
+        "| Method universe | Run start | Final | Still uncovered |",
+        "|---|--:|--:|--:|",
+        f"| Public API | {first['apiCovered']}/{api_universe} | "
+        f"{last['apiCovered']}/{api_universe} | "
+        f"{api_universe - int(last['apiCovered'])} |",
+        f"| Internal | {first['deepCovered']}/{deep_universe} | "
+        f"{last['deepCovered']}/{deep_universe} | "
+        f"{deep_universe - int(last['deepCovered'])} |",
     ]
+    return lines
 
 
 def _token_cell(value: Any) -> str:
@@ -692,9 +757,7 @@ def _render_code_coverage_improvement(
         "## JaCoCo coverage",
         "",
     ]
-    lines += _coverage_phase_lines("Simple Jacoco guidance phase", metrics["apiJacoco"])
-    lines += [""] + _coverage_phase_lines("PGO guidance phase", metrics["deepJacoco"])
-    lines += [""] + _coverage_combined_lines(metrics["apiJacoco"], metrics["deepJacoco"])
+    lines += _coverage_universe_lines(metrics["runCoverage"])
     lines += [""]
     token_lines = _coverage_token_lines(render.get("token_usage") or [])
     if token_lines:

--- a/docs/tck.md
+++ b/docs/tck.md
@@ -212,7 +212,7 @@ These emit the GitHub Actions matrices the workflows consume, all driven by
 | `generateDynamicAccessCoverageReport`, `analyzeExternalLibraryDynamicAccess` | Dynamic-access coverage reporting (§FS-repository-functional-spec.4.5). |
 | `nativeTestPGOSampling` | Build coordinate native tests with sampled PGO and the analysis call-tree CSV dump for Forge deep-coverage navigation (§forge/WF-code-coverage-improvement.3.2). |
 | `runNativeTestPGO` | Run the sampling image and write its sampled `.iprof` to the required absolute `pgoProfilePath`. |
-| `generateLibraryStats`, `listTopCoordinatesByMetric`, `generateTopCoordinatesByMetricMatrix`, `generateReadmeBadgeSummary`, `generateDependencyGraph` | Produce and query the stats mirror, README badge inputs, and dependency graphs that feed the coverage dashboard (§CI-publish-scheduled-coverage). |
+| `generateLibraryStats`, `listTopCoordinatesByMetric`, `generateTopCoordinatesByMetricMatrix`, `generateReadmeBadgeSummary`, `generateDependencyGraph` | Produce and query the stats mirror, README badge inputs, and dependency graphs that feed the coverage dashboard (§CI-publish-scheduled-coverage). Library coverage analyzes only the coordinate's unclassified main JAR and includes both the regular and tracked extension suites. |
 | `package` | Zip the `metadata/` directory into the release artifact consumed by native-build-tools (§FS-repository-functional-spec.4). |
 
 Dynamic-access coverage normally marks a call site covered when its stack frame
@@ -243,6 +243,13 @@ and sampled-PGO root tasks forward that property to the coordinate project.
 This keeps broad coverage tests separate from metadata-generation tests while
 reusing the coordinate's dependencies and build configuration
 (§forge/WF-code-coverage-improvement.3.1).
+
+JaCoCo coverage reports analyze only the coordinate's unclassified main JAR;
+classified artifacts such as upstream test JARs stay on the execution classpath
+but never contribute classes to the coverage denominator. `generateLibraryStats`
+uses the combined `jacocoCodeCoverageReport`, so newly added regular tests and
+tracked code-coverage extension tests are reflected in the committed
+`libraryCoverage` line, instruction, and method statistics.
 
 `nativeTestPGOSampling` builds with `--pgo-sampling`, a positive
 `-H:PGOSamplingPeriodMicros=<micros>`, `-H:+PrintAnalysisCallTree`, and

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -661,9 +661,9 @@ states:
 
       # Step 5: finalize separate API/deep JaCoCo metrics and guidance-only PGO
       # evidence from the recorded reports and target state.
-      def report_bounds(directory: str, stem: str) -> tuple:
+      def report_bounds(directory: str, stem: str, suffix: str = ".json") -> tuple:
           reports = sorted(
-              Path(directory).glob(f"{stem}-[0-9]*.json"),
+              Path(directory).glob(f"{stem}-[0-9]*{suffix}"),
               key=lambda p: int(p.stem.rsplit("-", 1)[1]),
           )
           if not reports:
@@ -672,6 +672,14 @@ states:
 
       api_baseline, api_final = report_bounds("runtime/code-coverage/validation", "api-cover-report")
       deep_baseline, deep_final = report_bounds("runtime/code-coverage/discovery", "discovery-report")
+      # Whole-run checkpoints. The API/deep boundary is read from the deep
+      # phase's own first report so both universes are counted from one instant:
+      # pairing it with the API phase's last report would put two different
+      # instants of the run on one scale.
+      jacoco_run_start, _ = report_bounds("runtime/code-coverage/validation", "jacoco", ".xml")
+      jacoco_after_api, jacoco_final = report_bounds(
+          "runtime/code-coverage/discovery", "jacoco-deep", ".xml"
+      )
       finalize_command = [
           sys.executable,
           f"{work_path}/utility_scripts/code_coverage_finalize.py",
@@ -681,6 +689,9 @@ states:
           "--api-final", str(api_final),
           "--deep-baseline", str(deep_baseline),
           "--deep-final", str(deep_final),
+          "--jacoco-run-start", str(jacoco_run_start),
+          "--jacoco-after-api", str(jacoco_after_api),
+          "--jacoco-final", str(jacoco_final),
           "--output-dir", "runtime/code-coverage/finalization",
       ]
       for validation_command in [checkstyle_command] + jvm_commands:

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -659,7 +659,22 @@ states:
           except OSError as error:
               fail(4, f"JVM tests could not run: {error}")
 
-      # Step 5: finalize separate API/deep JaCoCo metrics and guidance-only PGO
+      # Step 5: persist coverage from the newly written tests. The stats task
+      # consumes the combined report, whose denominator is only the coordinate's
+      # unclassified main JAR (§root/TCK-test-harness.8).
+      stats_command = [
+          f"{worktree_path}/gradlew",
+          "generateLibraryStats",
+          f"-Pcoordinates={coordinate}",
+          "--stacktrace",
+      ]
+      try:
+          if subprocess.run(stats_command, cwd=worktree_path).returncode != 0:
+              fail(5, "generateLibraryStats failed")
+      except OSError as error:
+          fail(5, f"generateLibraryStats could not run: {error}")
+
+      # Step 6: finalize separate API/deep JaCoCo metrics and guidance-only PGO
       # evidence from the recorded reports and target state.
       def report_bounds(directory: str, stem: str, suffix: str = ".json") -> tuple:
           reports = sorted(
@@ -667,7 +682,7 @@ states:
               key=lambda p: int(p.stem.rsplit("-", 1)[1]),
           )
           if not reports:
-              fail(5, f"no {stem} reports under {directory}")
+              fail(6, f"no {stem} reports under {directory}")
           return reports[0], reports[-1]
 
       api_baseline, api_final = report_bounds("runtime/code-coverage/validation", "api-cover-report")
@@ -694,16 +709,16 @@ states:
           "--jacoco-final", str(jacoco_final),
           "--output-dir", "runtime/code-coverage/finalization",
       ]
-      for validation_command in [checkstyle_command] + jvm_commands:
+      for validation_command in [checkstyle_command] + jvm_commands + [stats_command]:
           finalize_command += ["--validation-command", " ".join(validation_command)]
       for target_state in sorted(Path("runtime/code-coverage/targets").glob("*.json")):
           finalize_command += ["--target-state", str(target_state)]
       finalize_env = dict(os.environ, PYTHONPATH=work_path)
       try:
           if subprocess.run(finalize_command, env=finalize_env).returncode != 0:
-              fail(5, "code_coverage_finalize.py failed")
+              fail(6, "code_coverage_finalize.py failed")
       except OSError as error:
-          fail(5, f"code_coverage_finalize.py could not run: {error}")
+          fail(6, f"code_coverage_finalize.py could not run: {error}")
       PY
     program_timeout: 90m
     inputs:
@@ -777,7 +792,9 @@ states:
         coverage tests; do not suppress or weaken the checkstyle rules.
       - step 4: JVM tests failed - fix the generated coverage tests in the
         issue worktree; do not weaken or delete meaningful assertions.
-      - step 5: `code_coverage_finalize.py` failed - repair the report or
+      - step 5: `generateLibraryStats` failed - repair the coverage report or
+        stats input; do not hand-edit `stats.json`.
+      - step 6: `code_coverage_finalize.py` failed - repair the report or
         target-state artifacts it rejected; never edit its output by hand.
       - verification: finalization artifacts are missing, empty, or
         schema-invalid - repair the inputs and let the program regenerate them.

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -191,8 +191,9 @@
 - Final API report: highest-iteration `runtime/code-coverage/validation/api-cover-report-<n>.json`
 - Final deep report: highest-iteration `runtime/code-coverage/discovery/discovery-report-<n>.json`
 - Helper script: `forge/utility_scripts/code_coverage_finalize.py`
-- Purpose: gate publication on deterministic post-loop validation and
-  summarize separate JaCoCo results and sampled-path guidance.
+- Purpose: gate publication on deterministic post-loop validation, update the
+  committed library coverage stats, and summarize JaCoCo and sampled-path
+  guidance.
 - Execution: this task is a deterministic program (the `reviewed-execute`
   state), not an agent checklist. A nonzero exit code is the number of the
   failed step and routes to `finalize-fix`. Finalization runs no Native Image
@@ -217,14 +218,18 @@
   4. Run the regular JVM tests and the tracked extension suite:
      `./gradlew javaTest -Pcoordinates=<resolved coordinate> --stacktrace` and
      `./gradlew codeCoverageTest -Pcoordinates=<resolved coordinate> --stacktrace`.
-  5. Invoke `forge/utility_scripts/code_coverage_finalize.py` with the resolved
+  5. Regenerate committed coverage statistics from the combined main-JAR-only
+     report by running `./gradlew generateLibraryStats -Pcoordinates=<resolved coordinate> --stacktrace`
+     (§root/TCK-test-harness.8).
+  6. Invoke `forge/utility_scripts/code_coverage_finalize.py` with the resolved
      `--coordinate`, repository-relative `--coverage-suite-path`, the API
      baseline/final reports (`api-cover-report-0.json` and the highest-iteration report),
      the deep baseline/final reports (`discovery-report-0.json` and the
      highest-iteration report), any externally provided
      `runtime/code-coverage/targets/*.json` as repeated `--target-state`
      arguments (the workflow itself no longer produces them), the exact
-     checkstyle and JVM test commands as repeated `--validation-command`s, and
+     checkstyle, JVM test, and stats commands as repeated
+     `--validation-command`s, and
      `--output-dir runtime/code-coverage/finalization`.
 - Verification: the `finalize-verify` program then schema-validates
   `final-metrics.json` (`code_coverage_final_metrics` alias) and requires

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -250,7 +250,8 @@
     `runtime/code-coverage/finalization/final-metrics.json`.
   - Confirm the issue worktree branch is the expected issue branch.
   - Leave verified changes uncommitted or committed; the helper stages the
-    coverage suite and touched metadata itself and commits them.
+    coverage suite, touched metadata, and the regenerated coverage stats itself
+    and commits them.
   - Run the helper with `--repo-path`, `--coordinate`, `--issue-number`,
     `--finalization-dir`, `--coverage-suite-path`, and
     `--worker-agent {{worker_agent}}`. The helper names the head branch after
@@ -266,9 +267,10 @@
     task: `Forge Branch Ready` validates the exact commit as data, and only its
     success lets `Forge Open PR` render the body and open the pull request
     (§GIT-actions-publication).
-  - The descriptor carries the coordinate, coverage suite path, separate
-    baseline and final API/deep JaCoCo coverage, the human-intervention flag,
-    the generating model, and per-phase token usage.
+  - The descriptor carries the coordinate, coverage suite path, the whole-run
+    coverage checkpoints and phase gains on one shared denominator (§4.1), the
+    per-phase JaCoCo records, the human-intervention flag, the generating model,
+    and per-phase token usage.
     The trusted renderer writes every section of the body from it. Do not
     hand-write a pull request body: a section an agent types is one no run
     publishes.

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -197,7 +197,8 @@
 - Execution: this task is a deterministic program (the `reviewed-execute`
   state), not an agent checklist. A nonzero exit code is the number of the
   failed step and routes to `finalize-fix`. Finalization runs no Native Image
-  validation at this stage.
+  validation of the coverage tests; the stats step (5) does build a native image,
+  because the dynamic-access half of `stats.json` is only observable from one.
 - Program steps:
   1. Read `runtime/code-coverage/issues/conversion.json` for the resolved
      coordinate, worktree, work path, and coverage suite paths.
@@ -220,7 +221,10 @@
      `./gradlew codeCoverageTest -Pcoordinates=<resolved coordinate> --stacktrace`.
   5. Regenerate committed coverage statistics from the combined main-JAR-only
      report by running `./gradlew generateLibraryStats -Pcoordinates=<resolved coordinate> --stacktrace`
-     (§root/TCK-test-harness.8).
+     (§root/TCK-test-harness.8). The task re-runs the coverage report and builds
+     the dynamic-access native image, so this is the step that dominates the
+     program's wall clock; a failed native build degrades `dynamicAccess` to
+     `N/A` rather than failing the step.
   6. Invoke `forge/utility_scripts/code_coverage_finalize.py` with the resolved
      `--coordinate`, repository-relative `--coverage-suite-path`, the API
      baseline/final reports (`api-cover-report-0.json` and the highest-iteration report),

--- a/forge/docs/workflows/code-coverage-improvement.md
+++ b/forge/docs/workflows/code-coverage-improvement.md
@@ -424,13 +424,18 @@ The Rhei template should decompose the workflow into these phases:
    internal methods through public behavior, and always returns to measurement;
    it writes no target state — measurement tracks attempts and rotation
    deterministically from its own report history.
-7. **Finalization** — a deterministic step program: read the machine-readable
-   conversion record; run `splitTestOnlyMetadata` and then `checkMetadataFiles`;
-   run checkstyle over the coordinate's subprojects (including the tracked
-   coverage suite); run the regular JVM tests (`javaTest`) and the tracked
-   extension suite (`codeCoverageTest`); and persist final metrics from the
-   baseline and highest-iteration JaCoCo and deep reports. The split is the same
-   step the dynamic-access workflows run at their own finalization
+7. **Finalization and stats** — a deterministic step program: read the
+   machine-readable conversion record; run `splitTestOnlyMetadata` and then
+   `checkMetadataFiles`; run checkstyle over the coordinate's subprojects
+   (including the tracked coverage suite); run the regular JVM tests (`javaTest`)
+   and the tracked extension suite (`codeCoverageTest`); regenerate the
+   coordinate's committed library stats from the combined main-JAR-only JaCoCo
+   report; and persist final metrics from the baseline and highest-iteration
+   JaCoCo and deep reports. The stats update makes the repository coverage
+   dashboard reflect the tests this workflow adds without counting classified
+   artifacts such as an upstream test JAR in the denominator
+   (§root/TCK-test-harness.8). The metadata split is the same step the
+   dynamic-access workflows run at their own finalization
    (§WF-improve-library-coverage), and for the same reason: metadata the
    extension suite needed only for its own helper types must not reach a
    consumer, and deciding that by hand is exactly what the task automates
@@ -454,8 +459,9 @@ The Rhei template should decompose the workflow into these phases:
    The descriptor carries the render inputs and only those: coordinate, coverage
    suite path, the whole-run coverage checkpoints and phase gains, the per-phase
    JaCoCo records, the human-intervention flag, the generating model, and
-   per-phase token usage read from the Rhei accounting directory. The body links its issue with `Fixes:`,
-   never conditionally: one run publishes one pull request, so merging it closes
+   per-phase token usage read from the Rhei accounting directory. The body links
+   its issue with `Fixes:`, never conditionally: one run publishes one pull
+   request, so merging it closes
    the issue that claimed the coordinate (§GIT-issue-linking). Per-target
    rosters, sampled PGO evidence, and the validation command list stay in the
    finalization artifacts: the target counts restate what the coverage figures

--- a/forge/docs/workflows/code-coverage-improvement.md
+++ b/forge/docs/workflows/code-coverage-improvement.md
@@ -452,9 +452,9 @@ The Rhei template should decompose the workflow into these phases:
    opens nothing itself (§AR-forge-verification-publication-boundary).
 
    The descriptor carries the render inputs and only those: coordinate, coverage
-   suite path, baseline and final JaCoCo coverage for each guidance phase, the
-   human-intervention flag, the generating model, and per-phase token usage read
-   from the Rhei accounting directory. The body links its issue with `Fixes:`,
+   suite path, the whole-run coverage checkpoints and phase gains, the per-phase
+   JaCoCo records, the human-intervention flag, the generating model, and
+   per-phase token usage read from the Rhei accounting directory. The body links its issue with `Fixes:`,
    never conditionally: one run publishes one pull request, so merging it closes
    the issue that claimed the coordinate (§GIT-issue-linking). Per-target
    rosters, sampled PGO evidence, and the validation command list stay in the
@@ -463,14 +463,15 @@ The Rhei template should decompose the workflow into these phases:
    which no reader of the PR can execute. A reviewer who wants per-target detail
    reads it from the run.
 
-   The trusted renderer reports coverage against the methods JaCoCo reports, not
-   against every inventory entry: entries JaCoCo never reports are ones no run
-   can cover, and charging them to the run understates it. The combined figure
-   adds the two phases directly, which is sound because the deep universe holds
-   exactly the library methods the API inventory does not. A phase whose
-   accounting is not yet written is omitted from the token table rather than
-   reported as zero; publication itself is normally omitted, since its own
-   invocations are still running when the descriptor is written.
+   The trusted renderer presents the run as sequential checkpoints under the
+   coverage accounting rule below (§4.1), never as two phases on their own
+   scales: it divides every figure by the one frozen universe finalization
+   recorded, so a phase's gain is the distance from the checkpoint the previous
+   phase ended on. It computes no denominator of its own — the counting happens
+   once, where the JaCoCo reports are, and the renderer reads the result. A
+   phase whose accounting is not yet written is omitted from the token table
+   rather than reported as zero; publication itself is normally omitted, since
+   its own invocations are still running when the descriptor is written.
 
    The head branch is
    `ai/<login>/code-coverage-<artifact>-<version>-<model>[-<suffix>]-<publication-id>`.
@@ -483,6 +484,38 @@ The Rhei template should decompose the workflow into these phases:
    share a model while a retried publication of one run rebuilds the same branch
    and reuses its pull request. `branch_suffix` no longer keeps runs apart; it
    only labels which run a branch belongs to.
+
+
+### 4.1 Coverage accounting
+
+Every count and every ratio the workflow publishes obeys three rules. They exist
+because violating them silently understates a run: an earlier revision reported
+each phase against its own roster and took the two phases' snapshots at
+different points in the run, which both inflated the baseline and discarded the
+public API methods the deep phase covered after the API phase's last report.
+
+1. **One universe, frozen once.** The denominator is the complete set of library
+   method **ids** JaCoCo can rule on: the API inventory's reportable entries plus
+   the deep roster, which are disjoint by construction because the deep roster is
+   exactly the library methods the inventory does not hold. It is resolved once,
+   from the run's own rosters, and never recomputed per phase. Inventory entries
+   JaCoCo does not report are excluded — no run can cover them, so charging them
+   to a denominator understates every figure that divides by it.
+2. **One report per checkpoint, one routine.** A checkpoint counts both universes
+   from a single JaCoCo report by looking up the frozen ids. Summary fields that
+   separate phases computed for themselves are never added together: they belong
+   to different instants of the run, and combining them presents two different
+   instants as one figure. The API/deep boundary is therefore read from the deep
+   phase's own first report, not from the API phase's last one.
+3. **A missing id is an error, not a zero.** If a frozen id is absent from a later
+   report the universe moved, and finalization fails rather than quietly
+   reporting against a smaller denominator.
+
+Each phase's gain is then the distance between consecutive checkpoints, the
+phase gains sum to the run's gain, and no separate combined figure is needed.
+The per-phase `apiJacoco` and `deepJacoco` blocks remain in the finalization
+artifacts, since each phase's own guidance is ranked against its own roster;
+they are phase records, not run figures.
 
 The pipeline tasks run unreviewed: deterministic helpers, schema-validated
 artifacts, and zero-exit validation gates decide their completion. The

--- a/forge/docs/workflows/code-coverage-improvement.md
+++ b/forge/docs/workflows/code-coverage-improvement.md
@@ -434,19 +434,27 @@ The Rhei template should decompose the workflow into these phases:
    JaCoCo and deep reports. The stats update makes the repository coverage
    dashboard reflect the tests this workflow adds without counting classified
    artifacts such as an upstream test JAR in the denominator
-   (§root/TCK-test-harness.8). The metadata split is the same step the
-   dynamic-access workflows run at their own finalization
-   (§WF-improve-library-coverage), and for the same reason: metadata the
+   (§root/TCK-test-harness.8). It is also the one step here that builds a native
+   image: `generateLibraryStats` measures dynamic access from a native build, so
+   the stats step, not the JVM suites, sets this phase's wall clock. A native
+   build that fails degrades the coordinate's `dynamicAccess` figure to `N/A`
+   instead of failing the run, and that `N/A` replaces whatever the committed
+   stats held before. The metadata split is the same step the dynamic-access
+   workflows run at their own finalization (§WF-improve-library-coverage), and
+   for the same reason: metadata the
    extension suite needed only for its own helper types must not reach a
    consumer, and deciding that by hand is exactly what the task automates
-   (§root/METADATA-suite.2, §root/TCK-test-harness.5). The step also fails the run when a
-   legacy split-config file survives anywhere under the coordinate's test tree,
-   which is how a tracing-agent artifact left behind by metadata preparation is
-   caught before publication rather than in review (§2). No Native Image
-   validation runs at this stage; a nonzero exit code names the failed step.
+   (§root/METADATA-suite.2, §root/TCK-test-harness.5). The step also fails the
+   run when a legacy split-config file survives anywhere under the coordinate's
+   test tree, which is how a tracing-agent artifact left behind by metadata
+   preparation is caught before publication rather than in review (§2). Nothing
+   at this stage validates the coverage tests under Native Image — the native
+   build the stats step runs measures dynamic access and does not gate the run;
+   a nonzero exit code names the failed step.
 8. **Publication** — push the verified branch and let trusted GitHub Actions
-   open the pull request. Local publication stages the coverage suite and the
-   metadata it justified, rebases onto upstream `master`, runs the
+   open the pull request. Local publication stages the coverage suite, the
+   metadata it justified, and the stats finalization regenerated, rebases onto
+   upstream `master`, runs the
    pre-publication verification gate, writes
    `stats/<group>/<artifact>/<version>/forge-publication.json`, and pushes
    `ai/<login>/...` — nothing else. `Forge Branch Ready` then validates that

--- a/forge/git_scripts/publish_code_coverage_improvement.py
+++ b/forge/git_scripts/publish_code_coverage_improvement.py
@@ -145,10 +145,13 @@ def stage_coverage_paths(
         version: str,
         coverage_suite_path: str,
 ) -> None:
-    """Stage the code coverage suite and any touched metadata, then commit.
+    """Stage the code coverage suite, touched metadata, and stats, then commit.
 
     The coverage route's expected paths (§GIT-expected-paths): the dedicated
-    suite, the coordinate's test directory, and the metadata the suite justified.
+    suite, the coordinate's test directory, the metadata the suite justified, and
+    the coverage stats finalization regenerated from the combined main-JAR-only
+    JaCoCo report. Leaving the stats unstaged publishes tests whose effect the
+    repository's own coverage record never shows (§root/TCK-test-harness.8).
     """
     test_dir: str = os.path.relpath(
         resolve_test_dir(repo_path, group, artifact, version),
@@ -165,6 +168,7 @@ def stage_coverage_paths(
         test_dir,
         os.path.join("metadata", group, artifact, "index.json"),
         os.path.join("metadata", group, artifact, metadata_version),
+        os.path.join("stats", group, artifact, metadata_version, "stats.json"),
     ]
     existing: list[str] = [
         path for path in candidates if os.path.exists(os.path.join(repo_path, path))

--- a/forge/git_scripts/publish_code_coverage_improvement.py
+++ b/forge/git_scripts/publish_code_coverage_improvement.py
@@ -37,13 +37,16 @@ from utility_scripts.repo_path_resolver import resolve_repo_roots
 TASK_TYPE = "code-coverage-improvement"
 MAX_COMMIT_SUBJECT_LENGTH = 60
 
-#: The finalized evidence the trusted coverage template renders. Everything else
-#: `final-metrics.json` records — per-target rosters, sampled PGO guidance, the
-#: validation command list — stays in the finalization artifacts a reviewer reads
-#: from the run, so the committed descriptor holds render inputs and nothing else.
+#: The finalized evidence the trusted coverage template renders. `runCoverage`
+#: is the whole-run accounting the body is built from; the per-phase blocks ride
+#: along as each phase's own guidance record (§WF-code-coverage-improvement.4.1).
+#: Everything else `final-metrics.json` records — per-target rosters, sampled PGO
+#: guidance, the validation command list — stays in the finalization artifacts a
+#: reviewer reads from the run, so the descriptor holds render inputs and nothing else.
 COVERAGE_RENDER_KEYS: tuple[str, ...] = (
     "coordinate",
     "coverageSuitePath",
+    "runCoverage",
     "apiJacoco",
     "deepJacoco",
     "needsHumanIntervention",

--- a/forge/schemas/code_coverage_final_metrics_schema.json
+++ b/forge/schemas/code_coverage_final_metrics_schema.json
@@ -8,6 +8,7 @@
     "generatedAt",
     "coordinate",
     "coverageSuitePath",
+    "runCoverage",
     "apiJacoco",
     "deepJacoco",
     "pgoGuidance",
@@ -16,7 +17,7 @@
     "needsHumanIntervention"
   ],
   "properties": {
-    "schemaVersion": {"const": "1.0.0"},
+    "schemaVersion": {"const": "1.1.0"},
     "generatedAt": {
       "type": "string",
       "format": "date-time"
@@ -26,6 +27,7 @@
       "pattern": "^[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+:[A-Za-z0-9_.+-]+$"
     },
     "coverageSuitePath": {"type": "string", "minLength": 1},
+    "runCoverage": {"$ref": "#/$defs/runCoverage"},
     "apiJacoco": {"$ref": "#/$defs/apiEvidence"},
     "deepJacoco": {"$ref": "#/$defs/deepEvidence"},
     "pgoGuidance": {"$ref": "#/$defs/pgoGuidance"},
@@ -57,6 +59,65 @@
     }
   ],
   "$defs": {
+    "runCoverage": {
+      "description": "Whole-run coverage on one denominator: the complete count of library methods JaCoCo can rule on. Every checkpoint is counted over that one frozen method-id set from a single JaCoCo report, so each phase begins where the previous phase ended.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "universe",
+        "apiUniverse",
+        "deepUniverse",
+        "checkpoints",
+        "phases"
+      ],
+      "properties": {
+        "universe": {"type": "integer", "minimum": 0},
+        "apiUniverse": {"type": "integer", "minimum": 0},
+        "deepUniverse": {"type": "integer", "minimum": 0},
+        "checkpoints": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {"$ref": "#/$defs/runCheckpoint"}
+        },
+        "phases": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {"$ref": "#/$defs/runPhaseGain"}
+        }
+      }
+    },
+    "runCheckpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "apiCovered",
+        "deepCovered",
+        "covered",
+        "uncovered",
+        "coveragePercent"
+      ],
+      "properties": {
+        "name": {"enum": ["runStart", "afterApiPhase", "final"]},
+        "apiCovered": {"type": "integer", "minimum": 0},
+        "deepCovered": {"type": "integer", "minimum": 0},
+        "covered": {"type": "integer", "minimum": 0},
+        "uncovered": {"type": "integer", "minimum": 0},
+        "coveragePercent": {"type": "number", "minimum": 0, "maximum": 100}
+      }
+    },
+    "runPhaseGain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "covered", "coveragePercentagePoints"],
+      "properties": {
+        "name": {"enum": ["api", "deep"]},
+        "covered": {"type": "integer"},
+        "coveragePercentagePoints": {"type": "number"}
+      }
+    },
     "apiSnapshot": {
       "type": "object",
       "additionalProperties": false,

--- a/forge/tests/fixtures/code_coverage/final_metrics.json
+++ b/forge/tests/fixtures/code_coverage/final_metrics.json
@@ -1,8 +1,51 @@
 {
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "1.1.0",
   "generatedAt": "2026-08-20T10:15:30Z",
   "coordinate": "com.example:demo:1.0.0",
   "coverageSuitePath": "tests/src/com.example/demo/1.0.0/code-coverage-improvement",
+  "runCoverage": {
+    "universe": 30,
+    "apiUniverse": 10,
+    "deepUniverse": 20,
+    "checkpoints": [
+      {
+        "name": "runStart",
+        "apiCovered": 4,
+        "deepCovered": 5,
+        "covered": 9,
+        "uncovered": 21,
+        "coveragePercent": 30.0
+      },
+      {
+        "name": "afterApiPhase",
+        "apiCovered": 8,
+        "deepCovered": 8,
+        "covered": 16,
+        "uncovered": 14,
+        "coveragePercent": 53.33
+      },
+      {
+        "name": "final",
+        "apiCovered": 9,
+        "deepCovered": 12,
+        "covered": 21,
+        "uncovered": 9,
+        "coveragePercent": 70.0
+      }
+    ],
+    "phases": [
+      {
+        "name": "api",
+        "covered": 7,
+        "coveragePercentagePoints": 23.33
+      },
+      {
+        "name": "deep",
+        "covered": 5,
+        "coveragePercentagePoints": 16.67
+      }
+    ]
+  },
   "apiJacoco": {
     "baseline": {
       "total": 16,

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -215,6 +215,28 @@ class FinalizerTests(unittest.TestCase):
         self.assertIn("the universe moved", str(raised.exception))
         self.assertIn("example.Api#m9():void", str(raised.exception))
 
+    def test_run_start_report_defines_both_rosters(self) -> None:
+        """A method the run never reports is dropped on either side, not fatal.
+
+        The deep roster gets the same treatment as the inventory: charging an
+        unreportable method to the denominator understates every figure, and
+        aborting on one roster while quietly dropping from the other would make
+        the same condition fatal or free depending on which side it landed on.
+        """
+        run_start = module.load_jacoco_method_coverage(
+            [self._write_xml("narrow.xml", _jacoco(1, 1, 2, 2))]
+        )
+
+        api_ids, deep_ids = module._universe_ids(
+            _api(["covered", "uncovered", "not-reported"]),
+            _deep(["covered", "uncovered", "uncovered"], 12),
+            run_start,
+        )
+
+        self.assertEqual(len(api_ids), 2)
+        self.assertEqual(len(deep_ids), 2)
+        self.assertNotIn("example.Internal#m2():void", deep_ids)
+
     def test_finalizes_without_target_state_files(self) -> None:
         metrics = self._run(include_target_state=False)
 

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -55,6 +55,29 @@ def _deep(statuses: list[str], samples: int) -> dict:
     }
 
 
+def _jacoco(api_covered: int, deep_covered: int, api_total: int, deep_total: int) -> str:
+    """A JaCoCo XML naming the same ids the API and deep rosters use.
+
+    The first `api_covered` / `deep_covered` methods of each class carry a
+    covered METHOD counter; the rest are reported but uncovered.
+    """
+    def methods(prefix: str, total: int, covered: int) -> str:
+        return "".join(
+            f'<method name="m{index}" desc="()V" line="{index + 1}">'
+            f'<counter type="METHOD" missed="{0 if index < covered else 1}" '
+            f'covered="{1 if index < covered else 0}"/></method>'
+            for index in range(total)
+        )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?><report name="demo">'
+        f'<package name="example"><class name="example/Api" sourcefilename="Api.java">'
+        f'{methods("Api", api_total, api_covered)}</class>'
+        f'<class name="example/Internal" sourcefilename="Internal.java">'
+        f'{methods("Internal", deep_total, deep_covered)}</class>'
+        "</package></report>"
+    )
+
+
 class FinalizerTests(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -65,6 +88,12 @@ class FinalizerTests(unittest.TestCase):
         path = os.path.join(self.directory.name, name)
         with open(path, "w", encoding="utf-8") as output:
             json.dump(value, output)
+        return path
+
+    def _write_xml(self, name: str, value: str) -> str:
+        path = os.path.join(self.directory.name, name)
+        with open(path, "w", encoding="utf-8") as output:
+            output.write(value)
         return path
 
     def _run(self, include_target_state: bool = True) -> dict:
@@ -125,6 +154,16 @@ class FinalizerTests(unittest.TestCase):
                 ],
             },
         )
+        # Three checkpoints of one run: 1/9 -> 4/9 -> 6/9 of the frozen universe
+        # of 4 API plus 5 deep methods.
+        checkpoints = tuple(
+            self._write_xml(f"jacoco-{name}.xml", _jacoco(api, deep, 4, 5))
+            for name, api, deep in (
+                ("run-start", 1, 0),
+                ("after-api", 3, 1),
+                ("final", 3, 3),
+            )
+        )
         return module.finalize_coverage(
             coordinate=COORDINATE,
             coverage_suite_path="tests/src/com.example/demo/1.0.0/code-coverage-improvement",
@@ -132,10 +171,49 @@ class FinalizerTests(unittest.TestCase):
             api_final_path=final_api,
             deep_baseline_path=baseline_deep,
             deep_final_path=final_deep,
+            jacoco_paths=checkpoints,
             target_state_paths=[state] if include_target_state else [],
             validation_commands=["./gradlew test -Pcoordinates=com.example:demo:1.0.0"],
             output_dir=os.path.join(self.directory.name, "output"),
         )
+
+    def test_run_coverage_is_one_denominator_and_sequential_checkpoints(self) -> None:
+        """Each phase begins at the checkpoint the previous phase ended on."""
+        run = self._run()["runCoverage"]
+
+        self.assertEqual(run["universe"], 9)
+        self.assertEqual((run["apiUniverse"], run["deepUniverse"]), (4, 5))
+        self.assertEqual(
+            [(point["name"], point["covered"]) for point in run["checkpoints"]],
+            [("runStart", 1), ("afterApiPhase", 4), ("final", 6)],
+        )
+        # Every share divides by the same 9, so the phase gains sum to the run's.
+        self.assertEqual(
+            [point["coveragePercent"] for point in run["checkpoints"]],
+            [11.11, 44.44, 66.67],
+        )
+        self.assertEqual(
+            [(phase["name"], phase["covered"]) for phase in run["phases"]],
+            [("api", 3), ("deep", 2)],
+        )
+        gains = sum(phase["coveragePercentagePoints"] for phase in run["phases"])
+        first, last = run["checkpoints"][0], run["checkpoints"][-1]
+        self.assertAlmostEqual(
+            gains, last["coveragePercent"] - first["coveragePercent"], places=2
+        )
+
+    def test_run_coverage_rejects_a_universe_that_moved(self) -> None:
+        """A frozen id missing from a later report is an error, not a zero."""
+        with self.assertRaises(module.FinalizationError) as raised:
+            module._checkpoint(
+                "final",
+                self._write_xml("short.xml", _jacoco(1, 1, 2, 2)),
+                ["example.Api#m0():void", "example.Api#m9():void"],
+                [],
+            )
+
+        self.assertIn("the universe moved", str(raised.exception))
+        self.assertIn("example.Api#m9():void", str(raised.exception))
 
     def test_finalizes_without_target_state_files(self) -> None:
         metrics = self._run(include_target_state=False)
@@ -184,7 +262,7 @@ class FinalizerTests(unittest.TestCase):
         loaded = module.load_validated_final_metrics(
             os.path.join(output, "final-metrics.json")
         )
-        self.assertEqual(loaded["schemaVersion"], "1.0.0")
+        self.assertEqual(loaded["schemaVersion"], "1.1.0")
         with open(
                 os.path.join(output, "final-summary.md"),
                 encoding="utf-8",

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -128,7 +128,17 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
         """One universe of 30: 10 reportable API entries plus 20 deep methods."""
         _, body = publisher.render_publication(_descriptor())
 
-        self.assertIn("the 30 library methods JaCoCo can rule on", body)
+        # The lead paragraph is wrapped, so it reads as text rather than as one
+        # line of it.
+        paragraph = body.split("## JaCoCo coverage\n\n", 1)[1].split("\n\n", 1)[0]
+        self.assertGreater(len(paragraph.splitlines()), 1)
+        self.assertLessEqual(
+            max(len(line) for line in paragraph.splitlines()),
+            publisher.BODY_TEXT_WIDTH,
+        )
+        self.assertIn(
+            "the 30 library methods JaCoCo can rule on", " ".join(paragraph.split())
+        )
         self.assertIn("| Run start | 9/30 | 30.0% |", body)
         self.assertIn("| After Simple Jacoco guidance phase | 16/30 | 53.33% |", body)
         self.assertIn("| After PGO guidance phase (final) | 21/30 | 70.0% |", body)

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -51,6 +51,7 @@ def _coverage_evidence(**overrides: Any) -> dict[str, Any]:
         for key in (
             "coordinate",
             "coverageSuitePath",
+            "runCoverage",
             "apiJacoco",
             "deepJacoco",
             "needsHumanIntervention",
@@ -123,28 +124,33 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
             title, "[GenAI] Improve code coverage for com.example:demo:1.0.0 using gpt-5.6-luna"
         )
 
-    def test_body_reports_phase_totals(self) -> None:
+    def test_body_reports_every_checkpoint_on_one_denominator(self) -> None:
+        """One universe of 30: 10 reportable API entries plus 20 deep methods."""
         _, body = publisher.render_publication(_descriptor())
 
-        self.assertIn("### Simple Jacoco guidance phase", body)
-        # `measured`, not `total`: the 6 not-reported entries are methods JaCoCo
-        # can never rule on, so counting them against the run understates it.
-        self.assertIn("Baseline: 4/10 (40.0%)", body)
-        self.assertIn("Final: 8/10 (80.0%)", body)
-        self.assertIn("Delta: +40.0pp", body)
-        self.assertIn("Remaining uncovered: 2", body)
-        self.assertIn("### PGO guidance phase", body)
-        self.assertIn("Final: 12/20 (60.0%)", body)
+        self.assertIn("the 30 library methods JaCoCo can rule on", body)
+        self.assertIn("| Run start | 9/30 | 30.0% |", body)
+        self.assertIn("| After Simple Jacoco guidance phase | 16/30 | 53.33% |", body)
+        self.assertIn("| After PGO guidance phase (final) | 21/30 | 70.0% |", body)
         self.assertNotIn("Sampled PGO", body)
 
-    def test_body_combines_both_phases(self) -> None:
+    def test_body_reports_phase_gains_that_sum_to_the_run(self) -> None:
+        """Each gain is the distance from the previous checkpoint, so they add up."""
         _, body = publisher.render_publication(_descriptor())
 
-        # Disjoint universes, so 10 measured API + 20 deep methods add up.
-        self.assertIn("### Both phases combined", body)
-        self.assertIn("Baseline: 9/30 (30.0%)", body)
-        self.assertIn("Final: 20/30 (66.67%)", body)
-        self.assertIn("Delta: +36.67pp", body)
+        self.assertIn("- Simple Jacoco guidance phase: +7 methods, +23.33pp", body)
+        self.assertIn("- PGO guidance phase: +5 methods, +16.67pp", body)
+        self.assertIn("- Run total: +12 methods, +40.0pp", body)
+        self.assertIn("- Remaining uncovered: 9 of 30", body)
+        self.assertNotIn("Both phases combined", body)
+
+    def test_body_credits_the_deep_phase_with_the_api_methods_it_covered(self) -> None:
+        """The old accounting stopped counting API coverage at the phase boundary."""
+        _, body = publisher.render_publication(_descriptor())
+
+        # 8 API methods at the boundary, 9 at the end: the deep phase covered one.
+        self.assertIn("| Public API | 4/10 | 9/10 | 1 |", body)
+        self.assertIn("| Internal | 5/20 | 12/20 | 8 |", body)
 
     def test_body_reports_token_usage_in_the_order_the_descriptor_carries(self) -> None:
         usage = [
@@ -199,6 +205,22 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             publisher._validate_render_inputs(descriptor)
+
+    def test_render_validation_rejects_missing_run_coverage(self) -> None:
+        """Without the frozen universe the body has no denominator to render."""
+        evidence = _coverage_evidence()
+        evidence.pop("runCoverage")
+
+        with self.assertRaises(ValueError):
+            publisher._validate_render_inputs(_descriptor(code_coverage=evidence))
+
+    def test_render_validation_rejects_a_truncated_checkpoint_list(self) -> None:
+        evidence = _coverage_evidence()
+        evidence["runCoverage"] = dict(evidence["runCoverage"])
+        evidence["runCoverage"]["checkpoints"] = evidence["runCoverage"]["checkpoints"][:2]
+
+        with self.assertRaises(ValueError):
+            publisher._validate_render_inputs(_descriptor(code_coverage=evidence))
 
     def test_render_validation_rejects_a_half_built_phase(self) -> None:
         evidence = _coverage_evidence()

--- a/forge/tests/test_publish_code_coverage_improvement.py
+++ b/forge/tests/test_publish_code_coverage_improvement.py
@@ -123,6 +123,65 @@ class CoveragePublicationTests(unittest.TestCase):
         self.assertNotIn(requested_metadata_dir, staged_paths)
         self.assertEqual(stage_and_commit.call_args.kwargs["cwd"], repo_path)
 
+    def test_stages_the_regenerated_coverage_stats(self) -> None:
+        """Finalization rewrites `stats.json`; the commit must carry it."""
+        with tempfile.TemporaryDirectory(prefix="coverage-stats-") as repo_path:
+            group = "com.example"
+            artifact = "demo"
+            requested_version = "1.1.0"
+            metadata_version = "1.0.0"
+            index_dir = os.path.join(repo_path, "metadata", group, artifact)
+            os.makedirs(index_dir)
+            with open(
+                    os.path.join(index_dir, "index.json"),
+                    "w",
+                    encoding="utf-8",
+            ) as index_file:
+                json.dump(
+                    [{
+                        "metadata-version": metadata_version,
+                        "test-version": "shared-tests",
+                        "tested-versions": [requested_version],
+                    }],
+                    index_file,
+                )
+            stats_path = os.path.join(
+                "stats", group, artifact, metadata_version, "stats.json"
+            )
+            os.makedirs(os.path.dirname(os.path.join(repo_path, stats_path)))
+            with open(
+                    os.path.join(repo_path, stats_path), "w", encoding="utf-8"
+            ) as stats_file:
+                json.dump({}, stats_file)
+            coverage_suite = os.path.join(
+                "tests",
+                "src",
+                group,
+                artifact,
+                "shared-tests",
+                "code-coverage-improvement",
+            )
+            os.makedirs(os.path.join(repo_path, coverage_suite))
+
+            with patch.object(module, "stage_and_commit") as stage_and_commit:
+                module.stage_coverage_paths(
+                    repo_path,
+                    group,
+                    artifact,
+                    requested_version,
+                    coverage_suite,
+                )
+
+        staged_paths, _ = stage_and_commit.call_args.args
+        # The stats mirror is keyed by metadata version, like the metadata itself.
+        self.assertIn(stats_path, staged_paths)
+        self.assertNotIn(
+            os.path.join(
+                "stats", group, artifact, requested_version, "stats.json"
+            ),
+            staged_paths,
+        )
+
     def _publish(
             self,
             branch_suffix: str | None = None,

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -238,12 +238,15 @@ def _universe_ids(
 ) -> tuple[list[str], list[str]]:
     """The complete method set every ratio in this run divides by.
 
-    Frozen once, from the run's own inventory and deep rosters, and never
-    recomputed per phase. Inventory entries JaCoCo does not report at all are
-    dropped: no run can cover them, so charging them to a denominator understates
-    every figure that divides by it. The two rosters must not overlap, since the
-    deep roster is by construction the library methods the inventory does not
-    hold, and an overlap would double count (§WF-code-coverage-improvement.4.1).
+    The run-start report defines the universe: both rosters are cut down to the
+    methods it reports, and every later checkpoint must then still report all of
+    them, which is where a universe that moved mid-run is caught. Methods JaCoCo
+    does not report at all are dropped rather than charged to a denominator no
+    run can cover them against, and the same rule applies to both rosters so
+    that an unreported method is not silently dropped on one side and a hard
+    error on the other. The two rosters must not overlap, since the deep roster
+    is by construction the library methods the inventory does not hold, and an
+    overlap would double count (§WF-code-coverage-improvement.4.1).
     """
     inventory_ids: list[str] = list(
         _coverage_statuses(
@@ -270,6 +273,7 @@ def _universe_ids(
     api_ids: list[str] = [
         method_id for method_id in inventory_ids if method_id in run_start
     ]
+    deep_ids = [method_id for method_id in deep_ids if method_id in run_start]
     if not api_ids and not deep_ids:
         raise FinalizationError("The coverage universe is empty.")
     return api_ids, deep_ids
@@ -285,7 +289,9 @@ def _checkpoint(
 
     One report, one routine, both universes. Assembling a checkpoint from
     summary fields that separate phases computed for themselves is what lets two
-    different instants of the run be presented as if they were comparable.
+    different instants of the run be presented as if they were comparable. The
+    universe is cut from the run-start report, so a method missing here means a
+    later report stopped covering ground the first one held.
     """
     coverage: dict[str, Any] = load_jacoco_method_coverage([jacoco_path])
     missing: list[str] = [

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -22,8 +22,14 @@ from typing import Any
 from jsonschema import Draft202012Validator
 
 from utility_scripts.code_coverage_model import parse_inventory_id
+from utility_scripts.code_coverage_jacoco import load_jacoco_method_coverage
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
+
+#: Run checkpoints, in run order. Each is one JaCoCo report, and each phase
+#: begins at the checkpoint the previous phase ended on
+#: (§WF-code-coverage-improvement.4.1).
+CHECKPOINT_NAMES: tuple[str, ...] = ("runStart", "afterApiPhase", "final")
 SCHEMA_FILE = "code_coverage_final_metrics_schema.json"
 TARGET_STATE_SCHEMA_FILE = "code_coverage_target_state_schema.json"
 COORDINATE_PATTERN = re.compile(
@@ -222,6 +228,134 @@ def _deep_snapshot(
         "covered": covered,
         "uncovered": uncovered,
         "coveragePercent": _percent(covered, total),
+    }
+
+
+def _universe_ids(
+        api_baseline_report: dict[str, Any],
+        deep_baseline_report: dict[str, Any],
+        run_start: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """The complete method set every ratio in this run divides by.
+
+    Frozen once, from the run's own inventory and deep rosters, and never
+    recomputed per phase. Inventory entries JaCoCo does not report at all are
+    dropped: no run can cover them, so charging them to a denominator understates
+    every figure that divides by it. The two rosters must not overlap, since the
+    deep roster is by construction the library methods the inventory does not
+    hold, and an overlap would double count (§WF-code-coverage-improvement.4.1).
+    """
+    inventory_ids: list[str] = list(
+        _coverage_statuses(
+            api_baseline_report,
+            "targets",
+            "API baseline",
+            frozenset({"covered", "uncovered", "not-reported"}),
+        )
+    )
+    deep_ids: list[str] = list(
+        _coverage_statuses(
+            deep_baseline_report,
+            "deepMethods",
+            "Deep baseline",
+            frozenset({"covered", "uncovered"}),
+        )
+    )
+    overlap: set[str] = set(inventory_ids) & set(deep_ids)
+    if overlap:
+        raise FinalizationError(
+            f"The API and deep rosters share {len(overlap)} method ids; "
+            f"the coverage universes must be disjoint."
+        )
+    api_ids: list[str] = [
+        method_id for method_id in inventory_ids if method_id in run_start
+    ]
+    if not api_ids and not deep_ids:
+        raise FinalizationError("The coverage universe is empty.")
+    return api_ids, deep_ids
+
+
+def _checkpoint(
+        name: str,
+        jacoco_path: str,
+        api_ids: list[str],
+        deep_ids: list[str],
+) -> dict[str, Any]:
+    """Count one instant of the run over the frozen universe.
+
+    One report, one routine, both universes. Assembling a checkpoint from
+    summary fields that separate phases computed for themselves is what lets two
+    different instants of the run be presented as if they were comparable.
+    """
+    coverage: dict[str, Any] = load_jacoco_method_coverage([jacoco_path])
+    missing: list[str] = [
+        method_id
+        for method_id in api_ids + deep_ids
+        if method_id not in coverage
+    ]
+    if missing:
+        raise FinalizationError(
+            f"Checkpoint '{name}' ({jacoco_path}) does not report "
+            f"{len(missing)} of the frozen universe's methods, so the universe "
+            f"moved during the run; first is '{missing[0]}'."
+        )
+    api_covered: int = sum(1 for i in api_ids if coverage[i].covered)
+    deep_covered: int = sum(1 for i in deep_ids if coverage[i].covered)
+    universe: int = len(api_ids) + len(deep_ids)
+    return {
+        "name": name,
+        "apiCovered": api_covered,
+        "deepCovered": deep_covered,
+        "covered": api_covered + deep_covered,
+        "uncovered": universe - api_covered - deep_covered,
+        "coveragePercent": _percent(api_covered + deep_covered, universe),
+    }
+
+
+def _run_coverage(
+        api_baseline_report: dict[str, Any],
+        deep_baseline_report: dict[str, Any],
+        jacoco_paths: tuple[str, str, str],
+) -> dict[str, Any]:
+    """Whole-run coverage: one denominator, one routine, sequential checkpoints.
+
+    The per-phase blocks record each phase against its own roster, which is what
+    a phase's own guidance is ranked on. This block is the run as a reader sees
+    it: every checkpoint a share of the same complete method count, so a phase's
+    gain is the distance from the previous checkpoint and the phase gains sum to
+    the run's gain (§WF-code-coverage-improvement.4.1).
+    """
+    run_start_coverage: dict[str, Any] = load_jacoco_method_coverage(
+        [jacoco_paths[0]]
+    )
+    api_ids: list[str]
+    deep_ids: list[str]
+    api_ids, deep_ids = _universe_ids(
+        api_baseline_report, deep_baseline_report, run_start_coverage
+    )
+    checkpoints: list[dict[str, Any]] = [
+        _checkpoint(name, path, api_ids, deep_ids)
+        for name, path in zip(CHECKPOINT_NAMES, jacoco_paths)
+    ]
+    phases: list[dict[str, Any]] = [
+        {
+            "name": phase_name,
+            "covered": later["covered"] - earlier["covered"],
+            "coveragePercentagePoints": round(
+                later["coveragePercent"] - earlier["coveragePercent"], 2
+            ),
+        }
+        for phase_name, earlier, later in (
+            ("api", checkpoints[0], checkpoints[1]),
+            ("deep", checkpoints[1], checkpoints[2]),
+        )
+    ]
+    return {
+        "universe": len(api_ids) + len(deep_ids),
+        "apiUniverse": len(api_ids),
+        "deepUniverse": len(deep_ids),
+        "checkpoints": checkpoints,
+        "phases": phases,
     }
 
 
@@ -574,6 +708,7 @@ def finalize_coverage(
         api_final_path: str,
         deep_baseline_path: str,
         deep_final_path: str,
+        jacoco_paths: tuple[str, str, str],
         target_state_paths: list[str],
         validation_commands: list[str],
         output_dir: str,
@@ -612,6 +747,9 @@ def finalize_coverage(
         "generatedAt": _generated_at(),
         "coordinate": coordinate,
         "coverageSuitePath": _suite_path(coverage_suite_path),
+        "runCoverage": _run_coverage(
+            api_baseline_report, deep_baseline_report, jacoco_paths
+        ),
         "apiJacoco": {
             "baseline": api_baseline,
             "final": api_final,
@@ -660,6 +798,9 @@ def build_parser() -> argparse.ArgumentParser:
             "--api-final api-cover-report-5.json "
             "--deep-baseline discovery-report-0.json "
             "--deep-final discovery-report-5.json "
+            "--jacoco-run-start validation/jacoco-0.xml "
+            "--jacoco-after-api discovery/jacoco-deep-0.xml "
+            "--jacoco-final discovery/jacoco-deep-5.xml "
             "--target-state targets.json "
             "--validation-command './gradlew test -Pcoordinates=group:artifact:version' "
             "--output-dir runtime/code-coverage/finalization"
@@ -676,6 +817,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-final", required=True, help="API final JSON.")
     parser.add_argument("--deep-baseline", required=True, help="Deep baseline JSON.")
     parser.add_argument("--deep-final", required=True, help="Deep final JSON.")
+    parser.add_argument(
+        "--jacoco-run-start",
+        required=True,
+        help="JaCoCo XML for the run's first checkpoint, before any phase ran.",
+    )
+    parser.add_argument(
+        "--jacoco-after-api",
+        required=True,
+        help=(
+            "JaCoCo XML for the API/deep phase boundary. This is the deep "
+            "phase's own first report, so both universes are counted from one "
+            "instant rather than from two phases' separate snapshots."
+        ),
+    )
+    parser.add_argument(
+        "--jacoco-final",
+        required=True,
+        help="JaCoCo XML for the run's last checkpoint.",
+    )
     parser.add_argument(
         "--target-state",
         action="append",
@@ -708,6 +868,7 @@ def main() -> int:
             args.api_final,
             args.deep_baseline,
             args.deep_final,
+            (args.jacoco_run_start, args.jacoco_after_api, args.jacoco_final),
             args.target_state_paths,
             args.validation_commands,
             args.output_dir,

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -8,10 +8,12 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.graalvm.internal.tck.utils.DynamicAccessUtils
 import org.graalvm.internal.tck.utils.BaseLayerUtils
+import org.graalvm.internal.tck.utils.JarUtils
 import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import org.graalvm.buildtools.gradle.tasks.NativeRunTask
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitivity
@@ -371,31 +373,27 @@ dependencies {
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
-Closure<List<File>> resolveTestedLibraryJars = {
+Closure<List<ResolvedArtifact>> resolveTestedLibraryArtifacts = {
     String targetGroup = ""
     String targetArtifact = ""
     String targetVersion = ""
-    def coordsParts = (libraryGAV ?: "").split(":")
+    String[] coordsParts = (libraryGAV ?: "").split(":")
     if (coordsParts.length >= 3) {
         targetGroup = coordsParts[0]
         targetArtifact = coordsParts[1]
         targetVersion = coordsParts[2]
     }
 
-    def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
-    Set<File> matched = new LinkedHashSet<>(artifacts.findAll { artifact ->
+    Set<ResolvedArtifact> artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts
+    Set<ResolvedArtifact> matched = new LinkedHashSet<>(artifacts.findAll { ResolvedArtifact artifact ->
         (artifact.moduleVersion.id.group == targetGroup) && (artifact.moduleVersion.id.name == targetArtifact)
-    }.collect { artifact ->
-        artifact.file
     })
 
     if (matched.isEmpty()) {
         // Fallback for relocated or substituted modules: the requested G:A coordinates may resolve
         // to a different group in published metadata, so no resolved artifact carries the original group.
-        matched.addAll(artifacts.findAll { artifact ->
+        matched.addAll(artifacts.findAll { ResolvedArtifact artifact ->
             (artifact.moduleVersion.id.name == targetArtifact) && (artifact.moduleVersion.id.version == targetVersion)
-        }.collect { artifact ->
-            artifact.file
         })
     }
 
@@ -403,7 +401,24 @@ Closure<List<File>> resolveTestedLibraryJars = {
         throw new GradleException("No eligible artifacts found on the classpath for ${libraryGAV}.\nPlease verify that the provided artifact exists.")
     }
 
-    return matched.toList().sort { File file -> file.absolutePath }
+    return matched.toList().sort { ResolvedArtifact artifact -> artifact.file.absolutePath }
+}
+
+Closure<List<File>> resolveTestedLibraryJars = {
+    return resolveTestedLibraryArtifacts().collect { ResolvedArtifact artifact -> artifact.file }
+}
+
+Closure<List<File>> resolveTestedLibraryMainJars = {
+    List<ResolvedArtifact> mainArtifacts = resolveTestedLibraryArtifacts().findAll { ResolvedArtifact artifact ->
+        JarUtils.isUnclassifiedMainJar(artifact.extension, artifact.classifier)
+    }
+    if (mainArtifacts.isEmpty()) {
+        throw new GradleException(
+                "No unclassified main JAR found on the classpath for ${libraryGAV}.\n" +
+                        "Please verify that the coordinate publishes a main JAR."
+        )
+    }
+    return mainArtifacts.collect { ResolvedArtifact artifact -> artifact.file }
 }
 
 Closure<List<File>> resolveJUnitRuntimeJars = {
@@ -937,8 +952,8 @@ tasks.withType(org.gradle.testing.jacoco.tasks.JacocoReport).configureEach { r -
         csv.required = false
     }
 
-    // Collect resolved dependency artifacts from the test runtime classpath
-    def matched = resolveTestedLibraryJars()
+    // Classified artifacts remain executable dependencies but never enter the coverage denominator.
+    List<File> matched = resolveTestedLibraryMainJars()
 
     // Produce one deterministic directory of .class files that represents exactly what the JVM would load at runtime for a given library jar, without duplicates
     int runtimeMajor = (JavaVersion.current().majorVersion as int)

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/AbstractLibraryStatsTask.java
@@ -129,7 +129,7 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
     }
 
     protected boolean generateReportsForCoordinate(String coordinates) {
-        CommandResult jacoco = runGradle(List.of("jacocoTestReport", "-Pcoordinates=" + coordinates), true);
+        CommandResult jacoco = runGradle(List.of("jacocoCodeCoverageReport", "-Pcoordinates=" + coordinates), true);
         if (jacoco.exitCode() != 0) {
             throw new GradleException("JaCoCo report generation failed for " + coordinates + ":\n" + jacoco.stderr());
         }
@@ -186,8 +186,8 @@ public abstract class AbstractLibraryStatsTask extends CoordinatesAwareTask {
                 .resolve("build")
                 .resolve("reports")
                 .resolve("jacoco")
-                .resolve("test")
-                .resolve("jacocoTestReport.xml");
+                .resolve("jacocoCodeCoverageReport")
+                .resolve("jacocoCodeCoverageReport.xml");
     }
 
     protected Path getDynamicAccessDir(String coordinates) {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/JarUtils.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/JarUtils.java
@@ -28,6 +28,14 @@ public abstract class JarUtils {
     private static final String META_INF_VERSIONS = "META-INF/versions/";
 
     /**
+     * Returns whether a resolved artifact is the unclassified main JAR eligible
+     * for the coverage denominator. §TCK-test-harness.8
+     */
+    public static boolean isUnclassifiedMainJar(String extension, String classifier) {
+        return "jar".equals(extension) && (classifier == null || classifier.isEmpty());
+    }
+
+    /**
      * Scans the given JARs and returns all fully-qualified class names found.
      * Handles multi-release JARs by stripping the {@code META-INF/versions/N/} prefix.
      * Excludes {@code module-info.class}.

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/JarUtilsTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/utils/JarUtilsTests.java
@@ -25,6 +25,15 @@ class JarUtilsTests {
     Path tempDir;
 
     @Test
+    void unclassifiedMainJarExcludesClassifiedAndNonJarArtifacts() {
+        assertThat(JarUtils.isUnclassifiedMainJar("jar", null)).isTrue();
+        assertThat(JarUtils.isUnclassifiedMainJar("jar", "")).isTrue();
+        assertThat(JarUtils.isUnclassifiedMainJar("jar", "test")).isFalse();
+        assertThat(JarUtils.isUnclassifiedMainJar("jar", "sources")).isFalse();
+        assertThat(JarUtils.isUnclassifiedMainJar("pom", null)).isFalse();
+    }
+
+    @Test
     void loadClassNamesSkipsModuleInfoAndReadsMultiReleaseEntries() throws IOException {
         Path jar = createLibraryJar(tempDir.resolve("library.jar"), List.of(
                 "module-info.class",


### PR DESCRIPTION
Coverage figures published by the code coverage improvement workflow were not comparable between its two guidance phases, and understated every run.

## Where the old accounting lost coverage

Each phase was reported against its own roster, with snapshots taken at different points:

- `apiJacoco.final` was the API phase's last report. The later deep phase also covers public API methods, but those gains were discarded.
- `deepJacoco.baseline` was the deep phase's first report, after the API phase had already run. Internal methods covered collaterally by the API phase were charged to the baseline.

Both errors push in the same direction. For `org.apache.kafka:kafka-streams:3.6.2` (#9055, PR #9321), the published figures were 34.95% to 63.06%, a gain of 28.11 percentage points. Recounting over one universe gives 25.34% to 65.19%, a gain of 39.85 points; the deep phase alone covered 150 public API methods that were never counted.

Presenting the phases against a shared denominator without fixing their checkpoint timing would be worse: the PGO phase would appear to restart below the point where the API phase ended.

## One frozen method universe

[§WF-code-coverage-improvement.4.1](https://github.com/oracle/graalvm-reachability-metadata/blob/d6fcbe0c9ac60378c0224d7fdd58f33149f81938/forge/docs/workflows/code-coverage-improvement.md#L470) defines the accounting contract:

1. **Freeze one universe once.** The denominator is the complete set of library method IDs JaCoCo can rule on: reportable inventory entries plus the disjoint deep roster. Entries JaCoCo cannot report are excluded because no run can cover them.
2. **Count each checkpoint from one report.** Run start, the API/deep boundary, and final coverage each come from a single JaCoCo report over that frozen universe. The boundary is read from the deep phase's first report, so one phase begins exactly where the previous phase ended.
3. **Reject a moving universe.** If a frozen ID is absent from a later report, finalization fails instead of silently treating it as uncovered or reducing the denominator.

The final metrics schema now records these checkpoints and the two sequential phase gains in `runCoverage`. The existing `apiJacoco` and `deepJacoco` blocks remain as phase-local guidance records, while the PR body renders the comparable whole-run accounting and removes the redundant combined section.

## Library coverage stats

JaCoCo previously analyzed every resolved artifact matching the coordinate, including classified artifacts. Kafka therefore included its upstream `kafka-streams-3.6.2-test.jar` in the library denominator.

[§TCK-test-harness.8](https://github.com/oracle/graalvm-reachability-metadata/blob/0fe13385c1e78b550e9c7527e5ac1019c1bb9876/docs/tck.md#L244) now requires JaCoCo to analyze only the coordinate's unclassified main JAR. Classified artifacts remain available on the execution classpath.

`generateLibraryStats` now consumes the combined `jacocoCodeCoverageReport`, and Forge finalization runs it after both the regular and generated coverage suites. Newly written tests therefore update the committed `stats.json` coverage values.

Kafka regression results:

| Report | Covered methods | Total methods | Coverage |
| --- | ---: | ---: | ---: |
| Regular suite | 1,789 | 7,065 | 25.32% |
| Regular + improved coverage suite | 4,601 | 7,065 | 65.12% |

Both reports contain 895 main-library classes and zero test-named classes; only the covered count changes.

Fixes #9480
