### PR TITLE
Route every finalization step and budget its repairs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@
 ## Releases and Packaging
 - Package artifacts: ./gradlew package
 
+- **Never cite under `tests/src`.** Checkstyle holds that suite to ASCII, so the
+  `§` marker cannot appear in a test file.
+
 <!-- BEGIN GRUND MANAGED BLOCK -->
 ## Grounding with grund (v7)
 

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -235,6 +235,10 @@ states:
       - Hold one test class per subsystem the suite drives. Add a class when the
         group of classes you are covering has none, rather than growing a class
         built for something else.
+      - Open every test file with the CC0 header the sibling tests under
+        `src/test/java` already carry, and keep the whole file ASCII: checkstyle
+        runs over this suite at finalization and rejects both a missing header
+        and any non-ASCII character, the grund `§` marker included.
       - Target meaningful public user-callable behavior with real assertions,
         not superficial coverage hits.
       - Do not weaken metadata-generation tests.
@@ -482,6 +486,10 @@ states:
       - Hold one test class per subsystem the suite drives. Add a class when the
         group of classes you are covering has none, rather than growing a class
         built for something else.
+      - Open every test file with the CC0 header the sibling tests under
+        `src/test/java` already carry, and keep the whole file ASCII: checkstyle
+        runs over this suite at finalization and rejects both a missing header
+        and any non-ASCII character, the grund `§` marker included.
       - Do not weaken metadata-generation tests.
       - Do not write any target state: measurement tracks attempts and target
         rotation deterministically from its own report history.
@@ -566,7 +574,9 @@ states:
   reviewed-execute:
     description: Run the deterministic finalization steps; a nonzero exit code names the failed step.
     concurrent: true
-    visits: {{fix_passes}}
+    # The first entry is the finalization run itself, not a repair, so the cap
+    # is one above the repair budget it gates.
+    visits: {{fix_passes + 1}}
     program: |
       python3 - "$RHEI_INPUT_CONVERSION_PATH" <<'PY'
       import json
@@ -728,7 +738,7 @@ states:
   finalize-verify:
     description: Deterministically verify finalization artifacts and route by outcome.
     concurrent: true
-    visits: {{fix_passes}}
+    visits: {{fix_passes + 1}}
     program: |
       metrics="$RHEI_INPUT_FINAL_METRICS_PATH"
       summary="$RHEI_INPUT_FINAL_SUMMARY_PATH"
@@ -770,7 +780,7 @@ states:
     description: Repair the cause of a failed finalization step or verification.
     target: "{{worker_agent}}"
     concurrent: true
-    visits: {{fix_passes}}
+    visits: {{fix_passes * 2 + 2}}
     instructions: |
       Fix the finalization failure for Task {task_id}: {task_title}.
 
@@ -1037,19 +1047,31 @@ transitions:
     to: finalize-fix
     exit_code: 2
     condition: visitCount < visits
-    description: Step 2 failed - checkstyle failed for the coverage suite.
+    description: Step 2 failed - test-only metadata split, metadata validation, or the legacy Native Image config check.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 3
     condition: visitCount < visits
-    description: Step 3 failed - JVM tests with the coverage suite failed.
+    description: Step 3 failed - checkstyle failed for the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 4
     condition: visitCount < visits
-    description: Step 4 failed - code_coverage_finalize.py rejected its inputs.
+    description: Step 4 failed - JVM tests with the coverage suite failed.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 5
+    condition: visitCount < visits
+    description: Step 5 failed - generateLibraryStats did not persist coverage.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 6
+    condition: visitCount < visits
+    description: Step 6 failed - code_coverage_finalize.py rejected its inputs.
 
   - from: reviewed-execute
     to: human-intervention
@@ -1074,6 +1096,18 @@ transitions:
     exit_code: 4
     condition: visitCount >= visits
     description: Step 4 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 5
