### PR TITLE
Validate Forge branches only on publication pushes

### DIFF
--- a/.github/workflows/forge-branch-ready.yml
+++ b/.github/workflows/forge-branch-ready.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - "ai/**"
+    # Only a descriptor push can publish. An unscoped push-triggered check failed
+    # on the open PR whenever a maintainer repaired the published branch
+    # (§forge/AR-actions-publication).
+    paths:
+      - "stats/*/*/*/forge-publication.json"
 
 permissions:
   contents: read

--- a/forge/docs/architecture/git-scripts.md
+++ b/forge/docs/architecture/git-scripts.md
@@ -120,6 +120,15 @@ feature branch and must not create or modify GitHub resources. The title and
 body it publishes come from the shared non-mutating renderer
 (§AR-pr-preview-builders), never from a second rendering path.
 
+Its push trigger is scoped to the descriptor path, so it fires only on the push
+that carries a `forge-publication.json`. A publication is the only push it can
+act on: every validation reads the tip-committed descriptor, and a push without
+one fails the first check with nothing to publish. Because Actions reports a
+push-triggered job as a check run on the pushed commit, an unscoped trigger also
+made every later push to a published branch report a failing check on the open
+pull request. That check gates publication, not the pull request, so a
+maintainer repairing a published branch must not see it re-run and fail there.
+
 A Branch Ready failure leaves the branch, issue assignment, labels, and project
 status unchanged. Its job summary and logs must identify the exact SHA and each
 validation error so a maintainer can inspect or repair the preserved branch and


### PR DESCRIPTION
## What this does

`Forge Branch Ready` triggers on every push to `ai/**`. Actions reports a push-triggered job as a check run on the pushed commit, so as soon as the publisher opens a pull request from that branch, the gate keeps re-running there and reporting into a pull request it was never meant to judge.

It cannot pass on those pushes either. Every validation in `publisher.py validate` reads the descriptor committed **at the tip**, so a maintainer repairing a published branch fails the very first check:

```
ERROR: Exactly one tip-committed forge-publication.json is required
```

[#9490](https://github.com/oracle/graalvm-reachability-metadata/pull/9490) is the shape of it: a formatting repair pushed on top of the descriptor commit turned an otherwise-green PR red on a check that had already done its job and opened that PR.

This scopes the push trigger to the descriptor path, so a push without a descriptor starts no workflow run at all — and a run that never starts reports no check.

```yaml
on:
  push:
    branches:
      - "ai/**"
    paths:
      - "stats/*/*/*/forge-publication.json"
```

## Why that path is the right filter

It is not a heuristic about which pushes look like publications — it is the exact path `validate` already demands of every route:

```python
expected_descriptor = (
    f"stats/{library['group']}/{library['artifact']}/{library['version']}/forge-publication.json"
)
if descriptor_path != expected_descriptor:
    raise ValueError("Descriptor path does not match its library coordinate")
```

So the filter cannot starve a route: a push that this trigger now ignores is a push the job could only ever have rejected.

| Push | Before | After |
| --- | --- | --- |
| Publication (adds the descriptor) | validates, gates `Forge Open PR` | unchanged |
| Repair commit on a published branch | red check on the open PR | no run, no check |

The publication push still validates and still gates `Forge Open PR` through `workflow_run`, which reports no check of its own. [§forge/AR-actions-publication](https://github.com/oracle/graalvm-reachability-metadata/blob/7cd267e3787619e76f0347a6bc6d63dbbaba9651/forge/docs/architecture/git-scripts.md#ar-actions-publication-trusted-github-actions-publisher) records why the trigger is scoped, so the next person extending it does not widen it back.

## What this deliberately does not do

The green check that the publication push itself leaves on the resulting PR stays. Removing that one means unchaining `Forge Open PR` from the push event entirely — a `workflow_dispatch` or `repository_dispatch` fired by `forge/git_scripts` after it pushes — which trades a cosmetic check for a new way to silently never open a PR. Not worth it here.

