### PR TITLE
Check artifact repositories before Forge claims issues

### DIFF
--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -257,8 +257,10 @@ one manifest:
   `local_repositories/`, and temporary Gradle state.
 - **Network reachability** on 443, through the configured proxy when one is
   set: `github.com`, `api.github.com`, `chatgpt.com`, `services.gradle.org`,
-  `repo.maven.apache.org`, `plugins.gradle.org`, `registry-1.docker.io`,
-  `auth.docker.io`.
+  `plugins.gradle.org`, `registry-1.docker.io`, `auth.docker.io`. Each base URL
+  in `ARTIFACT_REPOSITORY_URLS` is checked separately with HTTP `HEAD` and must
+  return `200`; this currently covers `repo1.maven.org` and
+  `packages.confluent.io`, the exact hosts used by `check_issue_form()`.
 - **Git transport** to the monitored branch from each checkout, and access to
   the Docker daemon.
 

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -168,7 +168,10 @@ The host must provide:
   distribution and plugin services, Maven Central, and the Docker registry and
   its auth endpoint. Reachability is checked over the route Forge's own tools
   take — directly, or through the proxy the environment configures for HTTPS —
-  so a proxied host is not reported as offline.
+  so a proxied host is not reported as offline. Every configured artifact
+  repository is checked at its exact base URL with an HTTP `HEAD` request and
+  must return `200`, so Forge proves the same DNS, proxy, TLS, and HTTP path the
+  issue-form artifact lookup will use before it claims an issue.
 - **Git transport** to the monitored branch from every checkout the run uses.
 - **A complete reachability repository** for anything that runs its Gradle
   tasks: testing, dynamic-access reporting, native metadata exploration,

--- a/forge/tests/test_host_requirements.py
+++ b/forge/tests/test_host_requirements.py
@@ -15,6 +15,7 @@ from typing import Iterator
 from unittest.mock import Mock, patch
 
 from utility_scripts.host_requirements import (
+    ARTIFACT_REPOSITORY_URLS,
     GRAALVM_SCHEMA_PATH,
     HostRequirements,
     QueueRequirements,
@@ -30,6 +31,7 @@ from utility_scripts.host_requirements import (
     parse_grype_version,
     parse_args,
     parse_native_image_version,
+    probe_http_200,
     probe_proxied_host,
     resolve_graalvm_version_check,
     resolve_https_proxy,
@@ -430,7 +432,10 @@ class HostRequirementsTests(unittest.TestCase):
         ), patch(
             "utility_scripts.host_requirements.probe_tcp_host",
             return_value=(True, "reachable"),
-        ) as probe_host:
+        ) as probe_host, patch(
+            "utility_scripts.host_requirements.probe_http_200",
+            return_value=(True, "HTTP 200"),
+        ):
             host_requirements._check_write_permissions()
             host_requirements._check_network()
 
@@ -601,6 +606,7 @@ class HostRequirementsTests(unittest.TestCase):
         )
 
         with patch("utility_scripts.host_requirements.probe_tcp_host", return_value=(True, "reachable")), \
+                patch("utility_scripts.host_requirements.probe_http_200", return_value=(True, "HTTP 200")), \
                 patch.object(host_requirements, "_check_git_remote_access"):
             host_requirements._check_github()
             host_requirements._check_network()
@@ -610,6 +616,48 @@ class HostRequirementsTests(unittest.TestCase):
         self.assertEqual("SKIP", result_by_name["github.com"].status)
         self.assertEqual("SKIP", result_by_name["api.github.com"].status)
         self.assertEqual("PASS", result_by_name["chatgpt.com"].status)
+
+    def test_issue_work_requires_http_200_from_every_artifact_repository(self) -> None:
+        host_requirements = HostRequirements(
+            "/repo/forge",
+            "python3",
+            {},
+            requirements=QueueRequirements(issue_work=True, review_work=False, github_work=False),
+        )
+
+        with patch.object(host_requirements, "_check_git_remote_access"), \
+                patch("utility_scripts.host_requirements.probe_tcp_host", return_value=(True, "reachable")), \
+                patch(
+                    "utility_scripts.host_requirements.probe_http_200",
+                    side_effect=[(True, "HTTP 200"), (False, "HTTP 503")],
+                ) as probe_repository:
+            host_requirements._check_network()
+
+        self.assertEqual(
+            list(ARTIFACT_REPOSITORY_URLS),
+            [call.args[0] for call in probe_repository.call_args_list],
+        )
+        result_by_name = {result.name: result for result in host_requirements.results}
+        central = result_by_name[f"artifact repository {ARTIFACT_REPOSITORY_URLS[0]}"]
+        confluent = result_by_name[f"artifact repository {ARTIFACT_REPOSITORY_URLS[1]}"]
+        self.assertEqual("PASS", central.status)
+        self.assertEqual("FAIL", confluent.status)
+        self.assertTrue(confluent.blocks_work)
+
+    def test_http_repository_probe_requires_exactly_200(self) -> None:
+        response = Mock()
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+        response.getcode.return_value = 204
+
+        with patch("utility_scripts.host_requirements.urllib.request.urlopen", return_value=response) as open_url:
+            passed, detail = probe_http_200("https://repo.example/maven")
+
+        self.assertFalse(passed)
+        self.assertIn("HTTP 204", detail)
+        request = open_url.call_args.args[0]
+        self.assertEqual("HEAD", request.get_method())
+        self.assertEqual("https://repo.example/maven/", request.full_url)
 
     def test_selected_repository_paths_are_checked_instead_of_the_forge_parent_checkout(self) -> None:
         with tempfile.TemporaryDirectory() as target_repo:

