### PR TITLE
Fix ni-run metrics call and spec its test patch

### DIFF
--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -520,7 +520,6 @@ def main(argv=None) -> int:
             agent=agent,
             model_name=model_name,
             global_iterations=iterations,
-            tests_root=tests_root,
             strategy_name=args.strategy_name,
             status=finalize_status,
             starting_commit=checkpoint,

--- a/forge/tests/test_fix_ni_run.py
+++ b/forge/tests/test_fix_ni_run.py
@@ -93,6 +93,7 @@ class NativeImageRunDriverTests(unittest.TestCase):
             stack.enter_context(patch.object(
                 fix_ni_run.metrics_writer,
                 "create_java_run_fix_run_metrics_output_json",
+                autospec=True,
                 return_value={},
             ))
             stack.enter_context(patch.object(fix_ni_run.metrics_writer, "write_workflow_run_metrics"))


### PR DESCRIPTION
`fix_ni_run` passed `tests_root` to `create_javac_fix_run_metrics_output_json`, which has no such parameter. The call sits inside `if succeeded:`, after `finalize_run` returns, so it only fires once a native-image-run repair has fully passed — seed, native gate, `checkMetadataFiles` recovery, finalization — and then discards it with a `TypeError`.

Issue #9255 hit this: gate `PASSED after 5 cycles`, `checkMetadataFiles` repaired and passing, finalization successful, then the crash. The verified metadata was parked on a human-intervention branch, the issue went back to `Todo`, and no PR opened.

The argument was never needed. `collect_base_metrics` derives `tests_root` itself (`metrics_writer.py:370`) to count generated LOC, and `java_fail_workflow` passes it only to `init_agent` (`:578`), never to the metrics writer (`:639`). Removing it makes all three fix drivers agree, which is why javac and java-run were unaffected.

`tests/test_fix_ni_run.py` already exercised this line, but patched the function with a bare `Mock` that accepts any keyword argument. `autospec=True` binds the real signature: with the argument still present, three tests fail with the production error; with it removed, the file is green.

Verified locally: `test_fix_ni_run` passes, and the full suite is 717 tests with one pre-existing unrelated failure (`test_validate_no_scaffold_placeholders_rejects_placeholder_text`, which also fails on a clean tree).

Fixes #9565