### PR TITLE
Run Spotless in code coverage finalization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ spotless {
             'metadata/**', // only .json files
             '**/build/**', // not relevant
             '**/.gradle/**', // not relevant
+            'forge/local_repositories/**', // third-party sources Forge downloads, not ours to format
             'gradle/wrapper/**', // not relevant
             'tests/src/**/generated/**/*.java',
             'gradle/header.java',

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -239,6 +239,9 @@ states:
         `src/test/java` already carry, and keep the whole file ASCII: checkstyle
         runs over this suite at finalization and rejects both a missing header
         and any non-ASCII character, the grund `§` marker included.
+      - Put nothing between that header and the `package` declaration, and run
+        `./gradlew spotlessApply -Pcoordinates=<coordinate>` before you finish:
+        Spotless enforces that layout and gates every pull request.
       - Target meaningful public user-callable behavior with real assertions,
         not superficial coverage hits.
       - Do not weaken metadata-generation tests.
@@ -490,6 +493,9 @@ states:
         `src/test/java` already carry, and keep the whole file ASCII: checkstyle
         runs over this suite at finalization and rejects both a missing header
         and any non-ASCII character, the grund `§` marker included.
+      - Put nothing between that header and the `package` declaration, and run
+        `./gradlew spotlessApply -Pcoordinates=<coordinate>` before you finish:
+        Spotless enforces that layout and gates every pull request.
       - Do not weaken metadata-generation tests.
       - Do not write any target state: measurement tracks attempts and target
         rotation deterministically from its own report history.
@@ -637,7 +643,24 @@ states:
           print(format_legacy_test_native_image_config_error(legacy_paths), file=sys.stderr)
           fail(2, "legacy Native Image config files found under the test project")
 
-      # Step 3: checkstyle over the coordinate's subprojects, including the
+      # Step 3: formatting. `spotlessApply` writes the licence header and
+      # layout `spotlessCheck` and the CI Spotless job enforce, so trivially
+      # formattable output repairs itself here rather than spending a fix pass
+      # or failing review after publication.
+      for spotless_task in ("spotlessApply", "spotlessCheck"):
+          spotless_command = [
+              f"{worktree_path}/gradlew",
+              spotless_task,
+              f"-Pcoordinates={coordinate}",
+              "--stacktrace",
+          ]
+          try:
+              if subprocess.run(spotless_command, cwd=worktree_path).returncode != 0:
+                  fail(3, f"{spotless_task} failed")
+          except OSError as error:
+              fail(3, f"{spotless_task} could not run: {error}")
+
+      # Step 4: checkstyle over the coordinate's subprojects, including the
       # tracked coverage suite source set.
       checkstyle_command = [
           f"{worktree_path}/gradlew",
@@ -647,11 +670,11 @@ states:
       ]
       try:
           if subprocess.run(checkstyle_command, cwd=worktree_path).returncode != 0:
-              fail(3, "checkstyle failed")
+              fail(4, "checkstyle failed")
       except OSError as error:
-          fail(3, f"checkstyle could not run: {error}")
+          fail(4, f"checkstyle could not run: {error}")
 
-      # Step 4: regular JVM tests plus the tracked extension suite.
+      # Step 5: regular JVM tests plus the tracked extension suite.
       # Finalization runs no Native Image validation at this stage.
       jvm_commands = [
           [
@@ -665,11 +688,11 @@ states:
       for jvm_command in jvm_commands:
           try:
               if subprocess.run(jvm_command, cwd=worktree_path).returncode != 0:
-                  fail(4, f"JVM tests failed: {jvm_command[1]}")
+                  fail(5, f"JVM tests failed: {jvm_command[1]}")
           except OSError as error:
-              fail(4, f"JVM tests could not run: {error}")
+              fail(5, f"JVM tests could not run: {error}")
 
-      # Step 5: persist coverage from the newly written tests. The stats task
+      # Step 6: persist coverage from the newly written tests. The stats task
       # consumes the combined report, whose denominator is only the coordinate's
       # unclassified main JAR (§root/AR-test-harness.8).
       stats_command = [
@@ -680,11 +703,11 @@ states:
       ]
       try:
           if subprocess.run(stats_command, cwd=worktree_path).returncode != 0:
-              fail(5, "generateLibraryStats failed")
+              fail(6, "generateLibraryStats failed")
       except OSError as error:
-          fail(5, f"generateLibraryStats could not run: {error}")
+          fail(6, f"generateLibraryStats could not run: {error}")
 
-      # Step 6: finalize separate API/deep JaCoCo metrics and guidance-only PGO
+      # Step 7: finalize separate API/deep JaCoCo metrics and guidance-only PGO
       # evidence from the recorded reports and target state.
       def report_bounds(directory: str, stem: str, suffix: str = ".json") -> tuple:
           reports = sorted(
@@ -692,7 +715,7 @@ states:
               key=lambda p: int(p.stem.rsplit("-", 1)[1]),
           )
           if not reports:
-              fail(6, f"no {stem} reports under {directory}")
+              fail(7, f"no {stem} reports under {directory}")
           return reports[0], reports[-1]
 
       api_baseline, api_final = report_bounds("runtime/code-coverage/validation", "api-cover-report")
@@ -726,9 +749,9 @@ states:
       finalize_env = dict(os.environ, PYTHONPATH=work_path)
       try:
           if subprocess.run(finalize_command, env=finalize_env).returncode != 0:
-              fail(6, "code_coverage_finalize.py failed")
+              fail(7, "code_coverage_finalize.py failed")
       except OSError as error:
-          fail(6, f"code_coverage_finalize.py could not run: {error}")
+          fail(7, f"code_coverage_finalize.py could not run: {error}")
       PY
     program_timeout: 90m
     inputs:
@@ -798,7 +821,9 @@ states:
         single-file `reachability-metadata.json` format, delete them, and re-run;
         this repository loads no other format. If `checkMetadataFiles` rejects an
         entry, fix the entry or its `allowed-packages`, never the check.
-      - step 3: checkstyle failed - fix the style violations in the generated
+      - step 3: formatting failed - re-run `spotlessApply` and commit what it
+        rewrites; never edit the Spotless configuration to accept the output.
+      - step 4: checkstyle failed - fix the style violations in the generated
         coverage tests; do not suppress or weaken the checkstyle rules.
       - step 4: JVM tests failed - fix the generated coverage tests in the
         issue worktree; do not weaken or delete meaningful assertions.
@@ -1053,25 +1078,31 @@ transitions:
     to: finalize-fix
     exit_code: 3
     condition: visitCount < visits
-    description: Step 3 failed - checkstyle failed for the coverage suite.
+    description: Step 3 failed - spotlessApply or spotlessCheck rejected the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 4
     condition: visitCount < visits
-    description: Step 4 failed - JVM tests with the coverage suite failed.
+    description: Step 4 failed - checkstyle failed for the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 5
     condition: visitCount < visits
-    description: Step 5 failed - generateLibraryStats did not persist coverage.
+    description: Step 5 failed - JVM tests with the coverage suite failed.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 6
     condition: visitCount < visits
-    description: Step 6 failed - code_coverage_finalize.py rejected its inputs.
+    description: Step 6 failed - generateLibraryStats did not persist coverage.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 7
+    condition: visitCount < visits
+    description: Step 7 failed - code_coverage_finalize.py rejected its inputs.
 
   - from: reviewed-execute
     to: human-intervention
@@ -1108,6 +1139,12 @@ transitions:
     exit_code: 6
     condition: visitCount >= visits
     description: Step 6 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 7
+    condition: visitCount >= visits
+    description: Step 7 still fails after the maximum fix passes.
 
   - from: finalize-verify
     to: completed

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -825,11 +825,11 @@ states:
         rewrites; never edit the Spotless configuration to accept the output.
       - step 4: checkstyle failed - fix the style violations in the generated
         coverage tests; do not suppress or weaken the checkstyle rules.
-      - step 4: JVM tests failed - fix the generated coverage tests in the
+      - step 5: JVM tests failed - fix the generated coverage tests in the
         issue worktree; do not weaken or delete meaningful assertions.
-      - step 5: `generateLibraryStats` failed - repair the coverage report or
+      - step 6: `generateLibraryStats` failed - repair the coverage report or
         stats input; do not hand-edit `stats.json`.
-      - step 6: `code_coverage_finalize.py` failed - repair the report or
+      - step 7: `code_coverage_finalize.py` failed - repair the report or
         target-state artifacts it rejected; never edit its output by hand.
       - verification: finalization artifacts are missing, empty, or
         schema-invalid - repair the inputs and let the program regenerate them.

--- a/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
@@ -98,7 +98,7 @@ inputs:
       number of steps the step program can fail at, so one failing step cannot
       spend the allowance another one needs.
     type: number
-    default: 6
+    default: 7
     validate: "[1-9][0-9]*"
 
   - name: coverage_iterations

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -433,7 +433,8 @@ The Rhei template should decompose the workflow into these phases:
    deterministically from its own report history.
 7. **Finalization and stats** — a deterministic step program: read the
    machine-readable conversion record; run `splitTestOnlyMetadata` and then
-   `checkMetadataFiles`; run checkstyle over the coordinate's subprojects
+   `checkMetadataFiles`; apply and check formatting with `spotlessApply` and
+   `spotlessCheck`; run checkstyle over the coordinate's subprojects
    (including the tracked coverage suite); run the regular JVM tests (`javaTest`)
    and the tracked extension suite (`codeCoverageTest`); regenerate the
    coordinate's committed library stats from the combined main-JAR-only JaCoCo

--- a/forge/examples/code-coverage-improvement-example/states.yaml
+++ b/forge/examples/code-coverage-improvement-example/states.yaml
@@ -191,6 +191,9 @@ states:
         `src/test/java` already carry, and keep the whole file ASCII: checkstyle
         runs over this suite at finalization and rejects both a missing header
         and any non-ASCII character, the grund `§` marker included.
+      - Put nothing between that header and the `package` declaration, and run
+        `./gradlew spotlessApply -Pcoordinates=<coordinate>` before you finish:
+        Spotless enforces that layout and gates every pull request.
       - Target meaningful public user-callable behavior with real assertions,
         not superficial coverage hits.
       - Do not weaken metadata-generation tests.
@@ -405,6 +408,9 @@ states:
         `src/test/java` already carry, and keep the whole file ASCII: checkstyle
         runs over this suite at finalization and rejects both a missing header
         and any non-ASCII character, the grund `§` marker included.
+      - Put nothing between that header and the `package` declaration, and run
+        `./gradlew spotlessApply -Pcoordinates=<coordinate>` before you finish:
+        Spotless enforces that layout and gates every pull request.
       - Do not weaken metadata-generation tests.
       - Do not write any target state: measurement tracks attempts and target
         rotation deterministically from its own report history.
@@ -836,25 +842,31 @@ transitions:
     to: finalize-fix
     exit_code: 3
     condition: visitCount < visits
-    description: Step 3 failed - checkstyle failed for the coverage suite.
+    description: Step 3 failed - spotlessApply or spotlessCheck rejected the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 4
     condition: visitCount < visits
-    description: Step 4 failed - JVM tests with the coverage suite failed.
+    description: Step 4 failed - checkstyle failed for the coverage suite.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 5
     condition: visitCount < visits
-    description: Step 5 failed - generateLibraryStats did not persist coverage.
+    description: Step 5 failed - JVM tests with the coverage suite failed.
 
   - from: reviewed-execute
     to: finalize-fix
     exit_code: 6
     condition: visitCount < visits
-    description: Step 6 failed - code_coverage_finalize.py rejected its inputs.
+    description: Step 6 failed - generateLibraryStats did not persist coverage.
+
+  - from: reviewed-execute
+    to: finalize-fix
+    exit_code: 7
+    condition: visitCount < visits
+    description: Step 7 failed - code_coverage_finalize.py rejected its inputs.
 
   - from: reviewed-execute
     to: human-intervention
@@ -891,6 +903,12 @@ transitions:
     exit_code: 6
     condition: visitCount >= visits
     description: Step 6 still fails after the maximum fix passes.
+
+  - from: reviewed-execute
+    to: human-intervention
+    exit_code: 7
+    condition: visitCount >= visits
+    description: Step 7 still fails after the maximum fix passes.
 
   - from: finalize-verify
     to: completed


### PR DESCRIPTION
Closes #9493

Rebased onto merged #9492. This branch now contains only its three Spotless commits: the specification update, implementation, and repair-instruction correction.

## What this does

Finalization checked a run with `checkstyle`, `javaTest`, `codeCoverageTest`, and `generateLibraryStats`, then published a branch. It never ran Spotless, which gates every pull request, so a run could finalize clean and still be rejected by a check its own verification skipped. Run 9455 did exactly that: all eight tasks completed, `finalize-verify` accepted the artifacts, and #9490 opened with a failing Spotless job across twelve files. This adds the formatter to the step program ([§forge/AR-code-coverage-improvement.4](https://github.com/oracle/graalvm-reachability-metadata/blob/440f07991173adebb1ccae4fce77c0bf323959d1/forge/docs/architecture/code-coverage-improvement.md#4-workflow)).

## Why it runs before checkstyle

The root `spotless` block declares:

```groovy
licenseHeaderFile("$rootDir/gradle/header.java", "package |import |module ")
```

so the licence header must sit immediately before `package`, and `spotlessApply` writes it. Checkstyle's `RegexpHeader` demands the same header but only checks that the lines match — it is indifferent to what follows, which is how a suite passes finalization's checkstyle step and fails Spotless anyway.

Run 9455 stranded itself in `human-intervention` at the checkstyle step over missing CC0 headers. `spotlessApply` would have written them. Ordering the formatter first turns that repair pass into a no-op instead of spending budget on a problem the formatter fixes for free — which is why it goes at position 3 rather than alongside the other validations.

That renumbers the tail of the program:

| Step | Before | After |
|---|---|---|
| 3 | checkstyle | **spotlessApply, spotlessCheck** |
| 4 | JVM tests | checkstyle |
| 5 | stats | JVM tests |
| 6 | metrics | stats |
| 7 | — | metrics |

Every `fail(N)`, transition pair, description, and `finalize-fix` instruction moves with it, and `fix_passes` rises from six to seven so its documented meaning — one repair per step that can fail — stays true.

## The excluded tree

Root `spotlessJava` targets `**/*.java` and excludes only what `noHeaderDirs` lists. That list did not cover `forge/local_repositories/**`, where the prepare phase materializes the tested library's own sources. commons-compress ships an ISO-8859-1 file, so the task fails outright:

```console
$ ./gradlew spotlessApply -Pcoordinates=org.apache.commons:commons-compress:1.23.0
Encoding error! Spotless uses UTF-8 by default.  At line 300 col 32:
  y J?rg  <- UTF-8
  y Jörg  <- windows-1252
```

`-Pcoordinates` does not scope it away. The tree is gitignored so CI never met it, but a finalization step would hit it every run and fail on third-party code this repository neither owns nor formats. Reproduced in a clean worktree with a planted latin-1 file, and confirmed the exclusion clears it.

## The rendered example

`forge/examples/code-coverage-improvement-example/states.yaml` gets the new transitions, descriptions, and cover rule, but not the new program step: its embedded step program is an older four-step render (conversion, checkstyle, JVM tests, finalize) whose numbering already disagreed with its own transition table before this change. Mirroring a seven-step numbering onto a four-step body would deepen that drift rather than fix it, so this keeps the example consistent with the template's contract and leaves the stale body alone.

## Open questions

1. **Should the step program own the numbering rather than duplicating it?** — the transitions and `finalize-fix` instructions each restate step numbers that live in the Python program, and they have drifted apart once already (#9491). Deriving them from one source would make a renumbering like this one mechanical instead of a four-place edit. Worth settling before the program grows again.
2. **Should `forge/local_repositories` be excluded from root Spotless generally, or only scoped for this step?** — this takes the general route, since nothing in that tree is ours to format under any task. The narrower alternative is scoping the finalization invocation alone and leaving the root target as-is.
3. **Should the example be regenerated?** — its program body predates several template changes. Regenerating would settle it, but changes far more of the file than this PR touches, so it is left for a follow-up.

