### PR TITLE
Union-merge forge/FINDINGS.md to end PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Forge records one pre-push review finding per generated branch in
+# `forge/FINDINGS.md` (§forge/FS-local-branch-review). Every branch inserts its
+# entry at the same offset below the header, so any two concurrent pull requests
+# conflict on that file and on nothing else. The ledger is append-only, so
+# keeping both sides is always the correct resolution: `union` merges the entries
+# without conflict markers instead of stopping the merge.
+forge/FINDINGS.md merge=union

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -588,3 +588,20 @@ infrastructure errors must not be converted into `human-intervention` unless
 the review rules identify a semantic generated-result, repository-automation,
 metadata, or library-execution problem that requires maintainer judgment
 (§FS-human-intervention-policy).
+
+**A conflict that needs no judgment is resolved, not escalated.** An approved
+pull request whose only merge conflict is the shared findings ledger must not be
+left for a maintainer. Because every branch records its finding at the same
+offset in the append-only `forge/FINDINGS.md` (§FS-local-branch-review), any two
+open pull requests conflict there, and each merge re-conflicts the rest; keeping
+both entries is the only correct resolution, so the repository configures git to
+take it without asking. Forge must therefore, for an approved pull request whose
+checks pass but which GitHub reports as conflicting, merge the base branch into
+the pull request head and push the result when that merge left no conflict
+behind. A merge that still conflicts — in the ledger or in any other file — is a
+real disagreement over content and takes the human-intervention path instead, as
+does a head Forge cannot push to. Pushing restarts the pull request's checks, so
+the merge itself belongs to a later pass: Forge must re-read the review decision
+and the checks after pushing rather than carrying the pre-push state forward,
+which also means an approval dismissed by the push is re-earned by the normal
+review path rather than assumed.

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -317,6 +317,7 @@ SCRATCH_WORKTREE_DIRNAME = "forge_worktrees"
 PREFLIGHT_INFO_DIRNAME = "preflight_info"
 SCRATCH_REVIEW_WORKTREE_DIRNAME = "forge_review_worktrees"
 SCRATCH_FINAL_INDEX_VALIDATION_WORKTREE_DIRNAME = "forge_final_index_validation_worktrees"
+SCRATCH_CONFLICT_RESOLUTION_WORKTREE_DIRNAME = "forge_conflict_resolution_worktrees"
 SCRATCH_METRICS_DIRNAME = "forge_run_metrics"
 ISSUE_CLAIM_LOCK_DIRNAME = "metadata-forge-issue-claim-locks"
 ISSUE_CLAIM_CACHE_REASON_ASSIGNED = "assigned"
@@ -2191,6 +2192,8 @@ def get_pull_request_state(pr_number: int) -> dict:
           url
           body
           headRefOid
+          headRefName
+          isCrossRepository
           reviewDecision
           mergeStateStatus
           mergeable
@@ -2277,6 +2280,13 @@ def has_passing_pull_request_gates(pr: dict) -> bool:
         and pr.get("mergeStateStatus") == "CLEAN"
         and ci_state == "SUCCESS"
     )
+
+
+def has_successful_pull_request_ci(pr: dict) -> bool:
+    """Return True when the pull request's combined CI status is successful."""
+    status_check_rollup = pr.get("statusCheckRollup")
+    ci_state = status_check_rollup.get("state") if isinstance(status_check_rollup, dict) else None
+    return ci_state == "SUCCESS"
 
 
 def has_failed_pull_request_ci(pr: dict) -> bool:
@@ -2634,6 +2644,112 @@ def merge_pull_request(pr: dict, reachability_metadata_path: str | None = None) 
         apply_unblocked_issue_merge_follow_up(pr)
 
 