+    condition: visitCount >= visits
+    description: Step 5 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 6
+    condition: visitCount >= visits
+    description: Step 6 still fails after the maximum fix passes.
 
   - from: finalize-verify
     to: completed

--- a/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
@@ -92,9 +92,13 @@ inputs:
     default: pi[high]:openai-codex/gpt-5.6-luna
 
   - name: fix_passes
-    description: Maximum automated fix passes when finalization verification fails.
+    description: >-
+      Automated repairs allowed on each finalization path - failed steps and
+      failed artifact verification are budgeted separately. Defaults to the
+      number of steps the step program can fail at, so one failing step cannot
+      spend the allowance another one needs.
     type: number
-    default: 2
+    default: 6
     validate: "[1-9][0-9]*"
 
   - name: coverage_iterations

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -552,9 +552,15 @@ budget, route to human intervention.
 Every fix state that can be entered more than once is a counted Rhei state and
 writes a visit-scoped output. API and deep fix states use the corresponding
 measurement visit cap, which records each fix entry without tightening the
-measurement-owned retry budget. The finalization fix state uses the configured
-`fix_passes` cap. This ensures that an output from an earlier repair pass cannot
-satisfy the output-existence completion check for a later pass.
+measurement-owned retry budget. Finalization has two separate `fix_passes`
+repair budgets: one for failures from the numbered step program and one for
+failures from artifact verification. The execution and verification states each
+allow `fix_passes + 1` visits because their first visit is the initial attempt,
+not a repair. Both paths share the finalization fix state, whose
+`fix_passes * 2 + 2` visit cap is only large enough not to tighten either
+path-owned budget. Its counted visits ensure that an output from an earlier
+repair pass cannot satisfy the output-existence completion check for a later
+pass.
 
 ## 5. Acceptance Criteria
 

--- a/forge/examples/code-coverage-improvement-example/states.yaml
+++ b/forge/examples/code-coverage-improvement-example/states.yaml
@@ -187,6 +187,10 @@ states:
         `code-coverage-improvement/src/test/java` inside the coordinate's
         indexed test project (`coverageSuiteRepoRelativePath` in
         conversion.json); never touch the regular `src/test` sources.
+      - Open every test file with the CC0 header the sibling tests under
+        `src/test/java` already carry, and keep the whole file ASCII: checkstyle
+        runs over this suite at finalization and rejects both a missing header
+        and any non-ASCII character, the grund `§` marker included.
       - Target meaningful public user-callable behavior with real assertions,
         not superficial coverage hits.
       - Do not weaken metadata-generation tests.
@@ -397,6 +401,10 @@ states:
         `code-coverage-improvement/src/test/java` inside the coordinate's
         indexed test project (`coverageSuiteRepoRelativePath` in
         conversion.json); never touch the regular `src/test` sources.
+      - Open every test file with the CC0 header the sibling tests under
+        `src/test/java` already carry, and keep the whole file ASCII: checkstyle
+        runs over this suite at finalization and rejects both a missing header
+        and any non-ASCII character, the grund `§` marker included.
       - Do not weaken metadata-generation tests.
       - Do not write any target state: measurement tracks attempts and target
         rotation deterministically from its own report history.
@@ -458,7 +466,9 @@ states:
   reviewed-execute:
     description: Run the deterministic finalization steps; a nonzero exit code names the failed step.
     concurrent: true
-    visits: 2
+    # The first entry is the finalization run itself, not a repair, so the cap
+    # is one above the repair budget it gates.
+    visits: 3
     program: |
       python3 - "$RHEI_INPUT_CONVERSION_PATH" <<'PY'
       import json
@@ -556,7 +566,7 @@ states:
   finalize-verify:
     description: Deterministically verify finalization artifacts and route by outcome.
     concurrent: true
-    visits: 2
+    visits: 3
     program: |
       metrics="$RHEI_INPUT_FINAL_METRICS_PATH"
       summary="$RHEI_INPUT_FINAL_SUMMARY_PATH"
