### PR TITLE
Run native coverage validation via the root test task

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -146,7 +146,7 @@
     output to commit — this repository loads none of them
     (§root/METADATA-suite.1, §WF-code-coverage-improvement.2). Do not split shipped
     from test-only entries by hand: finalization runs `splitTestOnlyMetadata`.
-  - Run `./gradlew nativeTest -Pcoordinates=<resolved coordinate> -PincludeCodeCoverageSuite=true`; if it fails, repair
+  - Run `./gradlew test -Pcoordinates=<resolved coordinate> -PincludeCodeCoverageSuite=true`; if it fails, repair
     metadata with the Codex `fix-missing-reachability-metadata` skill and re-run,
     up to the helper's fix budget.
   - If Native Image validation cannot be repaired automatically, request

--- a/forge/examples/code-coverage-improvement-example/tasks/code-coverage-improvement.md
+++ b/forge/examples/code-coverage-improvement-example/tasks/code-coverage-improvement.md
@@ -124,7 +124,7 @@
   - Read the resolved coordinate and absolute suite root from the conversion
     and preparation artifacts.
   - Generate metadata with `./gradlew generateMetadata -Pcoordinates=<resolved coordinate> -PincludeCodeCoverageSuite=true`.
-  - Run `./gradlew nativeTest -Pcoordinates=<resolved coordinate> -PincludeCodeCoverageSuite=true`; if it fails, repair
+  - Run `./gradlew test -Pcoordinates=<resolved coordinate> -PincludeCodeCoverageSuite=true`; if it fails, repair
     metadata with the Codex `fix-missing-reachability-metadata` skill and re-run,
     up to the helper's fix budget.
   - If Native Image validation cannot be repaired automatically, request

--- a/forge/tests/test_code_coverage_prepare_native_metadata.py
+++ b/forge/tests/test_code_coverage_prepare_native_metadata.py
@@ -6,6 +6,7 @@
 from contextlib import redirect_stderr
 import io
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -15,7 +16,7 @@ from utility_scripts import code_coverage_prepare_native_metadata as prepare_mod
 
 
 class _Gradle:
-    """Stateful fake for run_gradle_test_command driven by scripted nativeTest results."""
+    """Stateful fake for run_gradle_test_command driven by scripted native-validation results."""
 
     def __init__(
             self,
@@ -34,10 +35,32 @@ class _Gradle:
                 if self.generate_succeeded
                 else "BUILD FAILED\nmetadata generation failed"
             )
-        if "nativeTest" in command:
+        if f"./gradlew {prepare_module.NATIVE_VALIDATION_TASK} " in command:
             succeeded = self.native_results.pop(0) if self.native_results else False
             return "BUILD SUCCESSFUL in 9s" if succeeded else "BUILD FAILED\nmissing metadata"
         return "BUILD SUCCESSFUL"
+
+
+_HARNESS_GRADLE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "tests", "tck-build-logic", "src", "main", "groovy",
+    "org.graalvm.internal.tck-harness.gradle",
+)
+
+
+class NativeValidationTaskTests(unittest.TestCase):
+    """The helper must name a task the harness root project registers.
+
+    Gradle matches an unknown task name by prefix, so a wrong name stays silent
+    until a sibling task makes it ambiguous. `nativeTest` was such a name: it is
+    registered on the per-library builds, never on the root project.
+    """
+
+    def test_native_validation_task_is_registered_on_the_root_project(self) -> None:
+        """Fails if the helper ever names a task only the per-library builds define."""
+        with open(_HARNESS_GRADLE, encoding="utf-8") as harness:
+            registered = set(re.findall(r'tasks\.register\("([^"]+)"', harness.read()))
+        self.assertIn(prepare_module.NATIVE_VALIDATION_TASK, registered)
 
 
 class PrepareNativeMetadataTests(unittest.TestCase):
@@ -98,8 +121,8 @@ class PrepareNativeMetadataTests(unittest.TestCase):
         self.assertTrue(report["nativeTestPassed"])
         self.assertFalse(report["needsHumanIntervention"])
         self.assertEqual(len(fix_calls), 1)
-        # The Codex fix is given the nativeTest reproduction command.
-        self.assertIn("nativeTest", fix_calls[0][2])
+        # The Codex fix is given the native-validation reproduction command.
+        self.assertIn(f"./gradlew {prepare_module.NATIVE_VALIDATION_TASK} ", fix_calls[0][2])
         self.assertIn("-PincludeCodeCoverageSuite=true", fix_calls[0][2])
 
     def test_exhausts_budget_routes_to_human(self) -> None:

--- a/forge/utility_scripts/code_coverage_prepare_native_metadata.py
+++ b/forge/utility_scripts/code_coverage_prepare_native_metadata.py
@@ -21,8 +21,8 @@ metadata and then repairs it with the Codex-backed
 the six deep collections (one baseline and five post-iteration reports) do not
 each have to discover and repair metadata gaps.
 
-Loop: `generateMetadata` -> `nativeTest`; while it fails and a fix budget
-remains, `run_codex_metadata_fix` then re-run `nativeTest`. If Native Image
+Loop: `generateMetadata` -> `test`; while it fails and a fix budget
+remains, `run_codex_metadata_fix` then re-run `test`. If Native Image
 validation still cannot pass automatically, the run is flagged
 `needsHumanIntervention` (exit code 3) so the reviewed Rhei task routes to
 human intervention. A failed `generateMetadata` stops immediately instead of
