### PR TITLE
Launch queued code coverage work with Rhei

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/README.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/README.md
@@ -4,8 +4,15 @@ This Rhei template converts one GitHub issue labeled `code-coverage-improvement`
 into a bounded workspace for the planned Forge code coverage workflow
 §AR-code-coverage-improvement.
 
-Instantiate it from `forge/` with the issue number and, optionally, an explicit
-coordinate override:
+From `forge/`, automatically select an eligible issue and start execution with
+the terminal TUI and browser dashboard:
+
+```console
+./run-code-coverage-improvement.sh
+```
+
+To instantiate a specific issue without immediately executing it, supply the
+issue number and, optionally, an explicit coordinate override:
 
 ```console
 rhei instantiate code-coverage-improvement \

--- a/forge/README.md
+++ b/forge/README.md
@@ -102,6 +102,7 @@ pip install -e .
 Required local tools depend on the work queue being processed:
 
 - `gh` for issue, PR, and review automation.
+- `rhei` for the interactive code-coverage-improvement workflow.
 - `pi` for Pi-agent strategies and automated style recovery.
 - `codex` for Codex-agent strategies and metadata fixups.
 - For issue work, set `GRAALVM_HOME`, `GRAALVM_HOME_25_0`, and
@@ -128,6 +129,17 @@ distribution cache under the system temp directory. Set
 The top-level worker delegates to these lower-level entry points. Use them
 directly when debugging a single task or reproducing a failure.
 §AR-forge-drivers
+
+To select the highest-priority eligible `code-coverage-improvement` issue and
+start its Rhei workspace with the terminal TUI and browser dashboard:
+
+```console
+./run-code-coverage-improvement.sh
+```
+
+Pass `rhei run` options after `--`, for example
+`./run-code-coverage-improvement.sh -- --parallel 2`.
+§AR-code-coverage-improvement.2
 
 ```console
 python3 forge_metadata.py --help

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -46,6 +46,15 @@ creates or reuses a per-issue worktree, and generates bounded Rhei tasks for
 preparation, inventory, coverage generation, validation, discovery, finalization,
 and publication.
 
+The operator entry point selects an issue when no issue number is supplied. It
+considers only open, unassigned, unblocked `code-coverage-improvement` issues in
+Project status `Todo`, drains `high-priority`, then `priority`, then normal work,
+and selects the newest issue number within a tier. If no issue is eligible, it
+fails before creating a workspace. For the selected issue it instantiates the
+required `code-coverage-<issue_number>` workspace and immediately executes it in
+the foreground with Rhei's browser dashboard enabled, preserving the terminal
+TUI and all ordinary run output.
+
 That worktree's branch is created from the HEAD of the source checkout, never
 from `origin/master`. Measurement resolves this workflow's own helpers from the
 issue worktree, so basing it on a commit that predates them fails the