@@ -598,7 +608,7 @@ states:
     description: Repair the cause of a failed finalization step or verification.
     target: "pi:openai-codex/gpt-5.6-terra"
     concurrent: true
-    visits: 2
+    visits: 6
     instructions: |
       Fix the finalization failure for Task {task_id}: {task_title}.
 
@@ -820,19 +830,31 @@ transitions:
     to: finalize-fix
     exit_code: 2
     condition: visitCount < visits
-    description: Step 2 failed - checkstyle failed for the coverage suite.
+    description: Step 2 failed - test-only metadata split, metadata validation, or the legacy Native Image config check.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 3
     condition: visitCount < visits
-    description: Step 3 failed - JVM tests with the coverage suite failed.
+    description: Step 3 failed - checkstyle failed for the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 4
     condition: visitCount < visits
-    description: Step 4 failed - code_coverage_finalize.py rejected its inputs.
+    description: Step 4 failed - JVM tests with the coverage suite failed.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 5
+    condition: visitCount < visits
+    description: Step 5 failed - generateLibraryStats did not persist coverage.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 6
+    condition: visitCount < visits
+    description: Step 6 failed - code_coverage_finalize.py rejected its inputs.
 
   - from: reviewed-execute
     to: human-intervention
@@ -857,6 +879,18 @@ transitions:
     exit_code: 4
     condition: visitCount >= visits
     description: Step 4 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 5
+    condition: visitCount >= visits
+    description: Step 5 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 6
+    condition: visitCount >= visits
+    description: Step 6 still fails after the maximum fix passes.
 
   - from: finalize-verify
     to: completed

--- a/forge/tests/test_code_coverage_rhei_template.py
+++ b/forge/tests/test_code_coverage_rhei_template.py
@@ -4,9 +4,34 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import os
+import re
 import unittest
 
 import yaml
+
+
+_TEMPLATE_NUMBERS: dict[str, int] = {
+    "measure_visits": 16,
+    "coverage_iterations": 5,
+    "fix_passes": 2,
+}
+
+
+def _render_numeric_placeholders(source: str) -> str:
+    """Resolve the numeric template placeholders, including arithmetic on them.
+
+    Visit caps are expressed relative to the budget they gate, so a placeholder
+    can be an expression rather than a bare name. Anything that is not numeric
+    is left untouched for the YAML parser to read as a plain string.
+    """
+
+    def render(match: re.Match) -> str:
+        try:
+            return str(eval(match.group(1).strip(), {"__builtins__": {}}, _TEMPLATE_NUMBERS))
+        except (NameError, SyntaxError, TypeError):
+            return match.group(0)
+
+    return re.sub(r"\{\{([^{}]+)\}\}", render, source)
 
 
 class CodeCoverageRheiTemplateTests(unittest.TestCase):
@@ -33,10 +58,7 @@ class CodeCoverageRheiTemplateTests(unittest.TestCase):
         for states_path in states_paths:
             with open(states_path, encoding="utf-8") as states_file:
                 source: str = states_file.read()
-            source = source.replace("{{measure_visits}}", "16")
-            source = source.replace("{{coverage_iterations}}", "5")
-            source = source.replace("{{fix_passes}}", "2")
-            machine: dict = yaml.safe_load(source)
+            machine: dict = yaml.safe_load(_render_numeric_placeholders(source))
 
             for state_name in ("api-fix", "deep-fix", "finalize-fix"):
                 with self.subTest(path=states_path, state=state_name):


### PR DESCRIPTION
Closes #9491

## What this does

Finalization could strand a run outright. The step program grew to six steps — a metadata split was inserted at position 2 and a stats persist at position 5 — but its transition table still only covered exit codes `1`..`4`. A failure in `generateLibraryStats` or `code_coverage_finalize.py` returned a code no transition matched, so the task sat in `reviewed-execute` with nowhere to go and the run halted, neither repaired nor reported.

