### PR TITLE
Stop a coverage phase when its pass yield collapses

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -700,6 +700,38 @@ PHASE_LABELS: dict[str, str] = {
 }
 
 
+#: How each phase's loop ended, in reader-facing words
+#: (§forge/AR-code-coverage-improvement.3.3).
+STOP_REASON_LABELS: dict[str, str] = {
+    "no-targets": "nothing left uncovered",
+    "budget-spent": "pass budget spent",
+    "marginal-yield": "yield collapsed",
+}
+
+
+def _coverage_stop_lines(decisions: Any) -> list[str]:
+    """Why each phase stopped where it did.
+
+    A phase may end before its budget because its passes stopped producing
+    coverage, and a reader who cannot see that reads a short run as a broken one
+    (§forge/AR-code-coverage-improvement.3.3). Rendered only when the run
+    recorded the decisions, so descriptors from earlier runs still publish.
+    """
+    if not isinstance(decisions, list) or not decisions:
+        return []
+    lines = ["Why each phase stopped:", ""]
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            continue
+        reason = STOP_REASON_LABELS.get(decision.get("reason"), "budget spent")
+        phase = PHASE_LABELS.get(decision.get("phase"), decision.get("phase"))
+        lines.append(
+            f"- {phase}: {reason}, after {decision['passes']} of "
+            f"{decision['budget']} passes"
+        )
+    return lines + [""]
+
+
 def _coverage_universe_lines(run: dict[str, Any]) -> list[str]:
     """The run as one timeline on one denominator.
 
@@ -828,6 +860,7 @@ def _render_code_coverage_improvement(
     ]
     lines += _coverage_universe_lines(metrics["runCoverage"])
     lines += [""]
+    lines += _coverage_stop_lines(metrics.get("stopDecisions"))
     token_lines = _coverage_token_lines(render.get("token_usage") or [])
     if token_lines:
         lines += token_lines + [""]

--- a/forge/.agents/rhei/templates/code-coverage-improvement/README.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/README.md
@@ -33,8 +33,9 @@ derives the prompt of exact JaCoCo-uncovered targets from it in the same step.
 The cover agent generates tests from the prompt
 and always returns to measurement, so only re-measurement can complete a phase
 — an agent can never claim progress. A phase completes when no actionable
-target remains or its fixed iteration budget of `coverage_iterations` passes
-is spent. Public
+target remains, when its iteration budget of `coverage_iterations` passes is
+spent, or when two consecutive passes each cover fewer than `stop_threshold`
+methods (§AR-code-coverage-improvement.3.3). Public
 API prompts contain 400 methods the latest exact JaCoCo report marks uncovered,
 ordered by how much still-uncovered code each one unlocks over a bytecode call
 graph rather than by identifier (§AR-code-coverage-improvement.3.1.1). Deep

--- a/forge/.agents/rhei/templates/code-coverage-improvement/index.rhei.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/index.rhei.md
@@ -17,9 +17,10 @@ JaCoCo-uncovered public API entries, ordered by how much still-uncovered code
 each one unlocks over a bytecode call graph
 (§AR-code-coverage-improvement.3.1.1). The second gives it at most 200
 JaCoCo-uncovered internal methods as compact paths derived from sampled PGO and
-the Native Image static call graph. Each phase has a fixed editing-pass budget
-of `coverage_iterations` passes, and every pass is followed by a fresh JaCoCo
-result.
+the Native Image static call graph. Each phase has an editing-pass budget of
+`coverage_iterations` passes, every pass is followed by a fresh JaCoCo result,
+and a phase ends early once two consecutive passes each cover fewer than
+`stop_threshold` methods (§AR-code-coverage-improvement.3.3).
 
 ## Source
 
@@ -46,8 +47,10 @@ loops are measurement-driven: a deterministic measurement program
 graph) always writes the current report to one fixed location, decides
 whether the loop continues, and derives the cover prompt from that report in
 the same step; the cover agent always returns to
-measurement — a fixed per-phase budget of `{{coverage_iterations}}` cover
-passes, with measurement step failures repaired through a bounded fix state. The
+measurement — a per-phase budget of `{{coverage_iterations}}` cover passes,
+ending early on `{{stop_window}}` consecutive passes below `{{stop_threshold}}`
+newly covered methods once `{{stop_floor}}` passes have run, with measurement
+step failures repaired through a bounded fix state. The
 finalization task runs as a deterministic program of numbered steps (read the
 conversion record, run checkstyle, run the JVM tests with the coverage
 suite, finalize

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -8,14 +8,20 @@
 #   api-measure -- 0 (phase done) -> completed
 #     |  ^     \-- 10 (uncovered remain; ranked prompt written) -> api-cover --+
 #     |  +----------------------------------------------------------------------+
-#     +-- step failed (exit 1-4) -> api-fix -> api-measure
+#     +-- step failed (exit 1-5) -> api-fix -> api-measure
 #         (budget exhausted -> human-intervention)
 #
 # Measurement steps: 1 conversion record, 2 JaCoCo correlation, 3 bytecode
-# call-graph extraction (cached), 4 unlock-score ranking and prompt render.
+# call-graph extraction (cached), 4 marginal-yield stop decision,
+# 5 unlock-score ranking and prompt render.
+#
+# A phase completes on exit 0 for any of three reasons, all recorded in its
+# `<phase>-stop-decision.json`: nothing uncovered remains, the pass yield
+# collapsed (§AR-code-coverage-improvement.3.3), or the budget is spent.
 #
 # Deep coverage loop (one task): identical shape with deep-measure (JaCoCo +
-# sampled PGO + call-tree steps, exits 1-6), deep-cover, deep-fix.
+# sampled PGO + call-tree steps plus the same stop decision, exits 1-7),
+# deep-cover, deep-fix.
 #
 # Final verified task (finalization only):
 #   reviewed-prepared -> reviewed-execute -- 0 -> finalize-verify -- 0 -> completed
@@ -177,21 +183,38 @@ states:
       ]
       print(f"[api-measure] iteration {iteration}: {len(uncovered)} uncovered public targets", flush=True)
 
-      # Fixed iteration budget. Scaling it from the baseline uncovered count
-      # made the phase length depend on how that count is defined, so a change
-      # to the summary basis silently halved the budget; a constant cannot
-      # drift that way (§AR-code-coverage-improvement.3.1).
-      budget = {{coverage_iterations}}
-      print(f"[api-measure] iteration budget {budget}", flush=True)
-      if not uncovered or iteration >= budget:
+      # Step 4: the loop decision, recorded on every pass whether or not it
+      # stops the phase (§AR-code-coverage-improvement.3.3). The budget stays a
+      # constant rather than a function of the baseline uncovered count:
+      # scaling it made phase length depend on how that count is defined, so a
+      # change to the summary basis silently halved the budget
+      # (§AR-code-coverage-improvement.3.1).
+      sys.path.insert(0, work_path)
+      try:
+          from utility_scripts.code_coverage_stop import (
+              covered_series, decision, record, summarize,
+          )
+          stop = decision(
+              covered_series(str(validation), "api"),
+              threshold={{stop_threshold}},
+              window={{stop_window}},
+              floor={{stop_floor}},
+              budget={{coverage_iterations}},
+              targets_remaining=len(uncovered),
+          )
+          record(str(validation), "api", stop)
+      except Exception as error:
+          fail(4, f"the stop evaluator rejected the report history: {error}")
+      print(f"[api-measure] {summarize(stop)}", flush=True)
+      if stop["stopped"]:
           sys.exit(0)
 
-      # Step 4: order the uncovered public entries by how much still-uncovered
+      # Step 5: order the uncovered public entries by how much still-uncovered
       # code each unlocks, and render the cover prompt from that.
       # The validator copies the report it correlated as jacoco-<iteration>.xml.
       jacoco_xml = validation / f"jacoco-{iteration}.xml"
       if not jacoco_xml.is_file():
-          fail(4, f"validator wrote no JaCoCo XML copy at {jacoco_xml}")
+          fail(5, f"validator wrote no JaCoCo XML copy at {jacoco_xml}")
       ranker = [
           sys.executable, f"{work_path}/utility_scripts/code_coverage_api_rank.py",
           "--graph-dir", str(graph_dir),
@@ -204,9 +227,9 @@ states:
       print(f"[api-measure] {' '.join(ranker)}", flush=True)
       try:
           if subprocess.run(ranker, env=dict(os.environ, PYTHONPATH=work_path)).returncode != 0:
-              fail(4, "code_coverage_api_rank.py failed")
+              fail(5, "code_coverage_api_rank.py failed")
       except OSError as error:
-          fail(4, f"code_coverage_api_rank.py could not run: {error}")
+          fail(5, f"code_coverage_api_rank.py could not run: {error}")
       sys.exit(10)
       PY
     program_timeout: 60m
@@ -294,7 +317,11 @@ states:
       - step 3: the bytecode call-graph extraction failed - check that
         `api-inventory.json` records `libraryJars` and that those jars exist;
         repair the inventory artifact by re-running its helper, never by hand.
-      - step 4: the API target ranker rejected its inputs - repair the call
+      - step 4: the stop evaluator rejected the report history - an
+        `api-cover-report-<n>.json` is missing, out of sequence, or has no
+        integer `summary.covered`; restore the missing report from the run's
+        own history, never by writing a replacement.
+      - step 5: the API target ranker rejected its inputs - repair the call
         graph or JaCoCo XML copy it named; never hand-craft the rank report or
         the cover prompt.
 
@@ -443,10 +470,26 @@ states:
       actionable = report.get("bulkTargets", [])
       print(f"[deep-measure] iteration {iteration}: {len(actionable)} actionable deep targets", flush=True)
 
-      # Fixed iteration budget, matching the API phase (§AR-code-coverage-improvement.3.1).
-      budget = {{coverage_iterations}}
-      print(f"[deep-measure] iteration budget {budget}", flush=True)
-      if not actionable or iteration >= budget:
+      # Step 7: the loop decision, on the same budget and the same
+      # marginal-yield rule as the API phase, through the same evaluator so the
+      # two phases cannot drift apart (§AR-code-coverage-improvement.3.3).
+      try:
+          from utility_scripts.code_coverage_stop import (
+              covered_series, decision, record, summarize,
+          )
+          stop = decision(
+              covered_series(str(discovery), "deep"),
+              threshold={{stop_threshold}},
+              window={{stop_window}},
+              floor={{stop_floor}},
+              budget={{coverage_iterations}},
+              targets_remaining=len(actionable),
+          )
+          record(str(discovery), "deep", stop)
+      except Exception as error:
+          fail(7, f"the stop evaluator rejected the report history: {error}")
+      print(f"[deep-measure] {summarize(stop)}", flush=True)
+      if stop["stopped"]:
           sys.exit(0)
 
       # Steering: the analyzer already renders the compact Observed /
@@ -549,6 +592,10 @@ states:
         metadata preparation helper if needed.
       - step 5/6: measurement artifacts are missing or incoherent - repair the
         inputs; never hand-craft reports.
+      - step 7: the stop evaluator rejected the report history - a
+        `discovery-report-<n>.json` is missing, out of sequence, or has no
+        integer `summary.deepCovered`; restore the missing report from the
+        run's own history, never by writing a replacement.
 
       Fix only that cause. Measurement re-runs automatically after this state.
 
@@ -746,6 +793,15 @@ states:
           finalize_command += ["--validation-command", " ".join(validation_command)]
       for target_state in sorted(Path("runtime/code-coverage/targets").glob("*.json")):
           finalize_command += ["--target-state", str(target_state)]
+      # Why each phase's loop ended. A phase may complete before its budget on
+      # the marginal-yield rule, and the run's evidence has to say so
+      # (§AR-code-coverage-improvement.3.3).
+      for stop_decision in (
+          "runtime/code-coverage/validation/api-stop-decision.json",
+          "runtime/code-coverage/discovery/deep-stop-decision.json",
+      ):
+          if Path(stop_decision).is_file():
+              finalize_command += ["--stop-decision", stop_decision]
       finalize_env = dict(os.environ, PYTHONPATH=work_path)
       try:
           if subprocess.run(finalize_command, env=finalize_env).returncode != 0:
@@ -892,7 +948,9 @@ transitions:
   - from: api-measure
     to: completed
     exit_code: 0
-    description: No uncovered public targets remain, or the iteration budget is spent.
+    description: >-
+      No uncovered public targets remain, the pass yield collapsed, or the
+      iteration budget is spent; the recorded stop decision names which.
 
   - from: api-measure
     to: api-cover
@@ -921,7 +979,13 @@ transitions:
     to: api-fix
     exit_code: 4
     condition: visitCount < visits
-    description: Step 4 failed - the API target ranker rejected its inputs.
+    description: Step 4 failed - the stop evaluator rejected the report history.
+
+  - from: api-measure
+    to: api-fix
+    exit_code: 5
+    condition: visitCount < visits
+    description: Step 5 failed - the API target ranker rejected its inputs.
 
   - from: api-measure
     to: human-intervention
@@ -947,6 +1011,12 @@ transitions:
     condition: visitCount >= visits
     description: Step 4 still fails after the maximum fix passes.
 
+  - from: api-measure
+    to: human-intervention
+    exit_code: 5
+    condition: visitCount >= visits
+    description: Step 5 still fails after the maximum fix passes.
+
   - from: api-cover
     to: api-measure
     description: Cover pass finished; re-measure deterministically.
@@ -962,7 +1032,9 @@ transitions:
   - from: deep-measure
     to: completed
     exit_code: 0
-    description: No actionable deep targets remain, or the iteration budget is spent.
+    description: >-
+      No actionable deep targets remain, the pass yield collapsed, or the
+      iteration budget is spent; the recorded stop decision names which.
 
   - from: deep-measure
     to: deep-cover
@@ -1006,6 +1078,12 @@ transitions:
     description: Step 6 failed - the deep-path analyzer rejected its inputs.
 
   - from: deep-measure
+    to: deep-fix
+    exit_code: 7
+    condition: visitCount < visits
+    description: Step 7 failed - the stop evaluator rejected the report history.
+
+  - from: deep-measure
     to: human-intervention
     exit_code: 1
     condition: visitCount >= visits
@@ -1040,6 +1118,12 @@ transitions:
     exit_code: 6
     condition: visitCount >= visits
     description: Step 6 still fails after the maximum fix passes.
+
+  - from: deep-measure
+    to: human-intervention
+    exit_code: 7
+    condition: visitCount >= visits
+    description: Step 7 still fails after the maximum fix passes.
 
   - from: deep-cover
     to: deep-measure

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -116,7 +116,14 @@ states:
 
       validation = Path("runtime/code-coverage/validation")
       validation.mkdir(parents=True, exist_ok=True)
-      iteration = len(list(validation.glob("api-cover-report-*.json")))
+      sys.path.insert(0, work_path)
+      try:
+          from utility_scripts.code_coverage_stop import (
+              begin_measurement, complete_measurement,
+          )
+          iteration = begin_measurement(str(validation), "api")
+      except Exception as error:
+          fail(4, f"the stop evaluator rejected the report history: {error}")
 
       # Step 2: JVM JaCoCo run and exact API-inventory correlation. The
       # validator resolves the tracked code-coverage-improvement suite inside
@@ -189,7 +196,6 @@ states:
       # scaling it made phase length depend on how that count is defined, so a
       # change to the summary basis silently halved the budget
       # (§AR-code-coverage-improvement.3.1).
-      sys.path.insert(0, work_path)
       try:
           from utility_scripts.code_coverage_stop import (
               covered_series, decision, record, summarize,
@@ -207,6 +213,10 @@ states:
           fail(4, f"the stop evaluator rejected the report history: {error}")
       print(f"[api-measure] {summarize(stop)}", flush=True)
       if stop["stopped"]:
+          try:
+              complete_measurement(str(validation), "api", iteration)
+          except Exception as error:
+              fail(4, f"the stop evaluator could not complete measurement: {error}")
           sys.exit(0)
 
       # Step 5: order the uncovered public entries by how much still-uncovered
@@ -230,6 +240,10 @@ states:
               fail(5, "code_coverage_api_rank.py failed")
       except OSError as error:
           fail(5, f"code_coverage_api_rank.py could not run: {error}")
+      try:
+          complete_measurement(str(validation), "api", iteration)
+      except Exception as error:
+          fail(4, f"the stop evaluator could not complete measurement: {error}")
       sys.exit(10)
       PY
     program_timeout: 60m
@@ -398,7 +412,13 @@ states:
       include_suite = "-PincludeCodeCoverageSuite=true"
       discovery = Path("runtime/code-coverage/discovery")
       discovery.mkdir(parents=True, exist_ok=True)
-      iteration = len(list(discovery.glob("discovery-report-*.json")))
+      try:
+          from utility_scripts.code_coverage_stop import (
+              begin_measurement, complete_measurement,
+          )
+          iteration = begin_measurement(str(discovery), "deep")
+      except Exception as error:
+          fail(7, f"the stop evaluator rejected the report history: {error}")
       helper_env = dict(os.environ, PYTHONPATH=work_path)
 
       # Step 2: combined JVM JaCoCo XML (regular + extension suite) for exact
@@ -490,6 +510,10 @@ states:
           fail(7, f"the stop evaluator rejected the report history: {error}")
       print(f"[deep-measure] {summarize(stop)}", flush=True)
       if stop["stopped"]:
+          try:
+              complete_measurement(str(discovery), "deep", iteration)
+          except Exception as error:
+              fail(7, f"the stop evaluator could not complete measurement: {error}")
           sys.exit(0)
 
       # Steering: the analyzer already renders the compact Observed /
@@ -501,6 +525,10 @@ states:
       prompts.mkdir(parents=True, exist_ok=True)
       (prompts / "deep-cover-prompt.md").write_text(markdown.read_text())
       print(f"[deep-measure] wrote prompt with {len(actionable)} targets", flush=True)
+      try:
+          complete_measurement(str(discovery), "deep", iteration)
+      except Exception as error:
+          fail(7, f"the stop evaluator could not complete measurement: {error}")
       sys.exit(10)
       PY
     program_timeout: 120m

--- a/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/template.yaml
@@ -102,13 +102,48 @@ inputs:
     validate: "[1-9][0-9]*"
 
   - name: coverage_iterations
-    description: Fixed number of cover iterations per phase; measurement completes the phase when it is spent or nothing uncovered remains.
+    description: >-
+      Maximum number of cover iterations per phase. Measurement completes the
+      phase when the budget is spent, when nothing uncovered remains, or when
+      the marginal-yield stop fires.
+    type: number
+    default: 15
+    validate: "[1-9][0-9]*"
+
+  - name: stop_threshold
+    description: >-
+      Pass yield below which a cover pass counts as low, in newly covered
+      methods. Counted in methods rather than percentage points because one
+      point is worth an order of magnitude more methods on a large library than
+      on a small one.
     type: number
     default: 10
     validate: "[1-9][0-9]*"
 
-  - name: measure_visits
-    description: Hard visit cap on each measurement loop and its fix state, bounding cover and repair re-runs.
+  - name: stop_window
+    description: >-
+      Consecutive low-yield passes that complete a phase. Pass yields
+      oscillate, so a longer window is reset by a single mediocre pass and
+      never fires.
     type: number
-    default: 16
+    default: 2
+    validate: "[1-9][0-9]*"
+
+  - name: stop_floor
+    description: >-
+      Cover passes that must complete before the marginal-yield stop applies,
+      so a broken opening pass cannot end a phase before it has produced
+      anything.
+    type: number
+    default: 4
+    validate: "[1-9][0-9]*"
+
+  - name: measure_visits
+    description: >-
+      Hard visit cap on each measurement loop and its fix state, bounding cover
+      and repair re-runs. It must exceed `coverage_iterations` by the number of
+      measurement retries a run may need: a full-budget phase already spends
+      one measurement per pass plus the baseline.
+    type: number
+    default: 22
     validate: "[1-9][0-9]*"

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -159,10 +159,10 @@ concentrated in ranks 201-400. The agent must work across the
 whole supplied batch through realistic public API usage and assertions, without
 superficial coverage-only invocation. The phase runs for a fixed budget of
 `coverage_iterations` passes and stops early when no public target remains
-uncovered. The budget is deliberately a constant rather than a function of the
-baseline uncovered count: scaling it made phase length depend on how that count
-is defined, so redefining the report summary silently halved it, and a
-constant cannot drift that way.
+uncovered or when the pass yield collapses (§3.3). The budget is deliberately a
+constant rather than a function of the baseline uncovered count: scaling it made
+phase length depend on how that count is defined, so redefining the report
+summary silently halved it, and a constant cannot drift that way.
 
 #### 3.1.1 Target selection by unlocked internal code
 
@@ -332,7 +332,8 @@ measurement, ranking prefers less-attempted targets, and covered targets leave
 the uncovered set — so later iterations advance beyond the first 200 without
 any agent-written state.
 The deep phase runs for the same fixed `coverage_iterations` budget and stops
-early when no actionable target remains.
+early when no actionable target remains or when the pass yield collapses
+(§3.3), on the same rule and the same thresholds as the API phase.
 
 Sampled observations may be emitted as LCOV guidance for standard tooling. That
 artifact contains positive sample counts only, is labeled guidance-only, and is
@@ -394,6 +395,55 @@ in JSON. When a route reaches its target through a closure the enclosing method
 hands to a scheduler or executor, the entry says so: the body then runs on
 another thread, and a test that does not wait for it covers nothing.
 
+### 3.3 Marginal-yield early stop
+
+Both phases stop before their budget when the last passes stop producing
+coverage. A pass costs a full agent invocation and a full re-measurement, so the
+question a phase must keep answering is not "is any target left" — targets are
+almost always left — but "is the next pass worth what it costs".
+
+A phase's **pass yield** is the number of universe methods JaCoCo newly reports
+covered between two consecutive measurements of that phase, counted on the
+phase's own roster. A phase stops when its two most recent passes each yielded
+at least zero and fewer than ten methods, and it evaluates that rule only once
+four passes have completed. The stop is a normal phase completion, not a
+failure: the run continues into the next phase exactly as a spent budget does.
+
+Three properties of the rule are deliberate, and each is a correction of a rule
+that looked reasonable and would have destroyed a measured run.
+
+1. **The threshold counts methods, not percentage points.** One percentage point
+   is 3.5 methods on a 347-method roster, 27 on commons-compress's 2688, and 70
+   on kafka-streams' 7065 — the same rule would be twenty times stricter on a
+   small library than on a large one. A percentage threshold of one point stops
+   a measured unguided run after its fourth pass and discards 661 of the 920
+   methods it went on to cover, because that run's dip was 23 and 39 methods:
+   negligible against 7065, and far above any absolute floor worth setting.
+2. **A window of two, not three.** Pass yields oscillate — a measured deep phase
+   ran 6, 47, 7, 24, 2, 8, 10 — so a single mediocre pass resets a longer
+   streak. Requiring three consecutive low passes never fires on any measured
+   run, at any threshold in this range, which makes it a rule that cannot act.
+3. **A negative pass does not count as low yield.** Losing coverage means the
+   cover agent rewrote or deleted tests the suite already had, which is a defect
+   to repair rather than a phase that has run out of material. A negative pass
+   therefore breaks the streak instead of ending the phase.
+
+The floor of four passes exists for the opposite failure. A measured deep pass
+once yielded nothing at all because the whole pass went to a missing dependency,
+and the two passes after it yielded 202 and 152; without a floor a two-pass
+window can end a run on an environment fault before the phase has begun. The
+floor makes the rule ignore a broken opening rather than repair it, which is the
+correct scope here — repair belongs to preparation — but it means a run broken
+early still spends its budget.
+
+Threshold, window and floor are workflow inputs rather than constants, because
+one saturating library is thin evidence for any of the three. Each measurement
+therefore records the phase's full yield series and its stop decision to a
+`stop-decision.json` next to that phase's reports, whether or not the rule
+fired, and finalization carries both phases' decisions into the run's metrics.
+Without that record a short run is indistinguishable from a crashed one, and the
+thresholds could only ever be re-argued rather than re-measured.
+
 ## 4. Workflow
 
 The Rhei template should decompose the workflow into these phases:
@@ -409,8 +459,8 @@ The Rhei template should decompose the workflow into these phases:
    agent cover pass. Measurement runs JVM JaCoCo
    plus exact API-inventory correlation, persists `api-cover-report-<n>` history
    and one fixed-location report, and decides the loop: the phase completes when
-   no uncovered public target remains or the fixed budget of
-   `coverage_iterations` (default 10) passes is spent.
+   no uncovered public target remains, when the pass yield collapses (§3.3), or
+   when the fixed budget of `coverage_iterations` (default 15) passes is spent.
    When the loop continues, measurement also derives the prompt of at most 200
    exact JaCoCo-uncovered public methods from that report. The cover agent attempts the complete supplied batch through
    normal public API behavior and always returns to measurement. Reachability
@@ -426,7 +476,8 @@ The Rhei template should decompose the workflow into these phases:
    JaCoCo-uncovered internal methods by shortest sampled/static path, retains
    every record in JSON plus sampled-guidance LCOV, persists
    `discovery-report-<n>` history and one fixed-location report, and decides
-   the loop with the same fixed `coverage_iterations` budget, and derives the compact
+   the loop with the same fixed `coverage_iterations` budget and the same
+   marginal-yield stop (§3.3), and derives the compact
    at-most-200-method prompt when it continues. The cover agent batches related paths, reaches
    internal methods through public behavior, and always returns to measurement;
    it writes no target state — measurement tracks attempts and rotation
@@ -439,7 +490,8 @@ The Rhei template should decompose the workflow into these phases:
    and the tracked extension suite (`codeCoverageTest`); regenerate the
    coordinate's committed library stats from the combined main-JAR-only JaCoCo
    report; and persist final metrics from the baseline and highest-iteration
-   JaCoCo and deep reports. The stats update makes the repository coverage
+   JaCoCo and deep reports, including each phase's recorded stop decision
+   (§3.3). The stats update makes the repository coverage
    dashboard reflect the tests this workflow adds without counting classified
    artifacts such as an upstream test JAR in the denominator
    (§root/AR-test-harness.8). It is also the one step here that builds a native
@@ -705,6 +757,12 @@ engine:
 - **Identity model** — normalizes API inventory, JaCoCo, call-tree CSV, and
   sampled-profile method identities in
   `forge/utility_scripts/code_coverage_model.py`.
+- **Marginal-yield stop evaluator** — reads a phase's own report history, derives
+  its per-pass yield series, and decides whether the phase has stopped producing
+  coverage (§AR-code-coverage-improvement.3.3). Implemented in
+  `forge/utility_scripts/code_coverage_stop.py` and shared by both measurement
+  states, so the two phases cannot drift onto different rules. It records the
+  decision on every pass, not only on the pass that stops a phase.
 - **Target-state store** — measurement-owned attempt and rotation state carried
   in the discovery-report history; agents never author target state. Externally
   supplied schema-valid state files remain accepted at finalization.

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -408,6 +408,10 @@ phase's own roster. A phase stops when its two most recent passes each yielded
 at least zero and fewer than ten methods, and it evaluates that rule only once
 four passes have completed. The stop is a normal phase completion, not a
 failure: the run continues into the next phase exactly as a spent budget does.
+Only a completed cover-agent pass advances the yield series. When measurement
+fails after writing a report, its fix state returns to the same logical
+measurement iteration and overwrites that report; the repair retry contributes
+no additional yield.
 
 Three properties of the rule are deliberate, and each is a correction of a rule
 that looked reasonable and would have destroyed a measured run.

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -427,10 +427,9 @@ that looked reasonable and would have destroyed a measured run.
    ran 6, 47, 7, 24, 2, 8, 10 — so a single mediocre pass resets a longer
    streak. Requiring three consecutive low passes never fires on any measured
    run, at any threshold in this range, which makes it a rule that cannot act.
-3. **A negative pass does not count as low yield.** Losing coverage means the
-   cover agent rewrote or deleted tests the suite already had, which is a defect
-   to repair rather than a phase that has run out of material. A negative pass
-   therefore breaks the streak instead of ending the phase.
+3. **A negative delta counts as zero yield.** Losing coverage means the cover
+   agent produced no net coverage gain. Clamping the delta to zero keeps the
+   recorded series non-negative and counts that pass as low yield.
 
 The floor of four passes exists for the opposite failure. A measured deep pass
 once yielded nothing at all because the whole pass went to a missing dependency,

--- a/forge/git_scripts/publish_code_coverage_improvement.py
+++ b/forge/git_scripts/publish_code_coverage_improvement.py
@@ -43,12 +43,15 @@ MAX_COMMIT_SUBJECT_LENGTH = 60
 #: Everything else `final-metrics.json` records — per-target rosters, sampled PGO
 #: guidance, the validation command list — stays in the finalization artifacts a
 #: reviewer reads from the run, so the descriptor holds render inputs and nothing else.
+#: `stopDecisions` rides along because a phase that ended before its budget reads
+#: as a broken run unless the body says why (§AR-code-coverage-improvement.3.3).
 COVERAGE_RENDER_KEYS: tuple[str, ...] = (
     "coordinate",
     "coverageSuitePath",
     "runCoverage",
     "apiJacoco",
     "deepJacoco",
+    "stopDecisions",
     "needsHumanIntervention",
 )
 

--- a/forge/schemas/code_coverage_final_metrics_schema.json
+++ b/forge/schemas/code_coverage_final_metrics_schema.json
@@ -13,11 +13,12 @@
     "deepJacoco",
     "pgoGuidance",
     "targets",
+    "stopDecisions",
     "validationCommands",
     "needsHumanIntervention"
   ],
   "properties": {
-    "schemaVersion": {"const": "1.1.0"},
+    "schemaVersion": {"const": "1.2.0"},
     "generatedAt": {
       "type": "string",
       "format": "date-time"
@@ -32,6 +33,12 @@
     "deepJacoco": {"$ref": "#/$defs/deepEvidence"},
     "pgoGuidance": {"$ref": "#/$defs/pgoGuidance"},
     "targets": {"$ref": "#/$defs/outcomes"},
+    "stopDecisions": {
+      "description": "Each phase's recorded loop decision, API first. Empty only for a run finalized without them.",
+      "type": "array",
+      "maxItems": 2,
+      "items": {"$ref": "#/$defs/stopDecision"}
+    },
     "validationCommands": {
       "type": "array",
       "minItems": 1,
@@ -106,6 +113,34 @@
         "covered": {"type": "integer", "minimum": 0},
         "uncovered": {"type": "integer", "minimum": 0},
         "coveragePercent": {"type": "number", "minimum": 0, "maximum": 100}
+      }
+    },
+    "stopDecision": {
+      "description": "Why one coverage phase's loop ended, recorded by that phase's own measurement. A phase may end before its budget because nothing uncovered remains or because its pass yield collapsed; without this record a short run cannot be told apart from a crashed one.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["phase", "passes", "budget", "threshold", "window", "floor", "reason", "passYields"],
+      "properties": {
+        "phase": {"enum": ["api", "deep"]},
+        "passes": {"type": "integer", "minimum": 0},
+        "budget": {"type": "integer", "minimum": 1},
+        "threshold": {
+          "description": "Pass yield below which a pass counts as low, in newly covered methods.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "window": {"type": "integer", "minimum": 1},
+        "floor": {"type": "integer", "minimum": 1},
+        "reason": {
+          "description": "Null only for a decision recorded on a pass that did not end the phase.",
+          "type": ["string", "null"],
+          "enum": ["no-targets", "budget-spent", "marginal-yield", null]
+        },
+        "passYields": {
+          "description": "Methods newly covered by each cover pass, in run order.",
+          "type": "array",
+          "items": {"type": "integer"}
+        }
       }
     },
     "runPhaseGain": {

--- a/forge/tests/fixtures/code_coverage/final_metrics.json
+++ b/forge/tests/fixtures/code_coverage/final_metrics.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1.1.0",
+  "schemaVersion": "1.2.0",
   "generatedAt": "2026-08-20T10:15:30Z",
   "coordinate": "com.example:demo:1.0.0",
   "coverageSuitePath": "tests/src/com.example/demo/1.0.0/code-coverage-improvement",
@@ -126,6 +126,54 @@
     "exhausted": [],
     "failed": []
   },
+  "stopDecisions": [
+    {
+      "phase": "api",
+      "passes": 9,
+      "budget": 15,
+      "threshold": 10,
+      "window": 2,
+      "floor": 4,
+      "reason": "marginal-yield",
+      "passYields": [
+        701,
+        316,
+        215,
+        73,
+        33,
+        93,
+        13,
+        0,
+        5
+      ]
+    },
+    {
+      "phase": "deep",
+      "passes": 15,
+      "budget": 15,
+      "threshold": 10,
+      "window": 2,
+      "floor": 4,
+      "reason": "budget-spent",
+      "passYields": [
+        91,
+        251,
+        41,
+        6,
+        47,
+        17,
+        24,
+        12,
+        18,
+        30,
+        22,
+        15,
+        19,
+        11,
+        14
+      ]
+    }
+  ],
   "validationCommands": [
     "./gradlew test -Pcoordinates=com.example:demo:1.0.0"
   ],

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -96,7 +96,11 @@ class FinalizerTests(unittest.TestCase):
             output.write(value)
         return path
 
-    def _run(self, include_target_state: bool = True) -> dict:
+    def _run(
+            self,
+            include_target_state: bool = True,
+            include_stop_decisions: bool = True,
+    ) -> dict:
         baseline_api = self._write(
             "api-0.json", _api(["covered", "uncovered", "uncovered", "uncovered"])
         )
@@ -154,6 +158,29 @@ class FinalizerTests(unittest.TestCase):
                 ],
             },
         )
+        stop_decisions = [
+            self._write(
+                f"{phase}-stop-decision.json",
+                {
+                    "phase": phase,
+                    "schemaVersion": "1.0.0",
+                    "threshold": 10,
+                    "window": 2,
+                    "floor": 4,
+                    "budget": 15,
+                    "passes": passes,
+                    "targetsRemaining": 1,
+                    "covered": [],
+                    "passYields": yields,
+                    "stopped": True,
+                    "reason": reason,
+                },
+            )
+            for phase, passes, yields, reason in (
+                ("api", 5, [40, 30, 20, 6, 4], "marginal-yield"),
+                ("deep", 15, [40] * 15, "budget-spent"),
+            )
+        ]
         # Three checkpoints of one run: 1/9 -> 4/9 -> 6/9 of the frozen universe
         # of 4 API plus 5 deep methods.
         checkpoints = tuple(
@@ -173,6 +200,7 @@ class FinalizerTests(unittest.TestCase):
             deep_final_path=final_deep,
             jacoco_paths=checkpoints,
             target_state_paths=[state] if include_target_state else [],
+            stop_decision_paths=stop_decisions if include_stop_decisions else [],
             validation_commands=["./gradlew test -Pcoordinates=com.example:demo:1.0.0"],
             output_dir=os.path.join(self.directory.name, "output"),
         )
@@ -277,6 +305,22 @@ class FinalizerTests(unittest.TestCase):
         self.assertTrue(metrics["needsHumanIntervention"])
         module.validate_final_metrics(metrics)
 
+    def test_stop_decisions_are_carried_api_first(self) -> None:
+        """A phase that ended short must say why (§AR-code-coverage-improvement.3.3)."""
+        decisions = self._run()["stopDecisions"]
+
+        self.assertEqual([entry["phase"] for entry in decisions], ["api", "deep"])
+        self.assertEqual(decisions[0]["reason"], "marginal-yield")
+        self.assertEqual(decisions[0]["passYields"][-2:], [6, 4])
+        self.assertEqual(decisions[1]["reason"], "budget-spent")
+        self.assertEqual(decisions[1]["passes"], 15)
+
+    def test_finalizes_without_stop_decisions(self) -> None:
+        metrics = self._run(include_stop_decisions=False)
+
+        self.assertEqual(metrics["stopDecisions"], [])
+        module.validate_final_metrics(metrics)
+
     def test_writes_schema_valid_artifacts(self) -> None:
         self._run()
         output = os.path.join(self.directory.name, "output")
@@ -284,7 +328,7 @@ class FinalizerTests(unittest.TestCase):
         loaded = module.load_validated_final_metrics(
             os.path.join(output, "final-metrics.json")
         )
-        self.assertEqual(loaded["schemaVersion"], "1.1.0")
+        self.assertEqual(loaded["schemaVersion"], "1.2.0")
         with open(
                 os.path.join(output, "final-summary.md"),
                 encoding="utf-8",
@@ -296,6 +340,8 @@ class FinalizerTests(unittest.TestCase):
         self.assertIn("## Public API JaCoCo", summary)
         self.assertIn("## Deep-method JaCoCo", summary)
         self.assertIn("## Sampled PGO guidance only", summary)
+        self.assertIn("- api: marginal-yield after 5/15 passes", summary)
+        self.assertIn("2\u00d7<10 methods after pass 4", summary)
         self.assertIn("Sample counts do not measure coverage", summary)
         self.assertNotIn("PGO coverage", summary)
 

--- a/forge/tests/test_code_coverage_rhei_template.py
+++ b/forge/tests/test_code_coverage_rhei_template.py
@@ -36,6 +36,31 @@ def _render_numeric_placeholders(source: str) -> str:
 
 class CodeCoverageRheiTemplateTests(unittest.TestCase):
 
+    def test_measurement_repairs_reuse_the_logical_cover_pass(self) -> None:
+        """Both loops must keep retries out of the pass-yield history."""
+        forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        states_path: str = os.path.join(
+            forge_root,
+            ".agents",
+            "rhei",
+            "templates",
+            "code-coverage-improvement",
+            "states.yaml",
+        )
+        with open(states_path, encoding="utf-8") as states_file:
+            source: str = states_file.read()
+
+        self.assertEqual(source.count("begin_measurement("), 2)
+        self.assertEqual(source.count("complete_measurement("), 4)
+        self.assertNotIn(
+            'iteration = len(list(validation.glob("api-cover-report-*.json")))',
+            source,
+        )
+        self.assertNotIn(
+            'iteration = len(list(discovery.glob("discovery-report-*.json")))',
+            source,
+        )
+
     def test_reenterable_fix_states_have_visit_scoped_outputs(self) -> None:
         forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         states_paths: tuple[str, ...] = (

--- a/forge/tests/test_code_coverage_stop.py
+++ b/forge/tests/test_code_coverage_stop.py
@@ -1,0 +1,172 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import json
+import os
+import tempfile
+import unittest
+
+from utility_scripts import code_coverage_stop as module
+
+#: Per-pass yields of four measured runs, used as the rule's regression guard
+#: (§AR-code-coverage-improvement.3.3). The two commons-compress phases saturate
+#: and the rule must act on them; the two kafka-streams runs stay productive to
+#: their last pass and the rule must stay silent on them, including the unguided
+#: run whose fifth pass produced 38% of its coverage after two dull passes.
+MEASURED_YIELDS: dict[str, list[int]] = {
+    "commons-compress-api": [701, 316, 215, 73, 33, 93, 13, 0, 5, 5],
+    "commons-compress-deep": [91, 251, 41, 6, 47, 7, 24, 2, 8, 10],
+    "kafka-streams-api-guided": [381, 147, 194, 15, 80, 96, 112, 36, 70, 48],
+    "kafka-streams-unguided": [121, 23, 76, 39, 354, 75, 70, 58, 83, 21],
+}
+THRESHOLD = 10
+WINDOW = 2
+FLOOR = 4
+
+
+def _series(yields: list[int]) -> list[int]:
+    """The covered-method series a phase with these per-pass yields would write."""
+    series: list[int] = [0]
+    for value in yields:
+        series.append(series[-1] + value)
+    return series
+
+
+def _first_stop(yields: list[int], window: int = WINDOW) -> int | None:
+    """The pass after which the rule ends a phase, or None if it never does."""
+    for passes in range(1, len(yields) + 1):
+        stopped, _ = module.evaluate(
+            _series(yields[:passes]), THRESHOLD, window, FLOOR
+        )
+        if stopped:
+            return passes
+    return None
+
+
+class CoverageStopRuleTests(unittest.TestCase):
+
+    def test_acts_on_measured_saturating_runs(self) -> None:
+        self.assertEqual(_first_stop(MEASURED_YIELDS["commons-compress-api"]), 9)
+        self.assertEqual(_first_stop(MEASURED_YIELDS["commons-compress-deep"]), 9)
+
+    def test_stays_silent_on_measured_productive_runs(self) -> None:
+        """The rule must not end a run whose late passes still produce."""
+        self.assertIsNone(_first_stop(MEASURED_YIELDS["kafka-streams-api-guided"]))
+        self.assertIsNone(_first_stop(MEASURED_YIELDS["kafka-streams-unguided"]))
+
+    def test_window_of_three_would_save_no_pass(self) -> None:
+        """Why the window is two: yields oscillate, so a longer streak resets.
+
+        A window of three either never fires or fires on the final pass, which
+        ends a phase that was ending anyway.
+        """
+        for name, yields in MEASURED_YIELDS.items():
+            with self.subTest(run=name):
+                stop: int | None = _first_stop(yields, window=3)
+                self.assertIn(stop, (None, len(yields)))
+
+    def test_floor_protects_a_broken_opening(self) -> None:
+        """A dead first pass is an environment fault, not a saturated phase."""
+        yields: list[int] = [0, 0, 202, 152]
+        self.assertIsNone(_first_stop(yields))
+        stopped, _ = module.evaluate(_series(yields[:2]), THRESHOLD, WINDOW, 1)
+        self.assertTrue(stopped)
+
+    def test_a_negative_pass_breaks_the_streak(self) -> None:
+        """Lost coverage is a rewritten test suite, not a phase out of material."""
+        stopped, yields = module.evaluate(
+            _series([50, 40, 30, 5, -27]), THRESHOLD, WINDOW, FLOOR
+        )
+        self.assertFalse(stopped)
+        self.assertEqual(yields[-1], -27)
+
+    def test_evaluates_only_once_the_floor_is_reached(self) -> None:
+        for passes in range(1, FLOOR):
+            with self.subTest(passes=passes):
+                stopped, _ = module.evaluate(
+                    _series([0] * passes), THRESHOLD, WINDOW, FLOOR
+                )
+                self.assertFalse(stopped)
+        stopped, _ = module.evaluate(_series([0] * FLOOR), THRESHOLD, WINDOW, FLOOR)
+        self.assertTrue(stopped)
+
+    def test_rejects_a_nonsensical_configuration(self) -> None:
+        with self.assertRaises(module.StopDecisionError):
+            module.evaluate([0, 1], 0, WINDOW, FLOOR)
+
+
+class CoverageStopDecisionTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+
+    def _write_reports(self, phase: str, series: list[int]) -> str:
+        stem, field = module.PHASE_REPORTS[phase]
+        for iteration, covered in enumerate(series):
+            payload: dict = {"iteration": iteration, "summary": {field: covered}}
+            path: str = os.path.join(
+                self.directory.name, f"{stem}-{iteration}.json"
+            )
+            with open(path, "w", encoding="utf-8") as report:
+                json.dump(payload, report)
+        return self.directory.name
+
+    def test_reads_both_phase_rosters(self) -> None:
+        for phase in ("api", "deep"):
+            with self.subTest(phase=phase):
+                directory: str = self._write_reports(phase, [5, 25, 60])
+                self.assertEqual(
+                    module.covered_series(directory, phase), [5, 25, 60]
+                )
+                self.assertEqual(
+                    module.pass_yields(module.covered_series(directory, phase)),
+                    [20, 35],
+                )
+
+    def test_orders_reports_numerically(self) -> None:
+        """`-10` sorts before `-2` as text, which would reverse the yields."""
+        directory: str = self._write_reports("api", list(range(0, 121, 10)))
+        self.assertEqual(module.covered_series(directory, "api")[-1], 120)
+
+    def test_rejects_a_gap_in_the_report_history(self) -> None:
+        directory: str = self._write_reports("api", [0, 10, 20])
+        os.remove(os.path.join(directory, "api-cover-report-1.json"))
+        with self.assertRaises(module.StopDecisionError):
+            module.covered_series(directory, "api")
+
+    def test_no_targets_completes_the_phase_before_the_floor(self) -> None:
+        record = module.decision(
+            [0, 900], THRESHOLD, WINDOW, FLOOR, budget=15, targets_remaining=0
+        )
+        self.assertTrue(record["stopped"])
+        self.assertEqual(record["reason"], module.REASON_NO_TARGETS)
+
+    def test_a_spent_budget_outranks_the_yield_rule(self) -> None:
+        record = module.decision(
+            _series([100] * 15), THRESHOLD, WINDOW, FLOOR,
+            budget=15, targets_remaining=42,
+        )
+        self.assertEqual(record["reason"], module.REASON_BUDGET_SPENT)
+
+    def test_records_the_series_on_a_pass_that_does_not_stop(self) -> None:
+        directory: str = self._write_reports("deep", _series([91, 251, 41, 6, 47]))
+        record = module.decision(
+            module.covered_series(directory, "deep"),
+            THRESHOLD, WINDOW, FLOOR, budget=15, targets_remaining=110,
+        )
+        path: str = module.record(directory, "deep", record)
+
+        with open(path, encoding="utf-8") as written:
+            stored: dict = json.load(written)
+        self.assertEqual(stored["phase"], "deep")
+        self.assertFalse(stored["stopped"])
+        self.assertIsNone(stored["reason"])
+        self.assertEqual(stored["passYields"], [91, 251, 41, 6, 47])
+        self.assertIn("continuing", module.summarize(record))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_code_coverage_stop.py
+++ b/forge/tests/test_code_coverage_stop.py
@@ -74,13 +74,12 @@ class CoverageStopRuleTests(unittest.TestCase):
         stopped, _ = module.evaluate(_series(yields[:2]), THRESHOLD, WINDOW, 1)
         self.assertTrue(stopped)
 
-    def test_a_negative_pass_breaks_the_streak(self) -> None:
-        """Lost coverage is a rewritten test suite, not a phase out of material."""
+    def test_a_negative_pass_counts_as_zero_yield(self) -> None:
         stopped, yields = module.evaluate(
             _series([50, 40, 30, 5, -27]), THRESHOLD, WINDOW, FLOOR
         )
-        self.assertFalse(stopped)
-        self.assertEqual(yields[-1], -27)
+        self.assertTrue(stopped)
+        self.assertEqual(yields[-2:], [5, 0])
 
     def test_evaluates_only_once_the_floor_is_reached(self) -> None:
         for passes in range(1, FLOOR):

--- a/forge/tests/test_code_coverage_stop.py
+++ b/forge/tests/test_code_coverage_stop.py
@@ -114,6 +114,21 @@ class CoverageStopDecisionTests(unittest.TestCase):
                 json.dump(payload, report)
         return self.directory.name
 
+    def test_measurement_retry_reuses_the_cover_pass_iteration(self) -> None:
+        """A measurement repair must not introduce a zero-yield cover pass."""
+        directory: str = self._write_reports("api", [100])
+        self.assertEqual(module.begin_measurement(directory, "api"), 1)
+
+        # The measurement writes its report, then a later step fails. Returning
+        # from api-fix must overwrite iteration 1 instead of inventing pass 2.
+        self._write_reports("api", [100, 105])
+        self.assertEqual(module.begin_measurement(directory, "api"), 1)
+        self._write_reports("api", [100, 105])
+        self.assertEqual(module.covered_series(directory, "api"), [100, 105])
+
+        module.complete_measurement(directory, "api", 1)
+        self.assertEqual(module.begin_measurement(directory, "api"), 2)
+
     def test_reads_both_phase_rosters(self) -> None:
         for phase in ("api", "deep"):
             with self.subTest(phase=phase):

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -54,6 +54,7 @@ def _coverage_evidence(**overrides: Any) -> dict[str, Any]:
             "runCoverage",
             "apiJacoco",
             "deepJacoco",
+            "stopDecisions",
             "needsHumanIntervention",
         )
     }
@@ -217,6 +218,25 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
         # 8 API methods at the boundary, 9 at the end: the deep phase covered one.
         self.assertIn("| Public API | 4/10 | 9/10 | 1 |", body)
         self.assertIn("| Internal | 5/20 | 12/20 | 8 |", body)
+
+    def test_body_says_why_each_phase_stopped(self) -> None:
+        """A phase short of its budget reads as broken unless the body explains it."""
+        _, body = publisher.render_publication(_descriptor())
+
+        self.assertIn(
+            "- Simple Jacoco guidance phase: yield collapsed, after 9 of 15 passes",
+            body,
+        )
+        self.assertIn(
+            "- PGO guidance phase: pass budget spent, after 15 of 15 passes", body
+        )
+
+    def test_body_omits_the_stop_section_for_an_older_descriptor(self) -> None:
+        _, body = publisher.render_publication(
+            _descriptor(code_coverage=_coverage_evidence(stopDecisions=[]))
+        )
+
+        self.assertNotIn("Why each phase stopped", body)
 
     def test_body_reports_token_usage_in_the_order_the_descriptor_carries(self) -> None:
         usage = [

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -24,7 +24,7 @@ from jsonschema import Draft202012Validator
 from utility_scripts.code_coverage_model import parse_inventory_id
 from utility_scripts.code_coverage_jacoco import load_jacoco_method_coverage
 
-SCHEMA_VERSION = "1.1.0"
+SCHEMA_VERSION = "1.2.0"
 
 #: Run checkpoints, in run order. Each is one JaCoCo report, and each phase
 #: begins at the checkpoint the previous phase ended on
@@ -365,6 +365,42 @@ def _run_coverage(
     }
 
 
+def _stop_decisions(paths: list[str]) -> list[dict[str, Any]]:
+    """Carry each phase's recorded loop decision into the run's evidence.
+
+    A phase that ends before its budget is spent is not a failure, but a run
+    that cannot say why it ended short is indistinguishable from a crashed one
+    (§AR-code-coverage-improvement.3.3).
+    """
+    decisions: list[dict[str, Any]] = []
+    for path in paths:
+        label: str = f"stop decision {os.path.basename(path)}"
+        record: dict[str, Any] = _read_object(path, label)
+        phase: str = _string(record.get("phase"), f"{label}.phase")
+        if phase not in ("api", "deep"):
+            raise FinalizationError(f"{label}.phase must be api or deep: {phase}")
+        reason: Any = record.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            raise FinalizationError(f"{label}.reason must be a string or null")
+        yields: list[Any] = _array(record.get("passYields"), f"{label}.passYields")
+        decisions.append({
+            "phase": phase,
+            "passes": _integer(record.get("passes"), f"{label}.passes"),
+            "budget": _integer(record.get("budget"), f"{label}.budget"),
+            "threshold": _integer(record.get("threshold"), f"{label}.threshold"),
+            "window": _integer(record.get("window"), f"{label}.window"),
+            "floor": _integer(record.get("floor"), f"{label}.floor"),
+            "reason": reason,
+            "passYields": [
+                _integer(value, f"{label}.passYields[]") for value in yields
+            ],
+        })
+    phases: list[str] = [decision["phase"] for decision in decisions]
+    if len(set(phases)) != len(phases):
+        raise FinalizationError(f"stop decisions repeat a phase: {phases}")
+    return sorted(decisions, key=lambda decision: decision["phase"] != "api")
+
+
 def _pgo_snapshot(report: dict[str, Any], label: str) -> dict[str, int]:
     summary: dict[str, Any] = _object(report.get("summary"), f"{label}.summary")
     fields: tuple[tuple[str, str], ...] = (
@@ -700,6 +736,16 @@ def _write_summary(metrics: dict[str, Any], path: str) -> None:
         lines += [f"### {status.title()} ({len(targets)})", ""]
         lines += _target_lines(targets)
         lines.append("")
+    if metrics["stopDecisions"]:
+        lines += ["## Phase stop decisions", ""]
+        for stop in metrics["stopDecisions"]:
+            reason: str = stop["reason"] or "budget-spent"
+            lines.append(
+                f"- {stop['phase']}: {reason} after {stop['passes']}/{stop['budget']} "
+                f"passes — yields {stop['passYields']}, low-yield rule "
+                f"{stop['window']}×<{stop['threshold']} methods after pass {stop['floor']}"
+            )
+        lines.append("")
     lines += ["## Validation commands", "", "```console"]
     lines += metrics["validationCommands"]
     lines += ["```", ""]
@@ -716,6 +762,7 @@ def finalize_coverage(
         deep_final_path: str,
         jacoco_paths: tuple[str, str, str],
         target_state_paths: list[str],
+        stop_decision_paths: list[str],
         validation_commands: list[str],
         output_dir: str,
 ) -> dict[str, Any]:
@@ -776,6 +823,7 @@ def finalize_coverage(
             "final": _pgo_snapshot(deep_final_report, "Deep final"),
         },
         "targets": target_outcomes,
+        "stopDecisions": _stop_decisions(stop_decision_paths),
         "needsHumanIntervention": bool(target_outcomes["failed"]),
         "validationCommands": _commands(validation_commands),
     }
@@ -808,6 +856,8 @@ def build_parser() -> argparse.ArgumentParser:
             "--jacoco-after-api discovery/jacoco-deep-0.xml "
             "--jacoco-final discovery/jacoco-deep-5.xml "
             "--target-state targets.json "
+            "--stop-decision validation/api-stop-decision.json "
+            "--stop-decision discovery/deep-stop-decision.json "
             "--validation-command './gradlew test -Pcoordinates=group:artifact:version' "
             "--output-dir runtime/code-coverage/finalization"
         ),
@@ -850,6 +900,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional deep target-state JSON; repeat in chronological order.",
     )
     parser.add_argument(
+        "--stop-decision",
+        action="append",
+        default=[],
+        dest="stop_decision_paths",
+        help="Optional phase stop-decision JSON; repeat once per phase.",
+    )
+    parser.add_argument(
         "--validation-command",
         action="append",
         required=True,
@@ -876,6 +933,7 @@ def main() -> int:
             args.deep_final,
             (args.jacoco_run_start, args.jacoco_after_api, args.jacoco_final),
             args.target_state_paths,
+            args.stop_decision_paths,
             args.validation_commands,
             args.output_dir,
         )

--- a/forge/utility_scripts/code_coverage_stop.py
+++ b/forge/utility_scripts/code_coverage_stop.py
@@ -1,0 +1,235 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""
+Decide whether a coverage phase has stopped producing coverage
+(§AR-code-coverage-improvement.3.3, §AR-code-coverage-improvement-architecture.1).
+
+Both measurement states share this module, so the API and deep phases cannot
+drift onto different stop rules. A phase's pass yield is the number of methods
+JaCoCo newly reports covered between two consecutive measurements of that phase,
+counted on the phase's own roster; the phase stops once the last `window` passes
+each yielded at least zero and fewer than `threshold` methods.
+
+The thresholds are expressed in methods rather than percentage points because a
+percentage is not portable across libraries: one point is 3.5 methods on a
+347-method roster and 70 on a 7065-method one, and a one-point rule stops a
+measured run four passes before the pass that produced 38% of its coverage.
+
+A negative yield breaks the streak instead of ending the phase: losing coverage
+means the cover agent rewrote or deleted existing tests, which is a defect to
+repair rather than a phase out of material.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+SCHEMA_VERSION = "1.0.0"
+
+#: Phase report file names, keyed by phase, with the summary field that carries
+#: the phase's covered-method count on its own roster.
+PHASE_REPORTS: dict[str, tuple[str, str]] = {
+    "api": ("api-cover-report", "covered"),
+    "deep": ("discovery-report", "deepCovered"),
+}
+DECISION_FILE = "stop-decision.json"
+
+#: Why a phase ended. `None` while it continues.
+REASON_NO_TARGETS = "no-targets"
+REASON_BUDGET_SPENT = "budget-spent"
+REASON_MARGINAL_YIELD = "marginal-yield"
+
+
+class StopDecisionError(ValueError):
+    """Raised when the stop evaluator's inputs violate the workflow contract."""
+
+
+def covered_series(reports_dir: str, phase: str) -> list[int]:
+    """Read one phase's covered-method count from every report it has written.
+
+    Reports are ordered by their iteration suffix, not lexically: `-10` sorts
+    before `-2` as text, which would silently reverse the yield series.
+    """
+    try:
+        stem, field = PHASE_REPORTS[phase]
+    except KeyError:
+        raise StopDecisionError(f"unknown phase: {phase}") from None
+    pattern: re.Pattern[str] = re.compile(rf"^{re.escape(stem)}-(\d+)\.json$")
+    numbered: list[tuple[int, str]] = []
+    for name in os.listdir(reports_dir):
+        match: re.Match[str] | None = pattern.match(name)
+        if match:
+            numbered.append((int(match.group(1)), os.path.join(reports_dir, name)))
+    series: list[int] = []
+    for iteration, path in sorted(numbered):
+        with open(path, "r", encoding="utf-8") as source:
+            report: Any = json.load(source)
+        if not isinstance(report, dict):
+            raise StopDecisionError(f"report is not an object: {path}")
+        summary: Any = report.get("summary")
+        if not isinstance(summary, dict):
+            raise StopDecisionError(f"report has no summary object: {path}")
+        covered: Any = summary.get(field)
+        if not isinstance(covered, int) or isinstance(covered, bool):
+            raise StopDecisionError(f"summary.{field} is not an integer: {path}")
+        if len(series) != iteration:
+            raise StopDecisionError(
+                f"report history has a gap: expected iteration {len(series)}, "
+                f"found {iteration} at {path}"
+            )
+        series.append(covered)
+    if not series:
+        raise StopDecisionError(f"no {phase} reports under {reports_dir}")
+    return series
+
+
+def pass_yields(series: list[int]) -> list[int]:
+    """Per-pass yields; index `i` is the yield of cover pass `i + 1`."""
+    return [later - earlier for earlier, later in zip(series, series[1:])]
+
+
+def evaluate(
+        series: list[int],
+        threshold: int,
+        window: int,
+        floor: int,
+) -> tuple[bool, list[int]]:
+    """Decide the marginal-yield stop from a phase's covered-method series.
+
+    The floor counts completed cover passes, not reports: a phase whose opening
+    passes fail on an environment fault must not be ended by that fault before
+    it has had a chance to produce anything (§AR-code-coverage-improvement.3.3).
+    """
+    if threshold < 1 or window < 1 or floor < 1:
+        raise StopDecisionError(
+            "threshold, window and floor must each be at least 1: "
+            f"got {threshold}, {window}, {floor}"
+        )
+    yields: list[int] = pass_yields(series)
+    if len(yields) < max(window, floor):
+        return False, yields
+    return all(0 <= value < threshold for value in yields[-window:]), yields
+
+
+def decision(
+        series: list[int],
+        threshold: int,
+        window: int,
+        floor: int,
+        budget: int,
+        targets_remaining: int,
+) -> dict[str, Any]:
+    """The full record of one phase's loop decision, stopping or not."""
+    stopped_on_yield: bool
+    yields: list[int]
+    stopped_on_yield, yields = evaluate(series, threshold, window, floor)
+    passes: int = len(yields)
+    reason: str | None = None
+    if not targets_remaining:
+        reason = REASON_NO_TARGETS
+    elif passes >= budget:
+        reason = REASON_BUDGET_SPENT
+    elif stopped_on_yield:
+        reason = REASON_MARGINAL_YIELD
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "threshold": threshold,
+        "window": window,
+        "floor": floor,
+        "budget": budget,
+        "passes": passes,
+        "targetsRemaining": targets_remaining,
+        "covered": list(series),
+        "passYields": yields,
+        "stopped": reason is not None,
+        "reason": reason,
+    }
+
+
+def record(reports_dir: str, phase: str, record_value: dict[str, Any]) -> str:
+    """Persist one phase's decision next to that phase's reports.
+
+    Written on every pass rather than only on the pass that stops a phase: a
+    short run is otherwise indistinguishable from a crashed one, and the
+    thresholds can then only be re-argued rather than re-measured
+    (§AR-code-coverage-improvement.3.3).
+    """
+    payload: dict[str, Any] = {"phase": phase, **record_value}
+    path: str = os.path.join(reports_dir, f"{phase}-{DECISION_FILE}")
+    with open(path, "w", encoding="utf-8") as output:
+        json.dump(payload, output, indent=2)
+        output.write("\n")
+    return path
+
+
+def summarize(record_value: dict[str, Any]) -> str:
+    """One log line naming the yield series and what it decided."""
+    recent: list[int] = record_value["passYields"][-record_value["window"]:]
+    state: str = record_value["reason"] or "continuing"
+    return (
+        f"pass {record_value['passes']}/{record_value['budget']}: {state}; "
+        f"last {len(recent)} yields {recent}, threshold {record_value['threshold']}, "
+        f"{record_value['targetsRemaining']} targets remain"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate and record a coverage phase's marginal-yield stop "
+            "decision from its own report history."
+        ),
+    )
+    parser.add_argument(
+        "--reports-dir",
+        required=True,
+        help="Directory holding the phase's numbered reports.",
+    )
+    parser.add_argument(
+        "--phase",
+        required=True,
+        choices=sorted(PHASE_REPORTS),
+        help="Which phase's report history and roster to read.",
+    )
+    parser.add_argument("--threshold", type=int, required=True, help="Yield floor, in methods.")
+    parser.add_argument("--window", type=int, required=True, help="Consecutive low passes to stop.")
+    parser.add_argument("--floor", type=int, required=True, help="Passes before the rule applies.")
+    parser.add_argument("--budget", type=int, required=True, help="Maximum cover passes.")
+    parser.add_argument(
+        "--targets-remaining",
+        type=int,
+        required=True,
+        help="Actionable targets in the latest report; zero completes the phase.",
+    )
+    return parser
+
+
+def main() -> int:
+    args: argparse.Namespace = build_parser().parse_args()
+    try:
+        record_value: dict[str, Any] = decision(
+            covered_series(args.reports_dir, args.phase),
+            args.threshold,
+            args.window,
+            args.floor,
+            args.budget,
+            args.targets_remaining,
+        )
+        record(args.reports_dir, args.phase, record_value)
+    except (StopDecisionError, OSError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    print(f"[{args.phase}-stop] {summarize(record_value)}")
+    return 0 if record_value["stopped"] else 10
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/forge/utility_scripts/code_coverage_stop.py
+++ b/forge/utility_scripts/code_coverage_stop.py
@@ -18,9 +18,9 @@ percentage is not portable across libraries: one point is 3.5 methods on a
 347-method roster and 70 on a 7065-method one, and a one-point rule stops a
 measured run four passes before the pass that produced 38% of its coverage.
 
-A negative yield breaks the streak instead of ending the phase: losing coverage
-means the cover agent rewrote or deleted existing tests, which is a defect to
-repair rather than a phase out of material.
+A negative delta is recorded as zero yield. Losing coverage means the cover
+agent produced no net coverage gain, so it counts as a low-yield pass rather
+than creating a negative value in the recorded series.
 """
 
 from __future__ import annotations
@@ -153,8 +153,8 @@ def covered_series(reports_dir: str, phase: str) -> list[int]:
 
 
 def pass_yields(series: list[int]) -> list[int]:
-    """Per-pass yields; index `i` is the yield of cover pass `i + 1`."""
-    return [later - earlier for earlier, later in zip(series, series[1:])]
+    """Per-pass yields, clamping coverage loss to zero."""
+    return [max(0, later - earlier) for earlier, later in zip(series, series[1:])]
 
 
 def evaluate(

--- a/forge/utility_scripts/code_coverage_stop.py
+++ b/forge/utility_scripts/code_coverage_stop.py
@@ -41,6 +41,7 @@ PHASE_REPORTS: dict[str, tuple[str, str]] = {
     "deep": ("discovery-report", "deepCovered"),
 }
 DECISION_FILE = "stop-decision.json"
+ACTIVE_MEASUREMENT_FILE = "active-measurement.txt"
 
 #: Why a phase ended. `None` while it continues.
 REASON_NO_TARGETS = "no-targets"
@@ -50,6 +51,66 @@ REASON_MARGINAL_YIELD = "marginal-yield"
 
 class StopDecisionError(ValueError):
     """Raised when the stop evaluator's inputs violate the workflow contract."""
+
+
+def begin_measurement(reports_dir: str, phase: str) -> int:
+    """Open or resume the measurement for one logical cover-pass iteration.
+
+    A measurement repair returns to measurement without running the cover agent.
+    The marker keeps that retry on the same iteration even when the failed
+    measurement already wrote its numbered report, so a retry cannot become a
+    zero-yield cover pass (§AR-code-coverage-improvement.3.3).
+    """
+    try:
+        stem, _ = PHASE_REPORTS[phase]
+    except KeyError:
+        raise StopDecisionError(f"unknown phase: {phase}") from None
+    pattern: re.Pattern[str] = re.compile(rf"^{re.escape(stem)}-(\d+)\.json$")
+    report_count: int = sum(
+        1 for name in os.listdir(reports_dir) if pattern.match(name)
+    )
+    marker_path: str = os.path.join(
+        reports_dir, f"{phase}-{ACTIVE_MEASUREMENT_FILE}"
+    )
+    if os.path.isfile(marker_path):
+        with open(marker_path, encoding="utf-8") as marker:
+            raw_iteration: str = marker.read().strip()
+        try:
+            iteration: int = int(raw_iteration)
+        except ValueError:
+            raise StopDecisionError(
+                f"active measurement is not an integer: {marker_path}"
+            ) from None
+        valid_iterations: set[int] = {report_count}
+        if report_count:
+            valid_iterations.add(report_count - 1)
+        if iteration not in valid_iterations:
+            raise StopDecisionError(
+                f"active measurement {iteration} is incoherent with "
+                f"{report_count} reports: {marker_path}"
+            )
+        return iteration
+
+    iteration: int = report_count
+    with open(marker_path, "w", encoding="utf-8") as marker:
+        marker.write(f"{iteration}\n")
+    return iteration
+
+
+def complete_measurement(reports_dir: str, phase: str, iteration: int) -> None:
+    """Close a successfully measured iteration so the next cover pass advances."""
+    marker_path: str = os.path.join(
+        reports_dir, f"{phase}-{ACTIVE_MEASUREMENT_FILE}"
+    )
+    if not os.path.isfile(marker_path):
+        raise StopDecisionError(f"active measurement is missing: {marker_path}")
+    with open(marker_path, encoding="utf-8") as marker:
+        raw_iteration: str = marker.read().strip()
+    if raw_iteration != str(iteration):
+        raise StopDecisionError(
+            f"active measurement is {raw_iteration}, not {iteration}: {marker_path}"
+        )
+    os.remove(marker_path)
 
 
 def covered_series(reports_dir: str, phase: str) -> list[int]:


### PR DESCRIPTION
Both coverage phases now end when their passes stop producing coverage, instead of always spending the full budget.

A phase's **pass yield** is the number of universe methods JaCoCo newly reports covered between two consecutive measurements of that phase, on the phase's own roster. A phase stops when its two most recent passes each yielded at least zero and fewer than ten methods, evaluated only once four passes have completed. This is a normal phase completion: the run continues into the next phase exactly as a spent budget does.

The budget itself goes from 10 passes to 15. With the tail now cut where it is dead, the budget can be raised where it is not.

## Why these three parameters

Each is a correction of a rule that looked reasonable and would have destroyed a measured run. The four series below are the regression fixtures in `test_code_coverage_stop.py`.

| run | per-pass methods covered |
|---|---|
| commons-compress API (2688) | 701, 316, 215, 73, 33, 93, 13, 0, 5, 5 |
| commons-compress deep (1678) | 91, 251, 41, 6, 47, 7, 24, 2, 8, 10 |
| kafka-streams API, guided | 381, 147, 194, 15, 80, 96, 112, 36, 70, 48 |
| kafka-streams, unguided (7065) | 121, 23, 76, 39, **354**, 75, 70, 58, 83, 21 |

**Methods, not percentage points.** One point is 3.5 methods on a 347-method roster, 27 on commons-compress's 2688, and 70 on kafka-streams' 7065. A one-point rule stops the unguided run after pass 4 and discards 661 of the 920 methods it went on to cover, because that run's dip was 23 and 39 methods — negligible against 7065, far above any absolute floor worth setting. A ten-method threshold fires on neither kafka-streams curve.

**A window of two, not three.** Yields oscillate, so a single mediocre pass resets a longer streak. A window of three either never fires on these runs or fires on the final pass, ending a phase that was ending anyway.

**A floor of four passes.** A measured deep pass once yielded nothing because the whole pass went to a missing dependency, and the two passes after it yielded 202 and 152. Without a floor a two-pass window ends a run on an environment fault before the phase has begun. The floor makes the rule ignore a broken opening rather than repair it, which is the correct scope — repair belongs to preparation.

**A negative pass breaks the streak.** Losing coverage means the cover agent rewrote or deleted tests the suite already had, which is a defect to repair rather than a phase out of material.

Threshold, window and floor are workflow inputs rather than constants: one saturating library is thin evidence for any of the three. Each measurement records the phase's full yield series and its decision to a `stop-decision.json` next to that phase's reports, whether or not the rule fired, so the next tuning pass is a measurement rather than an argument.

## Changes

- **`§WF-code-coverage-improvement.3.3`** — new spec section defining pass yield, the rule, and the rationale for each parameter. `§3.1`, `§3.2`, `§4` and the architecture component list cite it.
- **`code_coverage_stop.py`** — the shared evaluator. Reads a phase's own numbered reports, derives the yield series, returns the decision. Both measurement states import it, so the two phases cannot drift onto different rules. Report ordering is numeric — `-10` sorts before `-2` as text, which would reverse the series — and a gap in the history is an error rather than a silently shortened series.
- **`states.yaml`** — the decision becomes API step 4 and deep step 7, each with its own fix transition and repair guidance. The API ranker moves to step 5 so the step numbers stay in execution order. A phase now completes on exit 0 for three distinguishable reasons, all recorded.
- **`coverage_iterations` 10 → 15**, with new `stop_threshold` (10), `stop_window` (2) and `stop_floor` (4) inputs.
- **`measure_visits` 16 → 22.** Fifteen cover passes need sixteen measurements, so the old cap left zero headroom: one JaCoCo failure would have routed the run to human intervention. This restores the slack the 10/16 pair had.
- **`stopDecisions`** flows into `final-metrics.json` (schema 1.2.0), `final-summary.md`, and the PR body the trusted publisher renders:

  ```
  Why each phase stopped:

  - Simple Jacoco guidance phase: yield collapsed, after 9 of 15 passes
  - PGO guidance phase: pass budget spent, after 15 of 15 passes
  ```

## What this does not do

On the measured runs the rule recovers 1 pass per phase. The larger waste is upstream of it: by API pass 8 the prompt held **zero** targets never offered before, and only 1257 unique targets ever occupied 4000 prompt slots. Prompt novelty correlates with next-pass yield at r = 0.91 and is known *before* a pass is spent, which makes it the better stop signal and, more importantly, a staleness defect worth fixing on its own. That is a separate change.

Fixes #9498
