### PR TITLE
Say which phase and step a run failed in

### DIFF
--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -8,6 +8,15 @@ import subprocess
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
+from utility_scripts.run_location import (
+    PHASE_FIX as RUN_PHASE_FIX,
+    STEP_GENERATE_TESTS,
+    STEP_NATIVE_TRACE_GATE,
+    RunLocation,
+    enter_phase,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
 from utility_scripts.stage_logger import log_stage
@@ -155,6 +164,7 @@ class BasicIterativeStrategy(WorkflowStrategy):
             self.continuation_marker_path,
             lambda marker: marker.mark_phase_running(PHASE_FIX),
         )
+        enter_phase(RUN_PHASE_FIX)
         global_iterations = 0
         failed_iterations = 0
         unittest_number = 0
@@ -168,14 +178,15 @@ class BasicIterativeStrategy(WorkflowStrategy):
                     max_attempts=self.max_failed_generations,
                 )
             )
-            if failed_iterations > 0:
-                self._print_detail("agent: running failed-iteration prompt")
-                agent.send_prompt(self.prompt_after_failed)
-            else:
-                prompt_name = "initial" if unittest_number < 1 else "successful-iteration"
-                self._print_detail(f"agent: running {prompt_name} prompt")
-                agent.send_prompt(self.prompt_initial if unittest_number < 1 else self.prompt_after_success)
-            self._print_detail("agent: complete")
+            with run_step(RUN_PHASE_FIX, STEP_GENERATE_TESTS, operand=self.library):
+                if failed_iterations > 0:
+                    self._print_detail("agent: running failed-iteration prompt")
+                    agent.send_prompt(self.prompt_after_failed)
+                else:
+                    prompt_name = "initial" if unittest_number < 1 else "successful-iteration"
+                    self._print_detail(f"agent: running {prompt_name} prompt")
+                    agent.send_prompt(self.prompt_initial if unittest_number < 1 else self.prompt_after_success)
+                self._print_detail("agent: complete")
 
             global_iterations += 1
             save_phase_update(
@@ -241,17 +252,25 @@ class BasicIterativeStrategy(WorkflowStrategy):
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
             )
+            record_step_failure(
+                location=RunLocation(RUN_PHASE_FIX, STEP_GENERATE_TESTS, self.library),
+            )
             return RUN_STATUS_FAILURE, global_iterations, unittest_number
 
         # The loop above accepts a failing nativeTest as progress, so the gate is what
         # validates native-image behavior and traces misses this workflow cannot see —
         # including transitive-dependency metadata (§AR-basic-iterative).
-        if not self.verify_native_test_gate(global_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.test_version,
-        )):
+        with run_step(RUN_PHASE_FIX, STEP_NATIVE_TRACE_GATE, operand=self.library):
+            gate_passed = self.verify_native_test_gate(global_output_dir(
+                self.reachability_repo_path, self.group, self.artifact, self.test_version,
+            ))
+        if not gate_passed:
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
+            )
+            record_step_failure(
+                location=RunLocation(RUN_PHASE_FIX, STEP_NATIVE_TRACE_GATE, self.library),
             )
             return RUN_STATUS_FAILURE, global_iterations, unittest_number
 

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -23,6 +23,15 @@ from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustRe
 from utility_scripts.issue_requested_metadata import has_issue_requested_metadata_context
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.native_test_verification import per_class_output_dir
+from utility_scripts.run_location import (
+    PHASE_EXPLORE as RUN_PHASE_EXPLORE,
+    STEP_GENERATE_TESTS,
+    STEP_NATIVE_TRACE_GATE,
+    RunLocation,
+    enter_phase,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.strategy_loader import load_strategy_by_name
 
@@ -152,9 +161,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             text=True,
         ).strip()
         prompt_iterations = 1
-        self._print_issue_requested_metadata_message("agent: running reporter-requested metadata prompt")
-        agent.send_prompt(self._render_prompt("issue-requested-metadata"))
-        self._print_issue_requested_metadata_message("agent: complete")
+        with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand="reporter-requested metadata"):
+            self._print_issue_requested_metadata_message("agent: running reporter-requested metadata prompt")
+            agent.send_prompt(self._render_prompt("issue-requested-metadata"))
+            self._print_issue_requested_metadata_message("agent: complete")
 
         last_test_output = ""
         last_failed_task = None
@@ -202,6 +212,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             output_summary=self._summarize_gradle_issue(last_test_output),
         )
         subprocess.run(["git", "reset", "--hard", checkpoint], cwd=self.reachability_repo_path, check=False)
+        self._locate_explore_failure("reporter-requested metadata")
         return False, prompt_iterations
 
     def _run_dynamic_access_phase(self, agent, current_report=None) -> tuple[bool, int]:
@@ -228,6 +239,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 marker.mark_phase_running(PHASE_EXPLORE),
             ),
         )
+        enter_phase(RUN_PHASE_EXPLORE)
 
         exhausted_classes: set[str] = self._continuation_exhausted_classes()
         if self.dynamic_access_exhaust_report is not None:
@@ -292,6 +304,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         exhausted_classes,
                         len(terminal_classes_this_part),
                     )
+                    self._locate_explore_failure()
                     return False, prompt_iterations
                 if (
                         successful_classes == 0
@@ -369,9 +382,10 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     dynamic_access_progress=self._format_progress(delta, class_attempts),
                     uncovered_dynamic_access_calls=format_call_sites(active_class.uncovered_call_sites),
                 )
-                self._print_dynamic_access_detail("agent: running dynamic-access prompt", indent_level=2)
-                agent.send_prompt(dynamic_prompt)
-                self._print_dynamic_access_detail("agent: complete", indent_level=2)
+                with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand=class_name):
+                    self._print_dynamic_access_detail("agent: running dynamic-access prompt", indent_level=2)
+                    agent.send_prompt(dynamic_prompt)
+                    self._print_dynamic_access_detail("agent: complete", indent_level=2)
                 prompt_iterations += 1
                 save_phase_update(
                     self.continuation_marker_path,
@@ -450,6 +464,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         exhausted_classes,
                         len(terminal_classes_this_part),
                     )
+                    self._locate_explore_failure(class_name)
                     return False, prompt_iterations
                 record_indirectly_completed_classes(class_name)
 
@@ -556,6 +571,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     exhausted_classes,
                     len(terminal_classes_this_part),
                 )
+                self._locate_explore_failure(class_name)
                 return False, prompt_iterations
             if class_failed:
                 self._print_dynamic_access_detail(
@@ -588,6 +604,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                             exhausted_classes,
                             len(terminal_classes_this_part),
                         )
+                        self._locate_explore_failure(class_name)
                         return False, prompt_iterations
                     self._last_phase_status = RUN_STATUS_CHUNK_READY
                     self._print_dynamic_access_message(
@@ -643,6 +660,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         exhausted_classes,
                         len(terminal_classes_this_part),
                     )
+                    self._locate_explore_failure(class_name)
                     return False, prompt_iterations
                 self._last_phase_status = RUN_STATUS_CHUNK_READY
                 self._print_dynamic_access_message(
@@ -672,6 +690,16 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 marker.record_chunk_progress(self.chunk_class_count, chunk_processed_class_count),
                 marker.mark_phase_completed(PHASE_EXPLORE, iteration=iteration),
             ),
+        )
+
+    def _locate_explore_failure(self, class_name: str | None = None) -> None:
+        """Locate an explore failure that returned a status instead of raising.
+
+        The first recorded location wins, so a gate failure keeps its own step.
+        §FS-forge-run-location-reporting.3
+        """
+        record_step_failure(
+            location=RunLocation(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, class_name or self.library),
         )
 
     def _mark_continuation_explore_pending(
@@ -772,16 +800,18 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         success criterion for committed class progress; it writes durable
         metadata only after verification passes.
         """
-        output_dir = per_class_output_dir(
-            self.reachability_repo_path, self.group, self.artifact, self.test_version, class_name,
-        )
-        if not self.verify_native_test_gate(output_dir, label=class_name):
-            return False
-        self._commit_test_sources(f"Native-test gate fixes for {class_name}")
-        self._latest_class_checkpoint = self._commit_library_metadata(
-            f"Native metadata for {class_name}"
-        )
-        return True
+        with run_step(RUN_PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE, operand=class_name):
+            output_dir = per_class_output_dir(
+                self.reachability_repo_path, self.group, self.artifact, self.test_version, class_name,
+            )
+            if not self.verify_native_test_gate(output_dir, label=class_name):
+                record_step_failure()
+                return False
+            self._commit_test_sources(f"Native-test gate fixes for {class_name}")
+            self._latest_class_checkpoint = self._commit_library_metadata(
+                f"Native metadata for {class_name}"
+            )
+            return True
 
     def _refresh_report_after_gate(self, class_name: str):
         """Regenerate the dynamic-access report after the gate to reflect new coverage.

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -5,6 +5,15 @@
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
+from utility_scripts.run_location import (
+    PHASE_FIX as RUN_PHASE_FIX,
+    STEP_FIX_REPORTED_FAILURE,
+    STEP_NATIVE_TRACE_GATE,
+    RunLocation,
+    enter_phase,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.native_test_verification import global_output_dir
 
 
@@ -92,13 +101,15 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             self.continuation_marker_path,
             lambda marker: marker.mark_phase_running(PHASE_FIX),
         )
+        enter_phase(RUN_PHASE_FIX)
         workflow_status = RUN_STATUS_FAILURE
 
-        self._print_message("running initial gradle test to collect errors")
-        initial_error = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
-        self._print_message("running agent...")
-        agent.send_prompt(self._render_prompt("initial", initial_error=initial_error))
-        self._print_message("agent complete")
+        with run_step(RUN_PHASE_FIX, STEP_FIX_REPORTED_FAILURE, operand=self.library):
+            self._print_message("running initial gradle test to collect errors")
+            initial_error = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
+            self._print_message("running agent...")
+            agent.send_prompt(self._render_prompt("initial", initial_error=initial_error))
+            self._print_message("agent complete")
         global_iterations = 1
 
         for test_iter in range(self.max_test_iterations):
@@ -148,10 +159,12 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         # Both repair modes must prove the repaired tree under Native Image.
         # §AR-native-test-verification-callers
         if workflow_status == RUN_STATUS_SUCCESS:
-            if not self.verify_native_test_gate(global_output_dir(
-                self.reachability_repo_path, self.group, self.artifact, self.version,
-            )):
-                workflow_status = RUN_STATUS_FAILURE
+            with run_step(RUN_PHASE_FIX, STEP_NATIVE_TRACE_GATE, operand=self.library):
+                if not self.verify_native_test_gate(global_output_dir(
+                    self.reachability_repo_path, self.group, self.artifact, self.version,
+                )):
+                    record_step_failure()
+                    workflow_status = RUN_STATUS_FAILURE
 
         agent.clear_context()
         if workflow_status == RUN_STATUS_SUCCESS:
@@ -166,6 +179,9 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),
+            )
+            record_step_failure(
+                location=RunLocation(RUN_PHASE_FIX, STEP_FIX_REPORTED_FAILURE, self.library),
             )
         return workflow_status, global_iterations
 

--- a/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
@@ -8,6 +8,15 @@ import subprocess
 
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
+from utility_scripts.run_location import (
+    PHASE_EXPLORE as RUN_PHASE_EXPLORE,
+    STEP_GENERATE_TESTS,
+    STEP_NATIVE_TRACE_GATE,
+    RunLocation,
+    enter_phase,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.dynamic_access_report import format_full_report, load_dynamic_access_coverage_report
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
@@ -72,6 +81,7 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
                 marker.mark_phase_running(PHASE_EXPLORE),
             ),
         )
+        enter_phase(RUN_PHASE_EXPLORE)
         checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
         successful_iterations = 0
         prompt_iterations = 0
@@ -101,9 +111,10 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
                 dynamic_access_full_report=full_report_text,
                 iteration_progress=iteration_progress,
             )
-            self._print_detail("agent: sending optimistic prompt")
-            agent.send_prompt(prompt)
-            self._print_detail("agent: complete")
+            with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand=self.library):
+                self._print_detail("agent: sending optimistic prompt")
+                agent.send_prompt(prompt)
+                self._print_detail("agent: complete")
             prompt_iterations += 1
 
             # Inner loop: test and fix
@@ -167,9 +178,13 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
             successful_iterations += 1
 