+def is_pull_request_conflicting(pull_request: dict) -> bool:
+    """Return True when GitHub reports the pull request as conflicting with its base."""
+    return pull_request.get("mergeable") == "CONFLICTING"
+
+
+def resolve_pull_request_merge_conflict(
+        pull_request: dict,
+        reachability_metadata_path: str,
+) -> bool:
+    """Merge the base branch into a conflicting PR head and push what git resolved.
+
+    Returns True only when the merge left no conflict behind and the result
+    reached the head branch. Anything git could not resolve on its own is a real
+    disagreement over content and stays for a maintainer (§FS-automated-pr-review).
+    """
+    pr_number = pull_request.get("number")
+    head_ref_name = pull_request.get("headRefName")
+    head_ref_oid = pull_request.get("headRefOid")
+    if not isinstance(pr_number, int) or not isinstance(head_ref_name, str) or not head_ref_name:
+        print(f"ERROR: Missing head branch metadata for pull request #{pr_number}.", file=sys.stderr)
+        raise RuntimeError(f"Missing head branch metadata for pull request #{pr_number}")
+    if pull_request.get("isCrossRepository"):
+        print(
+            f"[Leaving PR #{pr_number} conflicting: its head branch lives in a fork "
+            "that Forge cannot push to.]"
+        )
+        return False
+
+    repo_root = get_repo_root()
+    conflict_worktrees_root = os.path.join(
+        repo_root,
+        "local_repositories",
+        SCRATCH_CONFLICT_RESOLUTION_WORKTREE_DIRNAME,
+    )
+    os.makedirs(conflict_worktrees_root, exist_ok=True)
+    worktree_path = os.path.join(
+        conflict_worktrees_root,
+        f"conflict-pr-{pr_number}-{uuid.uuid4().hex[:8]}",
+    )
+
+    fetch_review_base_ref(reachability_metadata_path)
+    run_git_transport(
+        ["fetch", "--quiet", "origin", f"refs/pull/{pr_number}/head"],
+        cwd=reachability_metadata_path,
+    )
+    create_detached_worktree(
+        reachability_metadata_path,
+        worktree_path,
+        "FETCH_HEAD",
+        f"Failed to create conflict resolution worktree for PR #{pr_number}",
+    )
+    try:
+        fetched_head = run_checked_command(
+            ["git", "rev-parse", "HEAD"],
+            worktree_path,
+            f"Failed to resolve fetched PR #{pr_number} head for conflict resolution",
+        ).stdout.strip()
+        if fetched_head != head_ref_oid:
+            print(
+                (
+                    f"[Leaving PR #{pr_number} conflicting: head changed before resolution, "
+                    f"expected {head_ref_oid}, fetched {fetched_head}.]"
+                )
+            )
+            return False
+
+        # `--no-ff` so a head that is merely behind the base can never fast-forward
+        # onto it, which would leave the pull request with nothing to merge.
+        merge_result = subprocess.run(
+            [
+                "git", "merge", "--no-ff",
+                f"origin/{DEFAULT_WORKTREE_BASE_REF}",
+                "-m", f"Merge {DEFAULT_WORKTREE_BASE_REF} into {head_ref_name}",
+            ],
+            cwd=worktree_path,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if merge_result.returncode != 0:
+            conflicted_paths = run_checked_command(
+                ["git", "diff", "--name-only", "--diff-filter=U"],
+                worktree_path,
+                f"Failed to list unresolved conflicts for PR #{pr_number}",
+            ).stdout.split()
+            subprocess.run(["git", "merge", "--abort"], cwd=worktree_path, check=False)
+            print(
+                f"[Leaving PR #{pr_number} conflicting: git could not resolve "
+                f"{', '.join(conflicted_paths) or 'the merge'}.]"
+            )
+            return False
+
+        run_git_transport(
+            ["push", "origin", f"HEAD:refs/heads/{head_ref_name}"],
+            cwd=worktree_path,
+        )
+        print(
+            f"[Merged {DEFAULT_WORKTREE_BASE_REF} into PR #{pr_number} and pushed it; "
+            "its checks restart, so the merge belongs to a later pass.]"
+        )
+        return True
+    finally:
+        remove_worktree(reachability_metadata_path, worktree_path)
+
+
 def reconcile_reviewed_pull_request(
         pr_number: int,
         reachability_metadata_path: str | None = None,
@@ -2692,6 +2808,14 @@ def reconcile_reviewed_pull_request(
                     f"[Skipping merge for approved PR #{pr_number}: CI failed, but no eligible "
                     "GitHub Actions workflow runs were found to rerun.]"
                 )
+            return True
+
+        if is_pull_request_conflicting(pr) and has_successful_pull_request_ci(pr):
+            # §FS-automated-pr-review: git resolves the ledger, the merge waits a pass.
+            resolve_pull_request_merge_conflict(
+                pr,
+                reachability_metadata_path or get_repo_root(),
+            )
             return True
 
         if not has_passing_pull_request_gates(pr):

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -4206,6 +4206,68 @@ class PullRequestReviewTests(unittest.TestCase):
         rerun_failed_jobs.assert_not_called()
         merge_pull_request.assert_not_called()
 
+    def test_reconcile_approved_conflicting_pr_resolves_the_conflict_instead_of_merging(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "headRefName": "ai/kimeta/demo",
+            "reviewDecision": "APPROVED",
+            "mergeable": "CONFLICTING",
+            "mergeStateStatus": "DIRTY",
+            "statusCheckRollup": {"state": "SUCCESS"},
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_state", return_value=pr), \
+                patch.object(
+                    forge_metadata,
+                    "resolve_pull_request_merge_conflict",
+                    return_value=True,
+                ) as resolve_conflict, \
+                patch.object(forge_metadata, "merge_pull_request") as merge_pull_request:
+            self.assertTrue(forge_metadata.reconcile_reviewed_pull_request(3513, "/tmp/reachability"))
+
+        resolve_conflict.assert_called_once_with(pr, "/tmp/reachability")
+        merge_pull_request.assert_not_called()
+
+    def test_reconcile_conflicting_pr_without_successful_ci_is_left_untouched(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "headRefName": "ai/kimeta/demo",
+            "reviewDecision": "APPROVED",
+            "mergeable": "CONFLICTING",
+            "mergeStateStatus": "DIRTY",
+            "statusCheckRollup": {"state": "PENDING"},
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_state", return_value=pr), \
+                patch.object(
+                    forge_metadata,
+                    "resolve_pull_request_merge_conflict",
+                ) as resolve_conflict, \
+                patch.object(forge_metadata, "merge_pull_request") as merge_pull_request:
+            self.assertTrue(forge_metadata.reconcile_reviewed_pull_request(3513, "/tmp/reachability"))
+
+        resolve_conflict.assert_not_called()
+        merge_pull_request.assert_not_called()
+
+    def test_resolve_pull_request_merge_conflict_leaves_fork_heads_alone(self) -> None:
+        pr = {
+            "number": 3513,
+            "headRefOid": "abc123",
+            "headRefName": "contributor-branch",
+            "isCrossRepository": True,
+        }
+
+        with patch.object(forge_metadata, "create_detached_worktree") as create_detached_worktree:
+            self.assertFalse(
+                forge_metadata.resolve_pull_request_merge_conflict(pr, "/tmp/reachability")
+            )
+
+        create_detached_worktree.assert_not_called()
+
     def test_rerun_failed_pull_request_workflow_jobs_reruns_failures_under_attempt_limit(self) -> None:
         workflow_runs = [
             {"id": 101, "conclusion": "failure", "run_attempt": 1},


### PR DESCRIPTION
`forge/FINDINGS.md` is an append-only ledger: every generated branch prepends one
entry below the header (§forge/FS-local-branch-review). Because every branch
writes at the same offset, any two concurrent Forge pull requests conflict there,
and each merge re-conflicts the rest. Keeping both entries is the only correct
resolution, so this should cost nobody a manual rebase.

Today it costs several. #9582 merged and immediately left #9580, #9563 and #9564
conflicting; all three were approved and none could merge.

## Two halves, because one is not enough

**Git resolves the file.** A root `.gitattributes` registers git's built-in
`union` driver for that one path:

```
forge/FINDINGS.md merge=union
```

`union` needs no driver registered in `.git/config`, so it applies in every clone
and in CI. For a conflicting hunk it emits the lines from both sides instead of
writing conflict markers, and reports success. Verified against the three blocked
pull requests, fetched from `refs/pull/*/head` and replayed onto current
`master`:

| PR | before | after |
| --- | --- | --- |
| #9563 | conflict: `forge/FINDINGS.md` | clean |
| #9564 | conflict: `forge/FINDINGS.md` | clean |
| #9580 | conflict: `forge/FINDINGS.md` | clean |

Both `git merge` and `git rebase` resolve cleanly, both entries survive, and
newest-first order holds. `git check-attr` confirms the attribute is scoped to
the single path.

**Forge pushes the result.** The attribute alone does not clear a conflict GitHub
has already computed, and GitHub performs the real merge server-side. Forge's
pre-merge index validation already merges the base branch in a throwaway worktree
and then discards the result, so nothing ever reaches the head branch and
`has_passing_pull_request_gates` rejects the pull request before the merge call —
the "merge gates are not fully passing yet" line #9580 printed.

So an approved pull request with passing checks that GitHub reports as
conflicting now has the base branch merged into its head and the result pushed.
A merge that still conflicts, in the ledger or anywhere else, is a real
disagreement and keeps the existing human-intervention path, as does a head in a
fork that Forge cannot push to. `--no-ff` keeps a head that is merely behind the
base from fast-forwarding onto it and emptying the pull request.

Pushing restarts the pull request's checks, so the merge itself lands on a later
queue pass. The state is re-read rather than carried forward, which also means an
approval dismissed by the push is re-earned through the normal review path rather
than assumed. Forge squash-merges (`resolve_pull_request_merge_flag`), so the
merge commit is squashed away and no force-push is involved.

## Notes

The reviewer agent is deliberately not involved. Every git and merge operation in
Forge is deterministic code — publication.md already requires Forge to stage and
commit changed paths itself "so a repair has one form", and `_commit_reviewer_edits`
restores `forge/FINDINGS.md` from HEAD precisely so the reviewer cannot own it.

`union` suppresses conflicts for every change to that file, not only appends. Two
branches editing the same existing entry differently would keep both versions
with no conflict raised. That is the cost of the driver; in practice only Forge
writes the file.

Three unit tests cover the new branch in `reconcile_reviewed_pull_request`:
resolution replaces the merge for a conflicting approved PR, a conflicting PR
without successful CI is left untouched, and a fork head is refused before any
git work. `python -m unittest tests.test_forge_metadata` passes 164 tests, and
`grund check` reports only the two warnings already present on master. `pylint`
could not be run — the module is absent from the checkout's virtualenv.

Fixes #9587