### PR TITLE
Exempt chunked PRs from coverage thresholds

### DIFF
--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -80,6 +80,13 @@ credible explanation such as a changed upstream API surface.
 | `library-update-request` | Coverage percentage does not drop at all against the previously supported version. |
 | `fixes-javac-fail`, `fixes-java-run-fail`, `fixes-native-image-run-fail` | Coverage percentage does not drop by more than 20 percentage points against the previously tested version. |
 
+Forge-generated PRs whose publication descriptor reports
+`modifiers.chunked_dynamic_access: true` are exempt from every percentage gate
+in this table, including the final chunk. A chunk covers only part of the
+library-wide dynamic-access report (§forge/FS-forge-chunked-dynamic-access), so
+its coverage gate fails only when the reported `dynamicAccess.coveredCalls` is
+zero. This exception does not relax any non-coverage rule or guardrail below.
+
 Two guardrails accompany the gates:
 
 - **Metadata entry count.** For the `fixes-*` repair labels, the new version's

--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -80,9 +80,8 @@ credible explanation such as a changed upstream API surface.
 | `library-update-request` | Coverage percentage does not drop at all against the previously supported version. |
 | `fixes-javac-fail`, `fixes-java-run-fail`, `fixes-native-image-run-fail` | Coverage percentage does not drop by more than 20 percentage points against the previously tested version. |
 
-Forge-generated PRs whose publication descriptor reports
-`modifiers.chunked_dynamic_access: true` are exempt from every percentage gate
-in this table, including the final chunk. A chunk covers only part of the
+PRs with the `chunked-dynamic-access` label are exempt from every percentage
+gate in this table, including the final chunk. A chunk covers only part of the
 library-wide dynamic-access report (§forge/FS-forge-chunked-dynamic-access), so
 its coverage gate fails only when the reported `dynamicAccess.coveredCalls` is
 zero. This exception does not relax any non-coverage rule or guardrail below.

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -10,6 +10,14 @@ These PRs repair tests, dependencies, or narrow runtime setup after an existing 
 
 The rules below implement the contribution contract: block only on a concrete violation of a must — the shape limits (§FS-contribution-contract.2), the coverage gates (§FS-contribution-contract.3), the cheating patterns (§FS-contribution-contract.4), and the test contract's musts (§FS-test-contract) — while shoulds stay advisory in review (§FS-contribution-contract.1).
 
+## Chunked dynamic-access PRs
+
+When the Forge publication descriptor has
+`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+dynamic-access coverage threshold and regression rule in this skill, including
+for the final chunk. Request changes for coverage only when the reported
+`dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3
+
 The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Review Principles

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -12,8 +12,7 @@ The rules below implement the contribution contract: block only on a concrete vi
 
 ## Chunked dynamic-access PRs
 
-When the Forge publication descriptor has
-`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+When the PR has the `chunked-dynamic-access` label, skip every percentage-based
 dynamic-access coverage threshold and regression rule in this skill, including
 for the final chunk. Request changes for coverage only when the reported
 `dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -10,6 +10,14 @@ These PRs repair test sources or test dependencies after an existing library is 
 
 The rules below implement the contribution contract: block only on a concrete violation of a must — the shape limits (§FS-contribution-contract.2), the coverage gates (§FS-contribution-contract.3), the cheating patterns (§FS-contribution-contract.4), and the test contract's musts (§FS-test-contract) — while shoulds stay advisory in review (§FS-contribution-contract.1).
 
+## Chunked dynamic-access PRs
+
+When the Forge publication descriptor has
+`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+dynamic-access coverage threshold and regression rule in this skill, including
+for the final chunk. Request changes for coverage only when the reported
+`dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3
+
 The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Review Principles

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -12,8 +12,7 @@ The rules below implement the contribution contract: block only on a concrete vi
 
 ## Chunked dynamic-access PRs
 
-When the Forge publication descriptor has
-`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+When the PR has the `chunked-dynamic-access` label, skip every percentage-based
 dynamic-access coverage threshold and regression rule in this skill, including
 for the final chunk. Request changes for coverage only when the reported
 `dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -10,6 +10,14 @@ These PRs repair metadata or tests after an existing library version compiles an
 
 The rules below implement the contribution contract: block only on a concrete violation of a must — the shape limits (§FS-contribution-contract.2), the coverage gates (§FS-contribution-contract.3), the cheating patterns (§FS-contribution-contract.4), and the test contract's musts (§FS-test-contract) — while shoulds stay advisory in review (§FS-contribution-contract.1).
 