@@ -89,6 +89,15 @@ def _normalize_coverage_suite(repo_path: str, coverage_suite: str) -> str:
     return suite_path
 
 
+# The harness root project registers no `nativeTest` task: the per-library test
+# projects are separate Gradle builds. Root `test` is the invocation task that
+# runs `nativeTest` inside the resolved library build and forwards
+# `-PincludeCodeCoverageSuite`. Naming `nativeTest` here resolves against the
+# root project, where Gradle matches it by prefix against `nativeTestCompile`
+# and `nativeTestPGOSampling` and fails as ambiguous. §TCK-test-harness.3
+NATIVE_VALIDATION_TASK: str = "test"
+
+
 def _gradle_command(task: str, coordinate: str) -> str:
     coordinate_arg: str = shlex.quote(f"-Pcoordinates={coordinate}")
     return f"./gradlew {task} {coordinate_arg} -PincludeCodeCoverageSuite=true --stacktrace"
@@ -125,7 +134,7 @@ def prepare_native_metadata(
         return report
 
     generate_command: str = _gradle_command("generateMetadata", coordinate)
-    native_command: str = _gradle_command("nativeTest", coordinate)
+    native_command: str = _gradle_command(NATIVE_VALIDATION_TASK, coordinate)
 
     generate_output: str = run_gradle_test_command(
         generate_command,
@@ -152,7 +161,7 @@ def prepare_native_metadata(
     )
     passed: bool = _gradle_succeeded(native_output)
     steps.append({
-        "task": "nativeTest",
+        "task": NATIVE_VALIDATION_TASK,
         "command": native_command,
         "attempt": 0,
         "succeeded": passed,
@@ -172,7 +181,7 @@ def prepare_native_metadata(
         )
         passed = _gradle_succeeded(native_output)
         steps.append({
-            "task": "nativeTest",
+            "task": NATIVE_VALIDATION_TASK,
             "command": native_command,
             "attempt": fix_passes,
             "succeeded": passed,


### PR DESCRIPTION
Closes #9485

## What this does

`code_coverage_prepare_native_metadata.py` validated freshly generated metadata by running `./gradlew nativeTest` from the repository root — a task the root project does not register. The per-library test projects are separate Gradle builds, so `nativeTest` exists only inside them, and the harness reaches them by shelling out with `cwd` set to the library test directory (`AbstractSubprojectTask:128`). Gradle matched the name by prefix instead, and once `nativeTestPGOSampling` existed there were two candidates and the build died as a `TaskSelectionException` in about a second.

The helper cannot tell that apart from a metadata failure. It spent its whole Codex fix budget repairing metadata that was never broken, then reported `needsHumanIntervention`. Every run that got this far hit it — `io.grpc:grpc-api` on 2026-07-14 and `org.apache.commons:commons-compress` on 2026-08-21 — so the deep coverage phase ([§forge/WF-code-coverage-improvement.3.2](https://github.com/oracle/graalvm-reachability-metadata/blob/fix/coverage-native-validation-task/forge/docs/workflows/code-coverage-improvement.md)) had never run.

The fix names root `test`: the invocation task that runs `nativeTest` inside the resolved library build and already forwards `-PincludeCodeCoverageSuite` (`TestInvocationTask.java:45`). It is the lane every other workflow already uses — `native-test-verify` runs `cycle-0-test` ([§TCK-test-harness.3](https://github.com/oracle/graalvm-reachability-metadata/blob/fix/coverage-native-validation-task/docs/tck.md)).

## Why the wrong name stayed invisible

Gradle resolves an unknown task name by prefix, so a wrong name is silent until a sibling collides with it:

```console
$ ./gradlew nativeTestPGO --dry-run -Pcoordinates=org.apache.commons:commons-compress:1.23.0
:nativeTestPGOSampling SKIPPED
BUILD SUCCESSFUL in 1s
```

`nativeTestPGO` is not a task. Before `nativeTestPGOSampling` was registered, `nativeTest` had exactly one prefix match — `nativeTestCompile` — so the call resolved, exited zero, and only ever *compiled* the image without running it.

The task name is now a constant carrying that reasoning, and a regression test parses the `tasks.register("...")` calls out of `org.graalvm.internal.tck-harness.gradle` and asserts the helper names one of them. It was checked against the old value and fails there. This is worth having because every pre-existing test in this module passes `skip_gradle` — nothing had ever executed the real command.

## What the phase does now

Verified end to end on #9455, `org.apache.commons:commons-compress:1.23.0`:

| Step | Before | After |
|---|---|---|
| `generateMetadata` | passed | passed |
| native validation | `Task 'nativeTest' is ambiguous`, ~1s | `:nativeTest`, 73 tests successful |
| `runNativeTestPGO` | never reached | passed, 6.6 MB profile |
| deep coverage loop | never ran | ran — first pass 44.82% → 50.24% internal, 59.08% → 61.76% public API |

## Open questions

1. **Should this phase validate with `test` or `nativeTestPGOSampling`?** — `test` restores the intended behavior and matches every other workflow, which is why it is what this PR uses. But the phase exists specifically to prepare the PGO-sampling image the deep loop consumes, so `nativeTestPGOSampling` may be the more precise target. Worth settling before the pattern spreads to other callers.
