### PR TITLE
Skip published Forge branch validation

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -28,6 +28,8 @@ MAX_BODY_CHARS = 60_000
 MAX_TEST_DIFF_CHARS = 12_000
 SEVERE_METADATA_DROP_RATIO = 0.25
 DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO = 1.75
+PUBLISHER_LOGIN = "graalvmbot"
+PUBLICATION_ID_SUFFIX = re.compile(r"(forge-\d+-\d{14,20}-[0-9a-f]{12})$")
 ROUTE_LABELS = {
     "library-new-request": ["GenAI", "library-new-request"],
     "library-update-request": ["GenAI", "library-update-request"],
@@ -69,6 +71,54 @@ def git(*args: str) -> str:
 def gh_json(*args: str) -> Any:
     output = run(["gh", *args])
     return json.loads(output) if output.strip() else None
+
+
+def _pull_requests_for_branch(branch: str) -> list[dict[str, Any]]:
+    """Return pull requests whose head is the exact upstream branch."""
+    owner: str = REPOSITORY.split("/", 1)[0]
+    response: Any = gh_json(
+        "api", f"repos/{REPOSITORY}/pulls", "--method", "GET",
+        "-f", "state=all", "-f", f"head={owner}:{branch}", "-f", "per_page=100",
+    )
+    if not isinstance(response, list) or any(
+            not isinstance(pull_request, dict) for pull_request in response
+    ):
+        raise TypeError("Expected a list of pull requests for the publication branch")
+    return response
+
+
+def find_existing_publication(branch: str) -> dict[str, Any] | None:
+    """Resolve a Forge PR that already consumed this publication branch.
+
+    Post-publication pushes maintain the PR and must not re-enter descriptor
+    validation or privileged publication (§forge/FS-forge-publication-readiness).
+    """
+    publication_match: re.Match[str] | None = PUBLICATION_ID_SUFFIX.search(branch)
+    if publication_match is None:
+        return None
+
+    publication_id: str = publication_match.group(1)
+    trailer: str = f"Forge-Publication-ID: {publication_id}"
+    existing: list[dict[str, Any]] = _pull_requests_for_branch(branch)
+    matching: list[dict[str, Any]] = [
+        pull_request
+        for pull_request in existing
+        if str((pull_request.get("user") or {}).get("login")) == PUBLISHER_LOGIN
+        and trailer in str(pull_request.get("body") or "").splitlines()
+    ]
+    if len(matching) > 1:
+        raise RuntimeError("Ambiguous pull requests for publication identity")
+    if not matching:
+        if existing:
+            raise RuntimeError("Head branch already has a PR with a different publication identity")
+        return None
+
+    pull_request: dict[str, Any] = matching[0]
+    if pull_request.get("merged_at"):
+        return pull_request
+    if pull_request.get("state") != "open":
+        raise RuntimeError("Matching publication PR is closed without merge")
+    return pull_request
 
 
 def load_schema() -> dict[str, Any]:
@@ -1373,29 +1423,12 @@ def publish(
     if mode == "shadow":
         return title, body, None
 
-    head = f"{REPOSITORY.split('/', 1)[0]}:{descriptor['branch']}"
-    existing = gh_json(
-        "api", f"repos/{REPOSITORY}/pulls", "--method", "GET",
-        "-f", "state=all", "-f", f"head={head}", "-f", "per_page=100",
-    )
-    trailer = f"Forge-Publication-ID: {descriptor['publication_id']}"
-    matching = [
-        pull_request
-        for pull_request in existing
-        if trailer in str(pull_request.get("body") or "").splitlines()
-    ]
-    if len(matching) > 1:
-        raise RuntimeError("Ambiguous pull requests for publication identity")
-    if matching:
-        pull_request = matching[0]
-        if pull_request.get("merged_at"):
-            return title, body, str(pull_request["html_url"])
-        if pull_request.get("state") != "open":
-            raise RuntimeError("Matching publication PR is closed without merge")
-        _ensure_pull_request_metadata(pull_request, descriptor, reviewers)
-        return title, body, str(pull_request["html_url"])
-    if existing:
-        raise RuntimeError("Head branch already has a PR with a different publication identity")
+    existing: dict[str, Any] | None = find_existing_publication(descriptor["branch"])
+    if existing is not None:
+        if existing.get("merged_at"):
+            return title, body, str(existing["html_url"])
+        _ensure_pull_request_metadata(existing, descriptor, reviewers)
+        return title, body, str(existing["html_url"])
 
     pull_request = gh_json(
         "api", f"repos/{REPOSITORY}/pulls", "--method", "POST",
@@ -1449,6 +1482,32 @@ def _ensure_pull_request_metadata(
             input_text=json.dumps({"reviewers": reviewer_names}),
         )
 
+
+def write_existing_publication_evidence(
+        branch: str,
+        head_sha: str,
+        pull_request: dict[str, Any],
+) -> None:
+    """Record that this publication branch already has its Forge PR."""
+    number: int = int(pull_request["number"])
+    url: str = str(pull_request["html_url"])
+    evidence: str = textwrap.dedent(f"""\
+        # Forge publication already exists
+
+        Branch `{branch}` already has [pull request #{number}]({url}).
+        Descriptor validation and privileged publication were skipped.
+        """)
+    Path("publication.md").write_text(evidence, encoding="utf-8")
+    summary_path: str | None = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write("## Forge publication already exists\n\n")
+            summary.write(f"- SHA: `{head_sha}`\n")
+            summary.write(f"- Branch: `{branch}`\n")
+            summary.write(f"- Pull request: {url}\n")
+            summary.write("- Result: skipped descriptor validation and publication\n")
+
+
 def write_evidence(title: str, body: str, validated: ValidatedPublication, pr_url: str | None) -> None:
     evidence = f"# {title}\n\n{body}\n"
     Path("publication.md").write_text(evidence, encoding="utf-8")
@@ -1477,6 +1536,13 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = build_parser().parse_args()
     try:
+        if args.repository != REPOSITORY:
+            raise ValueError(f"Unexpected head repository: {args.repository}")
+        existing: dict[str, Any] | None = find_existing_publication(args.branch)
+        if existing is not None:
+            write_existing_publication_evidence(args.branch, args.sha, existing)
+            return 0
+
         validated = validate_publication(
             head_sha=args.sha,
             branch=args.branch,

--- a/.github/workflows/forge-branch-ready.yml
+++ b/.github/workflows/forge-branch-ready.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches:
       - "ai/**"
-    # Only a descriptor push can publish. An unscoped push-triggered check failed
-    # on the open PR whenever a maintainer repaired the published branch
+    # The path filter excludes ordinary repairs; a force-pushed rebase can still
+    # match upstream descriptors, so the trusted publisher no-ops existing PRs
     # (§forge/AR-actions-publication).
     paths:
       - "stats/*/*/*/forge-publication.json"
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   validate:
@@ -38,6 +39,7 @@ jobs:
 
       - name: Validate publication descriptor and diff
         env:
+          GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
           HEAD_BRANCH: ${{ github.ref_name }}
           HEAD_ACTOR: ${{ github.actor }}

--- a/.github/workflows/forge-open-pr.yml
+++ b/.github/workflows/forge-open-pr.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: forge-open-pr-${{ github.event.workflow_run.head_sha }}

--- a/forge/docs/architecture/git-scripts.md
+++ b/forge/docs/architecture/git-scripts.md
@@ -120,14 +120,22 @@ feature branch and must not create or modify GitHub resources. The title and
 body it publishes come from the shared non-mutating renderer
 (§AR-pr-preview-builders), never from a second rendering path.
 
-Its push trigger is scoped to the descriptor path, so it fires only on the push
-that carries a `forge-publication.json`. A publication is the only push it can
-act on: every validation reads the tip-committed descriptor, and a push without
-one fails the first check with nothing to publish. Because Actions reports a
-push-triggered job as a check run on the pushed commit, an unscoped trigger also
-made every later push to a published branch report a failing check on the open
-pull request. That check gates publication, not the pull request, so a
-maintainer repairing a published branch must not see it re-run and fail there.
+Its push trigger is scoped to the descriptor path, which excludes ordinary
+repair pushes. A force-pushed rebase can still match that path when GitHub's
+push comparison includes descriptors that arrived from the new base. Both
+workflows therefore query pull requests for the exact head branch before they
+validate: an open or merged Forge pull request whose publication-ID trailer
+matches the branch is a successful no-op, while a branch with no such pull
+request follows the strict validation path. A closed-unmerged or ambiguous
+matching pull request still fails for inspection. This keeps post-publication
+maintenance out of both descriptor validation and privileged publication even
+when the path filter starts a run (§FS-forge-publication-readiness).
+
+Because Actions reports a push-triggered job as a check run on the pushed
+commit, an unscoped trigger made every later push to a published branch report
+a failing check on the open pull request. That check gates publication, not the
+pull request, so a maintainer repairing a published branch must not see it
+re-run and fail there.
 
 A Branch Ready failure leaves the branch, issue assignment, labels, and project
 status unchanged. Its job summary and logs must identify the exact SHA and each

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -9,6 +9,16 @@ push (§FS-local-branch-review), when the result needs maintainer judgment rathe
 than another automated attempt (§FS-human-intervention-policy), and the
 automated review the published PR receives (§FS-automated-pr-review).
 
+Publication readiness is consumed once per publication branch. After the
+trusted publisher opens the matching Forge pull request, identified by the
+exact head branch and publication ID, later pushes maintain that pull request;
+they are not new publication attempts and must not re-enter descriptor
+validation or privileged publication. This remains true when a force-pushed
+rebase makes GitHub's path comparison observe publication descriptors that
+arrived from the base branch. An open or merged matching Forge pull request is
+a successful no-op; an ambiguous match or a matching pull request closed
+without merge still fails for inspection. §GOAL-shorten-issue-to-shipped-metadata
+
 ## FS-local-ci-equivalent-verification: Local pre-publication verification
 
 Every Forge task must pass local verification before it is allowed to produce a

--- a/forge/tests/test_forge_pr_publisher_existing_pr.py
+++ b/forge/tests/test_forge_pr_publisher_existing_pr.py
@@ -1,0 +1,191 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cover idempotent trusted publication after a Forge PR exists.
+
+A force-pushed rebase can make GitHub's path filter observe descriptors from
+the new base. The resulting run must not revalidate or republish a branch whose
+matching Forge PR already exists (§FS-forge-publication-readiness).
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUBLISHER_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "publisher.py",
+)
+PUBLICATION_ID = "forge-9307-20260827212457173272-9358ee807703"
+BRANCH = f"ai/kimeta/fix-javac-demo-{PUBLICATION_ID}"
+HEAD_SHA = "a" * 40
+
+
+def _load_publisher() -> Any:
+    """Load the trusted publisher the way Actions runs it: straight from the file."""
+    spec = importlib.util.spec_from_file_location(
+        "forge_pr_publisher_existing_pr", PUBLISHER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+publisher = _load_publisher()
+
+
+def _pull_request(**overrides: Any) -> dict[str, Any]:
+    pull_request: dict[str, Any] = {
+        "number": 9563,
+        "html_url": "https://github.com/oracle/graalvm-reachability-metadata/pull/9563",
+        "body": f"Generated publication\n\nForge-Publication-ID: {PUBLICATION_ID}\n",
+        "state": "open",
+        "merged_at": None,
+        "user": {"login": "graalvmbot"},
+    }
+    pull_request.update(overrides)
+    return pull_request
+
+
+class ExistingForgePublicationTests(unittest.TestCase):
+
+    def test_legacy_short_timestamp_publication_identity_is_supported(self) -> None:
+        publication_id: str = "forge-8380-20260820101530-0123456789ab"
+        branch: str = f"ai/kimeta/code-coverage-demo-{publication_id}"
+        pull_request = _pull_request(
+            body=f"Forge-Publication-ID: {publication_id}\n",
+        )
+
+        with patch.object(publisher, "gh_json", return_value=[pull_request]):
+            resolved: dict[str, Any] | None = publisher.find_existing_publication(branch)
+
+        self.assertIs(resolved, pull_request)
+
+    def test_matching_open_publication_is_resolved(self) -> None:
+        pull_request = _pull_request()
+
+        with patch.object(publisher, "gh_json", return_value=[pull_request]):
+            resolved: dict[str, Any] | None = publisher.find_existing_publication(BRANCH)
+
+        self.assertIs(resolved, pull_request)
+
+    def test_matching_merged_publication_is_resolved(self) -> None:
+        pull_request = _pull_request(state="closed", merged_at="2026-08-28T15:00:00Z")
+
+        with patch.object(publisher, "gh_json", return_value=[pull_request]):
+            resolved: dict[str, Any] | None = publisher.find_existing_publication(BRANCH)
+
+        self.assertIs(resolved, pull_request)
+
+    def test_matching_closed_unmerged_publication_fails(self) -> None:
+        pull_request = _pull_request(state="closed")
+
+        with patch.object(publisher, "gh_json", return_value=[pull_request]):
+            with self.assertRaisesRegex(RuntimeError, "closed without merge"):
+                publisher.find_existing_publication(BRANCH)
+
+    def test_ambiguous_matching_publications_fail(self) -> None:
+        with patch.object(
+                publisher,
+                "gh_json",
+                return_value=[_pull_request(), _pull_request(number=9564)],
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Ambiguous"):
+                publisher.find_existing_publication(BRANCH)
+
+    def test_non_forge_pull_request_does_not_bypass_validation(self) -> None:
+        pull_request = _pull_request(user={"login": "someone-else"})
+
+        with patch.object(publisher, "gh_json", return_value=[pull_request]):
+            with self.assertRaisesRegex(RuntimeError, "different publication identity"):
+                publisher.find_existing_publication(BRANCH)
+
+    def test_branch_without_publication_identity_does_not_query_github(self) -> None:
+        with patch.object(publisher, "gh_json") as gh_json_mock:
+            resolved: dict[str, Any] | None = publisher.find_existing_publication(
+                "ai/kimeta/ordinary-branch",
+            )
+
+        self.assertIsNone(resolved)
+        gh_json_mock.assert_not_called()
+
+    def test_existing_pr_noops_before_validation_after_force_rebase(self) -> None:
+        pull_request = _pull_request()
+        for command in ("validate", "publish"):
+            with self.subTest(command=command):
+                argv: list[str] = [
+                    "publisher.py",
+                    command,
+                    "--sha",
+                    HEAD_SHA,
+                    "--branch",
+                    BRANCH,
+                    "--actor",
+                    "kimeta",
+                    "--repository",
+                    publisher.REPOSITORY,
+                ]
+                with (
+                        patch.object(sys, "argv", argv),
+                        patch.object(
+                            publisher,
+                            "find_existing_publication",
+                            return_value=pull_request,
+                        ),
+                        patch.object(publisher, "validate_publication") as validate_mock,
+                        patch.object(
+                            publisher,
+                            "write_existing_publication_evidence",
+                        ) as evidence_mock,
+                ):
+                    result: int = publisher.main()
+
+                self.assertEqual(result, 0)
+                validate_mock.assert_not_called()
+                evidence_mock.assert_called_once_with(BRANCH, HEAD_SHA, pull_request)
+
+    def test_first_publication_still_runs_strict_validation(self) -> None:
+        validated = publisher.ValidatedPublication({}, "descriptor.json", HEAD_SHA)
+        argv: list[str] = [
+            "publisher.py",
+            "validate",
+            "--sha",
+            HEAD_SHA,
+            "--branch",
+            BRANCH,
+            "--actor",
+            "kimeta",
+            "--repository",
+            publisher.REPOSITORY,
+        ]
+        with (
+                patch.object(sys, "argv", argv),
+                patch.object(publisher, "find_existing_publication", return_value=None),
+                patch.object(
+                    publisher,
+                    "validate_publication",
+                    return_value=validated,
+                ) as validate_mock,
+                patch.object(publisher, "render_publication", return_value=("title", "body")),
+                patch.object(publisher, "write_evidence") as evidence_mock,
+        ):
+            result: int = publisher.main()
+
+        self.assertEqual(result, 0)
+        validate_mock.assert_called_once_with(
+            head_sha=HEAD_SHA,
+            branch=BRANCH,
+            actor="kimeta",
+            repository=publisher.REPOSITORY,
+        )
+        evidence_mock.assert_called_once_with("title", "body", validated, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

PR #9495 scoped `Forge Branch Ready` to descriptor paths so ordinary repairs would not re-run a publication gate on an open PR. A force-pushed rebase is the missing case: GitHub's push comparison can include descriptors that arrived from the new base, so #9563 re-entered the gate and failed against a descriptor whose pull request already existed.

Publication readiness is now consumed once per publication branch. An open or merged matching Forge PR makes both the unprivileged validation and privileged publisher commands return an audited no-op before descriptor validation. [§forge/FS-forge-publication-readiness](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skip-published-forge-validation/forge/docs/functional-spec/publication.md#fs-forge-publication-readiness)

## How the no-op is decided

The trusted default-branch publisher queries pull requests for the exact upstream head branch and skips only when all identity checks agree:

| Input | Required value |
| --- | --- |
| PR author | `graalvmbot` |
| PR body | Exact `Forge-Publication-ID` trailer |
| Branch | Ends in the same publication ID |
| PR state | Open or merged |

A foreign or mismatched PR, ambiguous matches, and a matching PR closed without merge still fail. A branch with no existing Forge PR follows the unchanged strict descriptor and exact-SHA validation path.

Both workflows receive read-only pull-request access, and a skipped run writes `publication.md` plus a job-summary record explaining which PR already consumed the publication. The path-scoped push trigger remains in place; this closes the force-rebase hole without introducing an explicit-dispatch path that could silently fail to open the first PR. [§forge/AR-actions-publication](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skip-published-forge-validation/forge/docs/architecture/git-scripts.md#ar-actions-publication-trusted-github-actions-publisher)
