### PR TITLE
Validate Forge push access before work

### DIFF
--- a/forge/tests/test_host_requirements.py
+++ b/forge/tests/test_host_requirements.py
@@ -37,6 +37,7 @@ from utility_scripts.host_requirements import (
     resolve_graalvm_version_check,
     resolve_https_proxy,
     resolve_queue_requirements,
+    run_command,
 )
 
 
@@ -643,6 +644,91 @@ class HostRequirementsTests(unittest.TestCase):
         push_target = result_by_name["generated-branch push target"]
         self.assertTrue(push_target.passed)
         self.assertIn("oracle/graalvm-reachability-metadata", push_target.detail)
+
+    @patch("utility_scripts.host_requirements.run_command")
+    def test_build_work_requires_noninteractive_git_https_credentials(
+            self,
+            command: Mock,
+    ) -> None:
+        command.side_effect = [
+            subprocess.CompletedProcess(
+                ["git", "remote", "get-url", "origin"],
+                0,
+                "https://github.com/oracle/graalvm-reachability-metadata.git\n",
+                "",
+            ),
+            subprocess.CompletedProcess(
+                ["git", "credential", "fill"],
+                128,
+                "",
+                "fatal: could not read Username for https://github.com",
+            ),
+        ]
+        host_requirements = HostRequirements(
+            "/repo/forge",
+            "python3",
+            {},
+            requirements=COVERAGE_REQUIREMENTS,
+        )
+
+        host_requirements._check_git_https_credentials()
+
+        result = host_requirements.results[-1]
+        self.assertTrue(result.required)
+        self.assertFalse(result.passed)
+        self.assertIn("credential=unavailable", result.detail)
+        self.assertIn("gh auth setup-git --hostname github.com", result.remediation)
+        credential_call = command.call_args_list[-1]
+        self.assertEqual(
+            "protocol=https\nhost=github.com\n"
+            "path=oracle/graalvm-reachability-metadata.git\n\n",
+            credential_call.kwargs["input_text"],
+        )
+
+    @patch("utility_scripts.host_requirements.run_command")
+    def test_git_https_credential_probe_never_reports_the_secret(
+            self,
+            command: Mock,
+    ) -> None:
+        secret = "github-token-that-must-not-be-logged"
+        command.side_effect = [
+            subprocess.CompletedProcess(
+                ["git", "remote", "get-url", "origin"],
+                0,
+                "https://github.com/oracle/graalvm-reachability-metadata.git\n",
+                "",
+            ),
+            subprocess.CompletedProcess(
+                ["git", "credential", "fill"],
+                0,
+                f"protocol=https\nhost=github.com\nusername=forge-user\npassword={secret}\n",
+                "",
+            ),
+        ]
+        host_requirements = HostRequirements(
+            "/repo/forge",
+            "python3",
+            {},
+            requirements=COVERAGE_REQUIREMENTS,
+        )
+
+        host_requirements._check_git_https_credentials()
+
+        result = host_requirements.results[-1]
+        self.assertTrue(result.passed)
+        self.assertIn("credential=available", result.detail)
+        self.assertNotIn(secret, result.detail)
+        self.assertNotIn("forge-user", result.detail)
+
+    @patch("utility_scripts.host_requirements.subprocess.run")
+    def test_probe_commands_disable_git_terminal_prompts(self, command: Mock) -> None:
+        command.return_value = subprocess.CompletedProcess(["git"], 1, "", "failed")
+
+        run_command(["git", "credential", "fill"], {}, input_text="protocol=https\n\n")
+
+        environment = command.call_args.kwargs["env"]
+        self.assertEqual("0", environment["GIT_TERMINAL_PROMPT"])
+        self.assertEqual("protocol=https\n\n", command.call_args.kwargs["input"])
 
     def test_required_failure_stops_before_work_and_prints_remediation(self) -> None:
         environment = {

--- a/forge/tests/test_host_requirements.py
+++ b/forge/tests/test_host_requirements.py
@@ -645,23 +645,27 @@ class HostRequirementsTests(unittest.TestCase):
         self.assertTrue(push_target.passed)
         self.assertIn("oracle/graalvm-reachability-metadata", push_target.detail)
 
+    @patch("utility_scripts.host_requirements.uuid.uuid4", return_value=Mock(hex="probe-id"))
+    @patch("utility_scripts.host_requirements.find_remote_for_github_repo", return_value="upstream")
     @patch("utility_scripts.host_requirements.run_command")
-    def test_build_work_requires_noninteractive_git_https_credentials(
+    def test_build_work_requires_dry_run_push_to_publication_remote(
             self,
             command: Mock,
+            find_remote: Mock,
+            _uuid: Mock,
     ) -> None:
         command.side_effect = [
             subprocess.CompletedProcess(
-                ["git", "remote", "get-url", "origin"],
+                ["git", "remote", "get-url", "--push", "upstream"],
                 0,
                 "https://github.com/oracle/graalvm-reachability-metadata.git\n",
                 "",
             ),
             subprocess.CompletedProcess(
-                ["git", "credential", "fill"],
+                ["git", "push", "--dry-run"],
                 128,
                 "",
-                "fatal: could not read Username for https://github.com",
+                "fatal: Authentication failed",
             ),
         ]
         host_requirements = HostRequirements(
@@ -671,37 +675,49 @@ class HostRequirementsTests(unittest.TestCase):
             requirements=COVERAGE_REQUIREMENTS,
         )
 
-        host_requirements._check_git_https_credentials()
+        host_requirements._check_generated_branch_push_access()
 
         result = host_requirements.results[-1]
         self.assertTrue(result.required)
         self.assertFalse(result.passed)
-        self.assertIn("credential=unavailable", result.detail)
+        self.assertIn("remote=upstream", result.detail)
+        self.assertIn("dry-run push=failed", result.detail)
         self.assertIn("gh auth setup-git --hostname github.com", result.remediation)
-        credential_call = command.call_args_list[-1]
-        self.assertEqual(
-            "protocol=https\nhost=github.com\n"
-            "path=oracle/graalvm-reachability-metadata.git\n\n",
-            credential_call.kwargs["input_text"],
+        find_remote.assert_called_once_with(
+            "oracle/graalvm-reachability-metadata",
+            cwd="/repo",
         )
+        push_call = command.call_args_list[-1]
+        self.assertEqual(
+            [
+                "git", "-C", "/repo",
+                "push", "--dry-run", "--no-verify", "--porcelain",
+                "upstream", "HEAD:refs/heads/ai/forge-host-check-probe-id",
+            ],
+            push_call.args[0],
+        )
+        self.assertEqual(60, push_call.kwargs["timeout"])
 
+    @patch("utility_scripts.host_requirements.uuid.uuid4", return_value=Mock(hex="probe-id"))
+    @patch("utility_scripts.host_requirements.find_remote_for_github_repo", return_value="origin")
     @patch("utility_scripts.host_requirements.run_command")
-    def test_git_https_credential_probe_never_reports_the_secret(
+    def test_dry_run_push_probe_supports_ssh(
             self,
             command: Mock,
+            _find_remote: Mock,
+            _uuid: Mock,
     ) -> None:
-        secret = "github-token-that-must-not-be-logged"
         command.side_effect = [
             subprocess.CompletedProcess(
-                ["git", "remote", "get-url", "origin"],
+                ["git", "remote", "get-url", "--push", "origin"],
                 0,
-                "https://github.com/oracle/graalvm-reachability-metadata.git\n",
+                "git@github.com:oracle/graalvm-reachability-metadata.git\n",
                 "",
             ),
             subprocess.CompletedProcess(
-                ["git", "credential", "fill"],
+                ["git", "push", "--dry-run"],
                 0,
-                f"protocol=https\nhost=github.com\nusername=forge-user\npassword={secret}\n",
+                "To github.com:oracle/graalvm-reachability-metadata.git\n",
                 "",
             ),
         ]
@@ -712,23 +728,45 @@ class HostRequirementsTests(unittest.TestCase):
             requirements=COVERAGE_REQUIREMENTS,
         )
 
-        host_requirements._check_git_https_credentials()
+        host_requirements._check_generated_branch_push_access()
 
         result = host_requirements.results[-1]
         self.assertTrue(result.passed)
-        self.assertIn("credential=available", result.detail)
-        self.assertNotIn(secret, result.detail)
-        self.assertNotIn("forge-user", result.detail)
+        self.assertIn("protocol=ssh", result.detail)
+        self.assertIn("dry-run push=passed", result.detail)
+
+    @patch(
+        "utility_scripts.host_requirements.find_remote_for_github_repo",
+        side_effect=RuntimeError("missing"),
+    )
+    @patch("utility_scripts.host_requirements.run_command")
+    def test_push_probe_requires_remote_for_target_repository(
+            self,
+            command: Mock,
+            _find_remote: Mock,
+    ) -> None:
+        host_requirements = HostRequirements(
+            "/repo/forge",
+            "python3",
+            {},
+            requirements=COVERAGE_REQUIREMENTS,
+        )
+
+        host_requirements._check_generated_branch_push_access()
+
+        result = host_requirements.results[-1]
+        self.assertFalse(result.passed)
+        self.assertIn("remote=unavailable", result.detail)
+        command.assert_not_called()
 
     @patch("utility_scripts.host_requirements.subprocess.run")
     def test_probe_commands_disable_git_terminal_prompts(self, command: Mock) -> None:
         command.return_value = subprocess.CompletedProcess(["git"], 1, "", "failed")
 
-        run_command(["git", "credential", "fill"], {}, input_text="protocol=https\n\n")
+        run_command(["git", "push", "--dry-run"], {})
 
         environment = command.call_args.kwargs["env"]
         self.assertEqual("0", environment["GIT_TERMINAL_PROMPT"])
-        self.assertEqual("protocol=https\n\n", command.call_args.kwargs["input"])
 
     def test_required_failure_stops_before_work_and_prints_remediation(self) -> None:
         environment = {

--- a/forge/utility_scripts/host_requirements.py
+++ b/forge/utility_scripts/host_requirements.py
@@ -20,6 +20,7 @@ import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -37,6 +38,7 @@ from ai_workflows.agents.agent_runtime import (  # noqa: E402
     default_model_for_backend,
     normalize_backend_name,
 )
+from git_scripts.common_git import find_remote_for_github_repo  # noqa: E402
 from utility_scripts.native_image_artifact import ARTIFACT_REPOSITORY_URLS  # noqa: E402
 from utility_scripts.strategy_loader import (  # noqa: E402
     apply_test_agent_alias,
@@ -981,16 +983,16 @@ class HostRequirements:
             self.separate_repository,
             f"{self.repo_dir} is the checkout that contains Forge; covered by the Forge self-update check",
         )
-        self._check_git_https_credentials()
+        self._check_generated_branch_push_access()
 
-    def _check_git_https_credentials(self) -> None:
-        """Require noninteractive credentials for an HTTPS publication remote.
+    def _check_generated_branch_push_access(self) -> None:
+        """Verify a dry-run push through the remote publication will use.
 
-        A public `git ls-remote` can succeed anonymously, so it does not prove
-        that the later generated-branch push can authenticate
+        A fetch can succeed anonymously, so it does not prove that the later
+        generated-branch push can authenticate and write
         (§FS-forge-host-requirements).
         """
-        name: str = "generated-branch Git HTTPS credentials"
+        name: str = "generated-branch push access"
         required: bool = self.requirements.build_work and self.requirements.github_work
         if not required:
             self._add(
@@ -1002,67 +1004,75 @@ class HostRequirements:
             )
             return
 
-        remote_result: subprocess.CompletedProcess[str] = run_command(
-            ["git", "-C", self.repo_dir, "remote", "get-url", "origin"],
-            self.environment,
-        )
-        remote_url: str = first_output_line(remote_result)
-        if remote_result.returncode != 0 or not remote_url:
+        repository: str = f"{REPOSITORY_OWNER}/{REPOSITORY_NAME}"
+        try:
+            publication_remote: str = find_remote_for_github_repo(
+                repository,
+                cwd=self.repo_dir,
+            )
+        except (OSError, RuntimeError, subprocess.CalledProcessError):
             self._add(
                 "github",
                 name,
                 True,
                 False,
-                f"checkout={self.repo_dir}, origin URL unavailable",
-                "Configure the selected repository's `origin` remote, then run "
-                "`gh auth setup-git --hostname github.com`.",
+                f"checkout={self.repo_dir}, repository={repository}, remote=unavailable",
+                f"Configure a Git remote that points to `{repository}`.",
             )
             return
 
-        parsed_url: urllib.parse.ParseResult = urllib.parse.urlparse(remote_url)
-        if parsed_url.scheme != "https" or parsed_url.hostname != "github.com":
-            self._add(
-                "github",
-                name,
-                True,
-                True,
-                f"checkout={self.repo_dir}, origin does not use GitHub HTTPS",
-            )
-            return
-
-        credential_input: list[str] = [
-            "protocol=https",
-            "host=github.com",
-        ]
-        remote_path: str = parsed_url.path.lstrip("/")
-        if remote_path:
-            credential_input.append(f"path={remote_path}")
-        credential_result: subprocess.CompletedProcess[str] = run_command(
-            ["git", "-C", self.repo_dir, "credential", "fill"],
+        push_url_result: subprocess.CompletedProcess[str] = run_command(
+            [
+                "git", "-C", self.repo_dir,
+                "remote", "get-url", "--push", publication_remote,
+            ],
             self.environment,
-            input_text="\n".join(credential_input) + "\n\n",
         )
-        credentials: dict[str, str] = {}
-        for line in credential_result.stdout.splitlines():
-            key: str
-            separator: str
-            value: str
-            key, separator, value = line.partition("=")
-            if separator:
-                credentials[key] = value
-        passed: bool = (
-            credential_result.returncode == 0
-            and bool(credentials.get("username"))
-            and bool(credentials.get("password"))
+        push_url: str = (
+            first_output_line(push_url_result)
+            if push_url_result.returncode == 0
+            else ""
         )
+        parsed_url: urllib.parse.ParseResult = urllib.parse.urlparse(push_url)
+        if parsed_url.scheme == "https" and parsed_url.hostname == "github.com":
+            protocol: str = "https"
+            remediation: str = (
+                "Run `gh auth setup-git --hostname github.com` for an account "
+                f"with write access to `{repository}`."
+            )
+        elif push_url.startswith("git@github.com:") or parsed_url.scheme == "ssh":
+            protocol = "ssh"
+            remediation = (
+                "Load a GitHub-authorized SSH key for an account with write access "
+                f"to `{repository}`."
+            )
+        else:
+            protocol = "configured"
+            remediation = (
+                f"Configure remote `{publication_remote}` with noninteractive write "
+                f"access to `{repository}`."
+            )
+
+        target_ref: str = f"refs/heads/ai/forge-host-check-{uuid.uuid4().hex}"
+        push_result: subprocess.CompletedProcess[str] = run_command(
+            [
+                "git", "-C", self.repo_dir,
+                "push", "--dry-run", "--no-verify", "--porcelain",
+                publication_remote, f"HEAD:{target_ref}",
+            ],
+            self.environment,
+            timeout=60,
+        )
+        passed: bool = push_result.returncode == 0
         self._add(
             "github",
             name,
             True,
             passed,
-            f"checkout={self.repo_dir}, host=github.com, "
-            f"credential={'available' if passed else 'unavailable'}",
-            "Run `gh auth setup-git --hostname github.com` for the active Forge account.",
+            f"checkout={self.repo_dir}, repository={repository}, "
+            f"remote={publication_remote}, protocol={protocol}, "
+            f"dry-run push={'passed' if passed else 'failed'}",
+            remediation,
         )
 
     def _check_git_remote(self, name: str, checkout: str, required: bool, skip_detail: str) -> None:
@@ -1587,7 +1597,6 @@ def run_command(
         command: Sequence[str],
         environment: Mapping[str, str],
         timeout: int = 20,
-        input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one deterministic probe command without a shell or interactive prompt."""
     command_environment = dict(environment)
@@ -1602,7 +1611,6 @@ def run_command(
             timeout=timeout,
             check=False,
             env=command_environment,
-            input=input_text,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return subprocess.CompletedProcess(list(command), 1, "", str(exc))

--- a/forge/utility_scripts/host_requirements.py
+++ b/forge/utility_scripts/host_requirements.py
@@ -981,6 +981,89 @@ class HostRequirements:
             self.separate_repository,
             f"{self.repo_dir} is the checkout that contains Forge; covered by the Forge self-update check",
         )
+        self._check_git_https_credentials()
+
+    def _check_git_https_credentials(self) -> None:
+        """Require noninteractive credentials for an HTTPS publication remote.
+
+        A public `git ls-remote` can succeed anonymously, so it does not prove
+        that the later generated-branch push can authenticate
+        (§FS-forge-host-requirements).
+        """
+        name: str = "generated-branch Git HTTPS credentials"
+        required: bool = self.requirements.build_work and self.requirements.github_work
+        if not required:
+            self._add(
+                "github",
+                name,
+                False,
+                None,
+                "this run does not publish a generated branch",
+            )
+            return
+
+        remote_result: subprocess.CompletedProcess[str] = run_command(
+            ["git", "-C", self.repo_dir, "remote", "get-url", "origin"],
+            self.environment,
+        )
+        remote_url: str = first_output_line(remote_result)
+        if remote_result.returncode != 0 or not remote_url:
+            self._add(
+                "github",
+                name,
+                True,
+                False,
+                f"checkout={self.repo_dir}, origin URL unavailable",
+                "Configure the selected repository's `origin` remote, then run "
+                "`gh auth setup-git --hostname github.com`.",
+            )
+            return
+
+        parsed_url: urllib.parse.ParseResult = urllib.parse.urlparse(remote_url)
+        if parsed_url.scheme != "https" or parsed_url.hostname != "github.com":
+            self._add(
+                "github",
+                name,
+                True,
+                True,
+                f"checkout={self.repo_dir}, origin does not use GitHub HTTPS",
+            )
+            return
+
+        credential_input: list[str] = [
+            "protocol=https",
+            "host=github.com",
+        ]
+        remote_path: str = parsed_url.path.lstrip("/")
+        if remote_path:
+            credential_input.append(f"path={remote_path}")
+        credential_result: subprocess.CompletedProcess[str] = run_command(
+            ["git", "-C", self.repo_dir, "credential", "fill"],
+            self.environment,
+            input_text="\n".join(credential_input) + "\n\n",
+        )
+        credentials: dict[str, str] = {}
+        for line in credential_result.stdout.splitlines():
+            key: str
+            separator: str
+            value: str
+            key, separator, value = line.partition("=")
+            if separator:
+                credentials[key] = value
+        passed: bool = (
+            credential_result.returncode == 0
+            and bool(credentials.get("username"))
+            and bool(credentials.get("password"))
+        )
+        self._add(
+            "github",
+            name,
+            True,
+            passed,
+            f"checkout={self.repo_dir}, host=github.com, "
+            f"credential={'available' if passed else 'unavailable'}",
+            "Run `gh auth setup-git --hostname github.com` for the active Forge account.",
+        )
 
     def _check_git_remote(self, name: str, checkout: str, required: bool, skip_detail: str) -> None:
         """Check that one checkout reaches the monitored branch through its own origin remote."""
@@ -1504,11 +1587,13 @@ def run_command(
         command: Sequence[str],
         environment: Mapping[str, str],
         timeout: int = 20,
+        input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one deterministic probe command without a shell or interactive prompt."""
     command_environment = dict(environment)
     command_environment["GH_PROMPT_DISABLED"] = "1"
     command_environment["GH_PAGER"] = ""
+    command_environment["GIT_TERMINAL_PROMPT"] = "0"
     try:
         return subprocess.run(
             list(command),
@@ -1517,6 +1602,7 @@ def run_command(
             timeout=timeout,
             check=False,
             env=command_environment,
+            input=input_text,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return subprocess.CompletedProcess(list(command), 1, "", str(exc))


### PR DESCRIPTION
Closes #9653

## What this does

Forge can currently pass `gh auth status`, API permission checks, and a read-only `git ls-remote`, then fail hours later when publication needs to push. A public fetch does not prove that the Git transport identity can write to the repository. The host contract requires that capability before work begins ([§forge/FS-forge-host-requirements](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/validate-forge-git-credentials/forge/docs/functional-spec/functional-spec.md#fs-forge-host-requirements-host-requirements)).

Build-producing modes now resolve the same remote that shared publication uses for `oracle/graalvm-reachability-metadata` and perform a dry-run push through it before selecting work.

## How the check stays non-mutating

- `git push --dry-run --no-verify --porcelain` targets a unique temporary `ai/forge-host-check-*` ref, so no remote branch is created and local push hooks do not run.
- The resolved remote selects the real authentication path: HTTPS credentials or an SSH key.
- `GIT_TERMINAL_PROMPT=0` keeps the check unattended.
- Failures report the repository, remote, and protocol, with protocol-specific remediation.
- The existing `gh` API checks continue to validate repository and project permissions for the active CLI account.