+## Chunked dynamic-access PRs
+
+When the Forge publication descriptor has
+`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+dynamic-access coverage threshold and regression rule in this skill, including
+for the final chunk. Request changes for coverage only when the reported
+`dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3
+
 The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Review Principles

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -12,8 +12,7 @@ The rules below implement the contribution contract: block only on a concrete vi
 
 ## Chunked dynamic-access PRs
 
-When the Forge publication descriptor has
-`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+When the PR has the `chunked-dynamic-access` label, skip every percentage-based
 dynamic-access coverage threshold and regression rule in this skill, including
 for the final chunk. Request changes for coverage only when the reported
 `dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -10,6 +10,14 @@ These PRs usually add reachability metadata and tests for one target library coo
 
 The rules below implement the contribution contract: block only on a concrete violation of a must — the shape limits (§FS-contribution-contract.2), the coverage gates (§FS-contribution-contract.3), the cheating patterns (§FS-contribution-contract.4), and the test contract's musts (§FS-test-contract) — while shoulds stay advisory in review (§FS-contribution-contract.1).
 
+## Chunked dynamic-access PRs
+
+When the Forge publication descriptor has
+`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+dynamic-access coverage threshold and regression rule in this skill, including
+for the final chunk. Request changes for coverage only when the reported
+`dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3
+
 The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation (for example, an open review tab, a PR URL mentioned earlier, or the current branch's PR from `gh pr status`); only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Review Signals

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -12,8 +12,7 @@ The rules below implement the contribution contract: block only on a concrete vi
 
 ## Chunked dynamic-access PRs
 
-When the Forge publication descriptor has
-`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+When the PR has the `chunked-dynamic-access` label, skip every percentage-based
 dynamic-access coverage threshold and regression rule in this skill, including
 for the final chunk. Request changes for coverage only when the reported
 `dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3

--- a/skills/review-library-update-request/SKILL.md
+++ b/skills/review-library-update-request/SKILL.md
@@ -11,8 +11,7 @@ The rules below implement the contribution contract: block only on a concrete vi
 
 ## Chunked dynamic-access PRs
 
-When the Forge publication descriptor has
-`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+When the PR has the `chunked-dynamic-access` label, skip every percentage-based
 dynamic-access coverage threshold and regression rule in this skill, including
 for the final chunk. Request changes for coverage only when the reported
 `dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3

--- a/skills/review-library-update-request/SKILL.md
+++ b/skills/review-library-update-request/SKILL.md
@@ -9,6 +9,14 @@ These PRs update support for an existing library version. Review them as existin
 
 The rules below implement the contribution contract: block only on a concrete violation of a must — the shape limits (§FS-contribution-contract.2), the coverage gates (§FS-contribution-contract.3), the cheating patterns (§FS-contribution-contract.4), and the test contract's musts (§FS-test-contract) — while shoulds stay advisory in review (§FS-contribution-contract.1).
 
+## Chunked dynamic-access PRs
+
+When the Forge publication descriptor has
+`modifiers.chunked_dynamic_access: true`, skip every percentage-based
+dynamic-access coverage threshold and regression rule in this skill, including
+for the final chunk. Request changes for coverage only when the reported
+`dynamicAccess.coveredCalls` is `0`. Keep every non-coverage rule. §FS-contribution-contract.3
+
 The PR number or URL can be passed as an optional argument (for example, `1234`, `https://github.com/oracle/graalvm-reachability-metadata/pull/1234`). If the user says "review this PR" without an argument, infer the PR from the surrounding conversation or `gh pr status`; only ask the user when it cannot be inferred. Use `gh pr view <pr>`, `gh pr diff <pr>`, and `gh pr checks <pr>` against the resolved PR throughout the workflow below.
 
 ## Review Principles


### PR DESCRIPTION
Chunked dynamic-access PRs cover a bounded set of classes, while their reported statistics describe the whole library. Applying percentage-based coverage gates therefore makes library size and chunk position affect the review verdict. This raised a false coverage finding on #9537 even though that chunk covered 22 dynamic-access calls.

This change:

- Exempts PRs with the `chunked-dynamic-access` label, including the final chunk, from percentage thresholds and regression comparisons in [§FS-contribution-contract.3](https://github.com/oracle/graalvm-reachability-metadata/blob/codex/disable-chunk-coverage-threshold/docs/functional-spec/contribution-contract.md#3-coverage-and-metadata-gates).
- Applies the same override in all five dynamic-access review skills.
- Keeps the coverage gate blocking when `dynamicAccess.coveredCalls` is `0`.
- Leaves non-coverage rules and metadata guardrails unchanged.

Under this rule, #9537's `22/121` result no longer fails because the chunk has non-zero covered calls.

Validation:

- `grund check`
- `git diff --check origin/master..HEAD`

Fixes #9554