--- a/forge/utility_scripts/host_requirements.py
+++ b/forge/utility_scripts/host_requirements.py
@@ -17,7 +17,9 @@ import subprocess
 import sys
 import tempfile
 import tomllib
+import urllib.error
 import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -35,6 +37,7 @@ from ai_workflows.agents.agent_runtime import (  # noqa: E402
     default_model_for_backend,
     normalize_backend_name,
 )
+from utility_scripts.native_image_artifact import ARTIFACT_REPOSITORY_URLS  # noqa: E402
 from utility_scripts.strategy_loader import (  # noqa: E402
     apply_test_agent_alias,
     load_predefined_strategies,
@@ -80,7 +83,6 @@ REVIEW_LIMIT_ENV_VARS = (
 NETWORK_HOSTS_GITHUB = ("github.com", "api.github.com")
 NETWORK_HOSTS_WORK = ("services.gradle.org",)
 NETWORK_HOSTS_ISSUE_WORK = (
-    "repo.maven.apache.org",
     "plugins.gradle.org",
     "registry-1.docker.io",
     "auth.docker.io",
@@ -809,6 +811,7 @@ class HostRequirements:
 
     def _check_network(self) -> None:
         self._check_git_remote_access()
+        self._check_artifact_repositories()
         hosts: list[tuple[str, bool]] = [
             (host, self.requirements.github_work) for host in NETWORK_HOSTS_GITHUB
         ]
@@ -864,6 +867,29 @@ class HostRequirements:
                 None,
                 "Targets are discovered from each selected library and cannot be enumerated before queue selection",
                 "Allow outbound HTTPS to source-code/documentation URLs and registries declared by selected libraries.",
+            )
+
+    def _check_artifact_repositories(self) -> None:
+        """Require HTTP 200 from every repository used by issue-form artifact lookup.
+
+        §FS-forge-host-requirements
+        """
+        for repository_url in ARTIFACT_REPOSITORY_URLS:
+            name = f"artifact repository {repository_url}"
+            if not self.requirements.issue_work:
+                self._add("network", name, False, None, "not required by this run")
+                continue
+            passed, detail = probe_http_200(repository_url)
+            self._add(
+                "network",
+                name,
+                True,
+                passed,
+                detail,
+                (
+                    f"Make `HEAD {repository_url.rstrip('/')}/` return HTTP 200 from this host; "
+                    "check DNS, TLS, proxy or firewall policy, and repository availability."
+                ),
             )
 
     def _check_git_remote_access(self) -> None:
@@ -1381,6 +1407,23 @@ def resolve_executable(command: str) -> str | None:
     if os.path.sep in command:
         return command if os.path.isfile(command) and os.access(command, os.X_OK) else None
     return shutil.which(command)
+
+
+def probe_http_200(url: str, timeout: float = 20.0) -> tuple[bool, str]:
+    """Return whether an HTTP HEAD request to a base URL returns exactly 200.
+
+    §FS-forge-host-requirements
+    """
+    probe_url = f"{url.rstrip('/')}/"
+    request = urllib.request.Request(probe_url, method="HEAD")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = response.getcode()
+    except urllib.error.HTTPError as exc:
+        return False, f"HEAD {probe_url} returned HTTP {exc.code}"
+    except (OSError, urllib.error.URLError) as exc:
+        return False, f"HEAD {probe_url} failed: {exc}"
+    return status == 200, f"HEAD {probe_url} returned HTTP {status}"
 
 
 def run_command(


### PR DESCRIPTION
Closes #9569

## What this changes

Forge previously proved only that a TCP connection to `repo.maven.apache.org:443` could be opened at startup. Issue-form validation actually uses HTTP `HEAD` against `repo1.maven.org` and `packages.confluent.io`, so a different hostname or an HTTP-level proxy, TLS, rate-limit, or server failure could pass startup and then make Forge claim and release issue after issue.

Issue-work startup now checks every base URL in the shared `ARTIFACT_REPOSITORY_URLS` tuple and requires an exact HTTP 200 before Forge scans or claims queue items. This makes the host gate exercise the same route and request method as artifact lookup, following [§forge/FS-forge-host-requirements](https://github.com/oracle/graalvm-reachability-metadata/blob/codex/forge-repository-http-health/forge/docs/functional-spec/functional-spec.md#fs-forge-host-requirements) and the claim pipeline in [§forge/AR-forge-workflow-pipeline](https://github.com/oracle/graalvm-reachability-metadata/blob/codex/forge-repository-http-health/forge/docs/architecture/architecture.md#ar-forge-workflow-pipeline).

## How repository health is decided

- Normalize each configured repository base to a trailing-slash URL and send `HEAD`.
- Accept only HTTP 200; report other statuses and DNS, proxy, TLS, timeout, or connection failures directly in the host-requirements manifest.
- Block issue work with one concrete remediation when any configured repository is unhealthy.
- Report these checks as not required for modes that do not process issues, while retaining the existing generic network probes for other services.