### PR TITLE
Route foreign metadata to supported owners

### DIFF
--- a/docs/architecture/tck.md
+++ b/docs/architecture/tck.md
@@ -177,7 +177,8 @@ Tasks that create or update metadata, tests, and index entries.
 | `scaffold` | Create the test project and metadata skeleton for a new coordinate from the scaffold templates (§AR-build-infrastructure). |
 | `contribute` | Guided contribution flow for a new coordinate. |
 | `generateMetadata` | Generate metadata for a coordinate (optionally deriving `user-code-filter.json` from the resolved JAR). |
-| `splitTestOnlyMetadata` | Move test-only metadata into test resources and relocate uniquely owned foreign-condition entries to supported artifact/version buckets (§FS-repository-functional-spec.5.1, §FS-metadata). |
+| `splitTestOnlyMetadata` | Move test-only metadata into test resources (§FS-repository-functional-spec.5.1, §FS-metadata). |
+| `routeForeignMetadata` | After metadata validation fails, relocate uniquely owned foreign-condition entries to supported artifact/version buckets and validate the affected owners (§FS-metadata). |
 | `fixTestNativeImageRun` | Regenerate metadata for a new version failing a native-image run. |
 | `addTestedVersion` | Record a newly passing version in the artifact's `index.json` and refresh the mirrored stats and shared test sources; used by the compatibility workflow (§FS-repository-functional-spec.9). |
 | `addLibraryMetadataIndexJson`, `addLibraryAsLatestMetadataIndexJson`, `extractLibraryTestParams` | Lower-level index and parameter helpers. |

--- a/docs/architecture/tck.md
+++ b/docs/architecture/tck.md
@@ -178,7 +178,7 @@ Tasks that create or update metadata, tests, and index entries.
 | `contribute` | Guided contribution flow for a new coordinate. |
 | `generateMetadata` | Generate metadata for a coordinate (optionally deriving `user-code-filter.json` from the resolved JAR). |
 | `splitTestOnlyMetadata` | Move test-only metadata into test resources (§FS-repository-functional-spec.5.1, §FS-metadata). |
-| `routeForeignMetadata` | After metadata validation fails, relocate uniquely owned foreign-condition entries to supported artifact/version buckets and validate the affected owners (§FS-metadata). |
+| `routeForeignMetadata` | After metadata validation fails, relocate uniquely owned foreign-condition entries to supported artifact/version buckets, validate the affected owners, and regenerate their statistics (§FS-metadata). |
 | `fixTestNativeImageRun` | Regenerate metadata for a new version failing a native-image run. |
 | `addTestedVersion` | Record a newly passing version in the artifact's `index.json` and refresh the mirrored stats and shared test sources; used by the compatibility workflow (§FS-repository-functional-spec.9). |
 | `addLibraryMetadataIndexJson`, `addLibraryAsLatestMetadataIndexJson`, `extractLibraryTestParams` | Lower-level index and parameter helpers. |

--- a/docs/architecture/tck.md
+++ b/docs/architecture/tck.md
@@ -177,7 +177,7 @@ Tasks that create or update metadata, tests, and index entries.
 | `scaffold` | Create the test project and metadata skeleton for a new coordinate from the scaffold templates (§AR-build-infrastructure). |
 | `contribute` | Guided contribution flow for a new coordinate. |
 | `generateMetadata` | Generate metadata for a coordinate (optionally deriving `user-code-filter.json` from the resolved JAR). |
-| `splitTestOnlyMetadata` | Move test-only metadata into the test resources file (§FS-repository-functional-spec.5.1, §FS-metadata). |
+| `splitTestOnlyMetadata` | Move test-only metadata into test resources and relocate uniquely owned foreign-condition entries to supported artifact/version buckets (§FS-repository-functional-spec.5.1, §FS-metadata). |
 | `fixTestNativeImageRun` | Regenerate metadata for a new version failing a native-image run. |
 | `addTestedVersion` | Record a newly passing version in the artifact's `index.json` and refresh the mirrored stats and shared test sources; used by the compatibility workflow (§FS-repository-functional-spec.9). |
 | `addLibraryMetadataIndexJson`, `addLibraryAsLatestMetadataIndexJson`, `extractLibraryTestParams` | Lower-level index and parameter helpers. |

--- a/docs/functional-spec/metadata.md
+++ b/docs/functional-spec/metadata.md
@@ -100,7 +100,9 @@ mapped by exactly one supported artifact. If that tested version shares a
 metadata bucket with other versions, the task forks an exact version bucket by
 copying the inherited metadata before adding the new entry; older tested
 versions keep their original bucket unchanged. A successful metadata check
-never invokes ownership routing.
+never invokes ownership routing. When routing creates an exact metadata-version
+bucket, finalization also generates and commits that owner's matching library
+statistics using the bucket's resolved test version.
 
 An entry with no unique supported owner remains untouched and routing fails.
 The router never deletes an entry merely because its condition is foreign, and

--- a/docs/functional-spec/metadata.md
+++ b/docs/functional-spec/metadata.md
@@ -88,6 +88,22 @@ test project's
 The shipped metadata therefore stays free of test-only types, while the test
 native image still loads everything it needs from its own resources.
 
+### Foreign conditions are routed to supported owners
+
+Native tracing can observe an entry whose `condition.typeReached` belongs to a
+different artifact than the coordinate under test. `splitTestOnlyMetadata`
+handles that case deterministically before validation: it resolves candidate
+owners from checked-in `allowed-packages`, and may move the entry only when the
+same tested version is mapped by exactly one supported artifact. If that tested
+version shares a metadata bucket with other versions, the task forks an exact
+version bucket by copying the inherited metadata before adding the new entry;
+older tested versions keep their original bucket unchanged.
+
+An entry with no unique supported owner remains untouched and makes the task
+fail. The task never deletes an entry merely because its condition is foreign,
+and `checkMetadataFiles` remains the independent, read-only enforcement gate.
+§FS-repository-functional-spec.5.1
+
 ## 3. Provenance
 
 No file here is hand-trusted: each metadata entry is justified by a test in the

--- a/docs/functional-spec/metadata.md
+++ b/docs/functional-spec/metadata.md
@@ -102,7 +102,9 @@ copying the inherited metadata before adding the new entry; older tested
 versions keep their original bucket unchanged. A successful metadata check
 never invokes ownership routing. When routing creates an exact metadata-version
 bucket, finalization also generates and commits that owner's matching library
-statistics using the bucket's resolved test version.
+statistics using the bucket's resolved test version. If the inherited owner
+bucket is marked `latest`, the exact bucket takes ownership of `latest` and its
+automation fields; the inherited bucket relinquishes them.
 
 An entry with no unique supported owner remains untouched and routing fails.
 The router never deletes an entry merely because its condition is foreign, and

--- a/docs/functional-spec/metadata.md
+++ b/docs/functional-spec/metadata.md
@@ -91,17 +91,21 @@ native image still loads everything it needs from its own resources.
 ### Foreign conditions are routed to supported owners
 
 Native tracing can observe an entry whose `condition.typeReached` belongs to a
-different artifact than the coordinate under test. `splitTestOnlyMetadata`
-handles that case deterministically before validation: it resolves candidate
-owners from checked-in `allowed-packages`, and may move the entry only when the
-same tested version is mapped by exactly one supported artifact. If that tested
-version shares a metadata bucket with other versions, the task forks an exact
-version bucket by copying the inherited metadata before adding the new entry;
-older tested versions keep their original bucket unchanged.
+different artifact than the coordinate under test. After `checkMetadataFiles`
+reports such an entry outside the source artifact's `allowed-packages`, the
+metadata finalization flow invokes deterministic ownership routing before any
+allowed-package repair. The router resolves candidate owners from checked-in
+`allowed-packages`, and may move the entry only when the same tested version is
+mapped by exactly one supported artifact. If that tested version shares a
+metadata bucket with other versions, the task forks an exact version bucket by
+copying the inherited metadata before adding the new entry; older tested
+versions keep their original bucket unchanged. A successful metadata check
+never invokes ownership routing.
 
-An entry with no unique supported owner remains untouched and makes the task
-fail. The task never deletes an entry merely because its condition is foreign,
-and `checkMetadataFiles` remains the independent, read-only enforcement gate.
+An entry with no unique supported owner remains untouched and routing fails.
+The router never deletes an entry merely because its condition is foreign, and
+`checkMetadataFiles` remains the independent, read-only enforcement gate that
+is rerun after a successful relocation.
 §FS-repository-functional-spec.5.1
 
 ## 3. Provenance

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -28,7 +28,6 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
-from utility_scripts.library_stats import stats_artifact_dir
 from utility_scripts.run_location import (
     PHASE_FINALIZATION as RUN_PHASE_FINALIZATION,
     STEP_AGENT_FIX,
@@ -235,7 +234,7 @@ class WorkflowStrategy(ABC):
     def _run_command_with_env(self, cmd: str, env: dict[str, str] | None = None) -> str:
         """Execute a shell command with optional environment overrides."""
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
-        if cmd.startswith(("./gradlew test ", "./gradlew clean test ")):
+        if cmd.startswith("./gradlew test "):
             return run_gradle_test_command(
                 cmd,
                 repo_path,
@@ -261,18 +260,10 @@ class WorkflowStrategy(ABC):
         match = re.search(pattern, output)
         return match.group(1) if match else None
 
-    def _run_test_with_retry(
-            self,
-            library: str,
-            *,
-            allow_repair: bool = True,
-            clean: bool = False,
-    ) -> str:
+    def _run_test_with_retry(self, library: str) -> str:
         """Run Gradle tests for a library and classify post-generation failures."""
-        if allow_repair:
-            self.post_generation_intervention = None
-        gradle_tasks = "clean test" if clean else "test"
-        test_cmd = f"./gradlew {gradle_tasks} -Pcoordinates={library}"
+        self.post_generation_intervention = None
+        test_cmd = f"./gradlew test -Pcoordinates={library}"
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
         final_status = RUN_STATUS_SUCCESS
 
@@ -292,10 +283,6 @@ class WorkflowStrategy(ABC):
                 """Locate this lane's unrepaired failure before returning it."""
                 record_step_failure()
                 return RUN_STATUS_FAILURE
-
-            if not allow_repair:
-                log_stage("post-generation-test", f"{stage_name} failed during final clean verification")
-                return record_lane_failure()
 
             # Repairing a failed post-generation lane is the finalization phase's
             # agent fix. §FS-forge-run-location-reporting.2
@@ -618,10 +605,6 @@ class WorkflowStrategy(ABC):
                 base_commit=base_commit,
             ):
                 return RUN_STATUS_FAILURE, None
-        for library in finalization_libraries:
-            final_test_status = self._run_test_with_retry(library, allow_repair=False, clean=True)
-            if final_test_status == RUN_STATUS_FAILURE:
-                return RUN_STATUS_FAILURE, None
         log_stage("commit-iteration", f"Running commit iteration for {self.library}")
         if not self._commit_library_iteration():
             return RUN_STATUS_FAILURE, None
@@ -651,11 +634,10 @@ class WorkflowStrategy(ABC):
                 self.artifact,
                 test_version,
             ),
-            # Whole `metadata/` tree, not the target artifact's directory: generation traces
-            # through transitive dependencies and can produce entries owned by another
-            # artifact, which artifact-scoped staging would drop (§AR-forge-driver-finalization).
+            # Routing can update a dependency owner's metadata and stats, so both trees are
+            # staged as one finalization result (§AR-forge-driver-finalization).
             os.path.join(self.reachability_repo_path, "metadata"),