-            if not self.verify_native_test_gate(global_output_dir(
-                self.reachability_repo_path, self.group, self.artifact, self.test_version,
-            )):
+            with run_step(RUN_PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE, operand=self.library):
+                gate_passed = self.verify_native_test_gate(global_output_dir(
+                    self.reachability_repo_path, self.group, self.artifact, self.test_version,
+                ))
+                if not gate_passed:
+                    record_step_failure()
+            if not gate_passed:
                 self._print_failure_analysis(
                     "native_test_verification_gate_failed",
                     issue="nativeTest_did_not_pass_within_verification_budget",
@@ -193,6 +208,9 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         save_phase_update(
             self.continuation_marker_path,
             lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
+        )
+        record_step_failure(
+            location=RunLocation(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, self.library),
         )
         return RUN_STATUS_FAILURE, prompt_iterations, 0
 

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -29,6 +29,13 @@ from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION as RUN_PHASE_FINALIZATION,
+    STEP_AGENT_FIX,
+    STEP_FINALIZE_RUN,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.metadata_index import (
     coordinate_parts,
     find_index_entry_for_version,
@@ -273,43 +280,51 @@ class WorkflowStrategy(ABC):
                 log_stage("post-generation-test", f"{stage_name} passed for {library}")
                 return RUN_STATUS_SUCCESS
 
-            log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
-            codex_env = gradle_command_environment(repo_path, command_env)
-            codex_rc, codex_log_path, codex_timed_out = run_metadata_fix(
-                repo_path,
-                library,
-                reproduction_command=reproduction_command,
-                graalvm_home=codex_env.get("GRAALVM_HOME"),
-                base_env=command_env,
-            )
-            recovery_test_output = test_output
-            if not codex_timed_out and codex_rc == 0:
-                recovery_test_output = command_runner()
-                if self._get_first_failed_task(recovery_test_output) is None:
-                    log_stage("post-generation-test", f"{stage_name} passed for {library} after metadata fix")
-                    return RUN_STATUS_SUCCESS
-
-            log_stage(
-                "post-generation-fix",
-                f"Running post generation fix for {library} after {stage_name} failure",
-            )
-            pi_rc, intervention_path, pi_timed_out = run_post_generation_fix(
-                reachability_metadata_path=repo_path,
-                coordinates=library,
-                analysis_log_path=codex_log_path,
-                test_output=recovery_test_output,
-                timeout_seconds=self._parameter_int("post-generation-timeout-seconds", DEFAULT_POST_GENERATION_TIMEOUT_SECONDS),
-                max_test_output_chars=self._parameter_int(
-                    "post-generation-test-output-chars",
-                    DEFAULT_MAX_TEST_OUTPUT_CHARS,
-                ),
-            )
-            if pi_timed_out or pi_rc != 0:
+            def record_lane_failure() -> str:
+                """Locate this lane's unrepaired failure before returning it."""
+                record_step_failure()
                 return RUN_STATUS_FAILURE
 
-            rerun_output = command_runner()
-            if self._get_first_failed_task(rerun_output) is not None:
-                return RUN_STATUS_FAILURE
+            # Repairing a failed post-generation lane is the finalization phase's
+            # agent fix. §FS-forge-run-location-reporting.2
+            with run_step(RUN_PHASE_FINALIZATION, STEP_AGENT_FIX, operand=f"{library} {stage_name}"):
+                log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
+                codex_env = gradle_command_environment(repo_path, command_env)
+                codex_rc, codex_log_path, codex_timed_out = run_metadata_fix(
+                    repo_path,
+                    library,
+                    reproduction_command=reproduction_command,
+                    graalvm_home=codex_env.get("GRAALVM_HOME"),
+                    base_env=command_env,
+                )
+                recovery_test_output = test_output
+                if not codex_timed_out and codex_rc == 0:
+                    recovery_test_output = command_runner()
+                    if self._get_first_failed_task(recovery_test_output) is None:
+                        log_stage("post-generation-test", f"{stage_name} passed for {library} after metadata fix")
+                        return RUN_STATUS_SUCCESS
+
+                log_stage("post-generation-fix", f"Running post generation fix for {library} after {stage_name} failure")
+                pi_rc, intervention_path, pi_timed_out = run_post_generation_fix(
+                    reachability_metadata_path=repo_path,
+                    coordinates=library,
+                    analysis_log_path=codex_log_path,
+                    test_output=recovery_test_output,
+                    timeout_seconds=self._parameter_int(
+                        "post-generation-timeout-seconds",
+                        DEFAULT_POST_GENERATION_TIMEOUT_SECONDS,
+                    ),
+                    max_test_output_chars=self._parameter_int(
+                        "post-generation-test-output-chars",
+                        DEFAULT_MAX_TEST_OUTPUT_CHARS,
+                    ),
+                )
+                if pi_timed_out or pi_rc != 0:
+                    return record_lane_failure()
+
+                rerun_output = command_runner()
+                if self._get_first_failed_task(rerun_output) is not None:
+                    return record_lane_failure()
 
             with open(intervention_path, "r", encoding="utf-8") as intervention_file:
                 intervention_markdown = intervention_file.read().strip()
@@ -530,8 +545,13 @@ class WorkflowStrategy(ABC):
             self.continuation_marker_path,
             lambda marker: marker.mark_phase_running(PHASE_FINALIZATION),
         )
-        finalize_status, _ = self._finalize_successful_iteration(base_commit=base_commit)
+        # Finalization is one step of the run, and a status-code failure inside
+        # it still names its location. §FS-forge-run-location-reporting.2
+        with run_step(RUN_PHASE_FINALIZATION, STEP_FINALIZE_RUN, operand=self.library):
+            finalize_status, _ = self._finalize_successful_iteration(base_commit=base_commit)
         finalize_succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
+        if not finalize_succeeded:
+            record_step_failure(operand=self.library)
         if finalize_succeeded:
             save_phase_update(
                 self.continuation_marker_path,

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -61,6 +61,7 @@ from utility_scripts.repo_path_resolver import require_complete_reachability_rep
 from utility_scripts.run_location import (
     STEP_NORMAL_SETUP,
     STEP_RUN_WORKFLOW_ENGINE,
+    record_step_failure,
     report_run_failure,
     resolve_failure_location,
     run_step,
@@ -507,6 +508,7 @@ def main(argv=None):
                     return 0
                 run_scaffold(library)
             except ScaffoldError as exc:
+                record_step_failure()
                 report_run_failure(
                     resolve_failure_location(exc),
                     f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}\nERROR: {exc}",

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -58,6 +58,13 @@ from utility_scripts.library_preparation_preflight import (
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.run_location import (
+    STEP_NORMAL_SETUP,
+    STEP_RUN_WORKFLOW_ENGINE,
+    report_run_failure,
+    resolve_failure_location,
+    run_step,
+)
 from utility_scripts.schema_validator import validate_benchmark_run_metrics
 from utility_scripts.source_context import (
     discover_artifact_metadata,
@@ -491,22 +498,27 @@ def main(argv=None):
 
     os.chdir(reachability_repo_path)
     if not resume_existing_tree:
-        create_feature_branch_for_library(package, artifact, library_version)
-        try:
-            if not prepare_native_image_eligible_artifact(reachability_repo_path, library):
-                return 0
-            run_scaffold(library)
-        except ScaffoldError as exc:
-            print(f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}", file=sys.stderr)
-            print(f"ERROR: {exc}", file=sys.stderr)
-            return 1
-        populate_artifact_urls(reachability_repo_path, library)
-        save_phase_update(
-            continuation_marker_path,
-            lambda marker: marker.mark_setup_done(
-                skip_fix_phase=strategy_skips_initial_fix_phase(strategy),
-            ),
-        )
+        # Branching and scaffolding is the run's model-free setup.
+        # §FS-forge-run-location-reporting.2
+        with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
+            create_feature_branch_for_library(package, artifact, library_version)
+            try:
+                if not prepare_native_image_eligible_artifact(reachability_repo_path, library):
+                    return 0
+                run_scaffold(library)
+            except ScaffoldError as exc:
+                report_run_failure(
+                    resolve_failure_location(exc),
+                    f"ERROR: Gradle 'scaffold' task failed for coordinates: {library}\nERROR: {exc}",
+                )
+                return 1
+            populate_artifact_urls(reachability_repo_path, library)
+            save_phase_update(
+                continuation_marker_path,
+                lambda marker: marker.mark_setup_done(
+                    skip_fix_phase=strategy_skips_initial_fix_phase(strategy),
+                ),
+            )
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
     source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
@@ -607,10 +619,11 @@ def main(argv=None):
         global_iterations = 0
         unittest_number = 1
     else:
-        workflow_status, global_iterations, unittest_number = strategy_obj.run(
-            agent=agent,
-            checkpoint_commit_hash=checkpoint_commit_hash,
-        )
+        with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            workflow_status, global_iterations, unittest_number = strategy_obj.run(
+                agent=agent,
+                checkpoint_commit_hash=checkpoint_commit_hash,
+            )
 
     scaffold_placeholder_quality_gate_failed = False
     generated_test_validity_gate_failed = False

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -42,6 +42,7 @@ from utility_scripts.repo_path_resolver import require_complete_reachability_rep
 from utility_scripts.run_location import (
     STEP_NORMAL_SETUP,
     STEP_RUN_WORKFLOW_ENGINE,
+    clear_recorded_failure,
     record_step_failure,
     run_step,
 )
@@ -481,6 +482,7 @@ def main(argv=None) -> int:
         # already valid and the finalization gate decides PR eligibility.
         log_stage("explore", f"Dynamic-access exploration completed with status: {explore_status}")
         if explore_status != RUN_STATUS_SUCCESS:
+            clear_recorded_failure()
             save_phase_update(
                 args.continuation_marker_path,
                 lambda marker: marker.mark_phase_completed(PHASE_EXPLORE, iteration=iterations),

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -39,6 +39,12 @@ from utility_scripts.metadata_index import resolve_metadata_version, resolve_tes
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.native_test_verification import global_output_dir
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.run_location import (
+    STEP_NORMAL_SETUP,
+    STEP_RUN_WORKFLOW_ENGINE,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -381,60 +387,64 @@ def main(argv=None) -> int:
     model_name: str | None = None
     tests_root: str | None = None
     if not resume_existing_tree:
-        print(f"[pipeline] Creating branch: {branch}")
-        create_or_switch_branch(reachability_metadata_path, branch)
+        # Branching and the deterministic native-image fix are the run's
+        # model-free setup. §FS-forge-run-location-reporting.2
+        with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
+            print(f"[pipeline] Creating branch: {branch}")
+            create_or_switch_branch(reachability_metadata_path, branch)
 
-        print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
-        result = run_fix_test_native_image_run(
-            reachability_metadata_path=reachability_metadata_path,
-            current_coordinates=current_coordinates,
-            new_version=new_version,
-        )
-
-        if result.returncode != 0:
-            # The failed JVM-agent seed reaches runtime truth before any agent
-            # repair. §FS-native-test-verification-gate §AR-forge-workflow-pipeline
-            strategy_obj, agent, model_name, tests_root = build_strategy_and_agent(
-                strategy_name=args.strategy_name,
+            print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
+            result = run_fix_test_native_image_run(
                 reachability_metadata_path=reachability_metadata_path,
-                library=library,
-                group=group,
-                artifact=artifact,
-                version=new_version,
-                library_preparation_preflight_context=library_preparation_preflight_context,
-                explore=False,
-                continuation_marker_path=args.continuation_marker_path,
+                current_coordinates=current_coordinates,
+                new_version=new_version,
             )
-            test_version = resolve_test_version(
-                reachability_metadata_path,
-                group,
-                artifact,
-                new_version,
-            )
-            if not strategy_obj.verify_native_test_gate(
-                    global_output_dir(
-                        reachability_metadata_path,
-                        group,
-                        artifact,
-                        test_version,
-                    ),
-                    label="fixTestNativeImageRun failure",
-            ):
-                print(
-                    f"ERROR: native-test gate failed after fixTestNativeImageRun for {library}.",
-                    file=sys.stderr,
-                )
-                return 1
 
-        populate_artifact_urls(reachability_metadata_path, library)
-        checkpoint = commit_checkpoint(reachability_metadata_path, library)
-        save_phase_update(
-            args.continuation_marker_path,
-            lambda marker: (
-                marker.mark_setup_done(),
-                marker.mark_phase_completed(PHASE_FIX),
-            ),
-        )
+            if result.returncode != 0:
+                # The failed JVM-agent seed reaches runtime truth before any agent
+                # repair. §FS-native-test-verification-gate §AR-forge-workflow-pipeline
+                strategy_obj, agent, model_name, tests_root = build_strategy_and_agent(
+                    strategy_name=args.strategy_name,
+                    reachability_metadata_path=reachability_metadata_path,
+                    library=library,
+                    group=group,
+                    artifact=artifact,
+                    version=new_version,
+                    library_preparation_preflight_context=library_preparation_preflight_context,
+                    explore=False,
+                    continuation_marker_path=args.continuation_marker_path,
+                )
+                test_version = resolve_test_version(
+                    reachability_metadata_path,
+                    group,
+                    artifact,
+                    new_version,
+                )
+                if not strategy_obj.verify_native_test_gate(
+                        global_output_dir(
+                            reachability_metadata_path,
+                            group,
+                            artifact,
+                            test_version,
+                        ),
+                        label="fixTestNativeImageRun failure",
+                ):
+                    print(
+                        f"ERROR: native-test gate failed after fixTestNativeImageRun for {library}.",
+                        file=sys.stderr,
+                    )
+                    record_step_failure()
+                    return 1
+
+            populate_artifact_urls(reachability_metadata_path, library)
+            checkpoint = commit_checkpoint(reachability_metadata_path, library)
+            save_phase_update(
+                args.continuation_marker_path,
+                lambda marker: (
+                    marker.mark_setup_done(),
+                    marker.mark_phase_completed(PHASE_FIX),
+                ),
+            )
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
         checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
@@ -464,7 +474,8 @@ def main(argv=None) -> int:
     iterations = 0
     if explore:
         print(f"[pipeline] Running dynamic-access exploration for {library}")
-        run_result = strategy_obj.run(agent=agent, checkpoint_commit_hash=checkpoint)
+        with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=args.strategy_name):
+            run_result = strategy_obj.run(agent=agent, checkpoint_commit_hash=checkpoint)
         explore_status, iterations = run_result[0], run_result[1]
         # Best-effort: a partial or failed explore must not abort. The seed is
         # already valid and the finalization gate decides PR eligibility.

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -67,6 +67,13 @@ from utility_scripts.metadata_index import (
     resolve_version_backfill_baseline,
 )
 from utility_scripts.metrics_writer import count_metadata_entries, count_test_only_metadata_entries, create_failure_run_metrics_output
+from utility_scripts.run_location import (
+    STEP_NORMAL_SETUP,
+    STEP_RUN_WORKFLOW_ENGINE,
+    RunLocation,
+    record_step_failure,
+    run_step,
+)
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -701,10 +708,12 @@ def main(argv=None) -> int:
         )
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
     if not resume_existing_tree:
-        # Create feature branch
-        new_branch = build_ai_branch_name(f"improve-coverage-{group}-{artifact}-{version}")
-        delete_remote_branch_if_exists(new_branch)
-        subprocess.run(["git", "switch", "-C", new_branch], check=True)
+        # Branching the improvement run is its model-free setup.
+        # §FS-forge-run-location-reporting.2
+        with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
+            new_branch = build_ai_branch_name(f"improve-coverage-{group}-{artifact}-{version}")
+            delete_remote_branch_if_exists(new_branch)
+            subprocess.run(["git", "switch", "-C", new_branch], check=True)
     else:
         log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
 
@@ -725,6 +734,7 @@ def main(argv=None) -> int:
             ),
             file=sys.stderr,
         )
+        record_step_failure(location=RunLocation(PHASE_SETUP, STEP_NORMAL_SETUP, library))
         return 1
     if test_version != version:
         log_stage(
@@ -745,6 +755,7 @@ def main(argv=None) -> int:
                 f"{os.path.relpath(baseline_stats_path, reachability_repo_path)}",
                 file=sys.stderr,
             )
+            record_step_failure(location=RunLocation(PHASE_SETUP, STEP_NORMAL_SETUP, library))
             return 1
         log_stage("setup", f"Reusing cached baseline snapshot from {BASELINE_STATS_FILENAME}")
     else:
@@ -862,10 +873,11 @@ def main(argv=None) -> int:
         workflow_status = RUN_STATUS_SUCCESS
         iterations = 0
     else:
-        run_result = strategy_obj.run(
-            agent=agent,
-            checkpoint_commit_hash=checkpoint_commit,
-        )
+        with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            run_result = strategy_obj.run(
+                agent=agent,
+                checkpoint_commit_hash=checkpoint_commit,
+            )
         workflow_status, iterations = run_result[0], run_result[1]
 
     if workflow_status in {RUN_STATUS_SUCCESS, RUN_STATUS_CHUNK_READY}:

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -38,6 +38,7 @@ from utility_scripts.library_preparation_preflight import (
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.run_location import STEP_NORMAL_SETUP, STEP_RUN_WORKFLOW_ENGINE, run_step
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
@@ -509,14 +510,17 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     metadata_dir_preexisted = os.path.exists(metadata_dir)
 
     if not resume_existing_tree:
-        copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
-        update_metadata_index_json(config, group, artifact, updated_library_version)
-        create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
-        commit_checkpoint = create_project_prep_checkpoint(config, group, artifact, updated_library_version)
-        save_phase_update(
-            continuation_marker_path,
-            lambda marker: marker.mark_setup_done(),
-        )
+        # Copying the target version into the tree is the model-free setup.
+        # §FS-forge-run-location-reporting.2
+        with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=f"{group}:{artifact}:{updated_library_version}"):
+            copy_and_prepare_project_dir(group, artifact, old_library_version, updated_library_version)
+            update_metadata_index_json(config, group, artifact, updated_library_version)
+            create_versioned_metadata_dir(reachability_repo_path, group, artifact, updated_library_version)
+            commit_checkpoint = create_project_prep_checkpoint(config, group, artifact, updated_library_version)
+            save_phase_update(
+                continuation_marker_path,
+                lambda marker: marker.mark_setup_done(),
+            )
     else:
         log_stage("continuation", f"Resuming {group}:{artifact}:{updated_library_version} from phase {resume_from}")
         commit_checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
@@ -585,9 +589,10 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         workflow_status = RUN_STATUS_SUCCESS
         iterations = 0
     else:
-        workflow_status, iterations = strategy_obj.run(
-            agent=agent,
-        )
+        with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            workflow_status, iterations = strategy_obj.run(
+                agent=agent,
+            )
 
     last_passing_candidate_commit = None
     if workflow_status == RUN_STATUS_SUCCESS:

--- a/forge/docs/architecture/README.md
+++ b/forge/docs/architecture/README.md
@@ -19,6 +19,7 @@ file rather than by prefix.
 | --- | --- |
 | [§AR-forge-architecture](architecture.md#ar-forge-architecture-forge-architecture) | Forge architecture, and the map of every architecture ID |
 | [§AR-forge-workflow-pipeline](architecture.md#ar-forge-workflow-pipeline-forge-workflow-architecture) | What runs during one workflow, step by step, and who owns each step |
+| [§AR-forge-run-location](architecture.md#ar-forge-run-location-one-run-location-for-progress-and-failure) | How progress and failure output share one phase/step vocabulary |
 | [§AR-forge-control-plane](architecture.md#ar-forge-control-plane-worker-loop-and-dispatcher-own-queue-control) | Worker loop and dispatcher own queue control |
 | [§AR-forge-workflow-boundary](architecture.md#ar-forge-workflow-boundary-workflow-drivers-compose-setup-workflow-engine-and-metrics) | Workflow drivers compose setup, workflow engine, and metrics |
 | [§AR-forge-drivers](drivers.md#ar-forge-drivers-workflow-drivers) | Workflow drivers: one per issue queue |

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -13,6 +13,7 @@ structure chosen to satisfy it, with the workflow catalog in
 | ID | Concern |
 | --- | --- |
 | §AR-forge-workflow-pipeline | the end-to-end pipeline of one workflow run, step by step |
+| §AR-forge-run-location | how progress output and failure output share one phase/step vocabulary |
 | §AR-forge-control-plane | how the worker loop, dispatcher, GitHub queues, and worktrees compose |
 | §AR-forge-workflow-boundary | how workflow drivers turn a claimed issue into an isolated workflow run |
 | §AR-forge-strategy-agent-boundary | how strategy configuration, workflow engines, agents, and post-generation interventions are separated |
@@ -910,11 +911,27 @@ makes `(<n>/<total>)` derivable rather than hand-counted, and makes an
 unregistered step name a hard error at the step boundary instead of a wrong
 label in a log.
 
+The table lists the steps the pipeline enters today, in the order it enters
+them, not the full set of pseudo-methods §AR-forge-workflow-pipeline names. Two
+of those — `check_setup()` and `local_review()` — are still folded into larger
+methods, so registering them would make `<total>` count a step that never runs;
+they join the table when §ROADMAP-forge-algorithmic-then-neural-setup and the
+local-review work split them out. A step name may appear under several phases,
+because more than one phase runs `generate_tests()` and `native_trace_gate()`.
+
 **Steps are marked, not narrated.** A step is entered through the `run_step()`
 context manager — or the `pipeline_step()` decorator, which is the same thing
 applied to a whole function. Entering prints the progress line and pushes the
 location onto a run-local stack; leaving pops it. Nothing at a raise site
 mentions a step name, because a raise site does not know which step it is in.
+The decorator resolves its operand from the call's arguments **by parameter
+name**, binding the wrapped signature rather than indexing `args`, so a keyword
+call and a positional call of the same function locate identically.
+
+The state is thread-local because runs execute concurrently on a pool
+(§AR-forge-control-plane): each lifecycle resets it, names its run, and points
+it at that run's continuation marker, so two runs never read each other's
+location and interleaved banners say which run they belong to.
 
 **Failures propagate their location, they do not format it.** `run_step()`
 annotates a propagating exception with the location it was raised in and
@@ -922,7 +939,9 @@ re-raises the original exception object. Annotating rather than wrapping is
 required: `forge_metadata` classifies external failures by exception type
 (§FS-human-intervention-policy), and a wrapper would erase that type. The
 annotation is written once by the innermost step and never overwritten, so a
-location survives every intermediate `except` on the way out.
+location survives every intermediate `except` on the way out. A `KeyboardInterrupt`
+travels unmarked: an interrupt is not a run failure, and marking it would put a
+failure location on the marker of a run the operator stopped.
 
 Status-code failures — the many Forge paths that return `RUN_STATUS_FAILURE`
 rather than raise — call `record_step_failure()` instead. Both routes write to
@@ -939,6 +958,11 @@ comment.
 that no step claimed, it reports the step as `<unlocated-step>` and prints a
 defect notice: a code path raising outside the pipeline's step boundaries is a
 bug in Forge, and the report says so rather than quietly omitting the step.
+
+**The line is printed once.** A run has one terminal failure, and it passes
+several boundaries on the way out — the driver's status code, the workflow run
+result, the failed-issue handler. The reporter is idempotent for the run, so the
+boundary nearest the error owns the line and the rest add nothing.
 
 **Debug narration is separate from failure output.** `stage_logger` gains a
 debug level, enabled by `FORGE_DEBUG_LOGGING`, and the human-intervention

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -894,6 +894,59 @@ the terminal run status implies, apply review or human-intervention labels, and
 clean up the worktree (§AR-forge-orchestration). A chunk-ready run leaves
 the issue open for its next chunk (§AR-chunked-dynamic-access-pr-linking).
 
+## AR-forge-run-location: One run location for progress and failure
+
+The pipeline above already names every step; `utility_scripts/run_location.py`
+turns those names into the run's single location vocabulary, so progress output
+and failure output cannot disagree about what a phase or a step is called
+(§FS-forge-run-location-reporting).
+
+**One table, no parallel enum.** The five durable phases are imported from
+`utility_scripts/continuation_marker.py`, which already owns them for
+continuation (§FS-forge-run-continuation.1); `run_location` adds only `claim`,
+the dispatcher-side segment that exists before continuation state does. The
+phase-to-steps table is the only place a step name is written, which is what
+makes `(<n>/<total>)` derivable rather than hand-counted, and makes an
+unregistered step name a hard error at the step boundary instead of a wrong
+label in a log.
+
+**Steps are marked, not narrated.** A step is entered through the `run_step()`
+context manager — or the `pipeline_step()` decorator, which is the same thing
+applied to a whole function. Entering prints the progress line and pushes the
+location onto a run-local stack; leaving pops it. Nothing at a raise site
+mentions a step name, because a raise site does not know which step it is in.
+
+**Failures propagate their location, they do not format it.** `run_step()`
+annotates a propagating exception with the location it was raised in and
+re-raises the original exception object. Annotating rather than wrapping is
+required: `forge_metadata` classifies external failures by exception type
+(§FS-human-intervention-policy), and a wrapper would erase that type. The
+annotation is written once by the innermost step and never overwritten, so a
+location survives every intermediate `except` on the way out.
+
+Status-code failures — the many Forge paths that return `RUN_STATUS_FAILURE`
+rather than raise — call `record_step_failure()` instead. Both routes write to
+the same run-local failure slot, so the lifecycle boundary reads one location
+regardless of how the failure travelled.
+
+**The location crosses process and phase boundaries in the marker.**
+`ContinuationMarker` carries a `failure` object with the phase, step, and
+operand, written when the failure is recorded. That is what puts the same pair
+on the preserved branch, in the resumed run's log, and in the human-intervention
+comment.
+
+**An unlocated failure is loud.** When the lifecycle boundary reports a failure
+that no step claimed, it reports the step as `<unlocated-step>` and prints a
+defect notice: a code path raising outside the pipeline's step boundaries is a
+bug in Forge, and the report says so rather than quietly omitting the step.
+
+**Debug narration is separate from failure output.** `stage_logger` gains a
+debug level, enabled by `FORGE_DEBUG_LOGGING`, and the human-intervention
+handoff's git narration moves onto it. The git commands themselves capture their
+output and replay it only on failure or under debug, so the default failed-run
+output is the location, the error, and the preserved branch
+(§FS-forge-run-location-reporting.4).
+
 ## AR-forge-control-plane: Worker loop and dispatcher own queue control
 
 Forge is shaped as a small control plane around independent workflow entry

--- a/forge/docs/functional-spec/README.md
+++ b/forge/docs/functional-spec/README.md
@@ -26,6 +26,7 @@ contract in [strategies.md](strategies.md), the benchmark contract in
 | [§FS-forge-outputs](functional-spec.md#fs-forge-outputs-run-outputs) | Run outputs |
 | [§FS-forge-run-metrics](functional-spec.md#fs-forge-run-metrics-per-run-metrics-record) | Per-run metrics record |
 | [§FS-durable-generation-logs](functional-spec.md#fs-durable-generation-logs-durable-generation-and-session-logs) | Durable generation and session logs |
+| [§FS-forge-run-location-reporting](functional-spec.md#fs-forge-run-location-reporting-run-location-in-progress-and-failure-output) | Run location in progress and failure output |
 | [§FS-forge-publication-readiness](publication.md#fs-forge-publication-readiness-publication-readiness) | Publication readiness |
 | [§FS-local-ci-equivalent-verification](publication.md#fs-local-ci-equivalent-verification-local-pre-publication-verification) | Local pre-publication verification |
 | [§FS-native-test-verification-gate](publication.md#fs-native-test-verification-gate-native-test-verification-gate) | Native test verification gate |

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -522,11 +522,20 @@ phases (§FS-forge-run-continuation.1) and must not be redeclared anywhere else;
 therefore before continuation state exists.
 
 A **step** is the pipeline method that is executing, written with its
-parentheses exactly as the pipeline names it — `check_host_requirements()`,
-`neural_setup()`, `check_setup()`, `generate_tests()`, `native_trace_gate()`,
-`local_ci_check()`, `publish_branch()`, and the rest. Every step belongs to
-exactly one phase, and the phase's steps are ordered, so a step has a position
-`<n>` within a total `<total>`.
+parentheses exactly as the pipeline names it (§AR-forge-workflow-pipeline) —
+`check_host_requirements()`, `neural_setup()`, `normal_setup()`,
+`run_workflow_engine()`, `generate_tests()`, `native_trace_gate()`,
+`agent_fix()`, `finalize_run()`, `local_ci_check()`, `publish_branch()`. A step
+is registered under the phase that runs it, and a phase's registered steps are
+ordered by the order the run enters them, so a step has a position `<n>` within
+a total `<total>`. A step name may belong to more than one phase when more than
+one phase runs it, but the registry is the only place the binding is written: a
+step the run enters must be registered, and `<total>` is derived from the
+registry rather than counted by hand.
+
+Only steps the pipeline actually enters are registered. A pipeline method that
+is still folded into a larger one is registered when it becomes a step of its
+own, so `<n>/<total>` never counts a step that never runs.
 
 A step may carry an **operand**: the one value the step was working on when it
 ran — the class being generated, the gate command that returned non-zero, the
@@ -535,8 +544,11 @@ operand and `<phase>/<step>[<operand>]` with one.
 
 ### 2. Progress output
 
-Entering a phase prints a bounded, visually distinct banner naming the phase, so
-a phase transition is findable by eye in a long run log.
+Entering a phase prints a bounded, visually distinct banner naming the phase and
+the run it belongs to, so a phase transition is findable by eye in a long run
+log even though runs are interleaved on a pool (§AR-forge-control-plane). The
+banner marks a transition: re-entering the phase the run is already in prints
+nothing.
 
 Entering a step prints exactly one line:
 
@@ -562,6 +574,16 @@ driver returns to `forge_metadata`, the continuation marker, and the
 human-intervention comment, which leads with it
 (§FS-human-intervention-policy). A resumed run therefore states the location it
 is retrying.
+
+The location is reported once per run — the failure that ends a run is one
+failure, and the first boundary to report it owns the line — and the innermost
+step that failed is the one reported, however many intermediate handlers the
+failure passes through. A failure that returns a status code instead of raising
+records its location at the point it gives up, so both routes out reach the
+lifecycle boundary with one location.
+
+A user interrupt is not a run failure: it carries no location, records none, and
+prints none.
 
 No failure path may report a phase without a step. A failure raised outside
 every step boundary is a defect in Forge, not a formatting gap: it is reported

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -505,6 +505,80 @@ If a run fails or times out, the saved logs are part of the diagnostic artifact
 set that allows maintainers or a later Forge run to continue from evidence,
 keeping the loop short as called for by §GOAL-shorten-issue-to-shipped-metadata.
 
+## FS-forge-run-location-reporting: Run location in progress and failure output
+
+A Forge run must always be able to say **where** it is: the phase it is in and
+the step inside it. That location is one vocabulary used twice — to narrate
+progress while the run works, and to report the location of a failure — so a
+reader of a live run and a reader of a failed run name the same thing the same
+way, serving §GOAL-shorten-issue-to-shipped-metadata.
+
+### 1. Vocabulary
+
+A **phase** is one banded segment of the run: `claim`, `setup`, `fix`,
+`explore`, `finalization`, or `publication`. The last five are the continuation
+phases (§FS-forge-run-continuation.1) and must not be redeclared anywhere else;
+`claim` is the dispatcher-side segment that runs before a run exists and
+therefore before continuation state exists.
+
+A **step** is the pipeline method that is executing, written with its
+parentheses exactly as the pipeline names it — `check_host_requirements()`,
+`neural_setup()`, `check_setup()`, `generate_tests()`, `native_trace_gate()`,
+`local_ci_check()`, `publish_branch()`, and the rest. Every step belongs to
+exactly one phase, and the phase's steps are ordered, so a step has a position
+`<n>` within a total `<total>`.
+
+A step may carry an **operand**: the one value the step was working on when it
+ran — the class being generated, the gate command that returned non-zero, the
+coordinate being published. A location renders as `<phase>/<step>` without an
+operand and `<phase>/<step>[<operand>]` with one.
+
+### 2. Progress output
+
+Entering a phase prints a bounded, visually distinct banner naming the phase, so
+a phase transition is findable by eye in a long run log.
+
+Entering a step prints exactly one line:
+
+```
+Running step <step> (<n>/<total>) of phase <phase>
+```
+
+with ` on <operand>` appended when the step has an operand. The words "Running
+step" and "of phase" are fixed: this line is the anchor a reader and a log
+search look for.
+
+### 3. Failure output
+
+A terminal failure prints one line before its error detail:
+
+```
+run failed in <phase>/<step>
+```
+
+The same pair must appear, unchanged, in every place the failure surfaces: the
+worker's terminal output and run log, the terminal run status the workflow
+driver returns to `forge_metadata`, the continuation marker, and the
+human-intervention comment, which leads with it
+(§FS-human-intervention-policy). A resumed run therefore states the location it
+is retrying.
+
+No failure path may report a phase without a step. A failure raised outside
+every step boundary is a defect in Forge, not a formatting gap: it is reported
+with the step `<unlocated-step>` and an explicit defect notice on stderr, so it
+is visible rather than silently tolerated.
+
+### 4. Failure output stays short
+
+Failure output is the location, the error, and the preserved-work link. The
+human-intervention handoff itself is unchanged
+(§FS-human-intervention-policy) — the work is still preserved on a branch, the
+comment is still posted, the label is still applied — but its narration is
+debugging detail, not failure output: branch switches, staging, commits, pushes,
+and claim-revert bookkeeping are logged at debug level and are off unless debug
+logging is enabled. Errors, the failure location, and the preserved branch URL
+are never suppressed.
+
 ## FS-forge-run-status: Run status semantics
 
 Every workflow records one of these statuses:

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -394,7 +394,7 @@ the human-intervention comment leads with the same pair; no failure path
 reports a phase without a step; every phase entry prints a banner and every step
 entry prints `Running step <step> (<n>/<total>) of phase <phase>`; and the
 default failure output carries no git or push narration
-(§FS-forge-run-location-reporting).
+(§FS-forge-run-location-reporting, §AR-forge-run-location).
 
 # ROADMAP-forge-algorithmic-then-neural-setup: Algorithmic setup, then neural setup
 

--- a/forge/docs/roadmap.md
+++ b/forge/docs/roadmap.md
@@ -371,11 +371,30 @@ marker, and the human-intervention comment
 defect: an unlabeled failure means a code path is raising outside the pipeline's
 own step boundaries.
 
+The same pair is what the happy path is missing. A run that is working prints
+hundreds of lines with no statement of where it is, so a reader who wants to know
+whether a two-hour run is still in `explore` or already finalizing has to infer
+it. Naming the location only on failure would build the vocabulary and then use
+it once: the run must announce each phase it enters and each step it starts,
+from the same names the failure reports, so the progress log and the failure
+report can never disagree about what a phase or a step is called.
+
+Failure output must also get shorter, not longer. Today a failed run ends in a
+wall of text narrating the human-intervention handoff — branch switches, adds,
+commits, and pushes — and the actual error is somewhere inside it. Preserving
+the work and posting the handoff is required behavior (§FS-human-intervention-policy)
+and does not change; its narration is debugging detail and belongs at debug
+level, so what remains on a failed run is the location, the error, and the
+preserved-branch link.
+
 Acceptance: every terminal failure prints one line of the form
 `run failed in <phase>/<step>` before its error detail; the continuation marker
 records the same phase and step, so a resumed run states what it is retrying;
-the human-intervention comment leads with the same pair; and no failure path
-reports a phase without a step.
+the human-intervention comment leads with the same pair; no failure path
+reports a phase without a step; every phase entry prints a banner and every step
+entry prints `Running step <step> (<n>/<total>) of phase <phase>`; and the
+default failure output carries no git or push narration
+(§FS-forge-run-location-reporting).
 
 # ROADMAP-forge-algorithmic-then-neural-setup: Algorithmic setup, then neural setup
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -189,7 +189,27 @@ from utility_scripts.repo_path_resolver import (
     resolve_reachability_repo_root,
 )
 from utility_scripts.source_context import GradleBootstrapFailure
-from utility_scripts.stage_logger import log_failure_banner, log_stage, log_success_banner
+from utility_scripts.stage_logger import log_debug, log_failure_banner, log_stage, log_success_banner
+from utility_scripts.run_location import (
+    PHASE_CLAIM,
+    STEP_CHECK_HOST_REQUIREMENTS,
+    STEP_CHECK_ISSUE_FORM,
+    STEP_CHECK_STRATEGY_AND_MODEL,
+    STEP_CLAIM_ISSUE,
+    STEP_CREATE_ISSUE_WORKSPACE,
+    STEP_PUBLISH_BRANCH,
+    STEP_ROUTE_TO_DRIVER,
+    RunLocation,
+    bind_continuation_marker,
+    enter_phase,
+    format_run_failure_line,
+    marker_failure_location,
+    pipeline_step,
+    report_run_failure,
+    reset_run_location,
+    resolve_failure_location,
+    run_step,
+)
 from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
 from utility_scripts.task_logs import (
@@ -4695,6 +4715,31 @@ def refresh_preserved_branch_logs(
     log_stage("preserve-failed-work", f"Updated preserved branch logs for issue #{issue_number}.")
 
 
+def resolve_claimed_issue_failure_location(
+        claimed_issue: ClaimedIssue,
+        exc: BaseException | None = None,
+) -> RunLocation:
+    """Return the phase/step this claimed issue failed in.
+
+    Prefers the location the failing step recorded in this process; falls back to
+    the continuation marker so a driver-side or resumed failure still names its
+    step. §FS-forge-run-location-reporting.3
+    """
+    location = resolve_failure_location(exc)
+    if location.is_located:
+        return location
+    marker = load_continuation_marker(continuation_marker_path(claimed_issue.worktree_path))
+    return marker_failure_location(marker) or location
+
+
+def lead_comment_with_failure_location(comment_body: str, location: RunLocation) -> str:
+    """Lead the human-intervention comment with the same pair the terminal printed."""
+    failure_line = format_run_failure_line(location)
+    if comment_body.lstrip().startswith(("`" + failure_line, failure_line)):
+        return comment_body
+    return f"`{failure_line}`\n\n{comment_body}"
+
+
 def ensure_preserved_branch_link_in_comment(
         comment_body: str,
         preservation_result: FailurePreservationResult | None,
@@ -4828,6 +4873,7 @@ def apply_failed_run_follow_up(
         claimed_issue: ClaimedIssue,
         started_at: float | None = None,
         preservation_result: FailurePreservationResult | None = None,
+        failure_location: RunLocation | None = None,
 ) -> None:
     """Run Codex failure analysis and apply the `human-intervention` follow-up.
 
@@ -4852,7 +4898,10 @@ def apply_failed_run_follow_up(
             post_human_intervention_comment_and_label(
                 claimed_issue.issue["number"],
                 ensure_preserved_branch_link_in_comment(
-                    _build_finalization_failure_comment(claimed_issue),
+                    _lead_failed_run_comment(
+                        _build_finalization_failure_comment(claimed_issue),
+                        failure_location,
+                    ),
                     preservation_result,
                 ),
                 resumable=True,
@@ -4866,6 +4915,9 @@ def apply_failed_run_follow_up(
             started_at,
             preservation_result,
         )
+        # The comment leads with the same pair the terminal printed.
+        # §FS-forge-run-location-reporting.3
+        comment_body = _lead_failed_run_comment(comment_body, failure_location)
         comment_body = ensure_preserved_branch_link_in_comment(comment_body, preservation_result)
     except Exception as exc:
         print(
@@ -4873,7 +4925,7 @@ def apply_failed_run_follow_up(
             file=sys.stderr,
         )
         traceback.print_exc()
-        comment_body = None
+        comment_body = None if failure_location is None else _lead_failed_run_comment("", failure_location)
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
     post_human_intervention_comment_and_label(
@@ -4881,6 +4933,13 @@ def apply_failed_run_follow_up(
         comment_body,
         resumable=preservation_result_has_continuation_marker(preservation_result),
     )
+
+
+def _lead_failed_run_comment(comment_body: str, failure_location: RunLocation | None) -> str:
+    """Prefix a failed-run comment with its run location when one is known."""
+    if failure_location is None:
+        return comment_body
+    return lead_comment_with_failure_location(comment_body, failure_location).rstrip() + "\n"
 
 
 def dynamic_access_chunk_class_threshold() -> int:
@@ -5541,6 +5600,11 @@ def resolve_run_strategy_name(
     return strategy_override or default_strategy_name
 
 
+@pipeline_step(
+    PHASE_CLAIM,
+    STEP_ROUTE_TO_DRIVER,
+    operand=lambda claimed_issue, *args, **kwargs: f"issue #{claimed_issue.issue['number']}",
+)
 def invoke_pipeline(
         claimed_issue: ClaimedIssue,
         strategy_name: str | None,
@@ -6060,6 +6124,11 @@ def cleanup_review_workspace(
         )
 
 
+@pipeline_step(
+    PHASE_CLAIM,
+    STEP_CREATE_ISSUE_WORKSPACE,
+    operand=lambda *args, **kwargs: f"issue #{args[2] if len(args) > 2 else kwargs['issue_number']}",
+)
 def create_issue_workspace(
         base_reachability_metadata_path: str,
         canonical_metrics_repo_path: str,
@@ -6120,6 +6189,11 @@ def cleanup_issue_workspace(claimed_issue: ClaimedIssue, canonical_metrics_repo_
             )
 
 
+@pipeline_step(
+    PHASE_CLAIM,
+    STEP_CHECK_ISSUE_FORM,
+    operand=lambda issue, *args, **kwargs: f"issue #{issue['number']}",
+)
 def build_claim_metadata(
         issue: dict,
         label: str,
@@ -6611,6 +6685,7 @@ def claim_issue_for_processing(
     dynamic-access continuation derives its exhaust report from the coordinate
     in the checked-out repository (§AR-dynamic-access-exhaust-report).
     """
+    enter_phase(PHASE_CLAIM)
     if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
         return None
 
@@ -7457,6 +7532,7 @@ def finalize_successful_issue(
     workflow records a PR-eligible status (§AR-pr-eligibility), keeping
     generation and publication separate (§AR-forge-verification-publication-boundary).
     """
+    enter_phase(PHASE_PUBLICATION)
     coverage_follow_up = prepare_java_fix_coverage_follow_up(claimed_issue)
     coverage_follow_up_args = coverage_follow_up or (None, None, None)
     if is_fixture_testing_enabled():
@@ -7471,8 +7547,13 @@ def finalize_successful_issue(
         )
         return
 
-    handoff = build_publication_handoff(claimed_issue, *coverage_follow_up_args)
-    handoff.runner(handoff.argv)
+    with run_step(
+        PHASE_PUBLICATION,
+        STEP_PUBLISH_BRANCH,
+        operand=claimed_issue.issue_coordinates,
+    ):
+        handoff = build_publication_handoff(claimed_issue, *coverage_follow_up_args)
+        handoff.runner(handoff.argv)
 
 
 def preserve_failed_work_for_follow_up(claimed_issue: ClaimedIssue) -> FailurePreservationResult | None:
@@ -8202,6 +8283,11 @@ def is_issue_blocked(issue_number: int) -> bool:
     return bool(get_open_blocking_issue_numbers(issue_number))
 
 
+@pipeline_step(
+    PHASE_CLAIM,
+    STEP_CLAIM_ISSUE,
+    operand=lambda issue, *args, **kwargs: f"issue #{issue['number']}",
+)
 def try_claim_issue(
         issue: dict,
         authenticated_user: str,
@@ -9123,6 +9209,7 @@ def resolve_host_requirement_strategy_names(args: argparse.Namespace) -> list[st
     return strategy_names
 
 
+@pipeline_step(PHASE_CLAIM, STEP_CHECK_HOST_REQUIREMENTS)
 def require_host_requirements(args: argparse.Namespace, reachability_metadata_path: str) -> None:
     """Stop before any work when this host cannot run the invoked Forge mode.
 
@@ -9170,9 +9257,11 @@ def main() -> None:
             return
         # The gate must check the repository this run actually operates on, so it is resolved first.
         reachability_metadata_path = resolve_reachability_repo_root(args.reachability_metadata_path)
+        enter_phase(PHASE_CLAIM)
         require_host_requirements(args, reachability_metadata_path)
         if args.strategy_name:
-            require_strategy_by_name(args.strategy_name)
+            with run_step(PHASE_CLAIM, STEP_CHECK_STRATEGY_AND_MODEL, operand=args.strategy_name):
+                require_strategy_by_name(args.strategy_name)
         metrics_repo_path = resolve_metrics_repo_root(reachability_metadata_path, None)
 
         if not PROJECT_NUMBER:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -188,28 +188,32 @@ from utility_scripts.repo_path_resolver import (
     resolve_metrics_repo_root,
     resolve_reachability_repo_root,
 )
-from utility_scripts.source_context import GradleBootstrapFailure
-from utility_scripts.stage_logger import log_debug, log_failure_banner, log_stage, log_success_banner
 from utility_scripts.run_location import (
     PHASE_CLAIM,
+    PHASE_SETUP,
     STEP_CHECK_HOST_REQUIREMENTS,
     STEP_CHECK_ISSUE_FORM,
     STEP_CHECK_STRATEGY_AND_MODEL,
     STEP_CLAIM_ISSUE,
     STEP_CREATE_ISSUE_WORKSPACE,
+    STEP_NEURAL_SETUP,
     STEP_PUBLISH_BRANCH,
     STEP_ROUTE_TO_DRIVER,
     RunLocation,
     bind_continuation_marker,
+    bind_run_context,
     enter_phase,
     format_run_failure_line,
     marker_failure_location,
     pipeline_step,
+    record_step_failure,
     report_run_failure,
     reset_run_location,
     resolve_failure_location,
     run_step,
 )
+from utility_scripts.source_context import GradleBootstrapFailure
+from utility_scripts.stage_logger import log_debug, log_failure_banner, log_stage, log_success_banner
 from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
 from utility_scripts.task_logs import (
@@ -4574,6 +4578,40 @@ def git_rebase_in_progress(repo_path: str, git_env: dict[str, str]) -> bool:
     return False
 
 
+def run_preservation_git(
+        args: list[str],
+        cwd: str,
+        env: dict[str, str],
+        check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run one git command of the failure handoff without narrating it.
+
+    Failure output is the location, the error, and the preserved branch, so the
+    handoff's own git chatter is captured and replayed only when the command
+    fails or when debug logging is on. §FS-forge-run-location-reporting.4
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    detail = "\n".join(
+        stream.strip()
+        for stream in (result.stdout, result.stderr)
+        if stream and stream.strip()
+    )
+    if result.returncode != 0 and check:
+        if detail:
+            print(detail, file=sys.stderr)
+        raise subprocess.CalledProcessError(result.returncode, ["git", *args], result.stdout, result.stderr)
+    if detail:
+        log_debug("preserve-failed-work", detail)
+    return result
+
+
 def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservationResult:
     """Commit and push the failed run worktree so it survives workspace cleanup."""
     branch_name = build_failure_preservation_branch_name(claimed_issue)
@@ -4581,7 +4619,7 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     git_env = git_env_limited_to_repo_root(repo_path)
     issue_number = claimed_issue.issue["number"]
 
-    log_stage("preserve-failed-work", f"Preserving failed work for issue #{issue_number} on branch {branch_name}")
+    log_debug("preserve-failed-work", f"Preserving failed work for issue #{issue_number} on branch {branch_name}")
     # A publication `git rebase` that halts on an index.json conflict leaves the
     # worktree mid-rebase with unmerged entries, and `git switch -C` then refuses
     # ("resolve your current index first"). Clear the sequencer state first so the
@@ -4589,9 +4627,9 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
     # actual rebase so the common clean-worktree path does not log a spurious
     # "fatal: No rebase in progress?" from git. §FS-forge-run-continuation
     if git_rebase_in_progress(repo_path, git_env):
-        log_stage("preserve-failed-work", f"Aborting in-progress rebase before preserving issue #{issue_number}.")
-        subprocess.run(["git", "rebase", "--abort"], cwd=repo_path, env=git_env, check=False)
-    subprocess.run(["git", "switch", "-C", branch_name], cwd=repo_path, env=git_env, check=True)
+        log_debug("preserve-failed-work", f"Aborting in-progress rebase before preserving issue #{issue_number}.")
+        run_preservation_git(["rebase", "--abort"], repo_path, git_env, check=False)
+    run_preservation_git(["switch", "-C", branch_name], repo_path, git_env)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
     marker_path = continuation_marker_path(repo_path)
     marker = load_continuation_marker(marker_path)
@@ -4599,9 +4637,9 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
         record_publication_metrics_from_pending(marker, claimed_issue.scratch_metrics_repo_path)
         marker.record_preserved_branch(branch_name)
         marker.save(marker_path)
-    subprocess.run(["git", "add", "-A"], cwd=repo_path, env=git_env, check=True)
+    run_preservation_git(["add", "-A"], repo_path, git_env)
     if logs_destination_relpath is not None:
-        subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, env=git_env, check=True)
+        run_preservation_git(["add", "-f", "--", logs_destination_relpath], repo_path, git_env)
     force_add_paths = []
     marker_relpath = os.path.relpath(marker_path, repo_path)
     if os.path.exists(marker_path):
@@ -4611,18 +4649,17 @@ def preserve_failed_work_branch(claimed_issue: ClaimedIssue) -> FailurePreservat
         force_add_paths.append(pending_metrics_relpath)
     force_add_paths.extend(baseline_stats_relpaths_for_preservation(repo_path))
     if force_add_paths:
-        subprocess.run(["git", "add", "-f", "--", *force_add_paths], cwd=repo_path, env=git_env, check=True)
-    diff_result = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=repo_path, env=git_env, check=False)
+        run_preservation_git(["add", "-f", "--", *force_add_paths], repo_path, git_env)
+    diff_result = run_preservation_git(["diff", "--cached", "--quiet"], repo_path, git_env, check=False)
     committed_changes = diff_result.returncode != 0
     if committed_changes:
-        subprocess.run(
-            ["git", "commit", "-m", f"Preserve failed automation work for issue #{issue_number}"],
-            cwd=repo_path,
-            env=git_env,
-            check=True,
+        run_preservation_git(
+            ["commit", "-m", f"Preserve failed automation work for issue #{issue_number}"],
+            repo_path,
+            git_env,
         )
     else:
-        log_stage("preserve-failed-work", f"No uncommitted work found for issue #{issue_number}; pushing branch at current HEAD.")
+        log_debug("preserve-failed-work", f"No uncommitted work found for issue #{issue_number}; pushing branch at current HEAD.")
 
     run_git_transport(["push", "-u", "origin", branch_name], cwd=repo_path, env=git_env)
     branch_url = build_origin_branch_url(repo_path, branch_name)
@@ -4689,30 +4726,29 @@ def refresh_preserved_branch_logs(
     repo_path = require_claimed_issue_worktree(claimed_issue, "preserved log refresh")
     git_env = git_env_limited_to_repo_root(repo_path)
     issue_number = claimed_issue.issue["number"]
-    subprocess.run(["git", "switch", preservation_result.branch_name], cwd=repo_path, env=git_env, check=True)
+    run_preservation_git(["switch", preservation_result.branch_name], repo_path, git_env)
     logs_destination_relpath = copy_library_logs_to_preserved_worktree(claimed_issue)
     if logs_destination_relpath is None:
         return
 
-    subprocess.run(["git", "add", "-f", "--", logs_destination_relpath], cwd=repo_path, env=git_env, check=True)
-    diff_result = subprocess.run(
-        ["git", "diff", "--cached", "--quiet", "--", logs_destination_relpath],
-        cwd=repo_path,
-        env=git_env,
+    run_preservation_git(["add", "-f", "--", logs_destination_relpath], repo_path, git_env)
+    diff_result = run_preservation_git(
+        ["diff", "--cached", "--quiet", "--", logs_destination_relpath],
+        repo_path,
+        git_env,
         check=False,
     )
     if diff_result.returncode == 0:
-        log_stage("preserve-failed-work", f"No new workflow logs to add for issue #{issue_number}.")
+        log_debug("preserve-failed-work", f"No new workflow logs to add for issue #{issue_number}.")
         return
 
-    subprocess.run(
-        ["git", "commit", "-m", f"Add automation logs for issue #{issue_number}"],
-        cwd=repo_path,
-        env=git_env,
-        check=True,
+    run_preservation_git(
+        ["commit", "-m", f"Add automation logs for issue #{issue_number}"],
+        repo_path,
+        git_env,
     )
     run_git_transport(["push"], cwd=repo_path, env=git_env)
-    log_stage("preserve-failed-work", f"Updated preserved branch logs for issue #{issue_number}.")
+    log_debug("preserve-failed-work", f"Updated preserved branch logs for issue #{issue_number}.")
 
 
 def resolve_claimed_issue_failure_location(
@@ -5603,7 +5639,7 @@ def resolve_run_strategy_name(
 @pipeline_step(
     PHASE_CLAIM,
     STEP_ROUTE_TO_DRIVER,
-    operand=lambda claimed_issue, *args, **kwargs: f"issue #{claimed_issue.issue['number']}",
+    operand=lambda arguments: f"issue #{arguments['claimed_issue'].issue['number']}",
 )
 def invoke_pipeline(
         claimed_issue: ClaimedIssue,
@@ -5644,6 +5680,9 @@ def invoke_pipeline(
         claimed_issue,
         run_strategy_name,
     )
+    # Failures recorded from here on travel to the preserved branch in the
+    # marker. §FS-forge-run-location-reporting.3
+    bind_continuation_marker(continuation_path)
     marker = load_continuation_marker(continuation_path)
     record_library_update_route_in_marker(continuation_path, library_update_route)
     if marker is not None and marker.continue_from == PHASE_PUBLICATION:
@@ -5664,9 +5703,12 @@ def invoke_pipeline(
             f"Issue #{claimed_issue.issue['number']} skips completed setup preflight.",
         )
     else:
-        library_preparation_preflight_path = run_library_preparation_preflight(
-            claimed_issue,
-        )
+        # The preflight agent is the run's neural setup, and it runs before the
+        # driver prepares the tree. §FS-forge-run-location-reporting.1
+        with run_step(PHASE_SETUP, STEP_NEURAL_SETUP, operand=claimed_issue.issue_coordinates):
+            library_preparation_preflight_path = run_library_preparation_preflight(
+                claimed_issue,
+            )
         record_library_preparation_preflight_in_marker(
             continuation_path,
             library_preparation_preflight_path,
@@ -5713,12 +5755,14 @@ def invoke_pipeline(
         preserve_user_interrupt_reason()
         raise KeyboardInterrupt
     if rc != 0:
-        print(
+        # A driver that returns non-zero has already recorded the step it failed
+        # in; the location leads its error. §FS-forge-run-location-reporting.3
+        report_run_failure(
+            resolve_failure_location(),
             (
                 f"ERROR: {invocation.failure_name} workflow failed for issue "
                 f"#{invocation.issue_number} (exit {rc})"
             ),
-            file=sys.stderr,
         )
         return False
 
@@ -6127,7 +6171,7 @@ def cleanup_review_workspace(
 @pipeline_step(
     PHASE_CLAIM,
     STEP_CREATE_ISSUE_WORKSPACE,
-    operand=lambda *args, **kwargs: f"issue #{args[2] if len(args) > 2 else kwargs['issue_number']}",
+    operand=lambda arguments: f"issue #{arguments['issue_number']}",
 )
 def create_issue_workspace(
         base_reachability_metadata_path: str,
@@ -6192,7 +6236,7 @@ def cleanup_issue_workspace(claimed_issue: ClaimedIssue, canonical_metrics_repo_
 @pipeline_step(
     PHASE_CLAIM,
     STEP_CHECK_ISSUE_FORM,
-    operand=lambda issue, *args, **kwargs: f"issue #{issue['number']}",
+    operand=lambda arguments: f"issue #{arguments['issue']['number']}",
 )
 def build_claim_metadata(
         issue: dict,
@@ -6967,9 +7011,11 @@ def run_claimed_issue(
     except Exception as exc:
         if is_user_interrupt_requested():
             raise KeyboardInterrupt from exc
-        print(
+        # The location the step annotated onto the exception leads its detail.
+        # §FS-forge-run-location-reporting.3
+        report_run_failure(
+            resolve_failure_location(exc),
             f"ERROR: Issue #{claimed_issue.issue['number']} workflow raised an exception: {exc!r}",
-            file=sys.stderr,
         )
         traceback.print_exc()
         success = False
@@ -6993,9 +7039,11 @@ def revert_issue_claim(item_id: str, issue_number: int, reason: str) -> None:
         )
         return
 
-    print(f"\n[issue-revert] Reverting issue #{issue_number} claim because {reason}", file=sys.stderr)
+    # Claim-revert bookkeeping is narration, not failure output.
+    # §FS-forge-run-location-reporting.4
+    log_debug("issue-revert", f"Reverting issue #{issue_number} claim because {reason}")
     revert_errors: list[Exception] = []
-    print(f"[issue-revert] Reverting issue #{issue_number}: setting project item {item_id} -> {STATUS_TODO}", file=sys.stderr)
+    log_debug("issue-revert", f"Reverting issue #{issue_number}: setting project item {item_id} -> {STATUS_TODO}")
     try:
         set_item_status(item_id, STATUS_TODO)
     except Exception as exc:
@@ -7005,7 +7053,7 @@ def revert_issue_claim(item_id: str, issue_number: int, reason: str) -> None:
             f"to {STATUS_TODO}: {format_github_exception_details(exc)}",
             file=sys.stderr,
         )
-    print(f"[issue-revert] Reverting issue #{issue_number}: clearing all assignees", file=sys.stderr)
+    log_debug("issue-revert", f"Reverting issue #{issue_number}: clearing all assignees")
     try:
         clear_issue_assignees(issue_number)
     except Exception as exc:
@@ -7026,10 +7074,10 @@ def revert_issue_claim(item_id: str, issue_number: int, reason: str) -> None:
             raise verification_error from revert_errors[0]
         raise verification_error
     invalidate_issue_claim_cache_entry(issue_number)
-    print(
-        f"ERROR: Issue #{issue_number} failed due to {reason}; verified revert with "
+    log_debug(
+        "issue-revert",
+        f"Issue #{issue_number} failed due to {reason}; verified revert with "
         f"status={verified_status}, assignees={verified_assignees}",
-        file=sys.stderr,
     )
 
 
@@ -7634,6 +7682,10 @@ def handle_failed_claimed_issue(
     """
     if is_user_interrupt_requested():
         raise KeyboardInterrupt
+    # Every terminal failure names where it failed, whatever route it took here.
+    # §FS-forge-run-location-reporting.3
+    failure_location = resolve_claimed_issue_failure_location(claimed_issue)
+    report_run_failure(failure_location, f"ERROR: {reason}")
     if external:
         log_stage(
             "issue-external-failure",
@@ -7655,6 +7707,7 @@ def handle_failed_claimed_issue(
         claimed_issue,
         started_at=started_at,
         preservation_result=preservation_result,
+        failure_location=failure_location,
     )
     try:
         refresh_preserved_branch_logs(claimed_issue, preservation_result)
@@ -7725,6 +7778,10 @@ def process_claimed_issue_lifecycle(
     lifecycle_completed = False
     started_at = time.time()
     stable_cwd = claimed_issue.base_reachability_metadata_path
+    # This run owns its thread's location for the whole lifecycle.
+    # §FS-forge-run-location-reporting.2
+    reset_run_location()
+    bind_run_context(f"issue #{claimed_issue.issue['number']} {claimed_issue.issue_coordinates}")
     try:
         os.chdir(stable_cwd)
         run_result = run_claimed_issue(
@@ -8286,7 +8343,7 @@ def is_issue_blocked(issue_number: int) -> bool:
 @pipeline_step(
     PHASE_CLAIM,
     STEP_CLAIM_ISSUE,
-    operand=lambda issue, *args, **kwargs: f"issue #{issue['number']}",
+    operand=lambda arguments: f"issue #{arguments['issue']['number']}",
 )
 def try_claim_issue(
         issue: dict,

--- a/forge/git_scripts/branch_publication.py
+++ b/forge/git_scripts/branch_publication.py
@@ -49,6 +49,7 @@ from utility_scripts.continuation_marker import (
     load_continuation_marker,
 )
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
+from utility_scripts.run_location import STEP_LOCAL_CI_CHECK, run_step
 
 REPO: str = "oracle/graalvm-reachability-metadata"
 BASE_BRANCH: str = "master"
@@ -339,12 +340,15 @@ def publish_branch(
         # Library-update publishers may refine alias buckets before local CI
         # decides PR eligibility. §FS-library-update-tested-version-split
         before_verification(base_ref)
-    local_ci_verification = run_local_ci_verification(
-        repo_path=repo_path,
-        coordinates=coordinates,
-        base_commit=base_ref,
-        metrics_repo_path=metrics_repo_path,
-    )
+    # Local CI-equivalent verification is the publication phase's own step.
+    # §FS-forge-run-location-reporting.2
+    with run_step(PHASE_PUBLICATION, STEP_LOCAL_CI_CHECK, operand=coordinates):
+        local_ci_verification = run_local_ci_verification(
+            repo_path=repo_path,
+            coordinates=coordinates,
+            base_commit=base_ref,
+            metrics_repo_path=metrics_repo_path,
+        )
     if resolved_descriptor_input is not None:
         if publication_id is None:
             raise ValueError("Publication descriptor requires a publication ID")

--- a/forge/schemas/continuation_marker_schema.json
+++ b/forge/schemas/continuation_marker_schema.json
@@ -129,6 +129,43 @@
     },
     "strategyName": {
       "type": "string"
+    },
+    "failure": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "operand": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "phase": {
+              "enum": [
+                "claim",
+                "setup",
+                "fix",
+                "explore",
+                "finalization",
+                "publication"
+              ]
+            },
+            "step": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "phase",
+            "step",
+            "operand"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/forge/tests/test_add_new_library_support.py
+++ b/forge/tests/test_add_new_library_support.py
@@ -4,18 +4,25 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import unittest
+from contextlib import ExitStack
 from unittest.mock import Mock, patch
 
-from ai_workflows.drivers.add_new_library_support import _should_create_failure_run_metrics, init_agent
 from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_FAILURE,
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
 )
+from ai_workflows.drivers import add_new_library_support
+from ai_workflows.drivers.add_new_library_support import _should_create_failure_run_metrics, init_agent
+from utility_scripts.continuation_marker import PHASE_SETUP
+from utility_scripts.run_location import RunLocation, STEP_NORMAL_SETUP, reset_run_location
 
 
 class AddNewLibrarySupportTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        reset_run_location()
+
     def test_init_agent_forwards_strategy_thinking_level(self) -> None:
         agent_class = Mock(return_value=object())
         strategy = {
@@ -43,6 +50,87 @@ class AddNewLibrarySupportTests(unittest.TestCase):
 
     def test_scaffold_placeholder_gate_uses_failure_metrics(self) -> None:
         self.assertTrue(_should_create_failure_run_metrics(RUN_STATUS_SUCCESS, 1, True))
+
+    def test_scaffold_error_records_the_active_setup_step(self) -> None:
+        reset_run_location()
+        reported_locations: list[RunLocation] = []
+        parsed_flags = (
+            "g:a:1.0",
+            "g",
+            "a",
+            "1.0",
+            None,
+            "strategy",
+            False,
+            "/repo",
+            "/metrics",
+            False,
+            False,
+            0,
+            None,
+            None,
+            None,
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "parse_flags",
+                return_value=parsed_flags,
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "require_strategy_by_name",
+                return_value={"model": "model", "workflow": "workflow"},
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "load_continuation_marker",
+                return_value=None,
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "resolve_workflow_repo_paths",
+                return_value=("/repo", "/metrics", "/metrics-root"),
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "prepare_library_preparation_preflight",
+                return_value=(None, ""),
+            ))
+            stack.enter_context(patch.object(add_new_library_support, "save_phase_update"))
+            stack.enter_context(patch.object(add_new_library_support, "resolve_graalvm_java_home"))
+            stack.enter_context(patch.object(
+                add_new_library_support.WorkflowStrategy,
+                "get_class",
+                return_value=object,
+            ))
+            stack.enter_context(patch.object(add_new_library_support, "validate_repo_paths"))
+            stack.enter_context(patch.object(add_new_library_support.os, "chdir"))
+            stack.enter_context(patch.object(add_new_library_support, "create_feature_branch_for_library"))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "prepare_native_image_eligible_artifact",
+                return_value=True,
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "run_scaffold",
+                side_effect=add_new_library_support.ScaffoldError("boom"),
+            ))
+            stack.enter_context(patch.object(
+                add_new_library_support,
+                "report_run_failure",
+                side_effect=lambda location, _detail: reported_locations.append(location),
+            ))
+
+            returncode = add_new_library_support.main([])
+
+        self.assertEqual(returncode, 1)
+        self.assertEqual(len(reported_locations), 1)
+        self.assertEqual(reported_locations[0].phase, PHASE_SETUP)
+        self.assertEqual(reported_locations[0].step, STEP_NORMAL_SETUP)
+        self.assertEqual(reported_locations[0].operand, "g:a:1.0")
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_fix_ni_run.py
+++ b/forge/tests/test_fix_ni_run.py
@@ -8,13 +8,14 @@ import unittest
 from contextlib import ExitStack
 from unittest.mock import Mock, patch
 
-from ai_workflows.core.workflow_strategy import RUN_STATUS_SUCCESS
+from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS
 from ai_workflows.drivers import fix_ni_run
 
 
 class _FakeStrategy:
-    def __init__(self, gate_result: bool = True) -> None:
+    def __init__(self, gate_result: bool = True, run_status: str = RUN_STATUS_SUCCESS) -> None:
         self.gate_result = gate_result
+        self.run_status = run_status
         self.gate_calls: list[tuple[str, str | None]] = []
         self.run_calls: list[tuple[object, str]] = []
         self.finalize_calls: list[str] = []
@@ -26,7 +27,7 @@ class _FakeStrategy:
 
     def run(self, agent: object, checkpoint_commit_hash: str) -> tuple[str, int]:
         self.run_calls.append((agent, checkpoint_commit_hash))
-        return RUN_STATUS_SUCCESS, 1
+        return self.run_status, 1
 
     def finalize_run(self, checkpoint: str) -> str:
         self.finalize_calls.append(checkpoint)
@@ -39,7 +40,7 @@ class NativeImageRunDriverTests(unittest.TestCase):
             seed_returncode: int,
             explore: bool,
             strategy: _FakeStrategy,
-    ) -> tuple[int, Mock, Mock, object]:
+    ) -> tuple[int, Mock, Mock, Mock, object]:
         agent = object()
         seed_result = subprocess.CompletedProcess(args=["./gradlew"], returncode=seed_returncode)
 
@@ -75,6 +76,10 @@ class NativeImageRunDriverTests(unittest.TestCase):
                 return_value=explore,
             ))
             stack.enter_context(patch.object(fix_ni_run, "prepare_library_update_target"))
+            clear_recorded_failure = stack.enter_context(patch.object(
+                fix_ni_run,
+                "clear_recorded_failure",
+            ))
             stack.enter_context(patch.object(
                 fix_ni_run,
                 "build_strategy_and_agent",
@@ -97,12 +102,12 @@ class NativeImageRunDriverTests(unittest.TestCase):
                 "--new-version", "2.0",
             ])
 
-        return returncode, run_seed, populate_urls, agent
+        return returncode, run_seed, populate_urls, clear_recorded_failure, agent
 
     def test_failed_seed_enters_native_gate_then_finalization(self) -> None:
         strategy = _FakeStrategy()
 
-        returncode, run_seed, populate_urls, _agent = self._run_driver(
+        returncode, run_seed, populate_urls, _clear_recorded_failure, _agent = self._run_driver(
             seed_returncode=1,
             explore=False,
             strategy=strategy,
@@ -126,7 +131,7 @@ class NativeImageRunDriverTests(unittest.TestCase):
     def test_successful_seed_checks_exploration_then_finalizes(self) -> None:
         strategy = _FakeStrategy()
 
-        returncode, _run_seed, _populate_urls, agent = self._run_driver(
+        returncode, _run_seed, _populate_urls, clear_recorded_failure, agent = self._run_driver(
             seed_returncode=0,
             explore=True,
             strategy=strategy,
@@ -136,11 +141,26 @@ class NativeImageRunDriverTests(unittest.TestCase):
         self.assertEqual(strategy.gate_calls, [])
         self.assertEqual(strategy.run_calls, [(agent, "checkpoint")])
         self.assertEqual(strategy.finalize_calls, ["checkpoint"])
+        clear_recorded_failure.assert_not_called()
+
+    def test_failed_exploration_clears_its_non_terminal_failure(self) -> None:
+        strategy = _FakeStrategy(run_status=RUN_STATUS_FAILURE)
+
+        returncode, _run_seed, _populate_urls, clear_recorded_failure, agent = self._run_driver(
+            seed_returncode=0,
+            explore=True,
+            strategy=strategy,
+        )
+
+        self.assertEqual(returncode, 0)
+        self.assertEqual(strategy.run_calls, [(agent, "checkpoint")])
+        self.assertEqual(strategy.finalize_calls, ["checkpoint"])
+        clear_recorded_failure.assert_called_once_with()
 
     def test_failed_seed_stops_when_native_gate_fails(self) -> None:
         strategy = _FakeStrategy(gate_result=False)
 
-        returncode, _run_seed, populate_urls, _agent = self._run_driver(
+        returncode, _run_seed, populate_urls, _clear_recorded_failure, _agent = self._run_driver(
             seed_returncode=1,
             explore=False,
             strategy=strategy,

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import contextlib
 import dataclasses
 import io
 import json
@@ -18,7 +19,7 @@ import forge_metadata
 from types import SimpleNamespace
 from ai_workflows.agents.agent_runtime import AgentRunResult, AgentSelection
 from git_scripts import common_git
-from utility_scripts import host_requirements
+from utility_scripts import host_requirements, run_location
 from utility_scripts.continuation_marker import (
     PHASE_EXPLORE,
     PHASE_FINALIZATION,
@@ -3482,6 +3483,75 @@ class EnvironmentValidationTests(unittest.TestCase):
 
         clear_issue_caches.assert_called_once()
         ensure.assert_not_called()
+
+
+class RunFailureLocationTests(unittest.TestCase):
+    """The failure location a step recorded reaches every reporting surface.
+
+    §FS-forge-run-location-reporting.3
+    """
+
+    def setUp(self) -> None:
+        run_location.reset_run_location()
+
+    def tearDown(self) -> None:
+        run_location.reset_run_location()
+
+    def test_terminal_failure_prints_and_forwards_the_recorded_phase_and_step(self) -> None:
+        claimed_issue = _claimed_issue()
+        expected_line = "run failed in explore/native_trace_gate()[com.acme.Thing]"
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr), \
+                patch.object(forge_metadata, "preserve_failed_work_for_follow_up", return_value=None), \
+                patch.object(forge_metadata, "refresh_preserved_branch_logs"), \
+                patch.object(forge_metadata, "revert_claimed_issue"), \
+                patch.object(forge_metadata, "apply_failed_run_follow_up") as follow_up:
+            with run_location.run_step(
+                run_location.PHASE_EXPLORE,
+                run_location.STEP_NATIVE_TRACE_GATE,
+                operand="com.acme.Thing",
+            ):
+                run_location.record_step_failure()
+            forge_metadata.handle_failed_claimed_issue(claimed_issue, "workflow failure")
+
+        self.assertIn(expected_line, stderr.getvalue())
+        forwarded = follow_up.call_args.kwargs["failure_location"]
+        self.assertEqual(forge_metadata.format_run_failure_line(forwarded), expected_line)
+
+    def test_human_intervention_comment_leads_with_the_same_pair(self) -> None:
+        claimed_issue = _claimed_issue(forge_metadata.LABEL_JAVAC_FAIL)
+        failure_location = run_location.RunLocation(
+            run_location.PHASE_EXPLORE,
+            run_location.STEP_NATIVE_TRACE_GATE,
+            "com.acme.Thing",
+        )
+
+        with patch.object(
+                forge_metadata,
+                "resolve_human_intervention_candidate",
+                return_value="candidate",
+        ), \
+                patch.object(
+                    forge_metadata,
+                    "run_codex_failed_generation_analysis",
+                    return_value="Analysis body.",
+                ), \
+                patch.object(
+                    forge_metadata,
+                    "post_human_intervention_comment_and_label",
+                ) as post_follow_up:
+            forge_metadata.apply_failed_run_follow_up(
+                claimed_issue,
+                failure_location=failure_location,
+            )
+
+        comment_body = post_follow_up.call_args.args[1]
+        self.assertTrue(
+            comment_body.startswith("`run failed in explore/native_trace_gate()[com.acme.Thing]`"),
+            comment_body,
+        )
+        self.assertIn("Analysis body.", comment_body)
 
 
 class FailedRunFollowUpTests(unittest.TestCase):

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -30,6 +30,7 @@ from utility_scripts.run_location import (
     RunLocation,
     bind_continuation_marker,
     bind_run_context,
+    clear_recorded_failure,
     format_run_failure_line,
     marker_failure_location,
     pipeline_step,
@@ -222,6 +223,36 @@ class MarkerFailureLocationTests(unittest.TestCase):
         self.assertEqual(
             format_run_failure_line(marker_failure_location(reloaded)),
             "run failed in explore/generate_tests()[com.acme.Thing]",
+        )
+
+    def test_a_recovered_failure_is_cleared_before_a_later_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            marker_path = continuation_marker_path(repo_path)
+            ContinuationMarker.create(
+                strategy_name="strategy",
+                issue_number=1412,
+                label="fails-native-image-run",
+                coordinate="org.example:demo:1.0.0",
+                new_version="2.0.0",
+            ).save(marker_path)
+            bind_continuation_marker(marker_path)
+
+            with run_step(PHASE_EXPLORE, STEP_GENERATE_TESTS):
+                record_step_failure()
+            clear_recorded_failure()
+            self.assertIsNone(load_continuation_marker(marker_path).failure)
+
+            with run_step(PHASE_PUBLICATION, STEP_PUBLISH_BRANCH):
+                record_step_failure()
+            reloaded = load_continuation_marker(marker_path)
+
+        self.assertEqual(
+            format_run_failure_line(resolve_failure_location()),
+            "run failed in publication/publish_branch()",
+        )
+        self.assertEqual(
+            reloaded.failure,
+            {"phase": PHASE_PUBLICATION, "step": STEP_PUBLISH_BRANCH, "operand": None},
         )
 
 

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -1,0 +1,256 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import contextlib
+import io
+import tempfile
+import unittest
+
+from utility_scripts import run_location
+from utility_scripts.continuation_marker import (
+    ContinuationMarker,
+    continuation_marker_path,
+    load_continuation_marker,
+)
+from utility_scripts.run_location import (
+    PHASE_CLAIM,
+    PHASE_EXPLORE,
+    PHASE_FINALIZATION,
+    PHASE_PUBLICATION,
+    PHASE_SETUP,
+    STEP_CHECK_HOST_REQUIREMENTS,
+    STEP_GENERATE_TESTS,
+    STEP_NATIVE_TRACE_GATE,
+    STEP_PUBLISH_BRANCH,
+    UNLOCATED_FAILURE_DEFECT,
+    UNLOCATED_STEP,
+    PHASE_STEPS,
+    RunLocation,
+    bind_continuation_marker,
+    bind_run_context,
+    format_run_failure_line,
+    marker_failure_location,
+    pipeline_step,
+    record_step_failure,
+    report_run_failure,
+    reset_run_location,
+    resolve_failure_location,
+    run_step,
+    step_position,
+)
+
+
+def _captured(callable_under_test):
+    """Run a callable and return its (stdout, stderr) as text."""
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        callable_under_test()
+    return out.getvalue(), err.getvalue()
+
+
+class RunLocationVocabularyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_every_registered_phase_and_step_is_ordered_and_positioned(self) -> None:
+        for phase, steps in PHASE_STEPS.items():
+            for index, step in enumerate(steps, start=1):
+                self.assertEqual(step_position(phase, step), (index, len(steps)))
+
+    def test_unregistered_phase_and_step_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            step_position("nonsense", STEP_GENERATE_TESTS)
+        with self.assertRaises(ValueError):
+            step_position(PHASE_PUBLICATION, "nonsense()")
+
+    def test_location_renders_with_and_without_operand(self) -> None:
+        self.assertEqual(str(RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS)), "explore/generate_tests()")
+        self.assertEqual(
+            str(RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, "com.acme.Thing")),
+            "explore/generate_tests()[com.acme.Thing]",
+        )
+
+
+class ProgressOutputTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_step_entry_prints_the_running_step_line(self) -> None:
+        def enter() -> None:
+            with run_step(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE, operand="com.acme.Thing"):
+                pass
+
+        stdout, _ = _captured(enter)
+        position, total = step_position(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE)
+        self.assertIn(
+            f"Running step {STEP_NATIVE_TRACE_GATE} ({position}/{total}) of phase {PHASE_EXPLORE} on com.acme.Thing",
+            stdout,
+        )
+
+    def test_phase_banner_prints_once_per_transition(self) -> None:
+        bind_run_context("issue #1412 org.example:demo:1.0.0")
+
+        def enter() -> None:
+            with run_step(PHASE_EXPLORE, STEP_GENERATE_TESTS):
+                pass
+            with run_step(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE):
+                pass
+            with run_step(PHASE_PUBLICATION, STEP_PUBLISH_BRANCH):
+                pass
+
+        stdout, _ = _captured(enter)
+        self.assertEqual(stdout.count("PHASE: EXPLORE"), 1)
+        self.assertEqual(stdout.count("PHASE: PUBLICATION"), 1)
+        self.assertIn("issue #1412 org.example:demo:1.0.0", stdout)
+
+
+class FailureLocationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_terminal_failure_prints_one_located_line_before_its_detail(self) -> None:
+        def fail() -> None:
+            try:
+                with run_step(PHASE_EXPLORE, STEP_GENERATE_TESTS, operand="com.acme.Thing"):
+                    raise RuntimeError("boom")
+            except RuntimeError as exc:
+                report_run_failure(resolve_failure_location(exc), "ERROR: boom")
+
+        _, stderr = _captured(fail)
+        lines = [line for line in stderr.splitlines() if line]
+        self.assertEqual(lines[0], "run failed in explore/generate_tests()[com.acme.Thing]")
+        self.assertEqual(lines[1], "ERROR: boom")
+
+    def test_innermost_step_wins_and_survives_an_intermediate_handler(self) -> None:
+        def fail() -> None:
+            with run_step(PHASE_SETUP, "run_workflow_engine()"):
+                try:
+                    with run_step(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE, operand="com.acme.Thing"):
+                        raise RuntimeError("boom")
+                except RuntimeError as exc:
+                    raise ValueError("wrapped") from exc
+
+        with self.assertRaises(ValueError):
+            _captured(fail)
+        self.assertEqual(
+            str(run_location.failed_run_location()),
+            "explore/native_trace_gate()[com.acme.Thing]",
+        )
+
+    def test_the_failure_line_is_printed_once_per_run(self) -> None:
+        location = RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS)
+
+        def report_twice() -> None:
+            report_run_failure(location, "ERROR: first")
+            report_run_failure(location, "ERROR: second")
+
+        _, stderr = _captured(report_twice)
+        self.assertEqual(stderr.count("run failed in explore/generate_tests()"), 1)
+        self.assertNotIn("ERROR: second", stderr)
+
+    def test_a_user_interrupt_carries_and_records_no_location(self) -> None:
+        def interrupt() -> None:
+            with run_step(PHASE_EXPLORE, STEP_GENERATE_TESTS):
+                raise KeyboardInterrupt
+
+        with self.assertRaises(KeyboardInterrupt):
+            _captured(interrupt)
+        self.assertIsNone(run_location.failed_run_location())
+
+    def test_a_failure_outside_every_step_is_reported_as_a_defect(self) -> None:
+        def fail() -> None:
+            report_run_failure(resolve_failure_location(RuntimeError("boom")), "ERROR: boom")
+
+        _, stderr = _captured(fail)
+        self.assertIn(f"run failed in {PHASE_CLAIM}/{UNLOCATED_STEP}", stderr)
+        self.assertIn(UNLOCATED_FAILURE_DEFECT, stderr)
+
+    def test_a_status_code_failure_records_the_step_it_gave_up_in(self) -> None:
+        def give_up() -> None:
+            with run_step(PHASE_FINALIZATION, "finalize_run()", operand="org.example:demo:1.0.0"):
+                record_step_failure()
+
+        _captured(give_up)
+        self.assertEqual(
+            format_run_failure_line(resolve_failure_location()),
+            "run failed in finalization/finalize_run()[org.example:demo:1.0.0]",
+        )
+
+
+class MarkerFailureLocationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_the_recorded_location_reaches_the_continuation_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            marker_path = continuation_marker_path(repo_path)
+            ContinuationMarker.create(
+                strategy_name="strategy",
+                issue_number=1412,
+                label="library-new-request",
+                coordinate="org.example:demo:1.0.0",
+                new_version=None,
+            ).save(marker_path)
+            bind_continuation_marker(marker_path)
+
+            def fail() -> None:
+                with contextlib.suppress(RuntimeError):
+                    with run_step(PHASE_EXPLORE, STEP_GENERATE_TESTS, operand="com.acme.Thing"):
+                        raise RuntimeError("boom")
+
+            _captured(fail)
+            reloaded = load_continuation_marker(marker_path)
+
+        self.assertEqual(
+            reloaded.failure,
+            {"phase": PHASE_EXPLORE, "step": STEP_GENERATE_TESTS, "operand": "com.acme.Thing"},
+        )
+        self.assertEqual(
+            format_run_failure_line(marker_failure_location(reloaded)),
+            "run failed in explore/generate_tests()[com.acme.Thing]",
+        )
+
+
+class PipelineStepDecoratorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_the_operand_is_resolved_by_parameter_name_for_either_call_style(self) -> None:
+        @pipeline_step(
+            PHASE_CLAIM,
+            STEP_CHECK_HOST_REQUIREMENTS,
+            operand=lambda arguments: f"issue #{arguments['issue_number']}",
+        )
+        def gate(reachability_path: str, issue_number: int) -> None:
+            del reachability_path, issue_number
+            raise RuntimeError("boom")
+
+        for call in (lambda: gate("/repo", 1412), lambda: gate(issue_number=1412, reachability_path="/repo")):
+            reset_run_location()
+            with self.assertRaises(RuntimeError):
+                _captured(call)
+            self.assertEqual(
+                format_run_failure_line(resolve_failure_location()),
+                "run failed in claim/check_host_requirements()[issue #1412]",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -218,6 +218,7 @@ class WorkflowStrategyTests(unittest.TestCase):
             reachability_repo_path="/tmp/reachability",
             library="org.example:demo:1.0.0",
         )
+        strategy.library = "org.example:demo:1.0.0"
         # (finalization status, incoming workflow status) -> merged run status.
         cases = [
             (RUN_STATUS_SUCCESS, RUN_STATUS_SUCCESS, RUN_STATUS_SUCCESS),

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -88,6 +88,7 @@ class ContinuationMarker:
     library_update_route: dict[str, Any] | None = None
     library_preparation_preflight: dict[str, Any] | None = None
     publication_metrics: dict[str, Any] | None = None
+    failure: dict[str, Any] | None = None
     phases: dict[str, dict[str, Any]] = field(default_factory=_default_phases)
     schema_version: int = SCHEMA_VERSION
 
@@ -134,6 +135,7 @@ class ContinuationMarker:
             library_update_route=_optional_dict(payload.get("libraryUpdateRoute")),
             library_preparation_preflight=_optional_dict(payload.get("libraryPreparationPreflight")),
             publication_metrics=_optional_dict(payload.get("publicationMetrics")),
+            failure=_optional_dict(payload.get("failure")),
             phases=phases,
             schema_version=SCHEMA_VERSION,
         )
@@ -161,6 +163,7 @@ class ContinuationMarker:
             "libraryUpdateRoute": self.library_update_route,
             "libraryPreparationPreflight": self.library_preparation_preflight,
             "publicationMetrics": self.publication_metrics,
+            "failure": self.failure,
             "phases": self.phases,
         }
 
@@ -271,6 +274,16 @@ class ContinuationMarker:
         if chunk_processed_class_count is not None:
             phase["chunkProcessedClassCount"] = max(0, int(chunk_processed_class_count))
         self.recompute_continue_from()
+
+    def record_failure(self, phase: str, step: str, operand: str | None = None) -> None:
+        """Record where the run failed so a resume states what it is retrying.
+
+        The first recorded failure wins: the innermost step that failed is the
+        location every surface reports. §FS-forge-run-location-reporting.3
+        """
+        if self.failure is not None:
+            return
+        self.failure = {"phase": phase, "step": step, "operand": operand}
 
     def record_preserved_branch(self, branch_name: str) -> None:
         """Record the preservation branch that carries this marker."""

--- a/forge/utility_scripts/continuation_marker.py
+++ b/forge/utility_scripts/continuation_marker.py
@@ -285,6 +285,10 @@ class ContinuationMarker:
             return
         self.failure = {"phase": phase, "step": step, "operand": operand}
 
+    def clear_failure(self) -> None:
+        """Forget a non-terminal failure after recovery. §FS-forge-run-location-reporting.3"""
+        self.failure = None
+
     def record_preserved_branch(self, branch_name: str) -> None:
         """Record the preservation branch that carries this marker."""
         self.preserved_branch = branch_name

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -312,6 +312,17 @@ def record_step_failure(
     return _STATE.failure
 
 
+def clear_recorded_failure() -> None:
+    """Clear a status-code failure after the workflow has recovered from it.
+
+    Only terminal failures reach the lifecycle boundary, so a best-effort step
+    that deliberately continues must clear both run-local and durable state.
+    §FS-forge-run-location-reporting.3
+    """
+    _STATE.failure = None
+    save_phase_update(_STATE.marker_path, lambda marker: marker.clear_failure())
+
+
 def resolve_failure_location(exc: BaseException | None = None) -> RunLocation:
     """Return the location to report for a terminal failure.
 

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -1,0 +1,331 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Run location: the one phase/step vocabulary for progress and failure output.
+
+The pipeline (§AR-forge-workflow-pipeline) names every step; this module turns
+those names into the single vocabulary that both the progress logger and the
+failure reporter use, so they cannot disagree
+(§AR-forge-run-location, §FS-forge-run-location-reporting).
+"""
+
+import functools
+import sys
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from utility_scripts.continuation_marker import (
+    PHASE_EXPLORE,
+    PHASE_FINALIZATION,
+    PHASE_FIX,
+    PHASE_PUBLICATION,
+    PHASE_SETUP,
+    ContinuationMarker,
+    save_phase_update,
+)
+from utility_scripts.stage_logger import log_phase_banner, log_stage
+
+# The dispatcher-side segment that runs before a run — and therefore before any
+# continuation state — exists. §FS-forge-run-location-reporting.1
+PHASE_CLAIM = "claim"
+
+# The durable phases are imported, never redeclared. §FS-forge-run-continuation.1
+ORDERED_RUN_PHASES: tuple[str, ...] = (
+    PHASE_CLAIM,
+    PHASE_SETUP,
+    PHASE_FIX,
+    PHASE_EXPLORE,
+    PHASE_FINALIZATION,
+    PHASE_PUBLICATION,
+)
+
+STEP_CHECK_HOST_REQUIREMENTS = "check_host_requirements()"
+STEP_CHECK_STRATEGY_AND_MODEL = "check_strategy_and_model()"
+STEP_CLAIM_ISSUE = "claim_issue()"
+STEP_CHECK_ISSUE_FORM = "check_issue_form()"
+STEP_CREATE_ISSUE_WORKSPACE = "create_issue_workspace()"
+STEP_ROUTE_TO_DRIVER = "route_to_driver()"
+STEP_NORMAL_SETUP = "normal_setup()"
+STEP_NEURAL_SETUP = "neural_setup()"
+STEP_CHECK_SETUP = "check_setup()"
+STEP_RUN_WORKFLOW_ENGINE = "run_workflow_engine()"
+STEP_FIX_REPORTED_FAILURE = "fix_reported_failure()"
+STEP_GENERATE_TESTS = "generate_tests()"
+STEP_NATIVE_TRACE_GATE = "native_trace_gate()"
+STEP_AGENT_FIX = "agent_fix()"
+STEP_FINALIZE_RUN = "finalize_run()"
+STEP_LOCAL_CI_CHECK = "local_ci_check()"
+STEP_LOCAL_REVIEW = "local_review()"
+STEP_PUBLISH_BRANCH = "publish_branch()"
+STEP_CLOSE_OUT_ISSUE = "close_out_issue()"
+
+# The only place a step name is bound to a phase; `(<n>/<total>)` is derived from
+# it rather than hand-counted. §FS-forge-run-location-reporting.1
+PHASE_STEPS: dict[str, tuple[str, ...]] = {
+    PHASE_CLAIM: (
+        STEP_CHECK_HOST_REQUIREMENTS,
+        STEP_CHECK_STRATEGY_AND_MODEL,
+        STEP_CHECK_ISSUE_FORM,
+        STEP_CLAIM_ISSUE,
+        STEP_CREATE_ISSUE_WORKSPACE,
+        STEP_ROUTE_TO_DRIVER,
+    ),
+    PHASE_SETUP: (
+        STEP_NORMAL_SETUP,
+        STEP_NEURAL_SETUP,
+        STEP_CHECK_SETUP,
+    ),
+    PHASE_FIX: (
+        STEP_RUN_WORKFLOW_ENGINE,
+        STEP_FIX_REPORTED_FAILURE,
+        STEP_AGENT_FIX,
+    ),
+    PHASE_EXPLORE: (
+        STEP_RUN_WORKFLOW_ENGINE,
+        STEP_GENERATE_TESTS,
+        STEP_NATIVE_TRACE_GATE,
+        STEP_AGENT_FIX,
+    ),
+    PHASE_FINALIZATION: (
+        STEP_FINALIZE_RUN,
+        STEP_LOCAL_CI_CHECK,
+        STEP_AGENT_FIX,
+        STEP_LOCAL_REVIEW,
+    ),
+    PHASE_PUBLICATION: (
+        STEP_PUBLISH_BRANCH,
+        STEP_CLOSE_OUT_ISSUE,
+    ),
+}
+
+UNLOCATED_STEP = "<unlocated-step>"
+LOCATION_ATTRIBUTE = "forge_run_location"
+FAILURE_LINE_PREFIX = "run failed in "
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RunLocation:
+    """Where a run is: the phase, the step inside it, and the step's operand.
+
+    Rendered as `<phase>/<step>`, or `<phase>/<step>[<operand>]` when the step
+    has an operand. §FS-forge-run-location-reporting.1
+    """
+
+    phase: str
+    step: str
+    operand: str | None = None
+
+    def __str__(self) -> str:
+        rendered = f"{self.phase}/{self.step}"
+        return rendered if self.operand is None else f"{rendered}[{self.operand}]"
+
+    @property
+    def is_located(self) -> bool:
+        """Return False for the placeholder used when no step claimed the failure."""
+        return self.step != UNLOCATED_STEP
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the marker payload for this location."""
+        return {"phase": self.phase, "step": self.step, "operand": self.operand}
+
+
+class _RunLocationState(threading.local):
+    """Per-thread run location; issue runs are processed on a thread pool."""
+
+    def __init__(self) -> None:
+        self.stack: list[RunLocation] = []
+        self.failure: RunLocation | None = None
+        self.marker_path: str | None = None
+
+
+_STATE = _RunLocationState()
+
+
+def step_position(phase: str, step: str) -> tuple[int, int]:
+    """Return the 1-based position of a step and the phase's step total."""
+    steps = PHASE_STEPS.get(phase)
+    if steps is None:
+        raise ValueError(f"Unknown run phase: {phase!r}; expected one of {list(ORDERED_RUN_PHASES)}")
+    if step not in steps:
+        raise ValueError(f"Unknown step {step!r} for phase {phase!r}; expected one of {list(steps)}")
+    return steps.index(step) + 1, len(steps)
+
+
+def current_run_location() -> RunLocation | None:
+    """Return the innermost step currently executing on this thread."""
+    return _STATE.stack[-1] if _STATE.stack else None
+
+
+def failed_run_location() -> RunLocation | None:
+    """Return the location recorded for this thread's failure, if any."""
+    return _STATE.failure
+
+
+def bind_continuation_marker(marker_path: str | None) -> None:
+    """Point recorded failures at the run's continuation marker."""
+    _STATE.marker_path = marker_path
+
+
+def reset_run_location() -> None:
+    """Clear all run-location state; called at the start of each issue run."""
+    _STATE.stack = []
+    _STATE.failure = None
+    _STATE.marker_path = None
+
+
+def enter_phase(phase: str) -> None:
+    """Print the phase banner that opens a run phase."""
+    if phase not in PHASE_STEPS:
+        raise ValueError(f"Unknown run phase: {phase!r}; expected one of {list(ORDERED_RUN_PHASES)}")
+    log_phase_banner(phase)
+
+
+@contextmanager
+def run_phase(phase: str) -> Iterator[str]:
+    """Announce a phase and yield its name. §FS-forge-run-location-reporting.2"""
+    enter_phase(phase)
+    yield phase
+
+
+@contextmanager
+def run_step(phase: str, step: str, operand: str | None = None) -> Iterator[RunLocation]:
+    """Mark a pipeline step: announce it, and locate anything that fails inside it.
+
+    Entering prints the progress line; a propagating exception is annotated with
+    this location — never wrapped, because `forge_metadata` classifies external
+    failures by exception type. §FS-forge-run-location-reporting.2
+    """
+    position, total = step_position(phase, step)
+    location = RunLocation(phase=phase, step=step, operand=operand)
+    suffix = "" if operand is None else f" on {operand}"
+    log_stage(phase, f"Running step {step} ({position}/{total}) of phase {phase}{suffix}")
+    _STATE.stack.append(location)
+    try:
+        yield location
+    except BaseException as exc:
+        annotate_exception_location(exc, location)
+        record_step_failure(location=location)
+        raise
+    finally:
+        _STATE.stack.pop()
+
+
+def pipeline_step(
+        phase: str,
+        step: str,
+        operand: Callable[..., str | None] | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Mark a whole function as one pipeline step.
+
+    `operand` receives the wrapped call's arguments and returns the operand the
+    step failed on, when the step has one. §FS-forge-run-location-reporting.1
+    """
+    step_position(phase, step)
+
+    def decorator(function: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(function)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            resolved_operand = None if operand is None else operand(*args, **kwargs)
+            with run_step(phase, step, resolved_operand):
+                return function(*args, **kwargs)
+        return wrapper
+
+    return decorator
+
+
+def annotate_exception_location(exc: BaseException, location: RunLocation) -> None:
+    """Attach a location to an exception, letting the innermost step win."""
+    if getattr(exc, LOCATION_ATTRIBUTE, None) is None:
+        setattr(exc, LOCATION_ATTRIBUTE, location)
+
+
+def exception_run_location(exc: BaseException | None) -> RunLocation | None:
+    """Return the location an exception was raised in, when a step marked it."""
+    if exc is None:
+        return None
+    location = getattr(exc, LOCATION_ATTRIBUTE, None)
+    return location if isinstance(location, RunLocation) else None
+
+
+def record_step_failure(
+        location: RunLocation | None = None,
+        operand: str | None = None,
+) -> RunLocation | None:
+    """Record where this run failed, for status-code and raised failures alike.
+
+    Status-code paths that return `RUN_STATUS_FAILURE` instead of raising call
+    this so the lifecycle boundary reads one location either way. The first
+    recorded failure wins. §FS-forge-run-location-reporting.3
+    """
+    resolved = location or current_run_location()
+    if resolved is None:
+        return _STATE.failure
+    if operand is not None and resolved.operand != operand:
+        resolved = RunLocation(phase=resolved.phase, step=resolved.step, operand=operand)
+    if _STATE.failure is None:
+        _STATE.failure = resolved
+        _record_failure_in_marker(resolved)
+    return _STATE.failure
+
+
+def resolve_failure_location(exc: BaseException | None = None) -> RunLocation:
+    """Return the location to report for a terminal failure.
+
+    Falls back to the unlocated placeholder so a report always has both
+    coordinates. §FS-forge-run-location-reporting.3
+    """
+    located = exception_run_location(exc) or failed_run_location() or current_run_location()
+    if located is not None:
+        return located
+    return RunLocation(phase=PHASE_CLAIM, step=UNLOCATED_STEP)
+
+
+def marker_failure_location(marker: ContinuationMarker | None) -> RunLocation | None:
+    """Return the failure location a continuation marker carries."""
+    if marker is None or not isinstance(marker.failure, dict):
+        return None
+    phase = marker.failure.get("phase")
+    step = marker.failure.get("step")
+    if not isinstance(phase, str) or not isinstance(step, str) or not phase or not step:
+        return None
+    operand = marker.failure.get("operand")
+    return RunLocation(phase=phase, step=step, operand=operand if isinstance(operand, str) else None)
+
+
+def format_run_failure_line(location: RunLocation) -> str:
+    """Return the one line every terminal failure prints before its error detail."""
+    return f"{FAILURE_LINE_PREFIX}{location}"
+
+
+def report_run_failure(location: RunLocation, detail: str | None = None) -> str:
+    """Print the failure location, and shout when no step claimed the failure.
+
+    An unlocated failure means a code path raised outside the pipeline's own step
+    boundaries, which is a Forge defect rather than a formatting gap.
+    §FS-forge-run-location-reporting.3
+    """
+    line = format_run_failure_line(location)
+    print(line, file=sys.stderr)
+    if not location.is_located:
+        print(
+            "DEFECT: this failure was raised outside every pipeline step boundary; "
+            "the raising path must be marked with run_step()/pipeline_step().",
+            file=sys.stderr,
+        )
+    if detail:
+        print(detail, file=sys.stderr)
+    return line
+
+
+def _record_failure_in_marker(location: RunLocation) -> None:
+    save_phase_update(
+        _STATE.marker_path,
+        lambda marker: marker.record_failure(location.phase, location.step, location.operand),
+    )

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -12,9 +12,10 @@ failure reporter use, so they cannot disagree
 """
 
 import functools
+import inspect
 import sys
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, TypeVar
@@ -46,13 +47,12 @@ ORDERED_RUN_PHASES: tuple[str, ...] = (
 
 STEP_CHECK_HOST_REQUIREMENTS = "check_host_requirements()"
 STEP_CHECK_STRATEGY_AND_MODEL = "check_strategy_and_model()"
-STEP_CLAIM_ISSUE = "claim_issue()"
 STEP_CHECK_ISSUE_FORM = "check_issue_form()"
+STEP_CLAIM_ISSUE = "claim_issue()"
 STEP_CREATE_ISSUE_WORKSPACE = "create_issue_workspace()"
 STEP_ROUTE_TO_DRIVER = "route_to_driver()"
-STEP_NORMAL_SETUP = "normal_setup()"
 STEP_NEURAL_SETUP = "neural_setup()"
-STEP_CHECK_SETUP = "check_setup()"
+STEP_NORMAL_SETUP = "normal_setup()"
 STEP_RUN_WORKFLOW_ENGINE = "run_workflow_engine()"
 STEP_FIX_REPORTED_FAILURE = "fix_reported_failure()"
 STEP_GENERATE_TESTS = "generate_tests()"
@@ -60,12 +60,11 @@ STEP_NATIVE_TRACE_GATE = "native_trace_gate()"
 STEP_AGENT_FIX = "agent_fix()"
 STEP_FINALIZE_RUN = "finalize_run()"
 STEP_LOCAL_CI_CHECK = "local_ci_check()"
-STEP_LOCAL_REVIEW = "local_review()"
 STEP_PUBLISH_BRANCH = "publish_branch()"
-STEP_CLOSE_OUT_ISSUE = "close_out_issue()"
 
 # The only place a step name is bound to a phase; `(<n>/<total>)` is derived from
-# it rather than hand-counted. §FS-forge-run-location-reporting.1
+# it rather than hand-counted, and a step the pipeline does not enter is not
+# listed. §FS-forge-run-location-reporting.1
 PHASE_STEPS: dict[str, tuple[str, ...]] = {
     PHASE_CLAIM: (
         STEP_CHECK_HOST_REQUIREMENTS,
@@ -76,36 +75,38 @@ PHASE_STEPS: dict[str, tuple[str, ...]] = {
         STEP_ROUTE_TO_DRIVER,
     ),
     PHASE_SETUP: (
-        STEP_NORMAL_SETUP,
         STEP_NEURAL_SETUP,
-        STEP_CHECK_SETUP,
+        STEP_NORMAL_SETUP,
+        STEP_RUN_WORKFLOW_ENGINE,
     ),
     PHASE_FIX: (
-        STEP_RUN_WORKFLOW_ENGINE,
         STEP_FIX_REPORTED_FAILURE,
+        STEP_GENERATE_TESTS,
+        STEP_NATIVE_TRACE_GATE,
         STEP_AGENT_FIX,
     ),
     PHASE_EXPLORE: (
-        STEP_RUN_WORKFLOW_ENGINE,
         STEP_GENERATE_TESTS,
         STEP_NATIVE_TRACE_GATE,
         STEP_AGENT_FIX,
     ),
     PHASE_FINALIZATION: (
         STEP_FINALIZE_RUN,
-        STEP_LOCAL_CI_CHECK,
         STEP_AGENT_FIX,
-        STEP_LOCAL_REVIEW,
     ),
     PHASE_PUBLICATION: (
         STEP_PUBLISH_BRANCH,
-        STEP_CLOSE_OUT_ISSUE,
+        STEP_LOCAL_CI_CHECK,
     ),
 }
 
 UNLOCATED_STEP = "<unlocated-step>"
 LOCATION_ATTRIBUTE = "forge_run_location"
 FAILURE_LINE_PREFIX = "run failed in "
+UNLOCATED_FAILURE_DEFECT = (
+    "DEFECT: this failure was raised outside every pipeline step boundary; "
+    "the raising path must be marked with run_step()/pipeline_step()."
+)
 
 T = TypeVar("T")
 
@@ -143,6 +144,9 @@ class _RunLocationState(threading.local):
         self.stack: list[RunLocation] = []
         self.failure: RunLocation | None = None
         self.marker_path: str | None = None
+        self.phase: str | None = None
+        self.context: str | None = None
+        self.reported: bool = False
 
 
 _STATE = _RunLocationState()
@@ -150,12 +154,18 @@ _STATE = _RunLocationState()
 
 def step_position(phase: str, step: str) -> tuple[int, int]:
     """Return the 1-based position of a step and the phase's step total."""
-    steps = PHASE_STEPS.get(phase)
-    if steps is None:
-        raise ValueError(f"Unknown run phase: {phase!r}; expected one of {list(ORDERED_RUN_PHASES)}")
+    steps = require_phase_steps(phase)
     if step not in steps:
         raise ValueError(f"Unknown step {step!r} for phase {phase!r}; expected one of {list(steps)}")
     return steps.index(step) + 1, len(steps)
+
+
+def require_phase_steps(phase: str) -> tuple[str, ...]:
+    """Return the ordered steps of a phase, rejecting an unregistered phase name."""
+    steps = PHASE_STEPS.get(phase)
+    if steps is None:
+        raise ValueError(f"Unknown run phase: {phase!r}; expected one of {list(ORDERED_RUN_PHASES)}")
+    return steps
 
 
 def current_run_location() -> RunLocation | None:
@@ -173,25 +183,36 @@ def bind_continuation_marker(marker_path: str | None) -> None:
     _STATE.marker_path = marker_path
 
 
+def bind_run_context(context: str | None) -> None:
+    """Name the run whose phases this thread announces.
+
+    Runs execute concurrently on a pool (§AR-forge-control-plane), so a phase
+    banner states which run entered the phase. §FS-forge-run-location-reporting.2
+    """
+    _STATE.context = context
+
+
 def reset_run_location() -> None:
     """Clear all run-location state; called at the start of each issue run."""
     _STATE.stack = []
     _STATE.failure = None
     _STATE.marker_path = None
+    _STATE.phase = None
+    _STATE.context = None
+    _STATE.reported = False
 
 
 def enter_phase(phase: str) -> None:
-    """Print the phase banner that opens a run phase."""
-    if phase not in PHASE_STEPS:
-        raise ValueError(f"Unknown run phase: {phase!r}; expected one of {list(ORDERED_RUN_PHASES)}")
-    log_phase_banner(phase)
+    """Announce a phase the run is entering, once per transition into it.
 
-
-@contextmanager
-def run_phase(phase: str) -> Iterator[str]:
-    """Announce a phase and yield its name. §FS-forge-run-location-reporting.2"""
-    enter_phase(phase)
-    yield phase
+    Re-announcing the phase the run is already in is not a transition, so the
+    banner stays one per phase entry. §FS-forge-run-location-reporting.2
+    """
+    require_phase_steps(phase)
+    if _STATE.phase == phase:
+        return
+    _STATE.phase = phase
+    log_phase_banner(phase, context=_STATE.context)
 
 
 @contextmanager
@@ -200,41 +221,57 @@ def run_step(phase: str, step: str, operand: str | None = None) -> Iterator[RunL
 
     Entering prints the progress line; a propagating exception is annotated with
     this location — never wrapped, because `forge_metadata` classifies external
-    failures by exception type. §FS-forge-run-location-reporting.2
+    failures by exception type. A user interrupt is not a run failure, so it
+    travels unmarked. §FS-forge-run-location-reporting.2
     """
-    position, total = step_position(phase, step)
-    location = RunLocation(phase=phase, step=step, operand=operand)
-    suffix = "" if operand is None else f" on {operand}"
-    log_stage(phase, f"Running step {step} ({position}/{total}) of phase {phase}{suffix}")
+    location = announce_step(phase, step, operand)
     _STATE.stack.append(location)
     try:
         yield location
     except BaseException as exc:
-        annotate_exception_location(exc, location)
-        record_step_failure(location=location)
+        if not isinstance(exc, (KeyboardInterrupt, GeneratorExit)):
+            annotate_exception_location(exc, location)
+            record_step_failure(location=location)
         raise
     finally:
         _STATE.stack.pop()
 
 
+def announce_step(phase: str, step: str, operand: str | None = None) -> RunLocation:
+    """Print the progress line that opens a step and return its location."""
+    position, total = step_position(phase, step)
+    enter_phase(phase)
+    suffix = "" if operand is None else f" on {operand}"
+    log_stage(phase, f"Running step {step} ({position}/{total}) of phase {phase}{suffix}")
+    return RunLocation(phase=phase, step=step, operand=operand)
+
+
 def pipeline_step(
         phase: str,
         step: str,
-        operand: Callable[..., str | None] | None = None,
+        operand: Callable[[Mapping[str, Any]], str | None] | None = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Mark a whole function as one pipeline step.
 
-    `operand` receives the wrapped call's arguments and returns the operand the
-    step failed on, when the step has one. §FS-forge-run-location-reporting.1
+    `operand` receives the wrapped call's arguments by parameter name — never by
+    position, so a keyword call locates the same as a positional one — and
+    returns the operand the step failed on. §FS-forge-run-location-reporting.1
     """
     step_position(phase, step)
 
     def decorator(function: Callable[..., T]) -> Callable[..., T]:
+        signature = inspect.signature(function)
+
         @functools.wraps(function)
         def wrapper(*args: Any, **kwargs: Any) -> T:
-            resolved_operand = None if operand is None else operand(*args, **kwargs)
+            resolved_operand = None
+            if operand is not None:
+                bound = signature.bind(*args, **kwargs)
+                bound.apply_defaults()
+                resolved_operand = operand(bound.arguments)
             with run_step(phase, step, resolved_operand):
                 return function(*args, **kwargs)
+
         return wrapper
 
     return decorator
@@ -284,7 +321,7 @@ def resolve_failure_location(exc: BaseException | None = None) -> RunLocation:
     located = exception_run_location(exc) or failed_run_location() or current_run_location()
     if located is not None:
         return located
-    return RunLocation(phase=PHASE_CLAIM, step=UNLOCATED_STEP)
+    return RunLocation(phase=_STATE.phase or PHASE_CLAIM, step=UNLOCATED_STEP)
 
 
 def marker_failure_location(marker: ContinuationMarker | None) -> RunLocation | None:
@@ -305,20 +342,20 @@ def format_run_failure_line(location: RunLocation) -> str:
 
 
 def report_run_failure(location: RunLocation, detail: str | None = None) -> str:
-    """Print the failure location, and shout when no step claimed the failure.
+    """Print the failure location once per run, then its error detail.
 
-    An unlocated failure means a code path raised outside the pipeline's own step
-    boundaries, which is a Forge defect rather than a formatting gap.
-    §FS-forge-run-location-reporting.3
+    A run has one terminal failure, so the first reporter on the way out owns the
+    line and later boundaries do not repeat it. An unlocated failure means a code
+    path raised outside the pipeline's own step boundaries, which is a Forge
+    defect rather than a formatting gap. §FS-forge-run-location-reporting.3
     """
     line = format_run_failure_line(location)
+    if _STATE.reported:
+        return line
+    _STATE.reported = True
     print(line, file=sys.stderr)
     if not location.is_located:
-        print(
-            "DEFECT: this failure was raised outside every pipeline step boundary; "
-            "the raising path must be marked with run_step()/pipeline_step().",
-            file=sys.stderr,
-        )
+        print(UNLOCATED_FAILURE_DEFECT, file=sys.stderr)
     if detail:
         print(detail, file=sys.stderr)
     return line

--- a/forge/utility_scripts/stage_logger.py
+++ b/forge/utility_scripts/stage_logger.py
@@ -37,14 +37,16 @@ def log_debug(stage: str, message: str, indent_level: int = 0) -> None:
         log_stage(stage, message, indent_level)
 
 
-def log_phase_banner(phase: str, file: TextIO | None = None) -> None:
+def log_phase_banner(phase: str, context: str | None = None, file: TextIO | None = None) -> None:
     """Print the bounded banner that opens a run phase.
 
-    A phase transition must be findable by eye in a long run log.
+    A phase transition must be findable by eye in a long run log, and it names
+    the run it belongs to because runs are interleaved on a pool.
     §FS-forge-run-location-reporting.2
     """
     output = sys.stdout if file is None else file
-    title_line = f" PHASE: {phase.upper()} ".center(BANNER_WIDTH, "#")
+    title = f" PHASE: {phase.upper()} " if context is None else f" PHASE: {phase.upper()} — {context} "
+    title_line = title.center(BANNER_WIDTH, "#")
     print(f"\n{ANSI_BOLD_CYAN}{title_line}{ANSI_RESET}", file=output)
 
 

--- a/forge/utility_scripts/stage_logger.py
+++ b/forge/utility_scripts/stage_logger.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import os
 import sys
 from typing import TextIO
 
@@ -10,13 +11,41 @@ from typing import TextIO
 ANSI_RESET = "\033[0m"
 ANSI_BOLD_GREEN = "\033[1;32m"
 ANSI_BOLD_RED = "\033[1;31m"
+ANSI_BOLD_CYAN = "\033[1;36m"
 BANNER_WIDTH = 88
+DEBUG_LOGGING_ENV_VAR = "FORGE_DEBUG_LOGGING"
+
+
+def debug_logging_enabled() -> bool:
+    """Return True when narration-level logging is switched on."""
+    return os.environ.get(DEBUG_LOGGING_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def log_stage(stage: str, message: str, indent_level: int = 0) -> None:
     """Print a workflow log line that starts with the current stage."""
     indent = "  " * indent_level
     print(f"[{stage}] {indent}{message}")
+
+
+def log_debug(stage: str, message: str, indent_level: int = 0) -> None:
+    """Print narration that is debugging detail, not run output.
+
+    Keeps the human-intervention handoff's git narration out of failure output
+    unless debug logging is enabled. §FS-forge-run-location-reporting.4
+    """
+    if debug_logging_enabled():
+        log_stage(stage, message, indent_level)
+
+
+def log_phase_banner(phase: str, file: TextIO | None = None) -> None:
+    """Print the bounded banner that opens a run phase.
+
+    A phase transition must be findable by eye in a long run log.
+    §FS-forge-run-location-reporting.2
+    """
+    output = sys.stdout if file is None else file
+    title_line = f" PHASE: {phase.upper()} ".center(BANNER_WIDTH, "#")
+    print(f"\n{ANSI_BOLD_CYAN}{title_line}{ANSI_RESET}", file=output)
 
 
 def log_status_banner(title: str, message: str, color: str, file: TextIO | None = None) -> None:


### PR DESCRIPTION
## What this does

When a Forge run failed, it told you *that* it failed and *what* the error was, never *where*. The location had to be reconstructed by reading the log backwards — and the log made that hard, because a failed run's output was dominated by the human-intervention handoff narrating every branch switch, stage, commit, and push it performed on the way out. The information was never missing in principle: the pipeline already names every step, and the continuation vocabulary already names every phase. It was simply never stated.

So the phase and the step become one **run location**, and that location is used twice: to narrate progress while the run works, and to report where a run died. Same vocabulary both times, from one table, so a reader of a live run and a reader of a failed run name the same thing the same way.

[`§FS-forge-run-location-reporting`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/failure-phase-and-step/forge/docs/functional-spec/functional-spec.md) is the behavior; [`§AR-forge-run-location`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/failure-phase-and-step/forge/docs/architecture/architecture.md) is the mechanism.

## What a run looks like now

```
############################ PHASE: SETUP — issue #9110 ############################
[setup] Running step normal_setup() (2/3) of phase setup
[setup] Running step run_workflow_engine() (3/3) of phase setup

############################# PHASE: FIX — issue #9110 #############################
[fix] Running step generate_tests() (2/4) of phase fix on org.example.Widget
[fix] Running step native_trace_gate() (3/4) of phase fix

run failed in fix/native_trace_gate()[./gradlew nativeTest]
```

The words `Running step` and `of phase` are fixed — that line is the anchor a reader and a `grep` both look for. The banner marks a *transition*: re-entering the phase you are already in prints nothing. It names its run because runs interleave on a pool.

## Steps are marked, not narrated

A raise site does not know which step it is in, so nothing at a raise site mentions a step name. A step is entered through the `run_step()` context manager, or the `pipeline_step()` decorator that applies it to a whole function:

```python
@pipeline_step(PHASE_FIX, STEP_GENERATE_TESTS, operand=lambda args: args["class_name"])
def generate_tests(self, class_name: str) -> RunStatus:
```

The decorator resolves its operand **by parameter name**, binding the wrapped signature rather than indexing `args`, so a keyword call and a positional call of the same function locate identically.

`PHASE_STEPS` is the only place a step name is bound to a phase, which is what makes `(<n>/<total>)` derivable instead of hand-counted and makes an unregistered step a hard error at the boundary rather than a wrong label in a log. It registers the steps the pipeline *enters today*: `check_setup()` and `local_review()` are still folded into larger methods, so registering them would make `<total>` count a step that never runs. They join when §ROADMAP-forge-algorithmic-then-neural-setup and the local-review work split them out.

The five durable phases are imported from `continuation_marker`, which already owns them ([`§FS-forge-run-continuation.1`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/failure-phase-and-step/forge/docs/functional-spec/functional-spec.md)). `run_location` adds only `claim` — the dispatcher-side segment that exists before continuation state does.

## Failures propagate their location

`run_step()` **annotates** a propagating exception with its location and re-raises the original object. Annotating rather than wrapping is required, not stylistic: `forge_metadata` classifies external failures by exception type ([`§FS-human-intervention-policy`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/failure-phase-and-step/forge/docs/functional-spec/functional-spec.md)), and a wrapper would erase that type. The innermost step wins and is never overwritten, so the location survives every intermediate `except` on the way out.

Three cases the mechanism has to get right:

| Case | Behavior |
| --- | --- |
| Status-code failure (returns `RUN_STATUS_FAILURE` instead of raising) | `record_step_failure()` writes the same run-local slot, so both routes reach the lifecycle boundary with one location |
| `KeyboardInterrupt` | travels unmarked — an interrupt is not a run failure, and marking it would stamp a failure location on the marker of a run the operator stopped |
| Raised outside every step boundary | reported as `<unlocated-step>` with an explicit defect notice on stderr — a code path raising outside the pipeline's boundaries is a bug in Forge, and the report says so instead of quietly omitting the step |

The line is printed **once per run**. A terminal failure passes several boundaries on the way out — the driver's status code, the workflow run result, the failed-issue handler — and the boundary nearest the error owns the line.

`ContinuationMarker` gains a `failure` object carrying phase, step, and operand, so the same pair reaches the preserved branch, the resumed run's log, and the human-intervention comment, which now leads with it. A resumed run states the location it is retrying.

## Failure output stays short

The human-intervention handoff is unchanged — work is still preserved on a branch, the comment is still posted, the label is still applied. Its *narration* is now debugging detail. `stage_logger` gains `log_debug()` behind `FORGE_DEBUG_LOGGING`, and the branch switches, staging, commits, pushes, and claim-revert bookkeeping move onto it. The git commands capture their output and replay it only on failure or under debug.

A failed run's default output is the location, the error, and the preserved branch URL. Those three are never suppressed.