--- a/forge/run-code-coverage-improvement.sh
+++ b/forge/run-code-coverage-improvement.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO="oracle/graalvm-reachability-metadata"
+readonly ISSUE_LABEL="code-coverage-improvement"
+
+# Launch one queued code-coverage run with its live Rhei dashboard.
+# §FS-forge-scope §AR-code-coverage-improvement.2
+
+usage() {
+    cat <<EOF
+Usage: $0 [-- RHEI_RUN_OPTIONS...]
+
+Purpose:
+  Select the highest-priority eligible code-coverage-improvement issue,
+  instantiate its Rhei workspace, and execute it with the browser dashboard.
+
+Options:
+  -h, --help
+      Show this help text.
+  -- RHEI_RUN_OPTIONS...
+      Forward options to rhei run. The dashboard is always enabled.
+
+Examples:
+  $0
+  $0 -- --parallel 2
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        ;;
+    "")
+        ;;
+    *)
+        printf 'ERROR: Unexpected argument: %s\n' "$1" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+    printf 'ERROR: gh is required and must be available on PATH.\n' >&2
+    exit 1
+fi
+if ! command -v rhei >/dev/null 2>&1; then
+    printf 'ERROR: rhei is required and must be available on PATH.\n' >&2
+    exit 1
+fi
+
+issue_number="$(
+    gh issue list \
+        --repo "$REPO" \
+        --label "$ISSUE_LABEL" \
+        --state open \
+        --search 'no:assignee -is:blocked' \
+        --limit 1000 \
+        --json number,labels,projectItems \
+        --jq '
+            [.[] | select(any(.projectItems[]; .title == "GraalVM Reachability Metadata" and .status.name == "Todo"))]
+            | sort_by(
+                (if any(.labels[]; .name == "high-priority") then 0
+                 elif any(.labels[]; .name == "priority") then 1
+                 else 2 end),
+                -.number
+              )
+            | first
+            | .number
+        '
+)"
+
+if [[ ! "$issue_number" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'ERROR: No eligible %s issue is available.\n' "$ISSUE_LABEL" >&2
+    exit 1
+fi
+
+printf 'Selected %s issue #%s.\n' "$ISSUE_LABEL" "$issue_number"
+
+cd "$SCRIPT_DIR"
+exec rhei instantiate "$ISSUE_LABEL" \
+    "issue_number=$issue_number" \
+    --output "code-coverage-$issue_number" \
+    --execute -- --dashboard "$@"

--- a/forge/tests/test_run_code_coverage_improvement.py
+++ b/forge/tests/test_run_code_coverage_improvement.py
@@ -1,0 +1,111 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+FORGE_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = FORGE_ROOT / "run-code-coverage-improvement.sh"
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+class RunCodeCoverageImprovementTests(unittest.TestCase):
+    def _run_launcher(
+            self,
+            issue_number: str,
+            *arguments: str,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        temp_path = Path(temp_dir.name)
+        bin_path = temp_path / "bin"
+        bin_path.mkdir()
+        gh_arguments_path = temp_path / "gh-arguments.txt"
+        rhei_invocation_path = temp_path / "rhei-invocation.txt"
+
+        _write_executable(
+            bin_path / "gh",
+            """#!/usr/bin/env bash
+printf '%s\\n' "$@" > "$FAKE_GH_ARGUMENTS"
+printf '%s\\n' "$FAKE_ISSUE_NUMBER"
+""",
+        )
+        _write_executable(
+            bin_path / "rhei",
+            """#!/usr/bin/env bash
+pwd > "$FAKE_RHEI_INVOCATION"
+printf '%s\\n' "$@" >> "$FAKE_RHEI_INVOCATION"
+""",
+        )
+
+        environment = os.environ.copy()
+        environment.update({
+            "FAKE_GH_ARGUMENTS": str(gh_arguments_path),
+            "FAKE_ISSUE_NUMBER": issue_number,
+            "FAKE_RHEI_INVOCATION": str(rhei_invocation_path),
+            "PATH": f"{bin_path}{os.pathsep}{environment['PATH']}",
+        })
+        result = subprocess.run(
+            [str(LAUNCHER), *arguments],
+            cwd=temp_path,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, gh_arguments_path, rhei_invocation_path
+
+    def test_selects_issue_and_executes_with_dashboard(self) -> None:
+        result, gh_arguments_path, rhei_invocation_path = self._run_launcher("9460")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Selected code-coverage-improvement issue #9460.", result.stdout)
+        gh_arguments = gh_arguments_path.read_text(encoding="utf-8").splitlines()
+        self.assertIn("code-coverage-improvement", gh_arguments)
+        self.assertIn("no:assignee -is:blocked", gh_arguments)
+        self.assertIn("number,labels,projectItems", gh_arguments)
+        invocation = rhei_invocation_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(str(FORGE_ROOT), invocation[0])
+        self.assertEqual([
+            "instantiate",
+            "code-coverage-improvement",
+            "issue_number=9460",
+            "--output",
+            "code-coverage-9460",
+            "--execute",
+            "--",
+            "--dashboard",
+        ], invocation[1:])
+
+    def test_forwards_rhei_run_options_after_dashboard(self) -> None:
+        result, _, rhei_invocation_path = self._run_launcher(
+            "9459",
+            "--",
+            "--parallel",
+            "2",
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        invocation = rhei_invocation_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(["--dashboard", "--parallel", "2"], invocation[-3:])
+
+    def test_fails_before_rhei_when_no_issue_is_eligible(self) -> None:
+        result, _, rhei_invocation_path = self._run_launcher("null")
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("No eligible code-coverage-improvement issue", result.stderr)
+        self.assertFalse(rhei_invocation_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9559

## What this does

Starting a code-coverage-improvement run currently requires choosing an issue number, instantiating its workspace, and invoking Rhei again. Add one Forge launcher that selects the next eligible issue and hands the foreground process directly to Rhei with `--execute`, keeping the terminal UI and browser dashboard available. This behavior is recorded in [§AR-code-coverage-improvement.2](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/run-code-coverage-issue/forge/docs/architecture/code-coverage-improvement.md#2-scope).

## How an issue is selected

`./run-code-coverage-improvement.sh` considers open, unassigned, unblocked issues in the repository project with status `Todo`. It drains `high-priority`, then `priority`, then normal issues, choosing the newest issue number within a tier. If none is eligible, it exits before creating a workspace.

The selected issue is launched as:

```console
rhei instantiate code-coverage-improvement issue_number=<number> \
  --output code-coverage-<number> \
  --execute -- --dashboard
```

Additional `rhei run` options remain available after the launcher separator, for example `./run-code-coverage-improvement.sh -- --parallel 2`.