### PR TITLE
Fix compatible baseline selection for version backfills

### DIFF
--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -26,7 +26,7 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import Any, Callable
+from typing import Any
 
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -64,6 +64,7 @@ from utility_scripts.metadata_index import (
     is_newer_than_latest_metadata_version,
     load_index_entries,
     resolve_library_update_target,
+    resolve_version_backfill_baseline,
 )
 from utility_scripts.metrics_writer import count_metadata_entries, count_test_only_metadata_entries, create_failure_run_metrics_output
 from utility_scripts.source_context import (
@@ -228,81 +229,8 @@ def _version_is_at_or_after(version: str, requested_version: str) -> bool:
     return _padded_version_numbers(version) >= _padded_version_numbers(requested_version)
 
 
-def _is_supported_index_entry(entry: dict[str, Any]) -> bool:
-    metadata_version = entry.get("metadata-version")
-    return isinstance(metadata_version, str) and bool(metadata_version)
-
-
 def _entry_test_version(entry: dict[str, Any]) -> str:
     return str(entry.get("test-version") or entry.get("metadata-version"))
-
-
-def _usable_clone_entry(repo_path: str, group: str, artifact: str, entry: dict[str, Any]) -> bool:
-    metadata_version = str(entry.get("metadata-version") or "")
-    if not metadata_version:
-        return False
-    test_version = _entry_test_version(entry)
-    metadata_dir = os.path.join(repo_path, "metadata", group, artifact, metadata_version)
-    test_dir = os.path.join(repo_path, "tests", "src", group, artifact, test_version)
-    return os.path.isdir(metadata_dir) and os.path.isdir(test_dir)
-
-
-def _closest_entry(
-        entries: list[dict[str, Any]],
-        requested_version: str,
-        predicate: Callable[[tuple[int, ...]], bool],
-) -> dict[str, Any] | None:
-    candidates = [entry for entry in entries if predicate(_padded_version_numbers(str(entry["metadata-version"])))]
-    if not candidates:
-        return None
-    requested_numbers = _padded_version_numbers(requested_version)
-
-    def rank(entry: dict[str, Any]) -> tuple[tuple[int, ...], tuple[int, ...]]:
-        candidate_numbers = _padded_version_numbers(str(entry["metadata-version"]))
-        distance = tuple(abs(candidate - requested) for candidate, requested in zip(candidate_numbers, requested_numbers))
-        descending_candidate = tuple(-part for part in candidate_numbers)
-        return distance, descending_candidate
-
-    return min(candidates, key=rank)
-
-
-def select_clone_baseline_entry(
-        repo_path: str,
-        group: str,
-        artifact: str,
-        requested_version: str,
-) -> dict[str, Any] | None:
-    """Select the closest compatible existing support to clone for a new version."""
-    entries = load_index_entries(repo_path, group, artifact) or []
-    usable_entries = [
-        entry for entry in entries
-        if isinstance(entry, dict) and _is_supported_index_entry(entry)
-        and _usable_clone_entry(repo_path, group, artifact, entry)
-    ]
-    if not usable_entries:
-        return None
-
-    requested_numbers = _padded_version_numbers(requested_version)
-    same_major_minor = _closest_entry(
-        usable_entries,
-        requested_version,
-        lambda numbers: numbers[:2] == requested_numbers[:2],
-    )
-    if same_major_minor is not None:
-        return same_major_minor
-
-    same_major = _closest_entry(
-        usable_entries,
-        requested_version,
-        lambda numbers: numbers[:1] == requested_numbers[:1],
-    )
-    if same_major is not None:
-        return same_major
-
-    latest_entries = [entry for entry in usable_entries if entry.get("latest") is True]
-    if latest_entries:
-        return latest_entries[0]
-    return None
 
 
 def _copytree_replace(destination: str, source: str) -> None:
@@ -611,16 +539,18 @@ def prepare_library_update_target(
     if target.match_type != MATCH_NEW_VERSION:
         return target
 
-    baseline_entry = select_clone_baseline_entry(repo_path, group, artifact, requested_version)
-    if baseline_entry is not None:
-        clone_library_update_support(repo_path, group, artifact, requested_version, baseline_entry)
+    baseline = resolve_version_backfill_baseline(repo_path, group, artifact, requested_version)
+    if baseline is not None:
+        clone_library_update_support(repo_path, group, artifact, requested_version, baseline.entry)
         log_stage(
             "library-update-target",
-            "Cloned support for {group}:{artifact}:{requested_version} from metadata-version {metadata_version}".format(
+            "Cloned support for {group}:{artifact}:{requested_version} from {baseline_coordinates}; "
+            "reason: {reason}".format(
                 group=group,
                 artifact=artifact,
                 requested_version=requested_version,
-                metadata_version=baseline_entry.get("metadata-version"),
+                baseline_coordinates=f"{group}:{artifact}:{baseline.test_version}",
+                reason=baseline.reason,
             ),
         )
     else:

--- a/forge/ai_workflows/drivers/library_update_router.py
+++ b/forge/ai_workflows/drivers/library_update_router.py
@@ -19,10 +19,8 @@ from ai_workflows.drivers.improve_library_coverage import clone_library_update_s
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.metadata_index import (
-    MATCH_NEW_VERSION,
     coordinate_parts,
-    is_not_for_native_image_entry,
-    load_index_entries,
+    require_version_backfill_baseline,
     resolve_library_update_target,
 )
 from utility_scripts.stage_logger import log_stage
@@ -144,13 +142,13 @@ def select_library_update_route(repo_path: str, metrics_repo_root: str, coordina
     """Select and persist the driver for one `library-update-request`.
 
     Existing requested-version suites keep the normal coverage path. Missing
-    requested-version suites are probed from the latest supported test suite,
+    requested-version suites are probed from a compatible supported test suite,
     then routed to the driver that owns the selected repair or coverage path.
     §WF-forge-workflow-drivers.2
     """
     group, artifact, requested_version = _require_versioned_coordinate(coordinates)
     target = resolve_library_update_target(repo_path, group, artifact, requested_version)
-    if target.match_type != MATCH_NEW_VERSION or os.path.isdir(target.test_dir):
+    if os.path.isdir(target.test_dir):
         route = LibraryUpdateRoute(
             selected_driver=ROUTE_IMPROVE_COVERAGE,
             baseline_coordinates=None,
@@ -163,22 +161,22 @@ def select_library_update_route(repo_path: str, metrics_repo_root: str, coordina
         write_library_update_route(metrics_repo_root, route)
         return route
 
-    latest_entry = _latest_supported_entry(repo_path, group, artifact, coordinates)
-    baseline_test_version = _entry_test_version(latest_entry)
+    baseline = require_version_backfill_baseline(repo_path, group, artifact, requested_version)
+    baseline_test_version = baseline.test_version
     baseline_coordinates = f"{group}:{artifact}:{baseline_test_version}"
     log_stage(
         "library-update-router",
         (
-            f"Missing requested-version test suite for {coordinates}; probing latest "
-            f"supported test version {baseline_coordinates}"
+            f"Missing requested-version test suite for {coordinates}; selected compatible "
+            f"baseline {baseline_coordinates}; reason: {baseline.reason}"
         ),
     )
-    compile_result, java_test_result, native_test_result = _probe_latest_suite(
+    compile_result, java_test_result, native_test_result = _probe_baseline_suite(
         repo_path=repo_path,
         group=group,
         artifact=artifact,
         requested_version=requested_version,
-        latest_entry=latest_entry,
+        baseline_entry=baseline.entry,
     )
     if compile_result.exit_code != 0:
         route = LibraryUpdateRoute(
@@ -212,12 +210,12 @@ def select_library_update_route(repo_path: str, metrics_repo_root: str, coordina
     return route
 
 
-def _probe_latest_suite(
+def _probe_baseline_suite(
         repo_path: str,
         group: str,
         artifact: str,
         requested_version: str,
-        latest_entry: dict[str, Any],
+        baseline_entry: dict[str, Any],
 ) -> tuple[_ProbeCommandResult, _ProbeCommandResult | None, _ProbeCommandResult | None]:
     requested_coordinates = f"{group}:{artifact}:{requested_version}"
     snapshot = _PathSnapshot([
@@ -227,7 +225,7 @@ def _probe_latest_suite(
         os.path.join(stats_artifact_dir(repo_path, group, artifact), requested_version),
     ])
     try:
-        clone_library_update_support(repo_path, group, artifact, requested_version, latest_entry)
+        clone_library_update_support(repo_path, group, artifact, requested_version, baseline_entry)
         compile_result = _run_probe_gradle_task(repo_path, requested_coordinates, "compileTestJava")
         if compile_result.exit_code != 0:
             return compile_result, None, None
@@ -258,77 +256,6 @@ def _run_probe_gradle_task(repo_path: str, coordinates: str, task: str) -> _Prob
             check=False,
         )
     return _ProbeCommandResult(exit_code=result.returncode, log_path=log_path)
-
-
-def _latest_supported_entry(repo_path: str, group: str, artifact: str, coordinates: str) -> dict[str, Any]:
-    entries = load_index_entries(repo_path, group, artifact)
-    if entries is None:
-        _raise_unusable_latest_supported_suite(repo_path, group, artifact, coordinates, [], [])
-    assert entries is not None
-    latest_entries = [
-        entry
-        for entry in entries
-        if isinstance(entry, dict)
-        and entry.get("latest") is True
-    ]
-    usable_latest_entries = [
-        entry
-        for entry in latest_entries
-        if _is_usable_supported_entry(repo_path, group, artifact, entry)
-    ]
-    if len(usable_latest_entries) != 1:
-        _raise_unusable_latest_supported_suite(
-            repo_path,
-            group,
-            artifact,
-            coordinates,
-            latest_entries,
-            usable_latest_entries,
-        )
-    return usable_latest_entries[0]
-
-
-def _raise_unusable_latest_supported_suite(
-        repo_path: str,
-        group: str,
-        artifact: str,
-        coordinates: str,
-        latest_entries: list[dict[str, Any]],
-        usable_latest_entries: list[dict[str, Any]],
-) -> None:
-    index_path = os.path.join(repo_path, "metadata", group, artifact, "index.json")
-    rel_index_path = os.path.relpath(index_path, repo_path)
-    raise RuntimeError(
-        "ERROR: Cannot route missing-version library-update request for "
-        f"{coordinates}: expected exactly one usable latest supported suite in "
-        f"{rel_index_path}, found {len(usable_latest_entries)} usable latest "
-        f"entries out of {len(latest_entries)} latest=true entries. A usable "
-        "latest entry must not be not-for-native-image, must have a non-empty "
-        "`metadata-version`, and must have both "
-        f"`metadata/{group}/{artifact}/<metadata-version>` and "
-        f"`tests/src/{group}/{artifact}/<test-version-or-metadata-version>`. "
-        "Fix the index or restore the latest test suite before rerunning."
-    )
-
-
-def _is_usable_supported_entry(repo_path: str, group: str, artifact: str, entry: dict[str, Any]) -> bool:
-    if is_not_for_native_image_entry(entry):
-        return False
-    metadata_version = entry.get("metadata-version")
-    if not isinstance(metadata_version, str) or not metadata_version:
-        return False
-    test_version = _entry_test_version(entry)
-    return (
-        os.path.isdir(os.path.join(repo_path, "metadata", group, artifact, metadata_version))
-        and os.path.isdir(os.path.join(repo_path, "tests", "src", group, artifact, test_version))
-    )
-
-
-def _entry_test_version(entry: dict[str, Any]) -> str:
-    test_version = entry.get("test-version") or entry.get("metadata-version")
-    if not isinstance(test_version, str) or not test_version:
-        raise RuntimeError(f"Index entry does not have a usable test version: {entry}")
-    return test_version
 
 
 def _require_versioned_coordinate(coordinates: str) -> tuple[str, str, str]:

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -91,8 +91,9 @@ This item of §ROADMAP-forge-implementation implements the missing
 requested-version path for `library-update-request`
 (§WF-improve-library-coverage.2).
 When the artifact is already supported but the requested version has no test
-suite, Forge must resolve the latest supported test version, prepare that
-suite against the requested version, run a compatibility probe, and dispatch
+suite, Forge must resolve a usable same-major baseline with the shared version-
+backfill resolver, prepare that suite against the requested version, run a
+compatibility probe, and dispatch
 the rest of the work to the owning driver (§WF-forge-workflow-drivers.2).
 
 The router must dispatch compilation failures to the javac-fix driver

--- a/forge/docs/workflows/improve-library-coverage.md
+++ b/forge/docs/workflows/improve-library-coverage.md
@@ -65,14 +65,20 @@ This case applies when the repository already supports the requested
 `group:artifact` artifact, but the requested `version` does not yet have a test
 suite in the repository.
 
-Forge must first resolve the latest supported test version for the artifact and
-probe the requested version with that latest test suite. The probe determines
+Forge must first resolve a usable version-compatible test baseline for the
+artifact with the shared version-backfill resolver and probe the requested
+version with that suite. Exact index ownership wins; otherwise Forge prefers
+the nearest prior version on the same major/minor line, then a following
+version on that line, and only then candidates within the same major. Forge
+must not use a cross-major baseline merely because it is marked `latest`; if no
+compatible baseline exists, routing fails with an actionable error
+(§WF-forge-workflow-drivers.2). The probe determines
 which driver owns the rest of the work:
 
-1. **Latest-suite preparation** — copy or otherwise prepare the latest
-   supported test suite so it runs against the requested version, preserving the
-   previous version as the baseline.
-2. **Compatibility probe** — run the requested version with the latest test
+1. **Baseline-suite preparation** — copy or otherwise prepare the selected
+   supported test suite so it runs against the requested version, preserving
+   the selected version as the baseline and logging why it was selected.
+2. **Compatibility probe** — run the requested version with the selected test
    suite before selecting the repair or coverage path.
 3. **Javac failure** — if the probe fails at Java compilation, dispatch the
    javac-fix driver for the previous version and requested version. That
@@ -83,7 +89,7 @@ which driver owns the rest of the work:
    strategy. That driver owns runtime repair and the composite coverage
    phase (§WF-java-fail-fix-workflow).
 5. **Compatible version** — if compilation and JVM tests both pass, the
-   requested version is compatible with the latest test suite. Forge should add
+   requested version is compatible with the selected test suite. Forge should add
    or select the requested version's test project and run the regular
    improve-coverage workflow for that requested version
    (§WF-improve-library-coverage.1).
@@ -95,7 +101,7 @@ coverage starts:
 - `ai_workflows/drivers/fix_javac_fail.py` for compilation failures.
 - `ai_workflows/drivers/fix_java_run_fail.py` for JVM runtime failures.
 - `ai_workflows/drivers/improve_library_coverage.py` when the requested version is
-  already compatible with the latest supported test suite.
+  already compatible with the selected baseline test suite.
 
 ### Publication
 

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -156,9 +156,30 @@ Preparation:
 
 - Resolve the requested `group:artifact:version`.
 - Confirm the repository already supports the requested `group:artifact`.
-- Resolve the latest supported test version for that artifact.
-- Prepare the latest supported test suite so it runs against the requested
-  version, preserving the latest supported version as the baseline.
+- Resolve one usable, version-compatible baseline with the shared version-
+  backfill resolver. Exact `tested-versions`, `metadata-version`, and
+  `default-for` ownership takes precedence. Otherwise, select the nearest
+  prior supported version on the same major/minor line, then the nearest
+  following version on that line, and only then repeat that ordering within
+  the same major version.
+- Treat `test-version` only as the directory alias used to locate a reusable
+  test suite. It does not declare library-version support and must not
+  contribute a compatibility candidate or version-line ownership.
+- Derive version lines from the leading numeric Maven components, including
+  conventional `v`- or `r`-prefixed numeric releases. Recognized prerelease
+  qualifiers retain their explicit ordering; other valid Maven suffixes such as
+  `-jre`, `.jre11`, `.GA`, and vendor/build identifiers retain the numeric
+  version line and use deterministic fallback ordering instead of making the
+  version ineligible for baseline selection.
+- Require both the selected metadata directory and test suite to exist. A
+  different major version, including a next-major prerelease marked `latest`,
+  is not a compatible baseline. If Forge cannot select one deterministically,
+  stop with an actionable routing error instead of probing a cross-major
+  suite (§FS-forge-issue-resolution-goal).
+- Log the selected baseline coordinate and the exact ownership or version-line
+  reason for selecting it.
+- Prepare the selected baseline test suite so it runs against the requested
+  version, preserving the selected supported version as the baseline.
 - Run a compatibility probe against the requested version.
 - If Java compilation fails, dispatch `ai_workflows/drivers/fix_javac_fail.py`;
   that driver owns the version-copy preparation, javac repair, and composite
@@ -171,7 +192,7 @@ Preparation:
   repair for the requested version.
 - If compilation, JVM tests, and native-image tests pass, dispatch
   `ai_workflows/drivers/improve_library_coverage.py` for the requested version
-  because the latest test suite is compatible.
+  because the selected baseline test suite is compatible.
 
 The selected driver must own its normal setup after the probe; the
 `library-update-request` router must not duplicate javac-fix, java-run-fix,
@@ -187,8 +208,12 @@ orchestration in `ai_workflows/drivers/java_fail_workflow.py`.
 
 Preparation:
 
-- Resolve the previous and failing library versions, repository roots, metrics
-  root, GitHub authentication, GraalVM home, and javac-fix strategy.
+- Resolve the previous version with the same shared version-backfill resolver
+  used by the missing-version `library-update-request` router, and resolve the
+  failing library version, repository roots, metrics root, GitHub
+  authentication, GraalVM home, and javac-fix strategy.
+- Log the selected previous-version coordinate and selection reason; fail with
+  an actionable error when no usable same-major baseline exists.
 - Copy the previous version's test project to the failing version.
 - Update the metadata index for the new version.
 - Create the versioned metadata directory.
@@ -211,6 +236,8 @@ Preparation:
 - Use the same version-copy, metadata-index update, metadata-directory
   creation, checkpoint, artifact URL, source-context, layout, and editable-file
   preparation as `fails-javac-compile`.
+- Use the same shared baseline resolution, logging, and failure behavior as
+  `fails-javac-compile`.
 - Load the java-run strategy, runtime-failure prompt wording, runtime task
   type, and `fix_java_run_fail.json` metrics target.
 - Prepare the project from the last supported version; the project is expected
@@ -222,8 +249,10 @@ Driver: `ai_workflows/drivers/fix_ni_run.py`.
 
 Preparation:
 
-- Resolve the current coordinate, new version, and reachability repository
-  path.
+- Resolve the current coordinate with the shared version-backfill resolver and
+  log its coordinate and selection reason. Resolve the new version and
+  reachability repository path. Fail with an actionable error when no usable
+  same-major baseline exists.
 - Create a `fix-native-image-run-*` feature branch.
 - Run the Gradle `fixTestNativeImageRun` task to copy or update the test
   project and generate native-image metadata for the new version.

--- a/forge/docs/workflows/workflow-drivers.md
+++ b/forge/docs/workflows/workflow-drivers.md
@@ -208,12 +208,13 @@ orchestration in `ai_workflows/drivers/java_fail_workflow.py`.
 
 Preparation:
 
-- Resolve the previous version with the same shared version-backfill resolver
-  used by the missing-version `library-update-request` router, and resolve the
-  failing library version, repository roots, metrics root, GitHub
-  authentication, GraalVM home, and javac-fix strategy.
-- Log the selected previous-version coordinate and selection reason; fail with
-  an actionable error when no usable same-major baseline exists.
+- Resolve the previous version from the index entry marked `latest`, then
+  resolve the failing library version, repository roots, metrics root, GitHub
+  authentication, GraalVM home, and javac-fix strategy. The `fails-*` issue
+  producer targets the newest version, so this route must not substitute the
+  compatible baseline resolver used by missing-version
+  `library-update-request` issues; a below-`latest` failure is producer-contract
+  evidence that must remain visible.
 - Copy the previous version's test project to the failing version.
 - Update the metadata index for the new version.
 - Create the versioned metadata directory.
@@ -236,7 +237,7 @@ Preparation:
 - Use the same version-copy, metadata-index update, metadata-directory
   creation, checkpoint, artifact URL, source-context, layout, and editable-file
   preparation as `fails-javac-compile`.
-- Use the same shared baseline resolution, logging, and failure behavior as
+- Resolve the previous version from the index entry marked `latest`, as in
   `fails-javac-compile`.
 - Load the java-run strategy, runtime-failure prompt wording, runtime task
   type, and `fix_java_run_fail.json` metrics target.
@@ -249,10 +250,10 @@ Driver: `ai_workflows/drivers/fix_ni_run.py`.
 
 Preparation:
 
-- Resolve the current coordinate with the shared version-backfill resolver and
-  log its coordinate and selection reason. Resolve the new version and
-  reachability repository path. Fail with an actionable error when no usable
-  same-major baseline exists.
+- Resolve the current coordinate from the index entry marked `latest`, then
+  resolve the new version and reachability repository path. As with the Java
+  failure routes, do not substitute a compatible historical baseline for a
+  malformed below-`latest` issue.
 - Create a `fix-native-image-run-*` feature branch.
 - Run the Gradle `fixTestNativeImageRun` task to copy or update the test
   project and generate native-image metadata for the new version.

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -162,6 +162,7 @@ from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
     get_not_for_native_image_marker,
     is_not_for_native_image,
+    require_version_backfill_baseline,
     resolve_metadata_version,
     resolve_test_dir,
 )
@@ -3229,35 +3230,6 @@ def extract_maven_coordinates(title: str) -> Optional[str]:
     return None
 
 
-def load_current_metadata_version(
-        reachability_metadata_path: str,
-        group: str,
-        artifact: str,
-) -> Optional[str]:
-    """Load the current metadata version from the latest index.json entry."""
-    index_json_path = os.path.join(
-        reachability_metadata_path,
-        "metadata",
-        group,
-        artifact,
-        "index.json",
-    )
-    index_json_path_display = _repo_relative_path(index_json_path, reachability_metadata_path)
-    if not os.path.isfile(index_json_path):
-        print(f"ERROR: Missing metadata index file: {index_json_path_display}", file=sys.stderr)
-        return None
-
-    with open(index_json_path, "r", encoding="utf-8") as index_file:
-        index_entries = json.load(index_file)
-
-    for entry in index_entries:
-        if entry.get("latest") is True:
-            return entry.get("test-version") or entry.get("metadata-version")
-
-    print(f"ERROR: No latest entry found in metadata index: {index_json_path_display}", file=sys.stderr)
-    return None
-
-
 def get_cached_field_info() -> tuple[str, str, dict[str, str]]:
     global project_node_id, field_id, option_ids
     if field_id is None:
@@ -6014,15 +5986,22 @@ def build_claim_metadata(
         return None
 
     group, artifact, new_version = coordinate_parts
-    current_version = load_current_metadata_version(
-        base_reachability_metadata_path,
-        group,
-        artifact,
-    )
-    if current_version is None:
+    try:
+        baseline = require_version_backfill_baseline(
+            base_reachability_metadata_path,
+            group,
+            artifact,
+            new_version,
+        )
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
         return None
 
-    current_coordinates = f"{group}:{artifact}:{current_version}"
+    current_coordinates = f"{group}:{artifact}:{baseline.test_version}"
+    log_stage(
+        "version-backfill-baseline",
+        f"Selected {current_coordinates} for {issue_coordinates}; reason: {baseline.reason}",
+    )
     return issue_coordinates, current_coordinates, new_version
 
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -162,7 +162,6 @@ from utility_scripts.metadata_index import (
     coordinate_parts as metadata_coordinate_parts,
     get_not_for_native_image_marker,
     is_not_for_native_image,
-    require_version_backfill_baseline,
     resolve_metadata_version,
     resolve_test_dir,
 )
@@ -3230,6 +3229,38 @@ def extract_maven_coordinates(title: str) -> Optional[str]:
     return None
 
 
+def load_current_metadata_version(
+        reachability_metadata_path: str,
+        group: str,
+        artifact: str,
+) -> Optional[str]:
+    """Load the current metadata version from the latest index.json entry."""
+    index_json_path = os.path.join(
+        reachability_metadata_path,
+        "metadata",
+        group,
+        artifact,
+        "index.json",
+    )
+    index_json_path_display = _repo_relative_path(index_json_path, reachability_metadata_path)
+    if not os.path.isfile(index_json_path):
+        print(f"ERROR: Missing metadata index file: {index_json_path_display}", file=sys.stderr)
+        return None
+
+    with open(index_json_path, "r", encoding="utf-8") as index_file:
+        index_entries = json.load(index_file)
+
+    for entry in index_entries:
+        if entry.get("latest") is True:
+            return entry.get("test-version") or entry.get("metadata-version")
+
+    print(
+        f"ERROR: No latest entry found in metadata index: {index_json_path_display}",
+        file=sys.stderr,
+    )
+    return None
+
+
 def get_cached_field_info() -> tuple[str, str, dict[str, str]]:
     global project_node_id, field_id, option_ids
     if field_id is None:
@@ -5986,22 +6017,17 @@ def build_claim_metadata(
         return None
 
     group, artifact, new_version = coordinate_parts
-    try:
-        baseline = require_version_backfill_baseline(
-            base_reachability_metadata_path,
-            group,
-            artifact,
-            new_version,
-        )
-    except RuntimeError as error:
-        print(str(error), file=sys.stderr)
+    # `fails-*` issues target the newest version, so keep `latest` as the signal.
+    # §WF-forge-workflow-drivers.2
+    current_version = load_current_metadata_version(
+        base_reachability_metadata_path,
+        group,
+        artifact,
+    )
+    if current_version is None:
         return None
 
-    current_coordinates = f"{group}:{artifact}:{baseline.test_version}"
-    log_stage(
-        "version-backfill-baseline",
-        f"Selected {current_coordinates} for {issue_coordinates}; reason: {baseline.reason}",
-    )
+    current_coordinates = f"{group}:{artifact}:{current_version}"
     return issue_coordinates, current_coordinates, new_version
 
 

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -382,7 +382,7 @@ class LibraryUpdateIssueTests(unittest.TestCase):
 
         self.assertEqual(claim_metadata, ("org.example:title-lib:1.2.3", None, None))
 
-    def test_direct_repair_uses_same_line_netty_backfill_instead_of_latest(self) -> None:
+    def test_direct_repair_uses_latest_entry_as_failure_baseline(self) -> None:
         with tempfile.TemporaryDirectory() as repo:
             group = "io.netty"
             artifact = "netty-common"
@@ -408,22 +408,20 @@ class LibraryUpdateIssueTests(unittest.TestCase):
                 "title": "Fails native image run io.netty:netty-common:4.1.132.Final",
             }
 
-            with patch.object(forge_metadata, "log_stage") as stage_log:
-                claim_metadata = forge_metadata.build_claim_metadata(
-                    issue,
-                    forge_metadata.LABEL_NI_RUN_FAIL,
-                    repo,
-                )
+            claim_metadata = forge_metadata.build_claim_metadata(
+                issue,
+                forge_metadata.LABEL_NI_RUN_FAIL,
+                repo,
+            )
 
             self.assertEqual(
                 claim_metadata,
                 (
                     "io.netty:netty-common:4.1.132.Final",
-                    "io.netty:netty-common:4.1.115.Final",
+                    "io.netty:netty-common:5.0.0.Alpha1",
                     "4.1.132.Final",
                 ),
             )
-            self.assertIn("nearest prior same major/minor", stage_log.call_args.args[1])
 
     def test_extract_issue_requested_metadata_context_keeps_full_issue_body(self) -> None:
         body = """

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -382,6 +382,49 @@ class LibraryUpdateIssueTests(unittest.TestCase):
 
         self.assertEqual(claim_metadata, ("org.example:title-lib:1.2.3", None, None))
 
+    def test_direct_repair_uses_same_line_netty_backfill_instead_of_latest(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            group = "io.netty"
+            artifact = "netty-common"
+            index_dir = os.path.join(repo, "metadata", group, artifact)
+            os.makedirs(index_dir, exist_ok=True)
+            with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump([
+                    {
+                        "metadata-version": "4.1.115.Final",
+                        "tested-versions": ["4.1.115.Final", "4.1.130.Final"],
+                    },
+                    {
+                        "latest": True,
+                        "metadata-version": "5.0.0.Alpha1",
+                        "tested-versions": ["5.0.0.Alpha1"],
+                    },
+                ], index_file)
+            for version in ["4.1.115.Final", "5.0.0.Alpha1"]:
+                os.makedirs(os.path.join(repo, "metadata", group, artifact, version), exist_ok=True)
+                os.makedirs(os.path.join(repo, "tests", "src", group, artifact, version), exist_ok=True)
+            issue = {
+                "number": 9408,
+                "title": "Fails native image run io.netty:netty-common:4.1.132.Final",
+            }
+
+            with patch.object(forge_metadata, "log_stage") as stage_log:
+                claim_metadata = forge_metadata.build_claim_metadata(
+                    issue,
+                    forge_metadata.LABEL_NI_RUN_FAIL,
+                    repo,
+                )
+
+            self.assertEqual(
+                claim_metadata,
+                (
+                    "io.netty:netty-common:4.1.132.Final",
+                    "io.netty:netty-common:4.1.115.Final",
+                    "4.1.132.Final",
+                ),
+            )
+            self.assertIn("nearest prior same major/minor", stage_log.call_args.args[1])
+
     def test_extract_issue_requested_metadata_context_keeps_full_issue_body(self) -> None:
         body = """
         The reporter may describe the missing metadata in arbitrary prose.
@@ -421,11 +464,8 @@ class LibraryUpdateIssueTests(unittest.TestCase):
                     "select_library_update_route",
                     return_value=forge_metadata.LibraryUpdateRoute(
                         selected_driver=forge_metadata.ROUTE_IMPROVE_COVERAGE,
-                        requested_coordinates="org.example:lib:1.0.0",
                         baseline_coordinates=None,
                         new_version="1.0.0",
-                        reason="test route",
-                        match_type="tested-version",
                     ),
                 ), \
                 patch.object(forge_metadata, "run_improve_library_coverage_workflow", return_value=0) as workflow:

--- a/forge/tests/test_library_update_router.py
+++ b/forge/tests/test_library_update_router.py
@@ -1,0 +1,72 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ai_workflows.drivers import library_update_router
+
+
+def _write_file(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as output_file:
+        output_file.write("\n")
+
+
+class LibraryUpdateRouterTests(unittest.TestCase):
+    def test_missing_netty_version_probes_same_line_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            group = "io.netty"
+            artifact = "netty-common"
+            index_dir = os.path.join(repo, "metadata", group, artifact)
+            os.makedirs(index_dir, exist_ok=True)
+            baseline_entry = {
+                "metadata-version": "4.1.115.Final",
+                "tested-versions": ["4.1.115.Final", "4.1.130.Final"],
+            }
+            latest_entry = {
+                "latest": True,
+                "metadata-version": "5.0.0.Alpha1",
+                "tested-versions": ["5.0.0.Alpha1"],
+            }
+            with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump([baseline_entry, latest_entry], index_file)
+            for version in ["4.1.115.Final", "5.0.0.Alpha1"]:
+                _write_file(os.path.join(repo, "metadata", group, artifact, version, "metadata.json"))
+                _write_file(os.path.join(repo, "tests", "src", group, artifact, version, "build.gradle"))
+            compile_failure = library_update_router._ProbeCommandResult(
+                exit_code=1,
+                log_path="compile.log",
+            )
+
+            with patch.object(
+                    library_update_router,
+                    "_probe_baseline_suite",
+                    return_value=(compile_failure, None, None),
+            ) as probe, patch.object(
+                    library_update_router,
+                    "write_library_update_route",
+            ), patch.object(library_update_router, "log_stage") as stage_log:
+                route = library_update_router.select_library_update_route(
+                    repo,
+                    os.path.join(repo, "metrics"),
+                    "io.netty:netty-common:4.1.132.Final",
+                )
+
+            self.assertEqual(route.selected_driver, library_update_router.ROUTE_FIX_JAVAC)
+            self.assertEqual(route.baseline_coordinates, "io.netty:netty-common:4.1.115.Final")
+            self.assertEqual(
+                probe.call_args.kwargs["baseline_entry"]["metadata-version"],
+                "4.1.115.Final",
+            )
+            messages = [call.args[1] for call in stage_log.call_args_list]
+            self.assertTrue(any("nearest prior same major/minor" in message for message in messages))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_library_update_target.py
+++ b/forge/tests/test_library_update_target.py
@@ -21,12 +21,19 @@ from utility_scripts.metadata_index import (
     MATCH_METADATA_VERSION,
     MATCH_NEW_VERSION,
     MATCH_TESTED_VERSION,
+    require_version_backfill_baseline,
     resolve_library_update_target,
+    resolve_version_backfill_baseline,
 )
 
 
-def _write_index(repo_path: str, entries: list[dict]) -> str:
-    index_dir = os.path.join(repo_path, "metadata", "org.example", "demo")
+def _write_index(
+        repo_path: str,
+        entries: list[dict],
+        group: str = "org.example",
+        artifact: str = "demo",
+) -> str:
+    index_dir = os.path.join(repo_path, "metadata", group, artifact)
     os.makedirs(index_dir, exist_ok=True)
     index_path = os.path.join(index_dir, "index.json")
     with open(index_path, "w", encoding="utf-8") as file:
@@ -41,6 +48,199 @@ def _write_file(path: str, content: str = "") -> None:
 
 
 class LibraryUpdateTargetTests(unittest.TestCase):
+    def test_netty_backfill_ignores_latest_next_major_prerelease(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            group = "io.netty"
+            artifact = "netty-common"
+            index_dir = os.path.join(repo, "metadata", group, artifact)
+            os.makedirs(index_dir, exist_ok=True)
+            with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump([
+                    {
+                        "metadata-version": "4.1.100.Final",
+                        "tested-versions": ["4.1.100.Final"],
+                    },
+                    {
+                        "metadata-version": "4.1.115.Final",
+                        "tested-versions": ["4.1.115.Final", "4.1.130.Final"],
+                    },
+                    {
+                        "metadata-version": "4.1.140.Final",
+                        "tested-versions": ["4.1.140.Final"],
+                    },
+                    {
+                        "latest": True,
+                        "metadata-version": "5.0.0.Alpha1",
+                        "tested-versions": ["5.0.0.Alpha1"],
+                    },
+                ], index_file)
+            for version in ["4.1.100.Final", "4.1.115.Final", "4.1.140.Final", "5.0.0.Alpha1"]:
+                _write_file(os.path.join(repo, "metadata", group, artifact, version, "reachability-metadata.json"))
+                _write_file(os.path.join(repo, "tests", "src", group, artifact, version, "build.gradle"))
+
+            baseline = require_version_backfill_baseline(
+                repo,
+                group,
+                artifact,
+                "4.1.132.Final",
+            )
+
+            self.assertEqual(baseline.metadata_version, "4.1.115.Final")
+            self.assertEqual(baseline.test_version, "4.1.115.Final")
+            self.assertEqual(baseline.match_type, "same-major-minor")
+            self.assertIn("nearest prior same major/minor", baseline.reason)
+
+    def test_backfill_accepts_common_maven_version_suffixes(self) -> None:
+        cases = [
+            (
+                "33.7.0-jre",
+                ["33.5.0-jre", "33.6.0-jre", "34.0.0-jre"],
+                "33.6.0-jre",
+                "same-major",
+            ),
+            (
+                "12.8.2.jre11",
+                ["12.8.0.jre8", "12.8.1.jre11", "12.9.0.jre11"],
+                "12.8.1.jre11",
+                "same-major-minor",
+            ),
+            (
+                "1.5.5.Final-format-002",
+                ["1.5.3.Final-format-001", "1.5.4.Final-format-002"],
+                "1.5.4.Final-format-002",
+                "same-major-minor",
+            ),
+            (
+                "r10",
+                ["r06", "r09"],
+                "r09",
+                "same-major",
+            ),
+        ]
+
+        for requested_version, supported_versions, expected_version, expected_match_type in cases:
+            with self.subTest(requested_version=requested_version), tempfile.TemporaryDirectory() as repo:
+                _write_index(repo, [
+                    {
+                        "metadata-version": version,
+                        "tested-versions": [version],
+                    }
+                    for version in supported_versions
+                ])
+                for version in supported_versions:
+                    _write_file(os.path.join(
+                        repo,
+                        "metadata",
+                        "org.example",
+                        "demo",
+                        version,
+                        "metadata.json",
+                    ))
+                    _write_file(os.path.join(
+                        repo,
+                        "tests",
+                        "src",
+                        "org.example",
+                        "demo",
+                        version,
+                        "build.gradle",
+                    ))
+
+                baseline = require_version_backfill_baseline(
+                    repo,
+                    "org.example",
+                    "demo",
+                    requested_version,
+                )
+
+                self.assertEqual(baseline.supported_version, expected_version)
+                self.assertEqual(baseline.match_type, expected_match_type)
+                self.assertIn("nearest prior", baseline.reason)
+
+    def test_backfill_fails_when_only_cross_major_suite_is_usable(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            _write_index(repo, [{
+                "latest": True,
+                "metadata-version": "2.0.0-RC1",
+                "tested-versions": ["2.0.0-RC1"],
+            }])
+            _write_file(os.path.join(repo, "metadata", "org.example", "demo", "2.0.0-RC1", "metadata.json"))
+            _write_file(os.path.join(repo, "tests", "src", "org.example", "demo", "2.0.0-RC1", "build.gradle"))
+
+            baseline = resolve_version_backfill_baseline(repo, "org.example", "demo", "1.9.9")
+
+            self.assertIsNone(baseline)
+            with self.assertRaisesRegex(RuntimeError, "cross-major `latest` entry"):
+                require_version_backfill_baseline(repo, "org.example", "demo", "1.9.9")
+
+    def test_exact_tested_version_owner_wins_over_nearer_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            _write_index(repo, [
+                {
+                    "metadata-version": "1.0.0",
+                    "tested-versions": ["1.2.4"],
+                },
+                {
+                    "latest": True,
+                    "metadata-version": "1.2.3",
+                    "tested-versions": ["1.2.3"],
+                },
+            ])
+            for version in ["1.0.0", "1.2.3"]:
+                _write_file(os.path.join(repo, "metadata", "org.example", "demo", version, "metadata.json"))
+                _write_file(os.path.join(repo, "tests", "src", "org.example", "demo", version, "build.gradle"))
+
+            baseline = require_version_backfill_baseline(repo, "org.example", "demo", "1.2.4")
+
+            self.assertEqual(baseline.metadata_version, "1.0.0")
+            self.assertEqual(baseline.match_type, MATCH_TESTED_VERSION)
+            self.assertIn("exact tested-version ownership", baseline.reason)
+
+    def test_test_version_alias_does_not_claim_compatibility_for_metadata_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            _write_index(repo, [
+                {
+                    "latest": True,
+                    "metadata-version": "4.2.1.Final",
+                    "test-version": "4.1.74.Final",
+                    "tested-versions": ["4.2.1.Final"],
+                },
+                {
+                    "metadata-version": "4.1.74.Final",
+                    "tested-versions": ["4.1.74.Final"],
+                },
+            ], group="io.netty", artifact="netty-codec-memcache")
+            for version in ["4.2.1.Final", "4.1.74.Final"]:
+                _write_file(os.path.join(
+                    repo,
+                    "metadata",
+                    "io.netty",
+                    "netty-codec-memcache",
+                    version,
+                    "reachability-metadata.json",
+                ))
+            _write_file(os.path.join(
+                repo,
+                "tests",
+                "src",
+                "io.netty",
+                "netty-codec-memcache",
+                "4.1.74.Final",
+                "build.gradle",
+            ))
+
+            baseline = require_version_backfill_baseline(
+                repo,
+                "io.netty",
+                "netty-codec-memcache",
+                "4.1.75.Final",
+            )
+
+            self.assertEqual(baseline.metadata_version, "4.1.74.Final")
+            self.assertEqual(baseline.test_version, "4.1.74.Final")
+            self.assertEqual(baseline.supported_version, "4.1.74.Final")
+            self.assertEqual(baseline.match_type, "same-major-minor")
+
     def test_issue_requested_metadata_context_includes_mandatory_test_coverage(self) -> None:
         context = format_issue_requested_metadata_context(
             "Caused by: org.graalvm.nativeimage.MissingReflectionRegistrationError: "

--- a/forge/utility_scripts/metadata_index.py
+++ b/forge/utility_scripts/metadata_index.py
@@ -18,6 +18,7 @@ MATCH_TESTED_VERSION = "tested-version"
 MATCH_METADATA_VERSION = "metadata-version"
 MATCH_DEFAULT_FOR = "default-for"
 MATCH_NEW_VERSION = "new-version"
+ParsedMetadataVersion: TypeAlias = tuple[tuple[int, ...], tuple[int, int]]
 
 
 @dataclass(frozen=True)
@@ -32,14 +33,36 @@ class LibraryUpdateTarget:
     test_dir: str
 
 
+@dataclass(frozen=True)
+class VersionBackfillBaseline:
+    """Usable test and metadata support selected for a version backfill."""
+
+    entry: dict[str, Any]
+    metadata_version: str
+    test_version: str
+    supported_version: str
+    match_type: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _BaselineCandidate:
+    entry: dict[str, Any]
+    supported_version: str
+    parsed_version: ParsedMetadataVersion
+
+
 _RELEASE_QUALIFIER = "release"
 _VERSION_PATTERN = re.compile(
     r"^(\d+(?:\.\d+)*)(?:\.(?:Final|RELEASE))?"
     r"(?:[-.](alpha\d*|beta\d*|rc\d*|cr\d*|m\d+|ea\d*|b\d+|\d+|preview)(?:[-.](.*))?)?$",
     re.IGNORECASE,
 )
+_MAVEN_NUMERIC_VERSION_PATTERN = re.compile(
+    r"^([vr]?)(\d+(?:\.\d+)*)(?:[A-Za-z._+\-][A-Za-z0-9._+\-]*)?$",
+    re.IGNORECASE,
+)
 _QUALIFIER_PATTERN = re.compile(r"^(alpha|beta|rc|cr|m|ea|b|preview)(\d*)$", re.IGNORECASE)
-ParsedMetadataVersion: TypeAlias = tuple[tuple[int, ...], tuple[int, int]]
 _QUALIFIER_RANK = {
     "alpha": 10,
     "beta": 20,
@@ -50,6 +73,7 @@ _QUALIFIER_RANK = {
     "cr": 50,
     "b": 60,
     "number": 70,
+    "variant": 90,
     _RELEASE_QUALIFIER: 100,
 }
 
@@ -196,6 +220,201 @@ def resolve_library_update_target(
     )
 
 
+def resolve_version_backfill_baseline(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        requested_version: str,
+) -> VersionBackfillBaseline | None:
+    """Resolve one usable same-major baseline for deterministic version backfill.
+
+    Exact index ownership takes precedence over version ordering. Non-exact
+    selection never crosses a major-version boundary. §WF-forge-workflow-drivers.2
+    """
+    target = resolve_library_update_target(repo_path, group, artifact, requested_version)
+    if target.match_type != MATCH_NEW_VERSION and target.matched_entry is not None:
+        if not _entry_has_usable_support(repo_path, group, artifact, target.matched_entry):
+            return None
+        return _version_backfill_baseline(
+            target.matched_entry,
+            requested_version,
+            target.match_type,
+            f"exact {target.match_type} ownership of {requested_version}",
+        )
+
+    requested_parsed = _parse_metadata_version(requested_version)
+    if requested_parsed is None:
+        return None
+
+    entries = load_index_entries(repo_path, group, artifact) or []
+    candidates: list[_BaselineCandidate] = []
+    for entry in entries:
+        if (
+                not isinstance(entry, dict)
+                or is_not_for_native_image_entry(entry)
+                or not _entry_has_usable_support(repo_path, group, artifact, entry)
+        ):
+            continue
+        for supported_version in _entry_declared_supported_versions(entry):
+            parsed_version = _parse_metadata_version(supported_version)
+            if parsed_version is None:
+                continue
+            candidates.append(_BaselineCandidate(
+                entry=entry,
+                supported_version=supported_version,
+                parsed_version=parsed_version,
+            ))
+
+    requested_numbers = requested_parsed[0]
+    same_major_minor = [
+        candidate for candidate in candidates
+        if _same_version_line(candidate.parsed_version[0], requested_numbers, 2)
+    ]
+    selected = _select_ordered_baseline_candidate(same_major_minor, requested_version)
+    if selected is not None:
+        ordering = _baseline_ordering_reason(selected.supported_version, requested_version)
+        return _version_backfill_baseline(
+            selected.entry,
+            selected.supported_version,
+            "same-major-minor",
+            f"{ordering} same major/minor supported version {selected.supported_version}",
+        )
+
+    same_major = [
+        candidate for candidate in candidates
+        if _same_version_line(candidate.parsed_version[0], requested_numbers, 1)
+    ]
+    selected = _select_ordered_baseline_candidate(same_major, requested_version)
+    if selected is not None:
+        ordering = _baseline_ordering_reason(selected.supported_version, requested_version)
+        return _version_backfill_baseline(
+            selected.entry,
+            selected.supported_version,
+            "same-major",
+            f"{ordering} same-major supported version {selected.supported_version}",
+        )
+    return None
+
+
+def require_version_backfill_baseline(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        requested_version: str,
+) -> VersionBackfillBaseline:
+    """Resolve a compatible baseline or raise an actionable routing error."""
+    baseline = resolve_version_backfill_baseline(
+        repo_path,
+        group,
+        artifact,
+        requested_version,
+    )
+    if baseline is not None:
+        return baseline
+
+    coordinate = f"{group}:{artifact}:{requested_version}"
+    index_display = os.path.relpath(index_path(repo_path, group, artifact), repo_path)
+    raise RuntimeError(
+        "ERROR: Cannot resolve a compatible version-backfill baseline for "
+        f"{coordinate} from {index_display}. Expected a usable exact owner or "
+        "a supported test suite in the same major version; each baseline must "
+        "have both metadata and test directories. A cross-major `latest` entry "
+        "is not a compatible baseline. Restore a compatible test suite or "
+        "route the issue for human intervention."
+    )
+
+
+def _version_backfill_baseline(
+        entry: dict[str, Any],
+        supported_version: str,
+        match_type: str,
+        reason: str,
+) -> VersionBackfillBaseline:
+    metadata_version = _entry_metadata_version(entry, supported_version)
+    test_version = _entry_test_version(entry, metadata_version)
+    return VersionBackfillBaseline(
+        entry=entry,
+        metadata_version=metadata_version,
+        test_version=test_version,
+        supported_version=supported_version,
+        match_type=match_type,
+        reason=reason,
+    )
+
+
+def _entry_has_usable_support(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        entry: dict[str, Any],
+) -> bool:
+    metadata_version = _entry_metadata_version(entry, "")
+    if not metadata_version:
+        return False
+    test_version = _entry_test_version(entry, metadata_version)
+    metadata_dir = os.path.join(repo_path, "metadata", group, artifact, metadata_version)
+    test_dir = os.path.join(repo_path, "tests", "src", group, artifact, test_version)
+    return os.path.isdir(metadata_dir) and os.path.isdir(test_dir)
+
+
+def _entry_declared_supported_versions(entry: dict[str, Any]) -> list[str]:
+    """Return library releases owned by an entry, excluding test-dir aliases."""
+    versions: list[str] = []
+    for version in [entry.get("metadata-version"), *_tested_versions(entry)]:
+        if isinstance(version, str) and version and version not in versions:
+            versions.append(version)
+    return versions
+
+
+def _same_version_line(
+        candidate_numbers: tuple[int, ...],
+        requested_numbers: tuple[int, ...],
+        component_count: int,
+) -> bool:
+    if len(candidate_numbers) < component_count or len(requested_numbers) < component_count:
+        return False
+    return candidate_numbers[:component_count] == requested_numbers[:component_count]
+
+
+def _select_ordered_baseline_candidate(
+        candidates: list[_BaselineCandidate],
+        requested_version: str,
+) -> _BaselineCandidate | None:
+    if not candidates:
+        return None
+    prior_candidates = [
+        candidate for candidate in candidates
+        if (_compare_parseable_metadata_versions(candidate.supported_version, requested_version) or 0) <= 0
+    ]
+    if prior_candidates:
+        selected = prior_candidates[0]
+        for candidate in prior_candidates[1:]:
+            comparison = _compare_parseable_metadata_versions(
+                candidate.supported_version,
+                selected.supported_version,
+            )
+            if comparison is not None and comparison > 0:
+                selected = candidate
+        return selected
+
+    selected = candidates[0]
+    for candidate in candidates[1:]:
+        comparison = _compare_parseable_metadata_versions(
+            candidate.supported_version,
+            selected.supported_version,
+        )
+        if comparison is not None and comparison < 0:
+            selected = candidate
+    return selected
+
+
+def _baseline_ordering_reason(supported_version: str, requested_version: str) -> str:
+    comparison = _compare_parseable_metadata_versions(supported_version, requested_version)
+    if comparison is not None and comparison <= 0:
+        return "nearest prior"
+    return "nearest following"
+
+
 def latest_metadata_version(repo_path: str, group: str, artifact: str) -> str | None:
     """Return the metadata-version of the single latest entry, if one exists."""
     entries = load_index_entries(repo_path, group, artifact)
@@ -253,9 +472,13 @@ def _compare_parseable_metadata_versions(first_version: str, second_version: str
 
 
 def _parse_metadata_version(version: str) -> ParsedMetadataVersion | None:
+    """Parse known qualifiers or retain the numeric line of a Maven variant.
+
+    §WF-forge-workflow-drivers.2
+    """
     match = _VERSION_PATTERN.match(version)
     if not match:
-        return None
+        return _parse_maven_numeric_version_fallback(version)
 
     base = tuple(int(part) for part in match.group(1).split("."))
     qualifier_token = match.group(2)
@@ -265,12 +488,12 @@ def _parse_metadata_version(version: str) -> ParsedMetadataVersion | None:
 
     if qualifier_token.isdigit():
         if qualifier_tail and any(not part.isdigit() for part in re.split(r"[-.]", qualifier_tail)):
-            return None
+            return _parse_maven_numeric_version_fallback(version)
         return base, (_QUALIFIER_RANK["number"], int(qualifier_token))
 
     qualifier_match = _QUALIFIER_PATTERN.match(qualifier_token)
     if not qualifier_match:
-        return None
+        return _parse_maven_numeric_version_fallback(version)
 
     qualifier = qualifier_match.group(1).lower()
     qualifier_number = qualifier_match.group(2)
@@ -279,6 +502,17 @@ def _parse_metadata_version(version: str) -> ParsedMetadataVersion | None:
         if first_tail_part.isdigit():
             qualifier_number = first_tail_part
     return base, (_QUALIFIER_RANK[qualifier], int(qualifier_number or "0"))
+
+
+def _parse_maven_numeric_version_fallback(version: str) -> ParsedMetadataVersion | None:
+    """Retain a Maven variant's complete leading numeric version line."""
+    match = _MAVEN_NUMERIC_VERSION_PATTERN.match(version)
+    if not match:
+        return None
+    base = tuple(int(part) for part in match.group(2).split("."))
+    if match.group(1):
+        base = (0, *base)
+    return base, (_QUALIFIER_RANK["variant"], 0)
 
 
 def _compare_version_numbers(first: tuple[int, ...], second: tuple[int, ...]) -> int:


### PR DESCRIPTION
### Summary

- resolve version-backfill baselines from exact index ownership, then the nearest compatible same-line support
- use the shared resolver for direct repair queues, missing-version routing, and coverage backfills
- reject cross-major latest suites and fail with an actionable error when no compatible suite exists
- treat test-version strictly as a test-directory alias, not as a supported library release
- log the selected baseline coordinate and selection reason

### Testing

- python3 -B -m unittest tests.test_library_update_target tests.test_library_update_router tests.test_forge_metadata.LibraryUpdateIssueTests
- ruff check --no-cache utility_scripts/metadata_index.py tests/test_library_update_target.py
- grund check
- git diff --check
- hermetic Forge fixture E2E for issue 9108

Fixes #9481