The same insertion left every transition description naming the wrong step, and the repair budget turned out to allow one fewer repair than its name promises. All three showed up on a single run of #9455 (`org.apache.commons:commons-compress:1.23.0`), which is also where the cover-agent gap below came from.

## Routing every step

Exit codes `5` and `6` now have both variants, so all six steps route symmetrically to `finalize-fix` while budget remains and to `human-intervention` once it is spent.

The descriptions were off by one against the program the whole time:

| Exit | Description said | Program actually does |
|---|---|---|
| 2 | checkstyle failed | metadata split, validation, legacy Native Image config check |
| 3 | JVM tests failed | checkstyle |
| 4 | `code_coverage_finalize.py` rejected its inputs | JVM tests |

Routing was unaffected — every code in `1`..`4` reached the same pair of targets — but the #9455 run reported "Step 2 failed" for a legacy-config problem and "Step 3 failed" for checkstyle, and `finalize-fix`'s own instructions already used the correct numbering. The state machine and the repair agent disagreed about what an exit code meant.

## Making `fix_passes` mean repairs

`visitCount` counts entries to the state a transition leaves, and the first entry to `reviewed-execute` is the finalization run rather than a repair:

```
entry 1  -> fails -> finalize-fix   (repair 1)
entry 2  -> fails -> finalize-fix   (repair 2)
entry 3
```

Three entries buy two repairs, so `visits: N` yielded `N-1`. At the old default of `2` that was exactly one repair, shared across all six steps rather than allocated per step. #9455 spent it on the legacy-config check at step 2, and when checkstyle failed at step 3 the run went straight to `human-intervention` — past a `finalize-fix` instruction written for precisely that failure.

The two gating states are now sized one above the budget they gate, and the default is the number of steps that can fail:

| State | Visits | Why |
|---|---|---|
| `reviewed-execute` | `{{fix_passes + 1}}` | first entry is the run, not a repair |
| `finalize-verify` | `{{fix_passes + 1}}` | same offset on the exit-`75` path |
| `finalize-fix` | `{{fix_passes * 2 + 2}}` | fed by both budgets, so it must not gate either |

`finalize-fix` is deliberately not a budget. Its visit count exists so each repair writes a visit-scoped output and an earlier pass's artifact cannot satisfy a later pass's existence check, per §forge/[AR-code-coverage-improvement.4](https://github.com/oracle/graalvm-reachability-metadata/blob/fix/coverage-finalization-routing/forge/docs/architecture/code-coverage-improvement.md).

The undersized cap had a second effect worth naming. `human-intervention -> reviewed-execute` exists so a maintainer can resume a parked run, and on #9455 it was refused:

```
the edge exists but its condition is unmet
```

`reviewed-execute` was already at its cap, so the recovery transition could not be taken and the run could only be restarted by re-instantiating the workspace and discarding every completed phase.

## Telling cover agents about the gate they are judged by

`checkstyle`, `CC0` and `ASCII` appeared nowhere in the `api-cover` or `deep-cover` instructions — only in the finalization program, three tasks after the tests are written. The repository's grounding conventions meanwhile tell agents to cite as they write, so the #9455 cover agents opened all sixteen generated files with a `§TESTS-...` declaration, which is both non-ASCII and displaces the mandatory CC0 header. Checkstyle rejected every one of them.

The rule is scoped, which is what makes it easy to miss: `tests/tck-build-logic` holds 33 Java files carrying `§` and is never checkstyled, while `tests/src` is held to ASCII by `org.graalvm.internal.tck.gradle`. Both cover states now carry the header-and-ASCII rule, and `AGENTS.md` records the boundary in one sentence so the citation convention stops at `tests/src`.

## Open question

1. **Should the step numbering come from one source?** The program and the transition table each carry their own copy, and they have now drifted apart once — silently, because routing kept working while the descriptions lied. Deriving the transitions from the program's step list, or at least asserting the two agree in `test_code_coverage_rhei_template.py`, would make the next insertion safe. My recommendation is the assertion first, since it is cheap and catches the drift without restructuring the template.