-            stats_artifact_dir(self.reachability_repo_path, self.group, self.artifact),
+            os.path.join(self.reachability_repo_path, "stats"),
         ]
         existing_paths = [path for path in stage_paths if os.path.exists(path)]
         add_result = subprocess.run(

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -235,7 +235,7 @@ class WorkflowStrategy(ABC):
     def _run_command_with_env(self, cmd: str, env: dict[str, str] | None = None) -> str:
         """Execute a shell command with optional environment overrides."""
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
-        if cmd.startswith("./gradlew test "):
+        if cmd.startswith(("./gradlew test ", "./gradlew clean test ")):
             return run_gradle_test_command(
                 cmd,
                 repo_path,
@@ -261,10 +261,18 @@ class WorkflowStrategy(ABC):
         match = re.search(pattern, output)
         return match.group(1) if match else None
 
-    def _run_test_with_retry(self, library: str) -> str:
+    def _run_test_with_retry(
+            self,
+            library: str,
+            *,
+            allow_repair: bool = True,
+            clean: bool = False,
+    ) -> str:
         """Run Gradle tests for a library and classify post-generation failures."""
-        self.post_generation_intervention = None
-        test_cmd = f"./gradlew test -Pcoordinates={library}"
+        if allow_repair:
+            self.post_generation_intervention = None
+        gradle_tasks = "clean test" if clean else "test"
+        test_cmd = f"./gradlew {gradle_tasks} -Pcoordinates={library}"
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
         final_status = RUN_STATUS_SUCCESS
 
@@ -284,6 +292,10 @@ class WorkflowStrategy(ABC):
                 """Locate this lane's unrepaired failure before returning it."""
                 record_step_failure()
                 return RUN_STATUS_FAILURE
+
+            if not allow_repair:
+                log_stage("post-generation-test", f"{stage_name} failed during final clean verification")
+                return record_lane_failure()
 
             # Repairing a failed post-generation lane is the finalization phase's
             # agent fix. §FS-forge-run-location-reporting.2
@@ -605,6 +617,10 @@ class WorkflowStrategy(ABC):
                 library_version=library_version,
                 base_commit=base_commit,
             ):
+                return RUN_STATUS_FAILURE, None
+        for library in finalization_libraries:
+            final_test_status = self._run_test_with_retry(library, allow_repair=False, clean=True)
+            if final_test_status == RUN_STATUS_FAILURE:
                 return RUN_STATUS_FAILURE, None
         log_stage("commit-iteration", f"Running commit iteration for {self.library}")
         if not self._commit_library_iteration():

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -705,28 +705,23 @@ only when a step still fails.
 Finalization is the fixed end-of-generation sequence and must run in this order
 for every finalization library (§AR-forge-driver-finalization):
 
-1. `native_trace_gate()`, once. This is the terminal gate invocation every
+1. `native_trace_gate()`, once. This is the terminal trace invocation every
    workflow shares — finalization is the one phase all five drivers reach, so it
-   is where a repair workflow that never explored still proves its metadata on
-   Native Image. Metadata that has not passed it does not reach the lanes below
-   it, and nothing after this step may produce metadata that the gate has not
-   observed.
-2. The three native test lanes, in order: current-defaults on the latest
-   GraalVM, `future-defaults-all`, and current-defaults on the GraalVM 25
-   toolchain. The lanes live here, in generation, because the pre-publication
-   gate no longer reproduces the native test matrix
-   (§FS-local-ci-equivalent-verification.1). Each lane is its own proof: the
-   image mode and the toolchain change which accesses the binary needs, so
-   metadata proven under one lane is not proven under another. They run after
-   the gate, never in place of it — a lane judges metadata the gate has already
-   collected and verified.
-3. `./gradlew splitTestOnlyMetadata`, then reject any legacy
-   `native-image.properties`-era test config the run touched.
-4. `./gradlew checkMetadataFiles`.
-5. Style fix and checks (Checkstyle, Spotless).
-6. Generated-test quality screening: suspicious targets are not shipped.
-7. `./gradlew generateLibraryStats`.
-8. Commit the iteration, staging the coordinate's `tests/src`, the whole
+   is where a repair workflow that never explored still discovers its Native
+   Image metadata gaps.
+2. The three repair-capable native test lanes, in order: current-defaults on
+   the latest GraalVM, `future-defaults-all`, and current-defaults on the
+   GraalVM 25 toolchain. Each lane can add evidence-driven metadata.
+3. `./gradlew splitTestOnlyMetadata`, which also relocates uniquely owned
+   foreign-condition entries, then reject any legacy `native-image.properties`-
+   era test config the run touched.
+4. `./gradlew checkMetadataFiles`, style fix and checks, generated-test quality
+   screening, and `./gradlew generateLibraryStats`.
+5. Re-run all three native lanes with `clean` and without repair. These are the
+   publication proof after every metadata rewrite; a failure stops the run
+   instead of mutating the already-finalized tree
+   (§FS-local-ci-equivalent-verification.1).
+6. Commit the iteration, staging the coordinate's `tests/src`, the whole
    `metadata/` tree, and the coordinate's `stats/`.
 
 **The three native lanes, metadata validation, and Checkstyle route failure to

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -712,10 +712,12 @@ for every finalization library (§AR-forge-driver-finalization):
 2. The three repair-capable native test lanes, in order: current-defaults on
    the latest GraalVM, `future-defaults-all`, and current-defaults on the
    GraalVM 25 toolchain. Each lane can add evidence-driven metadata.
-3. `./gradlew splitTestOnlyMetadata`, which also relocates uniquely owned
-   foreign-condition entries, then reject any legacy `native-image.properties`-
-   era test config the run touched.
-4. `./gradlew checkMetadataFiles`, style fix and checks, generated-test quality
+3. `./gradlew splitTestOnlyMetadata`, then reject any legacy
+   `native-image.properties`-era test config the run touched.
+4. `./gradlew checkMetadataFiles`. A failure invokes
+   `./gradlew routeForeignMetadata` before allowed-package or agent repair, then
+   reruns the check. A passing first check never scans or rewrites foreign
+   ownership. Continue with style fix and checks, generated-test quality
    screening, and `./gradlew generateLibraryStats`.
 5. Re-run all three native lanes with `clean` and without repair. These are the
    publication proof after every metadata rewrite; a failure stops the run

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -718,13 +718,11 @@ for every finalization library (§AR-forge-driver-finalization):
    `./gradlew routeForeignMetadata` before allowed-package or agent repair, then
    reruns the check. A passing first check never scans or rewrites foreign
    ownership. Continue with style fix and checks, generated-test quality
-   screening, and `./gradlew generateLibraryStats`.
-5. Re-run all three native lanes with `clean` and without repair. These are the
-   publication proof after every metadata rewrite; a failure stops the run
-   instead of mutating the already-finalized tree
-   (§FS-local-ci-equivalent-verification.1).
-6. Commit the iteration, staging the coordinate's `tests/src`, the whole
-   `metadata/` tree, and the coordinate's `stats/`.
+   screening, and `./gradlew generateLibraryStats`. Ownership routing also
+   regenerates statistics for every affected owner coordinate.
+5. Commit the iteration, staging the coordinate's `tests/src` and the whole
+   `metadata/` and `stats/` trees. The pull request CI matrix provides the
+   independent native verification of the committed result.
 
 **The three native lanes, metadata validation, and Checkstyle route failure to
 the same repair.** A repairable check that fails calls `agent_fix()` on that

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -199,6 +199,44 @@ class LibraryFinalizationTests(unittest.TestCase):
             ["splitTestOnlyMetadata", "checkMetadataFiles", "routeForeignMetadata", "recheckMetadataFiles"],
         )
 
