### PR TITLE
Chunk optimistic dynamic-access runs after gates

### DIFF
--- a/forge/DEVELOPING.md
+++ b/forge/DEVELOPING.md
@@ -123,7 +123,7 @@ python3 ai_workflows/drivers/add_new_library_support.py \
 ```
 
 Options:
-- `--strategy-name NAME` select a predefined workflow strategy from `strategies/predefined_strategies.json`. Defaults to `dynamic_access_bulk_pi_gpt-5.6-sol` (Pi agent).
+- `--strategy-name NAME` select a predefined workflow strategy from `strategies/predefined_strategies.json`. Defaults to `optimistic_dynamic_access_iterative_pi_gpt-5.6-sol` (Pi agent).
 - `--keep-tests-without-dynamic-access` keeps generated tests for dynamic-access workflows even if no dynamic-access call sites are covered.
 - `-v`, `--verbose` enable verbose agent output.
 

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -53,6 +53,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None
         iterative_chunk_count: int | None = None
+        required_iterative_chunk_phase: bool = False
         skip_dynamic_access_phase: bool = False
 
         if self.primary is None:
@@ -92,6 +93,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                         "classes={budget}".format(budget=iterative_chunk_count)
                     )
                     skip_dynamic_access_phase = iterative_chunk_count == 0
+                    required_iterative_chunk_phase = iterative_chunk_count > 0
 
         library = self.context.get("library") or self.context.get("updated_library")
         da_context = dict(self.context)
@@ -142,7 +144,12 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
 
         has_issue_requested_metadata = da.has_issue_requested_metadata_context()
         if not phase_ok:
-            if self.primary is None and not has_issue_requested_metadata:
+            if required_iterative_chunk_phase:
+                self._print_message(
+                    "required iterative dynamic-access chunk phase did not succeed"
+                )
+                status = RUN_STATUS_FAILURE
+            elif self.primary is None and not has_issue_requested_metadata:
                 self._print_message(
                     "dynamic-access coverage phase did not succeed and no reporter-requested metadata phase is available"
                 )
@@ -180,7 +187,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                 if len(result) == 2:
                     return status, iterations
                 return (status, iterations) + result[2:]
-            if status != RUN_STATUS_CHUNK_READY:
+            if status not in {RUN_STATUS_CHUNK_READY, RUN_STATUS_FAILURE}:
                 status = RUN_STATUS_SUCCESS
 
         if self.primary is None:

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -11,6 +11,7 @@ from ai_workflows.core.workflow_strategy import (
     WorkflowStrategy,
 )
 from utility_scripts.continuation_marker import PHASE_FIX, save_phase_update
+from utility_scripts.dynamic_access_report import BulkDynamicAccessProgress, DynamicAccessCoverageReport
 from utility_scripts.java_fix_coverage_follow_up import uncovered_dynamic_access_class_count
 
 
@@ -26,7 +27,8 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
 
     def __init__(self, strategy_obj: dict, **context):
         super().__init__(strategy_obj, **context)
-        primary_workflow_name = strategy_obj.get("primary-workflow")
+        self.primary_workflow_name: str | None = strategy_obj.get("primary-workflow")
+        self.chunk_class_count: int = int(self.context.get("chunk_class_count") or 0)
         self.reachability_repo_path = self.context["reachability_repo_path"]
         self.library = self.context.get("library") or self.context.get("updated_library")
         self.group, self.artifact, self.version = self.library.split(":")
@@ -35,9 +37,12 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
         )
         if self.dynamic_access_class_threshold < 0:
             raise ValueError("dynamic_access_class_threshold must be non-negative")
-        if primary_workflow_name:
-            PrimaryClass = WorkflowStrategy.get_class(primary_workflow_name)
-            self.primary = PrimaryClass(strategy_obj, **context)
+        if self.primary_workflow_name:
+            PrimaryClass = WorkflowStrategy.get_class(self.primary_workflow_name)
+            primary_context: dict = dict(context)
+            if self.primary_workflow_name == "optimistic_dynamic_access":
+                primary_context["defer_dynamic_access_chunk_decision"] = True
+            self.primary = PrimaryClass(strategy_obj, **primary_context)
         else:
             self.primary = None
 
@@ -46,6 +51,10 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
         print(f"[composition-workflow] {message}")
 
     def run(self, agent, **kwargs):
+        current_report: DynamicAccessCoverageReport | None = None
+        iterative_chunk_count: int | None = None
+        skip_dynamic_access_phase: bool = False
+
         if self.primary is None:
             self._print_message("no primary workflow configured, skipping to dynamic-access coverage phase")
             save_phase_update(
@@ -67,15 +76,33 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                 return result
 
             agent.clear_context()
+            if self.primary_workflow_name == "optimistic_dynamic_access":
+                current_report, iterative_chunk_count, chunk_ready = self._route_after_optimistic_bulk()
+                if chunk_ready:
+                    status = RUN_STATUS_CHUNK_READY
+                    self._print_message(
+                        "bulk filled the dynamic-access chunk boundary; skipping iterative exploration"
+                    )
+                    if len(result) == 2:
+                        return status, iterations
+                    return (status, iterations) + result[2:]
+                if iterative_chunk_count is not None:
+                    self._print_message(
+                        "iterative dynamic-access budget after bulk: "
+                        "classes={budget}".format(budget=iterative_chunk_count)
+                    )
+                    skip_dynamic_access_phase = iterative_chunk_count == 0
 
         library = self.context.get("library") or self.context.get("updated_library")
         da_context = dict(self.context)
         da_context["library"] = library
+        if iterative_chunk_count is not None:
+            da_context["chunk_class_count"] = iterative_chunk_count
 
         da = DynamicAccessIterativeStrategy(self.strategy_obj, **da_context)
-        current_report = None
         if self.dynamic_access_class_threshold > 0:
-            current_report = da._generate_dynamic_access_report()
+            if current_report is None:
+                current_report = da._generate_dynamic_access_report()
             uncovered_class_count = uncovered_dynamic_access_class_count(current_report)
             if uncovered_class_count > self.dynamic_access_class_threshold:
                 self._print_message(
@@ -96,11 +123,15 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                     return status, iterations
                 return (status, iterations) + result[2:]
 
-        self._print_message("starting dynamic-access coverage phase")
-        if current_report is None:
-            phase_ok, da_iterations = da._run_dynamic_access_phase(agent)
+        if skip_dynamic_access_phase:
+            phase_ok, da_iterations = True, 0
+            self._print_message("all dynamic-access classes are covered after bulk")
         else:
-            phase_ok, da_iterations = da._run_dynamic_access_phase(agent, current_report)
+            self._print_message("starting dynamic-access coverage phase")
+            if current_report is None:
+                phase_ok, da_iterations = da._run_dynamic_access_phase(agent)
+            else:
+                phase_ok, da_iterations = da._run_dynamic_access_phase(agent, current_report)
         iterations += da_iterations
         self._print_message(
             "dynamic-access coverage phase completed with phase_ok={phase_ok}, iterations_added={iterations}".format(
@@ -158,3 +189,50 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
         if len(result) == 2:
             return status, iterations
         return (status, iterations) + result[2:]
+
+    def _route_after_optimistic_bulk(
+            self,
+    ) -> tuple[DynamicAccessCoverageReport | None, int | None, bool]:
+        """Choose the iterative shortfall or publish after optimistic bulk.
+
+        Bulk completion contributes to the invocation-wide class boundary; the
+        iterative phase receives only what is still needed to fill it
+        (§AR-dynamic-access-composite).
+        """
+        progress: BulkDynamicAccessProgress | None = getattr(
+            self.primary,
+            "bulk_chunk_progress",
+            None,
+        )
+        if self.chunk_class_count <= 0 or progress is None:
+            return None, None, False
+
+        completed_class_count: int = len(progress.completed_classes)
+        remaining_class_count: int = len(progress.remaining_classes)
+        if remaining_class_count == 0:
+            iterative_chunk_count: int = 0
+        elif remaining_class_count <= self.chunk_class_count:
+            iterative_chunk_count = remaining_class_count
+        elif completed_class_count >= self.chunk_class_count:
+            self.primary.save_bulk_chunk_state()
+            self._print_message(
+                "bulk chunk boundary reached: "
+                "completed={completed} remaining={remaining} boundary={boundary}".format(
+                    completed=completed_class_count,
+                    remaining=remaining_class_count,
+                    boundary=self.chunk_class_count,
+                )
+            )
+            return progress.final_report, 0, True
+        else:
+            iterative_chunk_count = self.chunk_class_count - completed_class_count
+
+        self._print_message(
+            "bulk chunk boundary continues to iterative exploration: "
+            "completed={completed} remaining={remaining} iterative_budget={budget}".format(
+                completed=completed_class_count,
+                remaining=remaining_class_count,
+                budget=iterative_chunk_count,
+            )
+        )
+        return progress.final_report, iterative_chunk_count, False

--- a/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/optimistic_dynamic_access_strategy.py
@@ -6,7 +6,12 @@
 import os
 import subprocess
 
-from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
+from ai_workflows.core.workflow_strategy import (
+    RUN_STATUS_CHUNK_READY,
+    RUN_STATUS_FAILURE,
+    RUN_STATUS_SUCCESS,
+    WorkflowStrategy,
+)
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.run_location import (
     PHASE_EXPLORE as RUN_PHASE_EXPLORE,
@@ -17,7 +22,14 @@ from utility_scripts.run_location import (
     record_step_failure,
     run_step,
 )
-from utility_scripts.dynamic_access_report import format_full_report, load_dynamic_access_coverage_report
+from utility_scripts.dynamic_access_report import (
+    BulkDynamicAccessProgress,
+    DynamicAccessCoverageReport,
+    compute_bulk_dynamic_access_progress,
+    format_full_report,
+    load_dynamic_access_coverage_report,
+)
+from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
 from utility_scripts.stage_logger import log_stage
@@ -48,6 +60,19 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         )
         self.max_optimistic_iterations = self.parameters["max-optimistic-iterations"]
         self.max_test_iterations = self.parameters["max-test-iterations"]
+        self.chunk_class_count: int = int(self.context.get("chunk_class_count") or 0)
+        if self.chunk_class_count < 0:
+            raise ValueError("chunk_class_count must be non-negative")
+        self.dynamic_access_exhaust_report: DynamicAccessExhaustReport | None = self.context.get(
+            "dynamic_access_exhaust_report",
+        )
+        self.dynamic_access_exhaust_report_path: str | None = self.context.get(
+            "dynamic_access_exhaust_report_path",
+        )
+        self.defer_dynamic_access_chunk_decision: bool = bool(
+            self.context.get("defer_dynamic_access_chunk_decision", False)
+        )
+        self.bulk_chunk_progress: BulkDynamicAccessProgress | None = None
         self._last_dynamic_access_report_issue = "not_run"
         self.dynamic_access_report_path = os.path.join(
             self.reachability_repo_path,
@@ -86,6 +111,7 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
         successful_iterations = 0
         prompt_iterations = 0
         current_report = initial_report
+        last_successful_report: DynamicAccessCoverageReport | None = None
 
         for iteration in range(self.max_optimistic_iterations):
             agent.clear_context()
@@ -194,17 +220,23 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
                     lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
                 )
                 return RUN_STATUS_FAILURE, prompt_iterations, 0
+            last_successful_report = current_report
 
             if current_report.total_calls == current_report.covered_calls:
                 self._print_message("all call sites covered")
                 break
 
-        if successful_iterations > 0:
+        if successful_iterations > 0 and last_successful_report is not None:
+            self._record_bulk_chunk_progress(initial_report, last_successful_report)
+            workflow_status: str = RUN_STATUS_SUCCESS
+            if not self.defer_dynamic_access_chunk_decision and self._pure_bulk_chunk_is_ready():
+                self.save_bulk_chunk_state()
+                workflow_status = RUN_STATUS_CHUNK_READY
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_completed(PHASE_EXPLORE, iteration=prompt_iterations),
             )
-            return RUN_STATUS_SUCCESS, prompt_iterations, successful_iterations
+            return workflow_status, prompt_iterations, successful_iterations
         save_phase_update(
             self.continuation_marker_path,
             lambda marker: marker.mark_phase_pending(PHASE_EXPLORE, iteration=prompt_iterations),
@@ -213,6 +245,71 @@ class OptimisticDynamicAccessStrategy(WorkflowStrategy):
             location=RunLocation(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, self.library),
         )
         return RUN_STATUS_FAILURE, prompt_iterations, 0
+
+    def _record_bulk_chunk_progress(
+            self,
+            initial_report: DynamicAccessCoverageReport,
+            final_report: DynamicAccessCoverageReport,
+    ) -> None:
+        """Record the exact post-gate progress used by the chunk boundary.
+
+        Bulk can prove completed classes by report comparison but cannot
+        attribute skipped, exhausted, or failed classes
+        (§AR-dynamic-access-bulk).
+        """
+        processed_classes: set[str] = self._continuation_processed_classes()
+        if self.dynamic_access_exhaust_report is not None:
+            processed_classes.update(self.dynamic_access_exhaust_report.processed_classes())
+        progress: BulkDynamicAccessProgress = compute_bulk_dynamic_access_progress(
+            initial_report,
+            final_report,
+            processed_classes,
+        )
+        if self.dynamic_access_exhaust_report is not None:
+            for class_name in progress.completed_classes:
+                self.dynamic_access_exhaust_report.mark_completed(class_name)
+            self.dynamic_access_exhaust_report.update_chunk_limits(
+                self.chunk_class_count,
+                self.chunk_class_count,
+            )
+        self.bulk_chunk_progress = progress
+        self._print_message(
+            "bulk chunk progress: completed={completed} remaining={remaining} boundary={boundary}".format(
+                completed=len(progress.completed_classes),
+                remaining=len(progress.remaining_classes),
+                boundary=self.chunk_class_count,
+            )
+        )
+
+    def _continuation_processed_classes(self) -> set[str]:
+        """Return classes a resumed bulk run must exclude from its remainder."""
+        if self.continuation_marker is None:
+            return set()
+        explore_phase: dict[str, object] = self.continuation_marker.phases.get(PHASE_EXPLORE, {})
+        exhausted_classes: object = explore_phase.get("exhaustedClasses", [])
+        if not isinstance(exhausted_classes, list):
+            return set()
+        return {
+            class_name
+            for class_name in exhausted_classes
+            if isinstance(class_name, str) and class_name
+        }
+
+    def _pure_bulk_chunk_is_ready(self) -> bool:
+        """Return whether productive pure bulk should publish a non-final chunk."""
+        progress: BulkDynamicAccessProgress | None = self.bulk_chunk_progress
+        return bool(
+            self.chunk_class_count > 0
+            and progress is not None
+            and progress.completed_classes
+            and len(progress.remaining_classes) > self.chunk_class_count
+        )
+
+    def save_bulk_chunk_state(self) -> None:
+        """Persist bulk-completed classes for a non-final chunk."""
+        if self.dynamic_access_exhaust_report is None or self.dynamic_access_exhaust_report_path is None:
+            return
+        self.dynamic_access_exhaust_report.save(self.dynamic_access_exhaust_report_path)
 
     def _run_basic_iterative_fallback(self, agent, **kwargs):
         """Instantiate a BasicIterativeStrategy and delegate to it."""

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -91,7 +91,7 @@ from utility_scripts.workflow_setup import (
 )
 
 DEFAULT_MODEL_NAME = "gpt-5.4"
-DEFAULT_STRATEGY_NAME = "dynamic_access_bulk_pi_gpt-5.6-sol"
+DEFAULT_STRATEGY_NAME = "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol"
 METRICS_TASK_TYPE = "add_new_library_support"
 
 

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -14,7 +14,7 @@ Usage:
     [--reachability-metadata-path /path/to/graalvm-reachability-metadata] \
     [--metrics-repo-path /path/to/metrics-storage] \
     [--docs-path /path/to/docs] \
-    [--strategy-name "library_update_dynamic_access_bulk_pi_gpt-5.6-sol"] \
+    [--strategy-name "library_update_optimistic_pi_gpt-5.6-sol"] \
     [-v]
 """
 
@@ -92,7 +92,7 @@ from utility_scripts.workflow_setup import (
 from utility_scripts.worktree_reset import reset_worktree_preserving_paths
 
 DEFAULT_MODEL_NAME = "gpt-5.6-sol"
-DEFAULT_STRATEGY_NAME = "library_update_dynamic_access_bulk_pi_gpt-5.6-sol"
+DEFAULT_STRATEGY_NAME = "library_update_optimistic_pi_gpt-5.6-sol"
 METRICS_TASK_TYPE = "improve_library_coverage"
 BASELINE_STATS_FILENAME = ".baseline-stats.json"
 LIBRARY_UPDATE_TARGET_FILENAME = ".library_update_target.json"

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -175,15 +175,15 @@ what the bulk pass missed.
 
 ### 1. Chunking
 
-An oversized report is not explored in one run. When a coordinate has more
-uncovered classes than the configured threshold, the driver gives the workflow a
-class limit for this invocation; the workflow processes at most that many
-classes, returns a chunk-ready status once the chunk passes local verification,
-and the work resumes in a later run against the merged result. The threshold and
-the decision to chunk belong to the driver and the control plane, not the
-workflow (§FS-forge-chunked-dynamic-access, §AR-forge-drivers). What the
-workflow owns is the durable record of which classes are already done
-(§AR-dynamic-access-exhaust-report).
+An oversized report is not explored in one run. An iterative-only run receives
+a concrete class budget before it starts. A run with an optimistic bulk phase
+receives the configured class boundary and decides after bulk: classes completed
+by bulk count first, iterative exploration fills only the shortfall, and a final
+remainder no larger than the boundary is finished in the same run. The workflow
+returns a chunk-ready status once the resulting part passes local verification,
+and work resumes in a later run against the merged result
+(§FS-forge-chunked-dynamic-access). The workflow also owns the durable record of
+which classes are already done (§AR-dynamic-access-exhaust-report).
 
 ## AR-dynamic-access-iterative: Iterative exploration
 
@@ -220,7 +220,18 @@ runs the terminal gate.
 
 Unlike iterative exploration, this workflow does not commit per class and does
 not record exhausted classes — a bulk attempt is accepted or reset whole. It
-succeeds only if at least one iteration reached the accepted state.
+succeeds only if at least one iteration reached the accepted state. For a
+chunked run it retains the initial report and, after the full iteration budget,
+compares it with the report refreshed immediately before the last passing gate.
+Every class that changed from uncovered to covered is recorded as completed;
+bulk never records a class as skipped, exhausted, or failed because it cannot
+attribute those outcomes to one class. This comparison runs once after the
+bulk loop and does not regenerate the report.
+
+In a pure-bulk workflow, a productive pass with more than the configured
+threshold still remaining returns chunk-ready. A zero-yield pass is final, as
+is a pass whose remainder is no larger than the threshold, because no iterative
+phase exists to make a stronger class-scoped attempt.
 
 Optimistic exploration is the right first attempt when the library is expected
 to be easy, when a coverage improvement should be cheap, and for runs that
@@ -248,6 +259,16 @@ primary failure is the one worth reporting. When the exploration phase returns
 chunk-ready, the composite returns that immediately — a chunk is a reviewable
 boundary, and work that depends on reaching final success waits for the resumed
 run rather than blocking the chunk.
+
+When the primary workflow is `optimistic_dynamic_access`, the composite takes
+the chunk boundary after the bulk loop and its gates, before iterative
+exploration. Bulk-completed classes count toward the invocation's class
+boundary. If more than the boundary remain and bulk already met the boundary,
+the composite returns chunk-ready immediately. If bulk did not meet it,
+iterative exploration receives only the shortfall; a zero-yield bulk pass
+therefore gives iterative the whole boundary. When no more than the boundary
+remain, iterative exploration receives the entire remainder and finishes the
+final chunk even if bulk already met the boundary.
 
 Parameters: the primary workflow's parameters plus the iterative exploration
 parameters, from one bundle. Families: composite coverage strategies, Java-fix
@@ -334,8 +355,11 @@ its result, or treats a partial recovery as success.
 A chunk must link its pull request to the issue without completing it, because
 the issue is only done when the last chunk lands (§FS-forge-chunked-dynamic-access). Non-final chunk PRs reference
 the issue; only the final chunk PR closes it and moves it to done. Every chunk PR
-carries the merged exhaust state the next run needs to skip classes already
-completed, skipped, exhausted, or failed.
+carries the merged exhaust state the next run needs. Iterative exploration can
+attribute completed, skipped, exhausted, and failed classes and records all four
+states. Bulk can attribute only classes proven completed by its baseline/final
+report comparison and records only those; a composite carries the union of the
+states its two phases can attribute.
 
 If a non-final chunk PR has failing CI and no eligible job remains to rerun,
 Forge releases the linked issue so a replacement chunk can be generated —

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -90,7 +90,7 @@ Library version update automation (§root/FS-library-version-update-automation).
 | **Dynamic access** | Reflection, JNI, resource access, serialization, or proxy use that GraalVM `native-image` cannot determine statically. |
 | **Dynamic-access report** | JSON written by Gradle task `generateDynamicAccessCoverageReport` to `tests/src/<group>/<artifact>/<version>/build/reports/dynamic-access/dynamic-access-coverage.json`, listing classes and per-class call sites that require dynamic-access metadata, marked covered/uncovered. |
 | **Dynamic-access exhaust report** | Durable coordinate-scoped JSON state for chunked dynamic-access work. It records the coordinate, issue number, class threshold, completed/skipped/exhausted/failed classes, and latest publication ID/branch. It is stored with the target test suite so orchestration can find it from the coordinate. It does not predefine chunks; each resume regenerates the report and filters processed classes. Legacy PR-number/commit fields remain readable during migration. Specified by §AR-dynamic-access-exhaust-report. |
-| **Chunked dynamic-access workflow** | Dynamic-access generation mode for oversized `library-new-request` issues and `library-update-request` issues routed to dynamic-access coverage improvement. `forge_metadata.py` owns the class threshold decision and passes the current chunk size to the workflow. The workflow processes at most that many uncovered classes, publishes that chunk, then resumes after the chunk PR merges. PR linking rules are in §AR-chunked-dynamic-access-pr-linking. |
+| **Chunked dynamic-access workflow** | Dynamic-access generation mode for oversized `library-new-request` issues and `library-update-request` issues routed to dynamic-access coverage improvement. `forge_metadata.py` passes the configured class boundary to the workflow. An iterative-only workflow receives a concrete class budget; an optimistic-first composite counts classes completed by bulk toward that boundary and lets iterative exploration fill only the shortfall. The workflow publishes the chunk, then resumes after the chunk PR merges. PR linking rules are in §AR-chunked-dynamic-access-pr-linking. |
 | **Source context** | Read-only files supplied to the agent. Types: `main` (library source), `test` (upstream tests), `documentation` (Javadoc). Selected by the strategy parameter `source-context-types`. |
 | **Library update target** | The metadata and test directories selected for a `library-update-request` coordinate (§AR-forge-driver-queues.2). Resolution records the requested coordinate, match type (`tested-version`, `metadata-version`, `default-for`, or `new-version`), matched index entry, resolved metadata version, resolved test version, and edit directories. |
 
@@ -622,8 +622,6 @@ The exit code is `0` for PR-eligible statuses and `1` for failure.
   and the post-repair exploration decision for `fails-javac-compile` and
   `fails-java-run` issues.
   The implementation-defined default is `15`.
-  If the current dynamic-access report has more uncovered classes than this
-  threshold, Forge uses chunked mode for new-library and library-update work.
   Java-fix reports cannot be generated before their primary repair succeeds, so
   `forge_metadata.py` passes the threshold to their shared driver; the composite
   workflow evaluates it immediately after the repair and skips oversized
@@ -631,25 +629,44 @@ The exit code is `0` for PR-eligible statuses and `1` for failure.
   `library-update-request` for the fixed version, parks it until the repair
   merges, and records the issue number as a typed follow-up fact in the
   descriptor; the Actions publisher only references it. That issue then enters
-  the ordinary library-update workflow, where dispatcher-owned chunking
-  regenerates the report and selects chunks. The skip is decided exactly once:
-  the composite records it on the continuation marker's `explore` phase, and
-  descriptor creation reads that phase instead of regenerating a report. The
-  marker also records the created issue number, so retries of one publication
-  ID reuse one follow-up issue. For ordinary chunked runs, `forge_metadata.py`
-  still computes the concrete chunk size rather than passing a generic workflow
-  policy.
+  the ordinary library-update workflow, where its selected exploration workflow
+  owns the chunk boundary. The skip is decided exactly once: the composite
+  records it on the continuation marker's `explore` phase, and descriptor
+  creation reads that phase instead of regenerating a report. The marker also
+  records the created issue number, so retries of one publication ID reuse one
+  follow-up issue.
 
 For `library-new-request` issues and `library-update-request` issues routed to
-dynamic-access coverage improvement, `forge_metadata.py` must run or refresh the
-dynamic-access report before choosing the execution mode. If the current report
-has more uncovered dynamic-access classes than the configured class threshold,
-`forge_metadata.py` must invoke the matching orchestration script with chunking
-flags: issue number and current chunk size.
-The current chunk size is normally equal to the threshold; when fewer
-unexhausted classes remain than the threshold, it is equal to the remaining
-class count. For example, with threshold `15` and `22` uncovered classes, the
-first chunk size is `15` and the second chunk size is `7`.
+dynamic-access coverage improvement, `forge_metadata.py` must invoke the
+matching orchestration script with the issue number and configured class
+threshold. An iterative-only workflow may use a dispatcher-refreshed report to
+reduce that value to the current remaining class count before it starts.
+
+A workflow with an optimistic bulk phase must make the chunk decision after the
+bulk iteration budget and its native-test gates. The bulk phase keeps its
+initial report as the baseline and uses the last successful iteration's already
+refreshed report as the final report; it must not run another report solely for
+the chunk decision. Classes uncovered in the baseline and covered in the final
+report are completed by bulk. The remaining set is the final report's uncovered
+classes minus the exhaust report and continuation marker's processed set.
+
+For an optimistic-first composite, `--chunk-class-count` is the total class
+boundary for one non-final run across both phases. If the final remainder is no
+larger than the configured boundary, iterative exploration finishes that
+remainder. Otherwise, if bulk completed at least the boundary, the workflow
+returns chunk-ready without starting iterative exploration. If bulk completed
+less, iterative exploration receives only the shortfall. Its completed,
+skipped, exhausted, and failed classes all count toward that shortfall. Thus,
+with a boundary of `15`, a bulk pass that completes `10` classes is followed by
+at most `5` iterative terminal classes, while a bulk pass that completes `20`
+classes stops before iterative exploration unless no more than `15` classes
+remain.
+
+A pure-bulk strategy has no iterative phase with which to fill a shortfall. It
+returns chunk-ready after a productive run when more than the threshold remain;
+if bulk covers no new class, or the remainder is no larger than the threshold,
+the run is final so Forge cannot publish an unbounded sequence of identical
+bulk chunks.
 
 Chunked mode is automatic after the issue is marked with the
 `chunked-dynamic-access` label. The normal project status remains the run-state

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -382,7 +382,7 @@ DEFAULT_DYNAMIC_ACCESS_CHUNK_CLASS_THRESHOLD = 15
 
 
 PI_REVIEW_PROVIDER = PI_PROVIDER
-DEFAULT_WORK_QUEUE_STRATEGY_NAME = "dynamic_access_bulk_pi_gpt-5.6-sol"
+DEFAULT_WORK_QUEUE_STRATEGY_NAME = "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol"
 FAILURE_ANALYSIS_TIMEOUT_SECONDS = 1800
 REVIEW_TIMEOUT_SECONDS = 1800
 DEFAULT_WORKTREE_BASE_REF = "master"
@@ -5160,26 +5160,33 @@ def prepare_dynamic_access_chunking(
         claimed_issue: ClaimedIssue,
         strategy_name: str | None,
 ) -> int | None:
-    """Prepare dispatcher-owned chunking state and return the concrete chunk size.
+    """Return the iterative budget or optimistic post-bulk class boundary.
 
-    The control plane owns the class threshold decision for issue-driven
-    dynamic-access work (§AR-chunked-dynamic-access-pr-linking): it refreshes
-    the report, records the exhaust-report chunk fields, applies the public
-    label, and passes only the concrete chunk count to the workflow.
+    Iterative-only work keeps dispatcher-owned report selection. An optimistic
+    phase receives the configured boundary and decides after its gated bulk
+    loop, when its exact progress is known
+    (§FS-forge-chunked-dynamic-access).
     """
     if claimed_issue.label not in {LABEL_LIBRARY_NEW, LABEL_LIBRARY_UPDATE}:
         return None
 
+    threshold: int = dynamic_access_chunk_class_threshold()
     if strategy_name:
         strategy: dict = require_strategy_by_name(strategy_name)
-        if strategy.get("workflow") == "optimistic_dynamic_access":
-            # Pure bulk runs have no per-class checkpoints or budgets.
-            # §AR-dynamic-access-bulk §AR-chunked-dynamic-access-pr-linking
+        workflow_name: str | None = strategy.get("workflow")
+        has_optimistic_bulk_phase: bool = (
+            workflow_name == "optimistic_dynamic_access"
+            or (
+                workflow_name == "increase_dynamic_access_coverage"
+                and strategy.get("primary-workflow") == "optimistic_dynamic_access"
+            )
+        )
+        if has_optimistic_bulk_phase:
             log_stage(
                 "dynamic-access-chunking",
-                f"Chunking disabled for bulk strategy '{strategy_name}'; the bulk engine owns the full report.",
+                f"Deferring chunk selection for '{strategy_name}' until its optimistic bulk phase completes.",
             )
-            return None
+            return threshold
 
     if claimed_issue.label == LABEL_LIBRARY_NEW:
         if not _prepare_new_library_dynamic_access_report(claimed_issue):
@@ -5198,7 +5205,6 @@ def prepare_dynamic_access_chunking(
         )
         return None
 
-    threshold = dynamic_access_chunk_class_threshold()
     exhaust_report, exhaust_report_path = _resolve_dynamic_access_exhaust_report(claimed_issue)
     already_chunked = _issue_has_chunked_dynamic_access_state(claimed_issue.issue) or exhaust_report is not None
     current_uncovered_classes = [

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -5171,6 +5171,9 @@ def prepare_dynamic_access_chunking(
         return None
 
     threshold: int = dynamic_access_chunk_class_threshold()
+    active_chunk_remaining_budget: int | None = _continuation_active_chunk_remaining_budget(
+        claimed_issue.continuation_marker,
+    )
     if strategy_name:
         strategy: dict = require_strategy_by_name(strategy_name)
         workflow_name: str | None = strategy.get("workflow")
@@ -5182,11 +5185,18 @@ def prepare_dynamic_access_chunking(
             )
         )
         if has_optimistic_bulk_phase:
+            chunk_boundary: int = threshold
+            if active_chunk_remaining_budget is not None and active_chunk_remaining_budget > 0:
+                chunk_boundary = min(chunk_boundary, active_chunk_remaining_budget)
             log_stage(
                 "dynamic-access-chunking",
-                f"Deferring chunk selection for '{strategy_name}' until its optimistic bulk phase completes.",
+                "Deferring chunk selection for '{strategy}' until its optimistic bulk phase completes; "
+                "class_boundary={boundary}.".format(
+                    strategy=strategy_name,
+                    boundary=chunk_boundary,
+                ),
             )
-            return threshold
+            return chunk_boundary
 
     if claimed_issue.label == LABEL_LIBRARY_NEW:
         if not _prepare_new_library_dynamic_access_report(claimed_issue):

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -5186,7 +5186,7 @@ def prepare_dynamic_access_chunking(
         )
         if has_optimistic_bulk_phase:
             chunk_boundary: int = threshold
-            if active_chunk_remaining_budget is not None and active_chunk_remaining_budget > 0:
+            if active_chunk_remaining_budget is not None:
                 chunk_boundary = min(chunk_boundary, active_chunk_remaining_budget)
             log_stage(
                 "dynamic-access-chunking",

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -444,7 +444,8 @@
     "model": "gpt-5.4",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-iterations": 2,
@@ -644,7 +645,8 @@
     "model": "gpt-5.3-codex",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-iterations": 2,
@@ -667,7 +669,8 @@
     "model": "gpt-5.6-sol",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-iterations": 2,
@@ -690,7 +693,8 @@
     "model": "gpt-5.4",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-iterations": 2,
@@ -713,7 +717,8 @@
     "model": "gpt-5.6-sol",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-iterations": 2,
@@ -943,7 +948,8 @@
     "model": "gpt-5.6-sol",
     "prompts": {
       "optimistic-dynamic-access-iteration": "prompt_templates/dynamic_access/optimistic-dynamic-access-iteration-update.md",
-      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md"
+      "dynamic-access-iteration": "prompt_templates/dynamic_access/dynamic-access-iteration.md",
+      "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
       "max-optimistic-iterations": 3,

--- a/forge/tests/test_optimistic_dynamic_access_strategy.py
+++ b/forge/tests/test_optimistic_dynamic_access_strategy.py
@@ -1,0 +1,202 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import unittest
+from unittest.mock import patch
+
+from ai_workflows.core.increase_dynamic_access_coverage_strategy import (
+    IncreaseDynamicAccessCoverageStrategy,
+)
+from ai_workflows.core.optimistic_dynamic_access_strategy import OptimisticDynamicAccessStrategy
+from ai_workflows.core.workflow_strategy import RUN_STATUS_SUCCESS
+from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
+from utility_scripts.dynamic_access_report import (
+    BulkDynamicAccessProgress,
+    DynamicAccessClass,
+    DynamicAccessCoverageReport,
+    compute_bulk_dynamic_access_progress,
+)
+
+
+class OptimisticDynamicAccessChunkTests(unittest.TestCase):
+    def test_bulk_progress_compares_gated_report_and_excludes_processed_classes(self) -> None:
+        initial_report = self._report(["A", "B", "C", "D"], [])
+        final_report = self._report(["A", "B", "C", "D"], ["A", "B"])
+
+        progress = compute_bulk_dynamic_access_progress(
+            initial_report,
+            final_report,
+            {"D"},
+        )
+
+        self.assertIs(progress.final_report, final_report)
+        self.assertEqual(progress.completed_classes, ("A", "B"))
+        self.assertEqual(progress.remaining_classes, ("C",))
+
+    def test_bulk_progress_is_recorded_in_shared_exhaust_state(self) -> None:
+        exhaust_report = DynamicAccessExhaustReport.create(
+            coordinate="org.example:lib:1.0.0",
+            issue_number=1412,
+        )
+        exhaust_report.mark_skipped("D")
+        strategy = self._optimistic_strategy(
+            chunk_class_count=15,
+            dynamic_access_exhaust_report=exhaust_report,
+        )
+
+        strategy._record_bulk_chunk_progress(
+            self._report(["A", "B", "C", "D"], []),
+            self._report(["A", "B", "C", "D"], ["A", "B"]),
+        )
+
+        self.assertEqual(exhaust_report.completed_classes, ["A", "B"])
+        self.assertEqual(exhaust_report.skipped_classes, ["D"])
+        self.assertEqual(exhaust_report.class_threshold, 15)
+        self.assertEqual(exhaust_report.current_chunk_class_count, 15)
+        self.assertEqual(strategy.bulk_chunk_progress.remaining_classes, ("C",))
+
+    def test_composite_routes_post_bulk_quota(self) -> None:
+        scenarios = (
+            (20, 80, 0, True),
+            (10, 90, 5, False),
+            (20, 10, 10, False),
+            (0, 90, 15, False),
+        )
+
+        for completed, remaining, expected_budget, expected_chunk_ready in scenarios:
+            with self.subTest(completed=completed, remaining=remaining):
+                strategy = self._composite_strategy()
+                primary = self._FakePrimary(self._progress(completed, remaining))
+                strategy.primary = primary
+
+                report, iterative_budget, chunk_ready = strategy._route_after_optimistic_bulk()
+
+                self.assertIs(report, primary.bulk_chunk_progress.final_report)
+                self.assertEqual(iterative_budget, expected_budget)
+                self.assertEqual(chunk_ready, expected_chunk_ready)
+                self.assertEqual(primary.saved, expected_chunk_ready)
+
+    def test_composite_passes_shortfall_and_gated_report_to_iterative(self) -> None:
+        strategy = self._composite_strategy()
+        primary = self._FakePrimary(self._progress(10, 90))
+        strategy.primary = primary
+        strategy.primary_workflow_name = "optimistic_dynamic_access"
+        captured_context: dict[str, object] = {}
+        captured_reports: list[DynamicAccessCoverageReport] = []
+
+        class FakeDynamicAccess:
+            def __init__(self, strategy_obj: dict, **context: object) -> None:
+                captured_context.update(context)
+                self._last_phase_status = RUN_STATUS_SUCCESS
+
+            def _run_dynamic_access_phase(
+                    self,
+                    agent: object,
+                    report: DynamicAccessCoverageReport,
+            ) -> tuple[bool, int]:
+                captured_reports.append(report)
+                return True, 2
+
+            def has_issue_requested_metadata_context(self) -> bool:
+                return False
+
+        class FakeAgent:
+            def clear_context(self) -> None:
+                pass
+
+        with patch(
+                "ai_workflows.core.increase_dynamic_access_coverage_strategy.DynamicAccessIterativeStrategy",
+                FakeDynamicAccess,
+        ):
+            result = strategy.run(FakeAgent())
+
+        self.assertEqual(result, (RUN_STATUS_SUCCESS, 5, 1))
+        self.assertEqual(captured_context["chunk_class_count"], 5)
+        self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
+
+    @staticmethod
+    def _optimistic_strategy(**context: object) -> OptimisticDynamicAccessStrategy:
+        return OptimisticDynamicAccessStrategy(
+            {
+                "model": "test-model",
+                "prompts": {"optimistic-dynamic-access-iteration": "unused"},
+                "parameters": {
+                    "max-optimistic-iterations": 3,
+                    "max-test-iterations": 2,
+                },
+            },
+            library="org.example:lib:1.0.0",
+            reachability_repo_path="/tmp/reachability",
+            test_version="1.0.0",
+            **context,
+        )
+
+    @staticmethod
+    def _composite_strategy() -> IncreaseDynamicAccessCoverageStrategy:
+        strategy = IncreaseDynamicAccessCoverageStrategy(
+            {
+                "model": "test-model",
+                "parameters": {},
+                "prompts": {},
+            },
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:lib:1.0.0",
+            chunk_class_count=15,
+        )
+        strategy.primary_workflow_name = "optimistic_dynamic_access"
+        return strategy
+
+    @classmethod
+    def _progress(cls, completed: int, remaining: int) -> BulkDynamicAccessProgress:
+        final_report = cls._report(
+            [f"completed-{index}" for index in range(completed)]
+            + [f"remaining-{index}" for index in range(remaining)],
+            [f"completed-{index}" for index in range(completed)],
+        )
+        return BulkDynamicAccessProgress(
+            final_report=final_report,
+            completed_classes=tuple(f"completed-{index}" for index in range(completed)),
+            remaining_classes=tuple(f"remaining-{index}" for index in range(remaining)),
+        )
+
+    @staticmethod
+    def _report(
+            class_names: list[str],
+            covered_class_names: list[str],
+    ) -> DynamicAccessCoverageReport:
+        covered = set(covered_class_names)
+        return DynamicAccessCoverageReport(
+            coordinate="org.example:lib:1.0.0",
+            has_dynamic_access=True,
+            total_calls=len(class_names),
+            covered_calls=len(covered),
+            classes=[
+                DynamicAccessClass(
+                    class_name=class_name,
+                    source_file=None,
+                    resolved_source_file=None,
+                    total_calls=1,
+                    covered_calls=1 if class_name in covered else 0,
+                    call_sites=[],
+                )
+                for class_name in class_names
+            ],
+        )
+
+    class _FakePrimary:
+        def __init__(self, progress: BulkDynamicAccessProgress) -> None:
+            self.bulk_chunk_progress = progress
+            self.saved = False
+            self.post_generation_intervention = None
+
+        def run(self, agent: object, **kwargs: object) -> tuple[str, int, int]:
+            return RUN_STATUS_SUCCESS, 3, 1
+
+        def save_bulk_chunk_state(self) -> None:
+            self.saved = True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_optimistic_dynamic_access_strategy.py
+++ b/forge/tests/test_optimistic_dynamic_access_strategy.py
@@ -10,7 +10,7 @@ from ai_workflows.core.increase_dynamic_access_coverage_strategy import (
     IncreaseDynamicAccessCoverageStrategy,
 )
 from ai_workflows.core.optimistic_dynamic_access_strategy import OptimisticDynamicAccessStrategy
-from ai_workflows.core.workflow_strategy import RUN_STATUS_SUCCESS
+from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.dynamic_access_report import (
     BulkDynamicAccessProgress,
@@ -115,6 +115,49 @@ class OptimisticDynamicAccessChunkTests(unittest.TestCase):
         self.assertEqual(result, (RUN_STATUS_SUCCESS, 5, 1))
         self.assertEqual(captured_context["chunk_class_count"], 5)
         self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
+
+    def test_composite_fails_when_required_iterative_shortfall_fails(self) -> None:
+        for has_reporter_context in (False, True):
+            with self.subTest(has_reporter_context=has_reporter_context):
+                strategy = self._composite_strategy()
+                strategy.primary = self._FakePrimary(self._progress(10, 90))
+                reporter_phase_calls: list[bool] = []
+
+                class FailingDynamicAccess:
+                    def __init__(self, strategy_obj: dict, **context: object) -> None:
+                        self._last_phase_status = RUN_STATUS_SUCCESS
+
+                    def _run_dynamic_access_phase(
+                            self,
+                            agent: object,
+                            report: DynamicAccessCoverageReport,
+                    ) -> tuple[bool, int]:
+                        return False, 0
+
+                    def has_issue_requested_metadata_context(self) -> bool:
+                        return has_reporter_context
+
+                    def _run_issue_requested_metadata_phase(
+                            self,
+                            agent: object,
+                    ) -> tuple[bool, int]:
+                        reporter_phase_calls.append(True)
+                        return True, 1
+
+                class FakeAgent:
+                    def clear_context(self) -> None:
+                        pass
+
+                with patch(
+                        "ai_workflows.core.increase_dynamic_access_coverage_strategy."
+                        "DynamicAccessIterativeStrategy",
+                        FailingDynamicAccess,
+                ):
+                    result = strategy.run(FakeAgent())
+
+                expected_iterations = 4 if has_reporter_context else 3
+                self.assertEqual(result, (RUN_STATUS_FAILURE, expected_iterations, 1))
+                self.assertEqual(reporter_phase_calls, [True] if has_reporter_context else [])
 
     @staticmethod
     def _optimistic_strategy(**context: object) -> OptimisticDynamicAccessStrategy:

--- a/forge/tests/test_workflow_driver_defaults.py
+++ b/forge/tests/test_workflow_driver_defaults.py
@@ -89,6 +89,37 @@ class WorkflowDriverDefaultTests(unittest.TestCase):
         self.assertEqual(chunk_count, 3)
         prepare_report.assert_not_called()
 
+    def test_optimistic_resume_preserves_exhausted_active_chunk_budget(self) -> None:
+        marker = forge_metadata.ContinuationMarker.create(
+            strategy_name="optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
+            issue_number=1412,
+            label=forge_metadata.LABEL_LIBRARY_NEW,
+            coordinate="g:a:2.0",
+            new_version="2.0",
+        )
+        marker.mark_phase_completed("setup")
+        marker.mark_phase_skipped("fix")
+        marker.mark_phase_running("explore")
+        marker.record_chunk_progress(5, 5)
+        claimed_issue = _claimed_issue(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            continuation_marker=marker,
+        )
+
+        with patch.object(forge_metadata, "_prepare_new_library_dynamic_access_report") as prepare_report, \
+                patch.dict(
+                    "os.environ",
+                    {"FORGE_DYNAMIC_ACCESS_CHUNK_CLASS_THRESHOLD": "15"},
+                    clear=True,
+                ):
+            chunk_count = forge_metadata.prepare_dynamic_access_chunking(
+                claimed_issue,
+                "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
+            )
+
+        self.assertEqual(chunk_count, 0)
+        prepare_report.assert_not_called()
+
     def test_coverage_composites_declare_the_reporter_metadata_prompt(self) -> None:
         # A library-update issue body may carry reporter-requested metadata, and
         # the composite then runs that phase unconditionally. A coverage

--- a/forge/tests/test_workflow_driver_defaults.py
+++ b/forge/tests/test_workflow_driver_defaults.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import patch
 
 import forge_metadata
+from utility_scripts.strategy_loader import load_predefined_strategies
 
 
 def _claimed_issue(
@@ -87,6 +88,20 @@ class WorkflowDriverDefaultTests(unittest.TestCase):
 
         self.assertEqual(chunk_count, 3)
         prepare_report.assert_not_called()
+
+    def test_coverage_composites_declare_the_reporter_metadata_prompt(self) -> None:
+        # A library-update issue body may carry reporter-requested metadata, and
+        # the composite then runs that phase unconditionally. A coverage
+        # composite without the prompt raises instead of covering the request.
+        coverage_composites = [
+            strategy for strategy in load_predefined_strategies()
+            if strategy.get("workflow") == "increase_dynamic_access_coverage"
+            and strategy.get("primary-workflow") in {None, "optimistic_dynamic_access"}
+        ]
+        self.assertTrue(coverage_composites)
+        for strategy in coverage_composites:
+            with self.subTest(strategy=strategy["name"]):
+                self.assertIn("issue-requested-metadata", strategy["prompts"])
 
     def test_java_repair_queues_default_to_sol_strategies(self) -> None:
         expected_defaults = {

--- a/forge/tests/test_workflow_driver_defaults.py
+++ b/forge/tests/test_workflow_driver_defaults.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 import forge_metadata
 
 
-def _claimed_issue(label: str) -> forge_metadata.ClaimedIssue:
+def _claimed_issue(
+        label: str,
+        continuation_marker: forge_metadata.ContinuationMarker | None = None,
+) -> forge_metadata.ClaimedIssue:
     return forge_metadata.ClaimedIssue(
         issue={"number": 1412},
         label=label,
@@ -20,6 +23,7 @@ def _claimed_issue(label: str) -> forge_metadata.ClaimedIssue:
         issue_coordinates="g:a:2.0",
         current_coordinates="g:a:1.0",
         new_version="2.0",
+        continuation_marker=continuation_marker,
     )
 
 
@@ -51,6 +55,37 @@ class WorkflowDriverDefaultTests(unittest.TestCase):
                         strategy_name,
                     )
                     self.assertEqual(chunk_count, 15)
+        prepare_report.assert_not_called()
+
+    def test_optimistic_resume_uses_remaining_active_chunk_budget(self) -> None:
+        marker = forge_metadata.ContinuationMarker.create(
+            strategy_name="optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
+            issue_number=1412,
+            label=forge_metadata.LABEL_LIBRARY_NEW,
+            coordinate="g:a:2.0",
+            new_version="2.0",
+        )
+        marker.mark_phase_completed("setup")
+        marker.mark_phase_skipped("fix")
+        marker.mark_phase_running("explore")
+        marker.record_chunk_progress(5, 2)
+        claimed_issue = _claimed_issue(
+            forge_metadata.LABEL_LIBRARY_NEW,
+            continuation_marker=marker,
+        )
+
+        with patch.object(forge_metadata, "_prepare_new_library_dynamic_access_report") as prepare_report, \
+                patch.dict(
+                    "os.environ",
+                    {"FORGE_DYNAMIC_ACCESS_CHUNK_CLASS_THRESHOLD": "15"},
+                    clear=True,
+                ):
+            chunk_count = forge_metadata.prepare_dynamic_access_chunking(
+                claimed_issue,
+                "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
+            )
+
+        self.assertEqual(chunk_count, 3)
         prepare_report.assert_not_called()
 
     def test_java_repair_queues_default_to_sol_strategies(self) -> None:

--- a/forge/tests/test_workflow_driver_defaults.py
+++ b/forge/tests/test_workflow_driver_defaults.py
@@ -24,24 +24,33 @@ def _claimed_issue(label: str) -> forge_metadata.ClaimedIssue:
 
 
 class WorkflowDriverDefaultTests(unittest.TestCase):
-    def test_new_and_update_queues_default_to_sol_bulk_strategies(self) -> None:
+    def test_new_and_update_queues_default_to_sol_composite_strategies(self) -> None:
         self.assertEqual(
             forge_metadata.DEFAULT_NEW_LIBRARY_STRATEGY_NAME,
-            "dynamic_access_bulk_pi_gpt-5.6-sol",
+            "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
         )
         self.assertEqual(
             forge_metadata.DEFAULT_LIBRARY_UPDATE_STRATEGY_NAME,
-            "library_update_dynamic_access_bulk_pi_gpt-5.6-sol",
+            "library_update_optimistic_pi_gpt-5.6-sol",
+        )
+        self.assertEqual(
+            forge_metadata.DEFAULT_WORK_QUEUE_STRATEGY_NAME,
+            "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
         )
 
-    def test_bulk_strategy_skips_incompatible_class_chunking(self) -> None:
+    def test_optimistic_strategies_defer_chunk_selection_to_bulk(self) -> None:
+        strategies = (
+            "dynamic_access_bulk_pi_gpt-5.6-sol",
+            "optimistic_dynamic_access_iterative_pi_gpt-5.6-sol",
+        )
         with patch.object(forge_metadata, "_prepare_new_library_dynamic_access_report") as prepare_report:
-            chunk_count = forge_metadata.prepare_dynamic_access_chunking(
-                _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW),
-                "dynamic_access_bulk_pi_gpt-5.6-sol",
-            )
-
-        self.assertIsNone(chunk_count)
+            for strategy_name in strategies:
+                with self.subTest(strategy=strategy_name):
+                    chunk_count = forge_metadata.prepare_dynamic_access_chunking(
+                        _claimed_issue(forge_metadata.LABEL_LIBRARY_NEW),
+                        strategy_name,
+                    )
+                    self.assertEqual(chunk_count, 15)
         prepare_report.assert_not_called()
 
     def test_java_repair_queues_default_to_sol_strategies(self) -> None:

--- a/forge/utility_scripts/dynamic_access_report.py
+++ b/forge/utility_scripts/dynamic_access_report.py
@@ -83,6 +83,50 @@ class DynamicAccessCoverageReport:
 
 
 @dataclass(frozen=True)
+class BulkDynamicAccessProgress:
+    """Post-gate class progress from one optimistic bulk phase.
+
+    The workflow compares its baseline with the last successfully gated report
+    and carries that exact report into the composite boundary
+    (§AR-dynamic-access-bulk).
+    """
+
+    final_report: DynamicAccessCoverageReport
+    completed_classes: tuple[str, ...]
+    remaining_classes: tuple[str, ...]
+
+
+def compute_bulk_dynamic_access_progress(
+        initial_report: DynamicAccessCoverageReport,
+        final_report: DynamicAccessCoverageReport,
+        processed_classes: set[str],
+) -> BulkDynamicAccessProgress:
+    """Return completed and still-eligible classes after optimistic bulk."""
+    initial_uncovered_classes: set[str] = {
+        class_coverage.class_name
+        for class_coverage in initial_report.classes
+        if class_coverage.uncovered_calls > 0
+    }
+    completed_classes: tuple[str, ...] = tuple(sorted(
+        class_name
+        for class_name in initial_uncovered_classes
+        if (
+            (final_class := final_report.get_class(class_name)) is not None
+            and final_class.uncovered_calls == 0
+        )
+    ))
+    remaining_classes: tuple[str, ...] = tuple(
+        class_coverage.class_name
+        for class_coverage in final_report.classes
+        if (
+            class_coverage.uncovered_calls > 0
+            and class_coverage.class_name not in processed_classes
+        )
+    )
+    return BulkDynamicAccessProgress(final_report, completed_classes, remaining_classes)
+
+
+@dataclass(frozen=True)
 class DynamicAccessClassDelta:
     newly_covered: list[DynamicAccessCallSite]
     still_uncovered: list[DynamicAccessCallSite]


### PR DESCRIPTION
Closes #9560

## Put the boundary after optimistic work

Optimistic dynamic-access strategies previously bypassed dispatcher chunking, so the default new-library and library-update queues could repeatedly work the full report without updating the coordinate's exhaust state.

The chunk decision now happens once after every configured optimistic iteration and its native-test gate. The bulk baseline is compared with the last successfully gated report, and classes proven covered are recorded before the composite decides whether iterative exploration is still needed. This makes the configured boundary an invocation-wide quota across both phases, as specified by [§FS-forge-chunked-dynamic-access](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/optimistic-chunk-quota/forge/docs/functional-spec/functional-spec.md).

## Fill only the post-bulk shortfall

With the default boundary of 15:

| Bulk result | Remaining | Outcome |
| ---: | ---: | --- |
| 20 completed | 80 | Publish the bulk chunk; do not enter iterative |
| 10 completed | 90 | Let iterative process 5 terminal classes |
| 20 completed | 10 | Let iterative finish the final 10 classes |
| 0 completed | 90 | Give iterative the full 15-class quota |

The implementation carries the already-gated report into iterative exploration instead of regenerating it. Existing completed, skipped, exhausted, and failed classes are excluded from the remainder, while bulk itself records only classes it can prove completed. Pure-bulk runs keep their separate zero-yield/final-remainder behavior. These responsibilities are captured by [§AR-dynamic-access-bulk](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/optimistic-chunk-quota/forge/docs/architecture/workflows.md), [§AR-dynamic-access-composite](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/optimistic-chunk-quota/forge/docs/architecture/workflows.md), and [§AR-chunked-dynamic-access-pr-linking](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/optimistic-chunk-quota/forge/docs/architecture/workflows.md).

## Route queue defaults through both phases

The new-library, library-update, and generic work-queue defaults now select their optimistic-then-iterative strategies. This keeps the cheap broad pass first while ensuring iterative work fills a shortfall or finishes the last small remainder.