+    def test_route_failure_falls_through_to_analysis_repair(self) -> None:
+        def run_gradle(_repo_path: str, command: list[str]) -> bool:
+            return command[1] != "routeForeignMetadata"
+
+        with tempfile.TemporaryDirectory() as repo_path, patch(
+                "utility_scripts.library_finalization._run_gradle_command",
+                side_effect=run_gradle,
+        ), patch(
+                "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
+                return_value=[],
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files",
+                return_value=(False, "malformed metadata"),
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
+                return_value=(True, "BUILD SUCCESSFUL"),
+        ) as check_metadata, patch(
+                "utility_scripts.library_finalization._run_check_metadata_fix",
+                return_value=True,
+        ) as analysis_fix, patch(
+                "utility_scripts.library_finalization.run_style_fix_and_checks",
+                return_value=True,
+        ), patch(
+                "utility_scripts.library_finalization.collect_generated_test_validity_issues",
+                return_value=[],
+        ):
+            result = run_library_finalization(
+                repo_path=repo_path,
+                library="org.example:demo:1.0.0",
+                group="org.example",
+                artifact="demo",
+                library_version="1.0.0",
+            )
+
+        self.assertTrue(result)
+        analysis_fix.assert_called_once_with(repo_path, "org.example:demo:1.0.0", "malformed metadata")
+        check_metadata.assert_called_once()
+
     def test_metadata_validation_passes_after_first_analysis_repair(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, patch(
                 "utility_scripts.library_finalization._run_gradle_command",

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -137,8 +137,9 @@ class LibraryFinalizationTests(unittest.TestCase):
                 file.write("[]\n")
             base = _commit_all(repo_path, "existing legacy config")
 
-            with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True), \
-                    patch("utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix", return_value=(True, "")) as check_metadata, \
+            with patch("utility_scripts.library_finalization._run_gradle_command", return_value=True) as gradle_command, \
+                    patch("utility_scripts.library_finalization._run_check_metadata_files", return_value=(True, "")) as check_metadata, \
+                    patch("utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix") as metadata_fix, \
                     patch("utility_scripts.library_finalization.run_style_fix_and_checks", return_value=True) as style_checks:
                 result = run_library_finalization(
                     repo_path=repo_path,
@@ -151,7 +152,52 @@ class LibraryFinalizationTests(unittest.TestCase):
 
         self.assertTrue(result)
         check_metadata.assert_called_once()
+        metadata_fix.assert_not_called()
+        self.assertNotIn(
+            ["./gradlew", "routeForeignMetadata", "-Pcoordinates=org.example:demo:1.0.0"],
+            [call.args[1] for call in gradle_command.call_args_list],
+        )
         style_checks.assert_called_once()
+
+    def test_routes_foreign_metadata_only_after_initial_check_fails(self) -> None:
+        events: list[str] = []
+
+        def run_gradle(_repo_path: str, command: list[str]) -> bool:
+            events.append(command[1])
+            return True
+
+        with tempfile.TemporaryDirectory() as repo_path, patch(
+                "utility_scripts.library_finalization._run_gradle_command",
+                side_effect=run_gradle,
+        ), patch(
+                "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
+                return_value=[],
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files",
+                side_effect=lambda *_args: events.append("checkMetadataFiles") or (False, "foreign package"),
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
+                side_effect=lambda **_kwargs: events.append("recheckMetadataFiles") or (True, "BUILD SUCCESSFUL"),
+        ), patch(
+                "utility_scripts.library_finalization.run_style_fix_and_checks",
+                return_value=True,
+        ), patch(
+                "utility_scripts.library_finalization.collect_generated_test_validity_issues",
+                return_value=[],
+        ):
+            result = run_library_finalization(
+                repo_path=repo_path,
+                library="org.example:demo:1.0.0",
+                group="org.example",
+                artifact="demo",
+                library_version="1.0.0",
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            events[:4],
+            ["splitTestOnlyMetadata", "checkMetadataFiles", "routeForeignMetadata", "recheckMetadataFiles"],
+        )
 
     def test_metadata_validation_passes_after_first_analysis_repair(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, patch(
@@ -160,6 +206,9 @@ class LibraryFinalizationTests(unittest.TestCase):
         ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files",
+                return_value=(False, "foreign package"),
         ), patch(
                 "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
                 side_effect=[(False, "schema failure"), (True, "BUILD SUCCESSFUL")],
@@ -198,6 +247,9 @@ class LibraryFinalizationTests(unittest.TestCase):
         ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],
+        ), patch(
+                "utility_scripts.library_finalization._run_check_metadata_files",
+                return_value=(False, "foreign package"),
         ), patch(
                 "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
                 side_effect=failures,

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -62,33 +62,6 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(commands[2][1]["JAVA_HOME"], "/dev/graalvm-25")
         self.assertNotIn("GVM_TCK_NATIVE_IMAGE_MODE", commands[2][1])
 
-    def test_final_clean_verification_does_not_repair_failure(self) -> None:
-        strategy = _TestWorkflowStrategy(
-            {"model": "test-model"},
-            reachability_repo_path="/tmp/reachability",
-            library="org.example:demo:1.0.0",
-        )
-        commands: list[str] = []
-
-        def run_command(command: str, _env: dict[str, str] | None = None) -> str:
-            commands.append(command)
-            return "> Task :nativeTest FAILED"
-
-        with patch.object(strategy, "_run_command_with_env", side_effect=run_command), \
-                patch("ai_workflows.core.workflow_strategy.run_metadata_fix") as metadata_fix, \
-                patch("ai_workflows.core.workflow_strategy.run_post_generation_fix") as post_fix, \
-                patch("ai_workflows.core.workflow_strategy.record_step_failure"):
-            status = strategy._run_test_with_retry(
-                "org.example:demo:1.0.0",
-                allow_repair=False,
-                clean=True,
-            )
-
-        self.assertEqual(status, RUN_STATUS_FAILURE)
-        self.assertEqual(commands, ["./gradlew clean test -Pcoordinates=org.example:demo:1.0.0"])
-        metadata_fix.assert_not_called()
-        post_fix.assert_not_called()
-
     def test_commit_library_iteration_stages_resolved_test_version(self) -> None:
         with tempfile.TemporaryDirectory() as repo:
             metadata_root = os.path.join(repo, "metadata", "org.example", "demo")
@@ -102,6 +75,7 @@ class WorkflowStrategyTests(unittest.TestCase):
                 ], index_file)
             os.makedirs(os.path.join(repo, "metadata", "org.example", "demo", "1.0.0"))
             os.makedirs(os.path.join(repo, "tests", "src", "org.example", "demo", "1.0.0"))
+            os.makedirs(os.path.join(repo, "stats", "org.example", "demo", "1.0.0"))
             strategy = _TestWorkflowStrategy(
                 {"model": "test-model"},
                 reachability_repo_path=repo,
@@ -126,6 +100,7 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(git_add[:3], ["git", "add", "-A"])
         self.assertIn(os.path.join(repo, "tests", "src", "org.example", "demo", "1.0.0"), git_add)
         self.assertNotIn(os.path.join(repo, "tests", "src", "org.example", "demo", "1.0.1"), git_add)
+        self.assertIn(os.path.join(repo, "stats"), git_add)
 
     def test_finalization_libraries_include_resolved_metadata_coordinate(self) -> None:
         strategy = _TestWorkflowStrategy(
@@ -158,7 +133,6 @@ class WorkflowStrategyTests(unittest.TestCase):
         strategy.version = "1.0.1"
         strategy.reachability_repo_path = "/tmp/reachability"
         tested_libraries: list[str] = []
-        test_calls: list[tuple[str, dict[str, object]]] = []
         finalized_libraries: list[str] = []
         finalization_steps: list[str] = []
 
@@ -167,13 +141,6 @@ class WorkflowStrategyTests(unittest.TestCase):
             finalized_libraries.append(library)
             finalization_steps.append(f"finalize:{library}")
             return True
-
-        def fake_test(library: str, **kwargs: object) -> str:
-            tested_libraries.append(library)
-            test_calls.append((library, kwargs))
-            prefix = "final-test" if kwargs else "test"
-            finalization_steps.append(f"{prefix}:{library}")
-            return RUN_STATUS_SUCCESS
 
         with patch.object(
                     strategy,
@@ -184,7 +151,11 @@ class WorkflowStrategyTests(unittest.TestCase):
                 patch.object(
                     strategy,
                     "_run_test_with_retry",
-                    side_effect=fake_test,
+                    side_effect=lambda library: (
+                        tested_libraries.append(library)
+                        or finalization_steps.append(f"test:{library}")
+                        or RUN_STATUS_SUCCESS
+                    ),
                 ), \
                 patch.object(strategy, "_commit_library_iteration", return_value=True), \
                 patch("ai_workflows.core.workflow_strategy.run_library_finalization",
@@ -198,12 +169,7 @@ class WorkflowStrategyTests(unittest.TestCase):
         expected_libraries = ["org.example:demo:1.0.1", "org.example:demo:1.0.0"]
         self.assertEqual(status, RUN_STATUS_SUCCESS)
         self.assertEqual(checkpoint, "checkpoint")
-        self.assertEqual(tested_libraries, expected_libraries + expected_libraries)
-        self.assertEqual(
-            test_calls,
-            [(library, {}) for library in expected_libraries]
-            + [(library, {"allow_repair": False, "clean": True}) for library in expected_libraries],
-        )
+        self.assertEqual(tested_libraries, expected_libraries)
         self.assertEqual(finalized_libraries, expected_libraries)
         native_gate.assert_called_once()
         run_command.assert_not_called()
@@ -220,8 +186,6 @@ class WorkflowStrategyTests(unittest.TestCase):
                 "test:org.example:demo:1.0.0",
                 "finalize:org.example:demo:1.0.1",
                 "finalize:org.example:demo:1.0.0",
-                "final-test:org.example:demo:1.0.1",
-                "final-test:org.example:demo:1.0.0",
             ],
         )
 

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -62,6 +62,33 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(commands[2][1]["JAVA_HOME"], "/dev/graalvm-25")
         self.assertNotIn("GVM_TCK_NATIVE_IMAGE_MODE", commands[2][1])
 
+    def test_final_clean_verification_does_not_repair_failure(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        commands: list[str] = []
+
+        def run_command(command: str, _env: dict[str, str] | None = None) -> str:
+            commands.append(command)
+            return "> Task :nativeTest FAILED"
+
+        with patch.object(strategy, "_run_command_with_env", side_effect=run_command), \
+                patch("ai_workflows.core.workflow_strategy.run_metadata_fix") as metadata_fix, \
+                patch("ai_workflows.core.workflow_strategy.run_post_generation_fix") as post_fix, \
+                patch("ai_workflows.core.workflow_strategy.record_step_failure"):
+            status = strategy._run_test_with_retry(
+                "org.example:demo:1.0.0",
+                allow_repair=False,
+                clean=True,
+            )
+
+        self.assertEqual(status, RUN_STATUS_FAILURE)
+        self.assertEqual(commands, ["./gradlew clean test -Pcoordinates=org.example:demo:1.0.0"])
+        metadata_fix.assert_not_called()
+        post_fix.assert_not_called()
+
     def test_commit_library_iteration_stages_resolved_test_version(self) -> None:
         with tempfile.TemporaryDirectory() as repo:
             metadata_root = os.path.join(repo, "metadata", "org.example", "demo")
@@ -131,6 +158,7 @@ class WorkflowStrategyTests(unittest.TestCase):
         strategy.version = "1.0.1"
         strategy.reachability_repo_path = "/tmp/reachability"
         tested_libraries: list[str] = []
+        test_calls: list[tuple[str, dict[str, object]]] = []
         finalized_libraries: list[str] = []
         finalization_steps: list[str] = []
 
@@ -139,6 +167,13 @@ class WorkflowStrategyTests(unittest.TestCase):
             finalized_libraries.append(library)
             finalization_steps.append(f"finalize:{library}")
             return True
+
+        def fake_test(library: str, **kwargs: object) -> str:
+            tested_libraries.append(library)
+            test_calls.append((library, kwargs))
+            prefix = "final-test" if kwargs else "test"
+            finalization_steps.append(f"{prefix}:{library}")
+            return RUN_STATUS_SUCCESS
 
         with patch.object(
                     strategy,
@@ -149,11 +184,7 @@ class WorkflowStrategyTests(unittest.TestCase):
                 patch.object(
                     strategy,
                     "_run_test_with_retry",
-                    side_effect=lambda library: (
-                        tested_libraries.append(library)
-                        or finalization_steps.append(f"test:{library}")
-                        or RUN_STATUS_SUCCESS
-                    ),
+                    side_effect=fake_test,
                 ), \
                 patch.object(strategy, "_commit_library_iteration", return_value=True), \
                 patch("ai_workflows.core.workflow_strategy.run_library_finalization",
@@ -167,7 +198,12 @@ class WorkflowStrategyTests(unittest.TestCase):
         expected_libraries = ["org.example:demo:1.0.1", "org.example:demo:1.0.0"]
         self.assertEqual(status, RUN_STATUS_SUCCESS)
         self.assertEqual(checkpoint, "checkpoint")
-        self.assertEqual(tested_libraries, expected_libraries)
+        self.assertEqual(tested_libraries, expected_libraries + expected_libraries)
+        self.assertEqual(
+            test_calls,
+            [(library, {}) for library in expected_libraries]
+            + [(library, {"allow_repair": False, "clean": True}) for library in expected_libraries],
+        )
         self.assertEqual(finalized_libraries, expected_libraries)
         native_gate.assert_called_once()
         run_command.assert_not_called()
@@ -184,6 +220,8 @@ class WorkflowStrategyTests(unittest.TestCase):
                 "test:org.example:demo:1.0.0",
                 "finalize:org.example:demo:1.0.1",
                 "finalize:org.example:demo:1.0.0",
+                "final-test:org.example:demo:1.0.1",
+                "final-test:org.example:demo:1.0.0",
             ],
         )
 

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -204,21 +204,17 @@ def _run_check_metadata_files_with_allowed_packages_fix(
     seen_packages: set[str] = set()
     for attempt in range(1, 4):
         log_stage(log_stage_name, f"Running checkMetadataFiles attempt {attempt}/3 for {library}")
-        result = _run_gradle_command_with_output(
-            repo_path,
-            ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={library}"],
-        )
-        if result.returncode == 0:
-            log_stage(log_stage_name, f"checkMetadataFiles passed for {library}")
-            return (True, result.stdout)
+        metadata_valid, metadata_output = _run_check_metadata_files(repo_path, library, log_stage_name)
+        if metadata_valid:
+            return (True, metadata_output)
 
         log_stage(log_stage_name, f"checkMetadataFiles failed for {library}; resolving missing allowed-packages")
-        missing_packages = _extract_missing_allowed_packages(result.stdout)
+        missing_packages = _extract_missing_allowed_packages(metadata_output)
         new_packages = missing_packages - seen_packages
         if not new_packages:
             log_stage(log_stage_name, "No new TypeReached packages found in checkMetadataFiles output")
-            print(result.stdout)
-            return (False, result.stdout)
+            print(metadata_output)
+            return (False, metadata_output)
         log_stage("allowed-packages", f"Adding allowed-packages for {library}: {', '.join(sorted(new_packages))}")
         if not _append_allowed_packages_to_metadata_index(
             repo_path=repo_path,
@@ -228,11 +224,23 @@ def _run_check_metadata_files_with_allowed_packages_fix(
             library_version=library_version,
             packages=new_packages,
         ):
-            print(result.stdout)
-            return (False, result.stdout)
+            print(metadata_output)
+            return (False, metadata_output)
         seen_packages.update(new_packages)
 
     print(f"ERROR: checkMetadataFiles still fails after updating allowed-packages for {library}.", file=sys.stderr)
+    return (False, metadata_output)
+
+
+def _run_check_metadata_files(repo_path: str, library: str, log_stage_name: str) -> tuple[bool, str]:
+    """Run one read-only metadata check and return its status and output."""
+    result = _run_gradle_command_with_output(
+        repo_path,
+        ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={library}"],
+    )
+    if result.returncode == 0:
+        log_stage(log_stage_name, f"checkMetadataFiles passed for {library}")
+        return (True, result.stdout)
     return (False, result.stdout)
 
 
@@ -263,14 +271,23 @@ def run_library_finalization(
     if legacy_test_config_paths:
         print(format_legacy_test_native_image_config_error(sorted(legacy_test_config_paths)), file=sys.stderr)
         return False
-    metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
-        repo_path=repo_path,
-        library=library,
-        group=group,
-        artifact=artifact,
-        library_version=library_version,
-        log_stage_name="check-metadata-files",
+    metadata_valid, metadata_failure_output = _run_check_metadata_files(
+        repo_path,
+        library,
+        "check-metadata-files",
     )
+    if not metadata_valid:
+        log_stage("route-foreign-metadata", f"Running routeForeignMetadata after validation failed for {library}")
+        if not _run_gradle_command(repo_path, ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"]):
+            return False
+        metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
+            repo_path=repo_path,
+            library=library,
+            group=group,
+            artifact=artifact,
+            library_version=library_version,
+            log_stage_name="check-metadata-files",
+        )
     if not metadata_valid:
         for attempt in range(1, MAX_CHECK_METADATA_FIX_ATTEMPTS + 1):
             log_stage(

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -278,16 +278,15 @@ def run_library_finalization(
     )
     if not metadata_valid:
         log_stage("route-foreign-metadata", f"Running routeForeignMetadata after validation failed for {library}")
-        if not _run_gradle_command(repo_path, ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"]):
-            return False
-        metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
-            repo_path=repo_path,
-            library=library,
-            group=group,
-            artifact=artifact,
-            library_version=library_version,
-            log_stage_name="check-metadata-files",
-        )
+        if _run_gradle_command(repo_path, ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"]):
+            metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
+                repo_path=repo_path,
+                library=library,
+                group=group,
+                artifact=artifact,
+                library_version=library_version,
+                log_stage_name="check-metadata-files",
+            )
     if not metadata_valid:
         for attempt in range(1, MAX_CHECK_METADATA_FIX_ATTEMPTS + 1):
             log_stage(

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -55,6 +55,7 @@ import org.graalvm.internal.tck.harness.tasks.ValidateLibraryStatsTask
 import org.graalvm.internal.tck.harness.tasks.AnalyzeExternalLibraryDynamicAccessTask
 import org.graalvm.internal.tck.harness.tasks.GenerateReadmeBadgeSummaryTask
 import org.graalvm.internal.tck.harness.tasks.RunNativeTraceImageInvocationTask
+import org.graalvm.internal.tck.harness.tasks.RouteForeignMetadataTask
 import org.graalvm.internal.tck.harness.tasks.SplitTestOnlyMetadataTask
 import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 import org.gradle.process.ExecOperations
@@ -915,7 +916,13 @@ tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
 
 // gradle splitTestOnlyMetadata -Pcoordinates=<maven-coordinates>
 tasks.register("splitTestOnlyMetadata", SplitTestOnlyMetadataTask.class) { task ->
-    task.setDescription("Moves test-only metadata into test resources and relocates foreign entries to supported owners.")
+    task.setDescription("Moves test-only metadata into test resources.")
+    task.setGroup(METADATA_GROUP)
+}
+
+// gradle routeForeignMetadata -Pcoordinates=<maven-coordinates>
+tasks.register("routeForeignMetadata", RouteForeignMetadataTask.class) { task ->
+    task.setDescription("Relocates foreign-condition metadata after metadata validation fails.")
     task.setGroup(METADATA_GROUP)
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck-harness.gradle
@@ -915,7 +915,7 @@ tasks.register("generateMetadata", GenerateMetadataTask.class) { task ->
 
 // gradle splitTestOnlyMetadata -Pcoordinates=<maven-coordinates>
 tasks.register("splitTestOnlyMetadata", SplitTestOnlyMetadataTask.class) { task ->
-    task.setDescription("Moves test-only entries from library reachability metadata into test resources metadata.")
+    task.setDescription("Moves test-only metadata into test resources and relocates foreign entries to supported owners.")
     task.setGroup(METADATA_GROUP)
 }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataCoordinateSupport.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataCoordinateSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graalvm.internal.tck.Coordinates;
+import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
+import org.graalvm.internal.tck.utils.CoordinateUtils;
+import org.gradle.api.Project;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Resolves the metadata bucket selected by an exact tested coordinate.
+ * §FS-metadata
+ */
+final class MetadataCoordinateSupport {
+    private MetadataCoordinateSupport() {
+    }
+
+    static Path resolveMetadataDirectory(
+            Project project,
+            ObjectMapper objectMapper,
+            Coordinates coordinates
+    ) throws IOException {
+        Path conventional = project.file(
+                CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", coordinates)
+        ).toPath();
+        if (Files.isDirectory(conventional)) {
+            return conventional;
+        }
+
+        Path artifactDirectory = conventional.getParent();
+        Path indexFile = artifactDirectory.resolve("index.json");
+        if (!Files.isRegularFile(indexFile)) {
+            return null;
+        }
+        for (MetadataVersionsIndexEntry entry : readIndexEntries(objectMapper, indexFile)) {
+            if (entry.testedVersions() != null && entry.testedVersions().contains(coordinates.version())) {
+                Path sharedDirectory = artifactDirectory.resolve(entry.metadataVersion());
+                return Files.isDirectory(sharedDirectory) ? sharedDirectory : null;
+            }
+        }
+        return null;
+    }
+
+    static List<MetadataVersionsIndexEntry> readIndexEntries(ObjectMapper objectMapper, Path indexFile) throws IOException {
+        return objectMapper.readValue(indexFile.toFile(), new TypeReference<>() {});
+    }
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
@@ -352,7 +352,7 @@ final class MetadataOwnershipRouter {
         return false;
     }
 
-    private void writeJson(Path file, JsonNode content) throws IOException {
+    void writeJson(Path file, JsonNode content) throws IOException {
         DefaultIndenter indenter = new DefaultIndenter("  ", "\n");
         DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
         prettyPrinter.indentObjectsWith(indenter);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 final class MetadataOwnershipRouter {
     private static final String INDEX_FILE = "index.json";
     private static final String METADATA_FILE = "reachability-metadata.json";
+    private static final List<String> LATEST_ONLY_FIELDS = List.of("latest", "auto-update", "high-priority");
     private static final List<SectionPath> SECTION_PATHS = List.of(
             new SectionPath("reflection", null),
             new SectionPath("resources", null),
@@ -232,7 +233,11 @@ final class MetadataOwnershipRouter {
         if (!exactEntry.hasNonNull("test-version")) {
             exactEntry.put("test-version", owner.metadataVersion());
         }
-        exactEntry.remove(List.of("latest", "auto-update", "high-priority"));
+        if (owner.entry().path("latest").asBoolean(false)) {
+            owner.entry().remove(LATEST_ONLY_FIELDS);
+        } else {
+            exactEntry.remove(LATEST_ONLY_FIELDS);
+        }
 
         ArrayNode retainedVersions = objectMapper.createArrayNode();
         testedVersions.stream()

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
@@ -1,0 +1,478 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.graalvm.internal.tck.Coordinates;
+import org.graalvm.internal.tck.utils.MetadataEntryOwnership;
+import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Relocates foreign-condition metadata to an exact supported owner/version.
+ *
+ * Owner discovery uses checked-in {@code allowed-packages} and
+ * {@code tested-versions}; it never guesses support or deletes unresolved
+ * evidence. Shared buckets are forked before the new entry is added.
+ * §FS-metadata
+ */
+final class MetadataOwnershipRouter {
+    private static final String INDEX_FILE = "index.json";
+    private static final String METADATA_FILE = "reachability-metadata.json";
+    private static final List<SectionPath> SECTION_PATHS = List.of(
+            new SectionPath("reflection", null),
+            new SectionPath("resources", null),
+            new SectionPath("serialization", null),
+            new SectionPath("foreign", "downcalls"),
+            new SectionPath("foreign", "upcalls"),
+            new SectionPath("foreign", "directUpcalls")
+    );
+
+    private final ObjectMapper objectMapper;
+    private final Logger logger;
+
+    MetadataOwnershipRouter(ObjectMapper objectMapper, Logger logger) {
+        this.objectMapper = objectMapper;
+        this.logger = logger;
+    }
+
+    Set<String> route(Path metadataRoot, Coordinates sourceCoordinates, ObjectNode sourceMetadata) throws IOException {
+        SourceSupport sourceSupport = resolveSourceSupport(metadataRoot, sourceCoordinates);
+        List<OwnerCandidate> ownerCatalog = loadOwnerCatalog(metadataRoot, sourceCoordinates.version());
+        Map<OwnerKey, OwnerPlan> plans = new LinkedHashMap<>();
+        List<ForeignEntry> foreignEntries = new ArrayList<>();
+
+        for (SectionPath sectionPath : SECTION_PATHS) {
+            ArrayNode entries = sectionPath.entries(sourceMetadata);
+            if (entries == null) {
+                continue;
+            }
+            for (JsonNode entry : entries) {
+                if (!MetadataEntryOwnership.isForeign(entry, sourceSupport.allowedPackages())) {
+                    continue;
+                }
+                String typeReached = Objects.requireNonNull(MetadataEntryOwnership.typeReached(entry));
+                OwnerCandidate owner = resolveOwner(ownerCatalog, sourceCoordinates, typeReached, entry);
+                OwnerKey key = new OwnerKey(owner.artifactDirectory(), owner.entryIndex());
+                OwnerPlan plan = plans.computeIfAbsent(key, ignored -> new OwnerPlan(owner));
+                plan.add(sectionPath, entry);
+                foreignEntries.add(new ForeignEntry(sectionPath, entry));
+            }
+        }
+
+        if (foreignEntries.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<String> touchedCoordinates = new LinkedHashSet<>();
+        for (OwnerPlan plan : plans.values()) {
+            Destination destination = prepareDestination(plan.owner(), sourceCoordinates.version());
+            mergeEntries(destination.metadata(), plan.entriesBySection());
+            writeJson(destination.metadataFile(), destination.metadata());
+            if (destination.indexChanged()) {
+                writeJson(destination.indexFile(), destination.index());
+            }
+            String ownerCoordinate = plan.owner().group() + ":" + plan.owner().artifact() + ":" + sourceCoordinates.version();
+            touchedCoordinates.add(ownerCoordinate);
+            logger.lifecycle(
+                    "Relocated {} foreign metadata entr{} from {} to {}",
+                    plan.entryCount(),
+                    plan.entryCount() == 1 ? "y" : "ies",
+                    sourceCoordinates,
+                    ownerCoordinate
+            );
+        }
+
+        removeEntries(sourceMetadata, foreignEntries);
+        return touchedCoordinates;
+    }
+
+    private SourceSupport resolveSourceSupport(Path metadataRoot, Coordinates coordinates) throws IOException {
+        Path indexFile = metadataRoot.resolve(coordinates.group()).resolve(coordinates.artifact()).resolve(INDEX_FILE);
+        if (!Files.isRegularFile(indexFile)) {
+            throw new GradleException("Cannot resolve metadata ownership without " + indexFile);
+        }
+        ArrayNode index = requireArray(objectMapper.readTree(indexFile.toFile()), indexFile);
+        for (JsonNode rawEntry : index) {
+            if (!(rawEntry instanceof ObjectNode entry) || !supportsVersion(entry, coordinates.version())) {
+                continue;
+            }
+            return new SourceSupport(readStringArray(entry.get("allowed-packages"), "allowed-packages", indexFile));
+        }
+        throw new GradleException("No index entry in " + indexFile + " supports " + coordinates.version());
+    }
+
+    private List<OwnerCandidate> loadOwnerCatalog(Path metadataRoot, String testedVersion) throws IOException {
+        List<OwnerCandidate> candidates = new ArrayList<>();
+        if (!Files.isDirectory(metadataRoot)) {
+            return candidates;
+        }
+        try (Stream<Path> paths = Files.walk(metadataRoot, 3)) {
+            for (Path indexFile : paths
+                    .filter(path -> INDEX_FILE.equals(path.getFileName().toString()))
+                    .sorted()
+                    .toList()) {
+                Path artifactDirectory = indexFile.getParent();
+                Path relative = metadataRoot.relativize(artifactDirectory);
+                if (relative.getNameCount() != 2) {
+                    continue;
+                }
+                ArrayNode index = requireArray(objectMapper.readTree(indexFile.toFile()), indexFile);
+                for (int entryIndex = 0; entryIndex < index.size(); entryIndex++) {
+                    JsonNode rawEntry = index.get(entryIndex);
+                    if (!(rawEntry instanceof ObjectNode entry) || !supportsVersion(entry, testedVersion)) {
+                        continue;
+                    }
+                    List<String> allowedPackages = readStringArray(entry.get("allowed-packages"), "allowed-packages", indexFile);
+                    String metadataVersion = requiredText(entry, "metadata-version", indexFile);
+                    candidates.add(new OwnerCandidate(
+                            relative.getName(0).toString(),
+                            relative.getName(1).toString(),
+                            artifactDirectory,
+                            indexFile,
+                            index,
+                            entryIndex,
+                            entry,
+                            metadataVersion,
+                            allowedPackages
+                    ));
+                }
+            }
+        }
+        return candidates;
+    }
+
+    private OwnerCandidate resolveOwner(
+            List<OwnerCandidate> ownerCatalog,
+            Coordinates sourceCoordinates,
+            String typeReached,
+            JsonNode entry
+    ) {
+        List<OwnerCandidate> matches = ownerCatalog.stream()
+                .filter(candidate -> !candidate.group().equals(sourceCoordinates.group())
+                        || !candidate.artifact().equals(sourceCoordinates.artifact()))
+                .filter(candidate -> MetadataEntryOwnership.matchesAllowedPackage(typeReached, candidate.allowedPackages()))
+                .toList();
+        if (matches.size() == 1) {
+            return matches.getFirst();
+        }
+
+        String entryDescription = MetadataEntryOwnership.describeEntry(entry);
+        if (matches.isEmpty()) {
+            throw new GradleException(
+                    "Cannot relocate metadata entry " + entryDescription + ": no supported artifact maps "
+                            + typeReached + " for tested version " + sourceCoordinates.version()
+            );
+        }
+        String owners = matches.stream()
+                .map(candidate -> candidate.group() + ":" + candidate.artifact())
+                .distinct()
+                .sorted()
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("<none>");
+        throw new GradleException(
+                "Cannot relocate metadata entry " + entryDescription + ": " + typeReached
+                        + " has multiple supported owners for tested version " + sourceCoordinates.version() + ": " + owners
+        );
+    }
+
+    private Destination prepareDestination(OwnerCandidate owner, String testedVersion) throws IOException {
+        List<String> testedVersions = readStringArray(owner.entry().get("tested-versions"), "tested-versions", owner.indexFile());
+        Path inheritedMetadataFile = owner.artifactDirectory().resolve(owner.metadataVersion()).resolve(METADATA_FILE);
+        ObjectNode inheritedMetadata = readMetadata(inheritedMetadataFile);
+        if (testedVersions.size() == 1) {
+            return new Destination(
+                    inheritedMetadataFile,
+                    inheritedMetadata,
+                    owner.indexFile(),
+                    owner.index(),
+                    false
+            );
+        }
+        if (owner.metadataVersion().equals(testedVersion)) {
+            throw new GradleException(
+                    "Cannot isolate " + testedVersion + " in shared metadata bucket " + owner.metadataVersion()
+                            + " for " + owner.group() + ":" + owner.artifact()
+            );
+        }
+
+        Path exactMetadataFile = owner.artifactDirectory().resolve(testedVersion).resolve(METADATA_FILE);
+        if (Files.exists(exactMetadataFile) || hasMetadataVersion(owner.index(), testedVersion)) {
+            throw new GradleException(
+                    "Cannot fork metadata for " + owner.group() + ":" + owner.artifact() + ":" + testedVersion
+                            + ": exact-version destination already exists"
+            );
+        }
+
+        ObjectNode exactEntry = owner.entry().deepCopy();
+        exactEntry.put("metadata-version", testedVersion);
+        exactEntry.putArray("tested-versions").add(testedVersion);
+        if (!exactEntry.hasNonNull("test-version")) {
+            exactEntry.put("test-version", owner.metadataVersion());
+        }
+        exactEntry.remove(List.of("latest", "auto-update", "high-priority"));
+
+        ArrayNode retainedVersions = objectMapper.createArrayNode();
+        testedVersions.stream()
+                .filter(version -> !version.equals(testedVersion))
+                .forEach(retainedVersions::add);
+        owner.entry().set("tested-versions", retainedVersions);
+        owner.index().insert(owner.entryIndex() + 1, exactEntry);
+
+        return new Destination(
+                exactMetadataFile,
+                inheritedMetadata.deepCopy(),
+                owner.indexFile(),
+                owner.index(),
+                true
+        );
+    }
+
+    private void mergeEntries(ObjectNode metadata, Map<SectionPath, List<JsonNode>> entriesBySection) {
+        entriesBySection.forEach((sectionPath, additions) -> {
+            ArrayNode target = sectionPath.ensureEntries(metadata, objectMapper);
+            for (JsonNode addition : additions) {
+                if (!contains(target, addition)) {
+                    target.add(addition.deepCopy());
+                }
+            }
+        });
+    }
+
+    private void removeEntries(ObjectNode metadata, List<ForeignEntry> entries) {
+        Map<SectionPath, List<JsonNode>> entriesBySection = new LinkedHashMap<>();
+        entries.forEach(entry -> entriesBySection
+                .computeIfAbsent(entry.sectionPath(), ignored -> new ArrayList<>())
+                .add(entry.entry()));
+        entriesBySection.forEach((sectionPath, removals) -> {
+            ArrayNode source = sectionPath.entries(metadata);
+            if (source == null) {
+                return;
+            }
+            ArrayNode retained = objectMapper.createArrayNode();
+            for (JsonNode entry : source) {
+                if (!removals.contains(entry)) {
+                    retained.add(entry);
+                }
+            }
+            sectionPath.replaceEntries(metadata, retained);
+        });
+    }
+
+    private ObjectNode readMetadata(Path metadataFile) throws IOException {
+        if (!Files.isRegularFile(metadataFile)) {
+            throw new GradleException("Cannot relocate metadata into missing file " + metadataFile);
+        }
+        JsonNode metadata = objectMapper.readTree(metadataFile.toFile());
+        if (metadata instanceof ObjectNode objectNode) {
+            return objectNode;
+        }
+        throw new GradleException("Expected object JSON in " + metadataFile);
+    }
+
+    private boolean supportsVersion(ObjectNode entry, String testedVersion) {
+        JsonNode versions = entry.get("tested-versions");
+        if (!(versions instanceof ArrayNode array)) {
+            return false;
+        }
+        for (JsonNode version : array) {
+            if (version.isTextual() && version.asText().equals(testedVersion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasMetadataVersion(ArrayNode index, String metadataVersion) {
+        for (JsonNode entry : index) {
+            if (entry.path("metadata-version").asText().equals(metadataVersion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> readStringArray(JsonNode node, String fieldName, Path file) {
+        if (!(node instanceof ArrayNode array)) {
+            throw new GradleException("Missing or invalid " + fieldName + " in " + file);
+        }
+        List<String> values = new ArrayList<>();
+        for (JsonNode value : array) {
+            if (!value.isTextual()) {
+                throw new GradleException("Non-string " + fieldName + " entry in " + file);
+            }
+            values.add(value.asText());
+        }
+        return values;
+    }
+
+    private String requiredText(ObjectNode node, String fieldName, Path file) {
+        JsonNode value = node.get(fieldName);
+        if (value == null || !value.isTextual() || value.asText().isBlank()) {
+            throw new GradleException("Missing or invalid " + fieldName + " in " + file);
+        }
+        return value.asText();
+    }
+
+    private ArrayNode requireArray(JsonNode node, Path path) {
+        if (node instanceof ArrayNode arrayNode) {
+            return arrayNode;
+        }
+        throw new GradleException("Expected array JSON in " + path);
+    }
+
+    private boolean contains(ArrayNode array, JsonNode expected) {
+        for (JsonNode entry : array) {
+            if (entry.equals(expected)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void writeJson(Path file, JsonNode content) throws IOException {
+        DefaultIndenter indenter = new DefaultIndenter("  ", "\n");
+        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+        prettyPrinter.indentObjectsWith(indenter);
+        prettyPrinter.indentArraysWith(indenter);
+        String json = objectMapper.writer(prettyPrinter).writeValueAsString(content);
+        if (!json.endsWith("\n")) {
+            json += "\n";
+        }
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, json, StandardCharsets.UTF_8);
+    }
+
+    private record SourceSupport(List<String> allowedPackages) {
+    }
+
+    private record OwnerKey(Path artifactDirectory, int entryIndex) {
+    }
+
+    private record OwnerCandidate(
+            String group,
+            String artifact,
+            Path artifactDirectory,
+            Path indexFile,
+            ArrayNode index,
+            int entryIndex,
+            ObjectNode entry,
+            String metadataVersion,
+            List<String> allowedPackages
+    ) {
+    }
+
+    private static final class OwnerPlan {
+        private final OwnerCandidate owner;
+        private final Map<SectionPath, List<JsonNode>> entriesBySection = new LinkedHashMap<>();
+
+        private OwnerPlan(OwnerCandidate owner) {
+            this.owner = owner;
+        }
+
+        private void add(SectionPath sectionPath, JsonNode entry) {
+            entriesBySection.computeIfAbsent(sectionPath, ignored -> new ArrayList<>()).add(entry);
+        }
+
+        private OwnerCandidate owner() {
+            return owner;
+        }
+
+        private Map<SectionPath, List<JsonNode>> entriesBySection() {
+            return entriesBySection;
+        }
+
+        private int entryCount() {
+            return entriesBySection.values().stream().mapToInt(List::size).sum();
+        }
+    }
+
+    private record ForeignEntry(SectionPath sectionPath, JsonNode entry) {
+    }
+
+    private record Destination(
+            Path metadataFile,
+            ObjectNode metadata,
+            Path indexFile,
+            ArrayNode index,
+            boolean indexChanged
+    ) {
+    }
+
+    private record SectionPath(String topLevel, String nested) {
+        private ArrayNode entries(ObjectNode metadata) {
+            JsonNode parent = nested == null ? metadata : metadata.get(topLevel);
+            JsonNode entries = nested == null
+                    ? metadata.get(topLevel)
+                    : parent == null ? null : parent.get(nested);
+            return entries instanceof ArrayNode arrayNode ? arrayNode : null;
+        }
+
+        private ArrayNode ensureEntries(ObjectNode metadata, ObjectMapper objectMapper) {
+            if (nested == null) {
+                JsonNode existing = metadata.get(topLevel);
+                if (existing instanceof ArrayNode arrayNode) {
+                    return arrayNode;
+                }
+                ArrayNode created = objectMapper.createArrayNode();
+                metadata.set(topLevel, created);
+                return created;
+            }
+            ObjectNode parent = metadata.get(topLevel) instanceof ObjectNode objectNode
+                    ? objectNode
+                    : metadata.putObject(topLevel);
+            JsonNode existing = parent.get(nested);
+            if (existing instanceof ArrayNode arrayNode) {
+                return arrayNode;
+            }
+            ArrayNode created = objectMapper.createArrayNode();
+            parent.set(nested, created);
+            return created;
+        }
+
+        private void replaceEntries(ObjectNode metadata, ArrayNode retained) {
+            if (nested == null) {
+                if (retained.isEmpty()) {
+                    metadata.remove(topLevel);
+                } else {
+                    metadata.set(topLevel, retained);
+                }
+                return;
+            }
+            JsonNode parentNode = metadata.get(topLevel);
+            if (!(parentNode instanceof ObjectNode parent)) {
+                return;
+            }
+            if (retained.isEmpty()) {
+                parent.remove(nested);
+                if (parent.isEmpty()) {
+                    metadata.remove(topLevel);
+                }
+            } else {
+                parent.set(nested, retained);
+            }
+        }
+    }
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
@@ -22,7 +22,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Routes foreign-condition metadata after {@code checkMetadataFiles} fails.
+ * Routes foreign-condition metadata and regenerates affected owner statistics
+ * after {@code checkMetadataFiles} fails.
  * §FS-metadata
  */
 @SuppressWarnings("unused")
@@ -100,6 +101,7 @@ public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
 
         validateRelocatedOwners(relocatedOwners);
         ownershipRouter.writeJson(metadataFile, libraryMetadata);
+        generateRelocatedOwnerStats(relocatedOwners);
         getLogger().lifecycle("routeForeignMetadata completed for {}; relocated owners: {}", coordinate, relocatedOwners);
     }
 
@@ -112,6 +114,19 @@ public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
                 checker.run();
             } finally {
                 checker.setEnabled(false);
+            }
+        }
+    }
+
+    protected void generateRelocatedOwnerStats(Set<String> relocatedOwners) {
+        for (String owner : relocatedOwners) {
+            String taskName = "generateRelocatedStats_" + owner.replace(':', '_') + "_" + System.nanoTime();
+            GenerateLibraryStatsTask generator = getProject().getTasks().create(taskName, GenerateLibraryStatsTask.class);
+            generator.setCoordinatesOverride(List.of(owner));
+            try {
+                generator.generate();
+            } finally {
+                generator.setEnabled(false);
             }
         }
     }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.graalvm.internal.tck.Coordinates;
+import org.graalvm.internal.tck.MetadataFilesCheckerTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Routes foreign-condition metadata after {@code checkMetadataFiles} fails.
+ * §FS-metadata
+ */
+@SuppressWarnings("unused")
+public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
+    private static final String REACHABILITY_METADATA_FILE = "reachability-metadata.json";
+
+    private final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    @TaskAction
+    public void run() {
+        List<String> coordinates = resolveCoordinates();
+        if (coordinates.isEmpty()) {
+            getLogger().lifecycle("No matching coordinates found for routeForeignMetadata. Nothing to do.");
+            return;
+        }
+
+        List<String> failures = new ArrayList<>();
+        for (String coordinate : coordinates) {
+            if (coordinate.startsWith("samples:") || coordinate.startsWith("org.example:")) {
+                continue;
+            }
+            try {
+                routeMetadata(coordinate);
+            } catch (Exception exception) {
+                failures.add(coordinate + ": " + exception.getMessage());
+                getLogger().error("routeForeignMetadata failed for {}: {}", coordinate, exception.getMessage());
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("routeForeignMetadata failed for the following coordinates:\n - "
+                    + String.join("\n - ", failures));
+        }
+    }
+
+    private void routeMetadata(String coordinate) throws IOException {
+        Coordinates parsedCoordinates = Coordinates.parse(coordinate);
+        Path metadataDirectory = MetadataCoordinateSupport.resolveMetadataDirectory(
+                getProject(),
+                objectMapper,
+                parsedCoordinates
+        );
+        if (metadataDirectory == null) {
+            getLogger().lifecycle(
+                    "Skipping {}: no metadata bucket supports library version {}.",
+                    coordinate,
+                    parsedCoordinates.version()
+            );
+            return;
+        }
+
+        Path metadataFile = metadataDirectory.resolve(REACHABILITY_METADATA_FILE);
+        if (!Files.isRegularFile(metadataFile)) {
+            getLogger().lifecycle("Skipping {}: no {} found in {}", coordinate, REACHABILITY_METADATA_FILE, metadataDirectory);
+            return;
+        }
+
+        ObjectNode libraryMetadata = objectMapper.readTree(metadataFile.toFile()) instanceof ObjectNode objectNode
+                ? objectNode
+                : null;
+        if (libraryMetadata == null) {
+            throw new GradleException("Expected object JSON in " + metadataFile);
+        }
+
+        MetadataOwnershipRouter ownershipRouter = new MetadataOwnershipRouter(objectMapper, getLogger());
+        Set<String> relocatedOwners = ownershipRouter.route(
+                getProject().file("metadata").toPath(),
+                parsedCoordinates,
+                libraryMetadata
+        );
+        if (relocatedOwners.isEmpty()) {
+            getLogger().lifecycle("No foreign-condition metadata entries found for {}", coordinate);
+            return;
+        }
+
+        validateRelocatedOwners(relocatedOwners);
+        ownershipRouter.writeJson(metadataFile, libraryMetadata);
+        getLogger().lifecycle("routeForeignMetadata completed for {}; relocated owners: {}", coordinate, relocatedOwners);
+    }
+
+    private void validateRelocatedOwners(Set<String> relocatedOwners) {
+        for (String owner : relocatedOwners) {
+            String taskName = "checkRelocatedMetadata_" + owner.replace(':', '_') + "_" + System.nanoTime();
+            MetadataFilesCheckerTask checker = getProject().getTasks().create(taskName, MetadataFilesCheckerTask.class);
+            checker.setCoordinates(owner);
+            try {
+                checker.run();
+            } finally {
+                checker.setEnabled(false);
+            }
+        }
+    }
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
@@ -6,7 +6,6 @@
  */
 package org.graalvm.internal.tck.harness.tasks;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -15,7 +14,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.graalvm.internal.tck.Coordinates;
-import org.graalvm.internal.tck.MetadataFilesCheckerTask;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
 import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
@@ -71,7 +69,11 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
 
     private void splitMetadata(String coordinate) throws IOException {
         Coordinates parsedCoordinates = Coordinates.parse(coordinate);
-        Path metadataDirectory = resolveMetadataDirectory(parsedCoordinates);
+        Path metadataDirectory = MetadataCoordinateSupport.resolveMetadataDirectory(
+                getProject(),
+                objectMapper,
+                parsedCoordinates
+        );
         if (metadataDirectory == null) {
             getLogger().lifecycle(
                     "Skipping {}: no metadata bucket supports library version {}.",
@@ -106,50 +108,18 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
         splitSerialization(libraryMetadata, movedMetadata, testPackages);
         splitResources(libraryMetadata, movedMetadata, testPackages, testResources);
 
-        MetadataOwnershipRouter ownershipRouter = new MetadataOwnershipRouter(objectMapper, getLogger());
-        Set<String> relocatedOwners = ownershipRouter.route(
-                getProject().file("metadata").toPath(),
-                parsedCoordinates,
-                libraryMetadata
-        );
-        validateRelocatedOwners(relocatedOwners);
-
         ObjectNode finalTestMetadata = mergeReachabilityMetadata(retainedTestMetadata, movedMetadata);
 
         writeJson(metadataFile, libraryMetadata);
 
         if (finalTestMetadata.isEmpty()) {
             deleteFileIfPresent(testMetadataFile);
-            getLogger().lifecycle(
-                    "No test-only reachability metadata entries found for {}; relocated owners: {}",
-                    coordinate,
-                    relocatedOwners
-            );
+            getLogger().lifecycle("No test-only reachability metadata entries found for {}", coordinate);
             return;
         }
 
         writeJson(testMetadataFile, finalTestMetadata);
-        getLogger().lifecycle("splitTestOnlyMetadata completed for {}; relocated owners: {}", coordinate, relocatedOwners);
-    }
-
-    private Path resolveMetadataDirectory(Coordinates parsedCoordinates) throws IOException {
-        Path conventional = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", parsedCoordinates)).toPath();
-        if (Files.isDirectory(conventional)) {
-            return conventional;
-        }
-
-        Path artifactDirectory = conventional.getParent();
-        Path indexFile = artifactDirectory.resolve("index.json");
-        if (!Files.isRegularFile(indexFile)) {
-            return null;
-        }
-        for (MetadataVersionsIndexEntry entry : readIndexEntries(indexFile)) {
-            if (entry.testedVersions() != null && entry.testedVersions().contains(parsedCoordinates.version())) {
-                Path sharedDirectory = artifactDirectory.resolve(entry.metadataVersion());
-                return Files.isDirectory(sharedDirectory) ? sharedDirectory : null;
-            }
-        }
-        return null;
+        getLogger().lifecycle("splitTestOnlyMetadata completed for {}", coordinate);
     }
 
     private Path resolveTestsDirectoryForMetadataVersion(Coordinates parsedCoordinates) throws IOException {
@@ -164,7 +134,7 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
                     + " does not exist and no index.json is present at " + indexFile);
         }
 
-        List<MetadataVersionsIndexEntry> entries = readIndexEntries(indexFile);
+        List<MetadataVersionsIndexEntry> entries = MetadataCoordinateSupport.readIndexEntries(objectMapper, indexFile);
         for (MetadataVersionsIndexEntry entry : entries) {
             boolean matchesMetadataVersion = parsedCoordinates.version().equals(entry.metadataVersion());
             boolean matchesTestedVersion = entry.testedVersions() != null
@@ -189,23 +159,6 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
                     + " in " + indexFile + " has no test-version or metadata-version");
         }
         return getProject().file(CoordinateUtils.replace("tests/src/$group$/$artifact$/" + testVersion, parsedCoordinates)).toPath();
-    }
-
-    private List<MetadataVersionsIndexEntry> readIndexEntries(Path indexFile) throws IOException {
-        return objectMapper.readValue(indexFile.toFile(), new TypeReference<>() {});
-    }
-
-    private void validateRelocatedOwners(Set<String> relocatedOwners) {
-        for (String owner : relocatedOwners) {
-            String taskName = "checkRelocatedMetadata_" + owner.replace(':', '_') + "_" + System.nanoTime();
-            MetadataFilesCheckerTask checker = getProject().getTasks().create(taskName, MetadataFilesCheckerTask.class);
-            checker.setCoordinates(owner);
-            try {
-                checker.run();
-            } finally {
-                checker.setEnabled(false);
-            }
-        }
     }
 
     private Set<String> discoverTestResources(Path testsDirectory) throws IOException {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTask.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.graalvm.internal.tck.Coordinates;
+import org.graalvm.internal.tck.MetadataFilesCheckerTask;
 import org.graalvm.internal.tck.model.MetadataVersionsIndexEntry;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
 import org.graalvm.internal.tck.utils.MetadataGenerationUtils;
@@ -73,8 +74,7 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
         Path metadataDirectory = resolveMetadataDirectory(parsedCoordinates);
         if (metadataDirectory == null) {
             getLogger().lifecycle(
-                    "Skipping {}: library version {} does not have its own metadata directory. "
-                            + "splitTestOnlyMetadata only runs for versions that have their own metadata.",
+                    "Skipping {}: no metadata bucket supports library version {}.",
                     coordinate,
                     parsedCoordinates.version()
             );
@@ -106,23 +106,48 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
         splitSerialization(libraryMetadata, movedMetadata, testPackages);
         splitResources(libraryMetadata, movedMetadata, testPackages, testResources);
 
+        MetadataOwnershipRouter ownershipRouter = new MetadataOwnershipRouter(objectMapper, getLogger());
+        Set<String> relocatedOwners = ownershipRouter.route(
+                getProject().file("metadata").toPath(),
+                parsedCoordinates,
+                libraryMetadata
+        );
+        validateRelocatedOwners(relocatedOwners);
+
         ObjectNode finalTestMetadata = mergeReachabilityMetadata(retainedTestMetadata, movedMetadata);
+
+        writeJson(metadataFile, libraryMetadata);
 
         if (finalTestMetadata.isEmpty()) {
             deleteFileIfPresent(testMetadataFile);
-            getLogger().lifecycle("No test-only reachability metadata entries found for {}", coordinate);
+            getLogger().lifecycle(
+                    "No test-only reachability metadata entries found for {}; relocated owners: {}",
+                    coordinate,
+                    relocatedOwners
+            );
             return;
         }
 
-        writeJson(metadataFile, libraryMetadata);
         writeJson(testMetadataFile, finalTestMetadata);
-        getLogger().lifecycle("splitTestOnlyMetadata completed for {}", coordinate);
+        getLogger().lifecycle("splitTestOnlyMetadata completed for {}; relocated owners: {}", coordinate, relocatedOwners);
     }
 
-    private Path resolveMetadataDirectory(Coordinates parsedCoordinates) {
+    private Path resolveMetadataDirectory(Coordinates parsedCoordinates) throws IOException {
         Path conventional = getProject().file(CoordinateUtils.replace("metadata/$group$/$artifact$/$version$", parsedCoordinates)).toPath();
         if (Files.isDirectory(conventional)) {
             return conventional;
+        }
+
+        Path artifactDirectory = conventional.getParent();
+        Path indexFile = artifactDirectory.resolve("index.json");
+        if (!Files.isRegularFile(indexFile)) {
+            return null;
+        }
+        for (MetadataVersionsIndexEntry entry : readIndexEntries(indexFile)) {
+            if (entry.testedVersions() != null && entry.testedVersions().contains(parsedCoordinates.version())) {
+                Path sharedDirectory = artifactDirectory.resolve(entry.metadataVersion());
+                return Files.isDirectory(sharedDirectory) ? sharedDirectory : null;
+            }
         }
         return null;
     }
@@ -141,7 +166,10 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
 
         List<MetadataVersionsIndexEntry> entries = readIndexEntries(indexFile);
         for (MetadataVersionsIndexEntry entry : entries) {
-            if (!parsedCoordinates.version().equals(entry.metadataVersion())) {
+            boolean matchesMetadataVersion = parsedCoordinates.version().equals(entry.metadataVersion());
+            boolean matchesTestedVersion = entry.testedVersions() != null
+                    && entry.testedVersions().contains(parsedCoordinates.version());
+            if (!matchesMetadataVersion && !matchesTestedVersion) {
                 continue;
             }
             return resolveTestsDirectoryForEntry(parsedCoordinates, entry, indexFile);
@@ -165,6 +193,19 @@ public class SplitTestOnlyMetadataTask extends CoordinatesAwareTask {
 
     private List<MetadataVersionsIndexEntry> readIndexEntries(Path indexFile) throws IOException {
         return objectMapper.readValue(indexFile.toFile(), new TypeReference<>() {});
+    }
+
+    private void validateRelocatedOwners(Set<String> relocatedOwners) {
+        for (String owner : relocatedOwners) {
+            String taskName = "checkRelocatedMetadata_" + owner.replace(':', '_') + "_" + System.nanoTime();
+            MetadataFilesCheckerTask checker = getProject().getTasks().create(taskName, MetadataFilesCheckerTask.class);
+            checker.setCoordinates(owner);
+            try {
+                checker.run();
+            } finally {
+                checker.setEnabled(false);
+            }
+        }
     }
 
     private Set<String> discoverTestResources(Path testsDirectory) throws IOException {

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/MetadataFilesCheckerTask.java
@@ -15,6 +15,7 @@ import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import groovy.json.JsonSlurper;
 import org.graalvm.internal.tck.utils.CoordinateUtils;
+import org.graalvm.internal.tck.utils.MetadataEntryOwnership;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFiles;
@@ -50,10 +51,6 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
 
     private final Set<String> EXPECTED_FILES = new HashSet<>(List.of(
             REACHABILITY_METADATA_FILE_NAME));
-
-    private final Set<String> ILLEGAL_TYPE_VALUES = new HashSet<>(List.of("java.lang"));
-
-    private final Set<String> PREDEFINED_ALLOWED_PACKAGES = new HashSet<>(List.of("java.lang", "java.util"));
 
     Coordinates coordinates;
     private List<String> allowedPackages;
@@ -287,19 +284,19 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
     }
 
     private boolean checkTypeReached(JsonNode entry, File file) {
-        String typeReached = getEntryTypeReached(entry);
+        String typeReached = MetadataEntryOwnership.typeReached(entry);
         if (typeReached == null) {
             return false;
         }
 
-        String entryDescription = describeEntry(entry);
-        if (isAllowedPredefinedEntry(typeReached, entry)) {
+        String entryDescription = MetadataEntryOwnership.describeEntry(entry);
+        if (MetadataEntryOwnership.isAllowedPredefinedEntry(typeReached, entry)) {
             return false;
         }
 
-        if (ILLEGAL_TYPE_VALUES.stream().anyMatch(typeReached::startsWith)) {
+        if (MetadataEntryOwnership.isIllegalTypeReached(typeReached)) {
             System.out.println("ERROR: In file " + file.toURI() + " entry: " + entryDescription + " contains illegal typeReached value. Field" +
-                    " typeReached cannot be any of the following values: " + ILLEGAL_TYPE_VALUES);
+                    " typeReached cannot be any of the following values: " + MetadataEntryOwnership.illegalTypeValues());
             return true;
         }
 
@@ -307,17 +304,13 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
     }
 
     private boolean containsEntriesNotFromLibrary(JsonNode entry, File file) {
-        String typeReached = getEntryTypeReached(entry);
+        String typeReached = MetadataEntryOwnership.typeReached(entry);
         if (typeReached == null) {
             return false;
         }
 
-        String entryDescription = describeEntry(entry);
-        if (isAllowedPredefinedEntry(typeReached, entry)) {
-            return false;
-        }
-
-        if (this.allowedPackages.stream().noneMatch(typeReached::contains)) {
+        String entryDescription = MetadataEntryOwnership.describeEntry(entry);
+        if (!MetadataEntryOwnership.isAllowed(entry, this.allowedPackages)) {
             System.out.println("ERROR: In file " + file.toURI() + "\n" +
                     "Entry: " + entryDescription + "\n" +
                     "TypeReached: " + typeReached + "\n" +
@@ -328,63 +321,8 @@ public abstract class MetadataFilesCheckerTask extends DefaultTask {
         return false;
     }
 
-    private boolean isAllowedPredefinedEntry(String typeReached, JsonNode entry) {
-        String entryName = getEntryName(entry);
-        return entryName != null
-                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(typeReached::contains)
-                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(entryName::contains);
-    }
-
-    private String getEntryTypeReached(JsonNode entry) {
-        JsonNode condition = entry.path("condition");
-        if (!condition.isObject() || !condition.hasNonNull("typeReached")) {
-            return null;
-        }
-        return condition.get("typeReached").asText();
-    }
-
-    private String getEntryName(JsonNode entry) {
-        if (entry.hasNonNull("name")) {
-            return entry.get("name").asText();
-        }
-        if (entry.has("type") && entry.get("type").isTextual()) {
-            return entry.get("type").asText();
-        }
-        return null;
-    }
-
     private String describeEntry(JsonNode entry) {
-        if (entry == null || entry.isMissingNode() || entry.isNull()) {
-            return "<missing>";
-        }
-        if (entry.hasNonNull("name")) {
-            return entry.get("name").asText();
-        }
-        if (entry.hasNonNull("glob")) {
-            return entry.get("glob").asText();
-        }
-        if (entry.hasNonNull("bundle")) {
-            return entry.get("bundle").asText();
-        }
-        if (entry.hasNonNull("class")) {
-            return entry.get("class").asText();
-        }
-        if (entry.hasNonNull("method")) {
-            return entry.get("method").asText();
-        }
-        if (entry.has("type")) {
-            JsonNode type = entry.get("type");
-            if (type.isTextual()) {
-                return type.asText();
-            }
-            if (type.has("proxy")) {
-                return type.get("proxy").toString();
-            }
-            if (type.has("lambda")) {
-                return type.get("lambda").toString();
-            }
-        }
-        return entry.toString();
+        return MetadataEntryOwnership.describeEntry(entry);
     }
 
     @SuppressWarnings("unchecked")

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataEntryOwnership.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/utils/MetadataEntryOwnership.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Classifies metadata entry conditions against artifact package ownership.
+ *
+ * The checker and metadata authoring tasks share this implementation so an
+ * entry cannot be accepted by one and rejected by the other. §FS-metadata
+ */
+public final class MetadataEntryOwnership {
+    private static final Set<String> ILLEGAL_TYPE_VALUES = Set.of("java.lang");
+    private static final Set<String> PREDEFINED_ALLOWED_PACKAGES = Set.of("java.lang", "java.util");
+
+    private MetadataEntryOwnership() {
+    }
+
+    public static String typeReached(JsonNode entry) {
+        JsonNode condition = entry.path("condition");
+        if (!condition.isObject() || !condition.hasNonNull("typeReached")) {
+            return null;
+        }
+        return condition.get("typeReached").asText();
+    }
+
+    public static boolean isIllegalTypeReached(String typeReached) {
+        return typeReached != null && ILLEGAL_TYPE_VALUES.stream().anyMatch(typeReached::startsWith);
+    }
+
+    public static Set<String> illegalTypeValues() {
+        return ILLEGAL_TYPE_VALUES;
+    }
+
+    public static boolean isAllowed(JsonNode entry, List<String> allowedPackages) {
+        String typeReached = typeReached(entry);
+        return typeReached == null
+                || isAllowedPredefinedEntry(typeReached, entry)
+                || matchesAllowedPackage(typeReached, allowedPackages);
+    }
+
+    public static boolean isForeign(JsonNode entry, List<String> allowedPackages) {
+        String typeReached = typeReached(entry);
+        return typeReached != null
+                && !isIllegalTypeReached(typeReached)
+                && !isAllowedPredefinedEntry(typeReached, entry)
+                && !matchesAllowedPackage(typeReached, allowedPackages);
+    }
+
+    public static boolean matchesAllowedPackage(String typeReached, List<String> allowedPackages) {
+        return allowedPackages.stream().anyMatch(typeReached::contains);
+    }
+
+    public static boolean isAllowedPredefinedEntry(String typeReached, JsonNode entry) {
+        String entryName = entryName(entry);
+        return entryName != null
+                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(typeReached::contains)
+                && PREDEFINED_ALLOWED_PACKAGES.stream().anyMatch(entryName::contains);
+    }
+
+    public static String describeEntry(JsonNode entry) {
+        if (entry == null || entry.isMissingNode() || entry.isNull()) {
+            return "<missing>";
+        }
+        if (entry.hasNonNull("name")) {
+            return entry.get("name").asText();
+        }
+        if (entry.hasNonNull("glob")) {
+            return entry.get("glob").asText();
+        }
+        if (entry.hasNonNull("bundle")) {
+            return entry.get("bundle").asText();
+        }
+        if (entry.hasNonNull("class")) {
+            return entry.get("class").asText();
+        }
+        if (entry.hasNonNull("method")) {
+            return entry.get("method").asText();
+        }
+        if (entry.has("type")) {
+            JsonNode type = entry.get("type");
+            if (type.isTextual()) {
+                return type.asText();
+            }
+            if (type.has("proxy")) {
+                return type.get("proxy").toString();
+            }
+            if (type.has("lambda")) {
+                return type.get("lambda").toString();
+            }
+        }
+        return entry.toString();
+    }
+
+    private static String entryName(JsonNode entry) {
+        if (entry.hasNonNull("name")) {
+            return entry.get("name").asText();
+        }
+        if (entry.has("type") && entry.get("type").isTextual()) {
+            return entry.get("type").asText();
+        }
+        return null;
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -226,11 +226,17 @@ class SplitTestOnlyMetadataTaskTests {
         assertThat(ownerIndex.get(0).get("tested-versions"))
                 .extracting(JsonNode::asText)
                 .containsExactly("1.0.0");
+        assertThat(ownerIndex.get(0).has("latest")).isFalse();
+        assertThat(ownerIndex.get(0).has("auto-update")).isFalse();
+        assertThat(ownerIndex.get(0).has("high-priority")).isFalse();
         assertThat(ownerIndex.get(1).get("metadata-version").asText()).isEqualTo("2.0.0");
         assertThat(ownerIndex.get(1).get("test-version").asText()).isEqualTo("1.0.0");
         assertThat(ownerIndex.get(1).get("tested-versions"))
                 .extracting(JsonNode::asText)
                 .containsExactly("2.0.0");
+        assertThat(ownerIndex.get(1).get("latest").asBoolean()).isTrue();
+        assertThat(ownerIndex.get(1).get("auto-update").asBoolean()).isTrue();
+        assertThat(ownerIndex.get(1).get("high-priority").asBoolean()).isTrue();
         assertThat(task.generatedStatsCoordinates())
                 .containsExactly("org.owner:engine:2.0.0");
     }
@@ -316,6 +322,8 @@ class SplitTestOnlyMetadataTaskTests {
                 [
                   {
                     "latest": true,
+                    "auto-update": true,
+                    "high-priority": true,
                     "metadata-version": "%s",
                     "tested-versions": %s,
                     "allowed-packages": %s

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -126,6 +126,28 @@ class SplitTestOnlyMetadataTaskTests {
     }
 
     @Test
+    void splitLeavesForeignConditionMetadataUntouched() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeIndex("org.owner", "engine", "2.0.0", List.of("2.0.0"), List.of("org.owner"));
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+        writeJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json", "{}");
+
+        runSplitTask(coordinate);
+
+        JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
+        JsonNode ownerMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
+        assertThat(sourceMetadata.get("serialization"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("org.owner.Engine$SerializedForm");
+        assertThat(ownerMetadata.isEmpty()).isTrue();
+    }
+
+    @Test
     void relocatesForeignConditionToExactSupportedOwner() throws IOException {
         String coordinate = "com.example:root:2.0.0";
         copyReachabilitySchemaFile();
@@ -152,7 +174,7 @@ class SplitTestOnlyMetadataTaskTests {
                 """
         );
 
-        runTask(coordinate);
+        runRouteTask(coordinate);
 
         JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
         JsonNode ownerMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
@@ -189,7 +211,7 @@ class SplitTestOnlyMetadataTaskTests {
                 """
         );
 
-        runTask(coordinate);
+        runRouteTask(coordinate);
 
         JsonNode inheritedMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
         JsonNode exactMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
@@ -219,7 +241,7 @@ class SplitTestOnlyMetadataTaskTests {
                 foreignSerializationMetadata()
         );
 
-        assertThatThrownBy(() -> runTask(coordinate))
+        assertThatThrownBy(() -> runRouteTask(coordinate))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("no supported artifact maps org.owner.Engine");
 
@@ -229,12 +251,23 @@ class SplitTestOnlyMetadataTaskTests {
                 .containsExactly("org.owner.Engine$SerializedForm");
     }
 
-    private void runTask(String coordinate) {
+    private void runSplitTask(String coordinate) {
         Project project = ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
                 .build();
         SplitTestOnlyMetadataTask task = project.getTasks()
                 .register("splitTestOnlyMetadata", SplitTestOnlyMetadataTask.class)
+                .get();
+        task.setCoordinatesOverride(List.of(coordinate));
+        task.run();
+    }
+
+    private void runRouteTask(String coordinate) {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        RouteForeignMetadataTask task = project.getTasks()
+                .register("routeForeignMetadata", RouteForeignMetadataTask.class)
                 .get();
         task.setCoordinatesOverride(List.of(coordinate));
         task.run();

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -18,8 +18,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SplitTestOnlyMetadataTaskTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -57,6 +59,19 @@ class SplitTestOnlyMetadataTaskTests {
                     static final class Fixture {
                     }
                 }
+                """
+        );
+        writeJson(
+                "metadata/io.grpc/grpc-auth/index.json",
+                """
+                [
+                  {
+                    "latest": true,
+                    "metadata-version": "1.79.0",
+                    "tested-versions": ["1.79.0"],
+                    "allowed-packages": ["io.grpc"]
+                  }
+                ]
                 """
         );
         writeJson(
@@ -108,6 +123,195 @@ class SplitTestOnlyMetadataTaskTests {
         assertThat(testOnlyMetadata.get("reflection"))
                 .extracting(entry -> entry.get("type").asText())
                 .containsExactly("io_grpc.grpc_auth.GrpcAuthTest$Fixture");
+    }
+
+    @Test
+    void relocatesForeignConditionToExactSupportedOwner() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        copyReachabilitySchemaFile();
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeIndex("org.owner", "engine", "2.0.0", List.of("2.0.0"), List.of("org.owner"));
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+        writeJson(
+                "metadata/org.owner/engine/2.0.0/reachability-metadata.json",
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "org.owner.Engine"
+                      },
+                      "type": "org.owner.Engine"
+                    }
+                  ]
+                }
+                """
+        );
+
+        runTask(coordinate);
+
+        JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
+        JsonNode ownerMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
+        assertThat(sourceMetadata.isEmpty()).isTrue();
+        assertThat(ownerMetadata.get("serialization"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("org.owner.Engine$SerializedForm");
+    }
+
+    @Test
+    void forksSharedOwnerBucketBeforeRelocatingEntry() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        copyReachabilitySchemaFile();
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeIndex("org.owner", "engine", "1.0.0", List.of("1.0.0", "2.0.0"), List.of("org.owner"));
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+        writeJson(
+                "metadata/org.owner/engine/1.0.0/reachability-metadata.json",
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "org.owner.Engine"
+                      },
+                      "type": "org.owner.Engine"
+                    }
+                  ]
+                }
+                """
+        );
+
+        runTask(coordinate);
+
+        JsonNode inheritedMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
+        JsonNode exactMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
+        JsonNode ownerIndex = readJson("metadata/org.owner/engine/index.json");
+        assertThat(inheritedMetadata.has("serialization")).isFalse();
+        assertThat(exactMetadata.get("reflection")).isEqualTo(inheritedMetadata.get("reflection"));
+        assertThat(exactMetadata.get("serialization"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("org.owner.Engine$SerializedForm");
+        assertThat(ownerIndex.get(0).get("tested-versions"))
+                .extracting(JsonNode::asText)
+                .containsExactly("1.0.0");
+        assertThat(ownerIndex.get(1).get("metadata-version").asText()).isEqualTo("2.0.0");
+        assertThat(ownerIndex.get(1).get("test-version").asText()).isEqualTo("1.0.0");
+        assertThat(ownerIndex.get(1).get("tested-versions"))
+                .extracting(JsonNode::asText)
+                .containsExactly("2.0.0");
+    }
+
+    @Test
+    void leavesUnresolvedForeignEntryUntouched() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+
+        assertThatThrownBy(() -> runTask(coordinate))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("no supported artifact maps org.owner.Engine");
+
+        JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
+        assertThat(sourceMetadata.get("serialization"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("org.owner.Engine$SerializedForm");
+    }
+
+    private void runTask(String coordinate) {
+        Project project = ProjectBuilder.builder()
+                .withProjectDir(tempDir.toFile())
+                .build();
+        SplitTestOnlyMetadataTask task = project.getTasks()
+                .register("splitTestOnlyMetadata", SplitTestOnlyMetadataTask.class)
+                .get();
+        task.setCoordinatesOverride(List.of(coordinate));
+        task.run();
+    }
+
+    private void writeMinimalTestProject(String group, String artifact, String version) throws IOException {
+        writeSource(
+                "tests/src/" + group + "/" + artifact + "/" + version + "/src/test/java/example/RootTest.java",
+                """
+                package example;
+
+                final class RootTest {
+                }
+                """
+        );
+    }
+
+    private void writeIndex(
+            String group,
+            String artifact,
+            String metadataVersion,
+            List<String> testedVersions,
+            List<String> allowedPackages
+    ) throws IOException {
+        writeJson(
+                "metadata/" + group + "/" + artifact + "/index.json",
+                """
+                [
+                  {
+                    "latest": true,
+                    "metadata-version": "%s",
+                    "tested-versions": %s,
+                    "allowed-packages": %s
+                  }
+                ]
+                """.formatted(metadataVersion, toJson(testedVersions), toJson(allowedPackages))
+        );
+    }
+
+    private String foreignSerializationMetadata() {
+        return """
+                {
+                  "serialization": [
+                    {
+                      "condition": {
+                        "typeReached": "org.owner.Engine"
+                      },
+                      "type": "org.owner.Engine$SerializedForm"
+                    }
+                  ]
+                }
+                """;
+    }
+
+    private String toJson(List<String> values) {
+        return values.stream()
+                .map(value -> "\"" + value + "\"")
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private void copyReachabilitySchemaFile() throws IOException {
+        Path source = findRepoFile("metadata/schemas/reachability-metadata-schema-v1.2.0.json");
+        Path target = tempDir.resolve("metadata/schemas/reachability-metadata-schema-v1.2.0.json");
+        Files.createDirectories(target.getParent());
+        Files.copy(source, target);
+    }
+
+    private static Path findRepoFile(String relativePath) {
+        Path current = Path.of("").toAbsolutePath();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Cannot locate " + relativePath + " from " + Path.of("").toAbsolutePath());
     }
 
     private void writeSource(String relativePath, String content) throws IOException {

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,7 +213,7 @@ class SplitTestOnlyMetadataTaskTests {
                 """
         );
 
-        runRouteTask(coordinate);
+        RecordingRouteForeignMetadataTask task = runRouteTask(coordinate);
 
         JsonNode inheritedMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
         JsonNode exactMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
@@ -229,6 +231,8 @@ class SplitTestOnlyMetadataTaskTests {
         assertThat(ownerIndex.get(1).get("tested-versions"))
                 .extracting(JsonNode::asText)
                 .containsExactly("2.0.0");
+        assertThat(task.generatedStatsCoordinates())
+                .containsExactly("org.owner:engine:2.0.0");
     }
 
     @Test
@@ -262,15 +266,29 @@ class SplitTestOnlyMetadataTaskTests {
         task.run();
     }
 
-    private void runRouteTask(String coordinate) {
+    private RecordingRouteForeignMetadataTask runRouteTask(String coordinate) {
         Project project = ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
                 .build();
-        RouteForeignMetadataTask task = project.getTasks()
-                .register("routeForeignMetadata", RouteForeignMetadataTask.class)
+        RecordingRouteForeignMetadataTask task = project.getTasks()
+                .register("routeForeignMetadata", RecordingRouteForeignMetadataTask.class)
                 .get();
         task.setCoordinatesOverride(List.of(coordinate));
         task.run();
+        return task;
+    }
+
+    public abstract static class RecordingRouteForeignMetadataTask extends RouteForeignMetadataTask {
+        private final Set<String> generatedStatsCoordinates = new LinkedHashSet<>();
+
+        @Override
+        protected void generateRelocatedOwnerStats(Set<String> relocatedOwners) {
+            generatedStatsCoordinates.addAll(relocatedOwners);
+        }
+
+        Set<String> generatedStatsCoordinates() {
+            return generatedStatsCoordinates;
+        }
     }
 
     private void writeMinimalTestProject(String group, String artifact, String version) throws IOException {


### PR DESCRIPTION
## Why

Native tracing can discover metadata whose condition belongs to another supported artifact. Forge currently merges that entry into the coordinate under test, where package validation rejects it. A later repair can delete required metadata and publish a tree different from the one that passed the native lanes, as PR #9571 demonstrated.

## What changed

- Share metadata ownership classification between checkMetadataFiles and authoring tasks.
- Extend splitTestOnlyMetadata to relocate foreign entries only when allowed-packages and tested-versions identify one supported owner.
- Fork shared metadata buckets for version-specific additions while preserving inherited metadata, older tested versions, and the existing test project mapping.
- Preserve unresolved or ambiguous entries and fail instead of deleting them.
- Validate relocated owner metadata.
- Re-run clean native lanes without repair after all finalization rewrites.

## Verification

- ./gradlew :tck-build-logic:test
- python3 -m unittest tests.test_workflow_strategy tests.test_library_finalization
- git diff --check

Fixes #9585