### PR TITLE
Reuse safe local reviews during Forge PR review

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -36,6 +36,7 @@ TEST_DIFF_PATHS: tuple[str, ...] = (
 SEVERE_METADATA_DROP_RATIO = 0.25
 DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO = 1.75
 PUBLISHER_LOGIN = "graalvmbot"
+LOCAL_REVIEW_ATTESTATION_OUTPUT = "local_review_attestation"
 PUBLICATION_ID_SUFFIX = re.compile(r"(forge-\d+-\d{14,20}-[0-9a-f]{12})$")
 ROUTE_LABELS = {
     "library-new-request": ["GenAI", "library-new-request"],
@@ -53,6 +54,35 @@ class ValidatedPublication:
     descriptor: dict[str, Any]
     descriptor_path: str
     head_sha: str
+
+
+def local_review_attestation_eligible(validated: ValidatedPublication) -> bool:
+    """Return whether a validated descriptor carries a safe local approval.
+
+    §forge/FS-automated-pr-review
+    """
+    descriptor: dict[str, Any] = validated.descriptor
+    local_review: Any = descriptor.get("local_review")
+    local_ci_verification: Any = descriptor.get("local_ci_verification")
+    return (
+        isinstance(local_review, dict)
+        and isinstance(local_ci_verification, dict)
+        and local_review.get("status") == "completed"
+        and local_review.get("decision") == "approved"
+        and local_review.get("repair_reverted") is False
+        and local_ci_verification.get("status") == "success"
+    )
+
+
+def write_local_review_attestation_output(eligible: bool) -> None:
+    """Expose attestation eligibility to the calling Actions step."""
+    output_path: str | None = os.environ.get("GITHUB_OUTPUT")
+    if output_path is None:
+        return
+    with open(output_path, "a", encoding="utf-8") as output_file:
+        output_file.write(
+            f"{LOCAL_REVIEW_ATTESTATION_OUTPUT}={'true' if eligible else 'false'}\n"
+        )
 
 
 def run(command: list[str], *, input_text: str | None = None) -> str:
@@ -1583,6 +1613,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
+    local_review_attestation: bool = False
     try:
         if args.repository != REPOSITORY:
             raise ValueError(f"Unexpected head repository: {args.repository}")
@@ -1597,6 +1628,7 @@ def main() -> int:
             actor=args.actor,
             repository=args.repository,
         )
+        local_review_attestation = local_review_attestation_eligible(validated)
         if args.command == "publish":
             title, body, pr_url = publish(validated, args.mode, args.reviewers)
         else:
@@ -1611,6 +1643,9 @@ def main() -> int:
             with open(summary_path, "a", encoding="utf-8") as summary:
                 summary.write(f"## Forge publication validation failed\n\n- SHA: `{args.sha}`\n- Error: `{exc}`\n")
         return 1
+    finally:
+        if args.command == "validate":
+            write_local_review_attestation_output(local_review_attestation)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/forge-branch-ready.yml
+++ b/.github/workflows/forge-branch-ready.yml
@@ -18,6 +18,8 @@ jobs:
   validate:
     name: Validate exact Forge branch SHA
     runs-on: ubuntu-latest
+    outputs:
+      local_review_attestation: ${{ steps.validate.outputs.local_review_attestation }}
     steps:
       - name: Check out trusted publisher
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -38,6 +40,7 @@ jobs:
         run: python3 -m pip install --disable-pip-version-check jsonschema==4.25.1
 
       - name: Validate publication descriptor and diff
+        id: validate
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
@@ -58,3 +61,16 @@ jobs:
           path: publication.md
           if-no-files-found: error
           retention-days: 14
+
+  # False eligibility skips this check without failing publication.
+  # §forge/FS-automated-pr-review
+  local-review-attestation:
+    name: Forge Local Review Attestation
+    needs: validate
+    if: needs.validate.outputs.local_review_attestation == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Attest safe local review for exact SHA
+        env:
+          HEAD_SHA: ${{ github.sha }}
+        run: echo "Safe local review attested for $HEAD_SHA"

--- a/forge/docs/architecture/git-scripts.md
+++ b/forge/docs/architecture/git-scripts.md
@@ -120,6 +120,16 @@ feature branch and must not create or modify GitHub resources. The title and
 body it publishes come from the shared non-mutating renderer
 (§AR-pr-preview-builders), never from a second rendering path.
 
+Strict validation also computes the local-review attestation output for the
+triggering SHA. The publisher helper reads only the validated descriptor and
+returns true exactly for the four safe local review and verification values in
+§FS-automated-pr-review. The validation job exposes that result as a job output;
+a separate `Forge Local Review Attestation` job runs only for true and succeeds
+without reading feature-branch code. A false result skips that job rather than
+failing Branch Ready. The existing-publication no-op is resolved before strict
+validation and exports false, so a maintenance push cannot turn an old
+descriptor verdict into a new current-SHA attestation.
+
 Its push trigger is scoped to the descriptor path, which excludes ordinary
 repair pushes. A force-pushed rebase can still match that path when GitHub's
 push comparison includes descriptors that arrived from the new base. Both

--- a/forge/docs/architecture/orchestration-scripts.md
+++ b/forge/docs/architecture/orchestration-scripts.md
@@ -190,20 +190,34 @@ model, provider, or thinking override (§FS-forge-agent-runtime-selection).
 **Candidate selection.** For each queue, orchestration fetches PRs carrying the
 queue label, plus PRs carrying `human-intervention-fixed`. It first refreshes a
 conflicting same-repository head when git can merge the base without judgment,
-then selects for agent review only PRs whose CI checks all completed
-successfully, which are not authored by the authenticated review user, and
-which are not still blocked by `human-intervention`. Running checks wait, while
-failed checks enter deterministic retry or failure follow-up without launching
-an agent or consuming a review slot. PRs labeled `human-intervention` are
-skipped until a maintainer marks them `human-intervention-fixed`, at which point
-orchestration may dismiss stale requested-changes reviews and let normal merge
-gates proceed (§FS-automated-pr-review).
+then selects for review only PRs whose CI checks all completed successfully,
+which are not authored by the authenticated review user, and which are not
+still blocked by `human-intervention`. The loaded current-head state retains
+named check-run details and their Actions workflow provenance. Running checks
+wait, while failed checks enter deterministic retry or failure follow-up
+without launching an agent or consuming a review slot. PRs labeled
+`human-intervention` are skipped until a maintainer marks them
+`human-intervention-fixed`, at which point orchestration may dismiss stale
+requested-changes reviews and let normal merge gates proceed
+(§FS-automated-pr-review).
 
-**Isolated review run.** Before selecting review work, orchestration validates
+**Attested direct approval.** Before creating a review worktree, orchestration
+looks for one successful `Forge Local Review Attestation` check attached to the
+candidate's current `headRefOid`. The check is trusted only when its check suite
+belongs to GitHub Actions and its workflow run identifies the repository's
+`Forge Branch Ready` workflow. On a match, Forge creates a pull-request review
+with event `APPROVE` and an explicit `commit_id` equal to that head SHA, then
+calls the ordinary post-review reconciliation. Missing or unverifiable
+provenance, any other conclusion, malformed data, or an attestation on another
+commit leaves the candidate on the agent path. A failed direct-approval request
+records that PR as failed and does not reconcile it.
+
+**Isolated review run.** Before selecting agent review work, orchestration validates
 the parent process's GitHub CLI authentication and the selected analysis
 backend's authentication without invoking a model (§FS-automated-pr-review).
-Each selected PR is reviewed in a throwaway detached worktree created from a
-freshly fetched base ref, with the PR checked out in detached HEAD.
+Each selected PR without a reusable attestation is reviewed in a throwaway
+detached worktree created from a freshly fetched base ref, with the PR checked
+out in detached HEAD.
 The selected analysis agent is trusted with the authenticated GitHub CLI, reads
 live PR metadata and checks, applies the label-specific checked-in rules, and
 uses targeted diffs against the fresh base before submitting the review itself.

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -553,13 +553,37 @@ from the phase that failed instead of regenerating from scratch
 Forge review automation processes open pull requests by their PR labels only
 after CI has completed successfully. A pull request with running checks waits;
 a pull request with failed checks is handled by deterministic CI-failure
-follow-up and must not launch a review agent. It is the second review a
-generated branch receives; the first runs before the push, against evidence
-this one cannot see (§FS-local-branch-review). It is a PR review workflow, not
-an issue-resolution workflow:
-it must inspect an already published PR, use an isolated review worktree,
-compare the PR diff and status checks against the label-specific review rules,
-and submit either an approval or a requested-changes review on GitHub.
+follow-up and must not launch a review agent. A generated branch is reviewed
+locally before the push, against evidence a post-push reviewer cannot see
+(§FS-local-branch-review). The published-PR workflow either reuses a trusted,
+current-head attestation of that approval or launches the existing second
+review. It is a PR review workflow, not an issue-resolution workflow: it must
+satisfy the applicable label-specific review rules, submit an approval or a
+requested-changes review on GitHub, and retain the existing post-review
+reconciliation and merge gates.
+
+**A safe local approval may satisfy published-PR review.** The trusted `Forge
+Branch Ready` workflow may attest the exact push commit only after strict
+publication validation proves that the expected `forge-publication.json`
+changed in `HEAD`. The descriptor need not be the commit's only changed file.
+The attestation is eligible only when `local_review.status` is `completed`,
+`local_review.decision` is `approved`, `local_review.repair_reverted` is
+`false`, and `local_ci_verification.status` is `success`. It is a separate
+check named `Forge Local Review Attestation`: the check succeeds when all four
+facts hold and is skipped when they do not. An existing-publication no-op must
+not emit a fresh attestation, even when the descriptor still carries an older
+approval. GitHub's check association binds the successful attestation to the
+triggering commit.
+
+After successful PR CI, Forge may reuse only a successful `Forge Local Review
+Attestation` check on the pull request's current `headRefOid`, produced by the
+trusted `Forge Branch Ready` Actions workflow. It submits a deterministic
+approval explicitly against that head commit without launching an agent, then
+runs the same post-review reconciliation and merge-gate logic as an agent
+review. A missing, skipped, failed, malformed, untrusted, or older-SHA check
+must fall back to the existing isolated review-agent path. Failure to submit
+the direct approval is a review-processing failure: Forge must not reconcile or
+treat the pull request as reviewed.
 
 Review labels select the review rule set. `library-new-request`,
 `library-update-request`, `fixes-javac-fail`, `fixes-java-run-fail`,
@@ -590,7 +614,8 @@ interactive approval boundary, inspect the live pull request and its checked-out
 diff, and submit the approval or requested-changes review itself. Forge does not
 parse an agent verdict and resubmit it through a second GitHub client. An
 authentication failure, timeout, or unsuccessful agent turn must stop processing
-that review rather than being treated as an approval.
+that review rather than being treated as an approval. This agent contract is
+unchanged for every pull request without a reusable attestation.
 
 Automated review may add or request the `human-intervention` PR label only when
 the applicable label-specific review rules say the result cannot be handled by

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -392,6 +392,10 @@ DEFAULT_WORK_QUEUE_STRATEGY_NAME = "optimistic_dynamic_access_iterative_pi_gpt-5
 FAILURE_ANALYSIS_TIMEOUT_SECONDS = 1800
 REVIEW_TIMEOUT_SECONDS = 1800
 DEFAULT_WORKTREE_BASE_REF = "master"
+LOCAL_REVIEW_ATTESTATION_CHECK_NAME = "Forge Local Review Attestation"
+FORGE_BRANCH_READY_WORKFLOW_NAME = "Forge Branch Ready"
+FORGE_BRANCH_READY_WORKFLOW_PATH = ".github/workflows/forge-branch-ready.yml"
+GITHUB_ACTIONS_APP_SLUG = "github-actions"
 # The GraalVM lanes are named once in `host_requirements`, in this order.
 DEV_GRAALVM_ENV_VAR, POST_GENERATION_GRAALVM_ENV_VAR, LATEST_EA_GRAALVM_ENV_VAR = ISSUE_GRAALVM_ENV_VARS
 FORGE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -2194,6 +2198,33 @@ def get_pull_request_state(pr_number: int) -> dict:
           isMergeQueueEnabled
           statusCheckRollup {{
             state
+            contexts(first: 100) {{
+              nodes {{
+                __typename
+                ... on CheckRun {{
+                  name
+                  status
+                  conclusion
+                  checkSuite {{
+                    app {{
+                      slug
+                    }}
+                    commit {{
+                      oid
+                    }}
+                    workflowRun {{
+                      event
+                      workflow {{
+                        name
+                      }}
+                      file {{
+                        path
+                      }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
           }}
           repository {{
             viewerDefaultMergeMethod
@@ -2288,6 +2319,80 @@ def has_failed_pull_request_ci(pr: dict) -> bool:
     status_check_rollup = pr.get("statusCheckRollup")
     ci_state = status_check_rollup.get("state") if isinstance(status_check_rollup, dict) else None
     return ci_state in FAILED_CI_STATES
+
+
+def has_trusted_local_review_attestation(pull_request: dict) -> bool:
+    """Return whether the current PR head has the trusted local-review check.
+
+    §FS-automated-pr-review
+    """
+    head_sha = pull_request.get("headRefOid")
+    status_check_rollup = pull_request.get("statusCheckRollup")
+    contexts = (
+        status_check_rollup.get("contexts")
+        if isinstance(status_check_rollup, dict)
+        else None
+    )
+    nodes = contexts.get("nodes") if isinstance(contexts, dict) else None
+    if not isinstance(head_sha, str) or not head_sha or not isinstance(nodes, list):
+        return False
+
+    for check_run in nodes:
+        if not isinstance(check_run, dict):
+            continue
+        check_suite = check_run.get("checkSuite")
+        if not isinstance(check_suite, dict):
+            continue
+        app = check_suite.get("app")
+        commit = check_suite.get("commit")
+        workflow_run = check_suite.get("workflowRun")
+        if not all(isinstance(value, dict) for value in (app, commit, workflow_run)):
+            continue
+        workflow = workflow_run.get("workflow")
+        workflow_file = workflow_run.get("file")
+        if not isinstance(workflow, dict) or not isinstance(workflow_file, dict):
+            continue
+        if (
+            check_run.get("__typename") == "CheckRun"
+            and check_run.get("name") == LOCAL_REVIEW_ATTESTATION_CHECK_NAME
+            and check_run.get("status") == "COMPLETED"
+            and check_run.get("conclusion") == "SUCCESS"
+            and commit.get("oid") == head_sha
+            and app.get("slug") == GITHUB_ACTIONS_APP_SLUG
+            and workflow_run.get("event") == "push"
+            and workflow.get("name") == FORGE_BRANCH_READY_WORKFLOW_NAME
+            and workflow_file.get("path") == FORGE_BRANCH_READY_WORKFLOW_PATH
+        ):
+            return True
+    return False
+
+
+def approve_pull_request_from_local_review_attestation(pull_request: dict) -> None:
+    """Approve the exact attested PR head without launching a review agent.
+
+    §FS-automated-pr-review
+    """
+    pr_number = pull_request.get("number")
+    head_sha = pull_request.get("headRefOid")
+    if not isinstance(pr_number, int) or not isinstance(head_sha, str) or not head_sha:
+        print(
+            f"ERROR: Missing head metadata for attested PR #{pr_number}.",
+            file=sys.stderr,
+        )
+        raise RuntimeError(f"Missing head metadata for attested PR #{pr_number}")
+
+    gh(
+        "api",
+        "--method",
+        "POST",
+        f"/repos/{REPO}/pulls/{pr_number}/reviews",
+        "-f",
+        f"commit_id={head_sha}",
+        "-f",
+        "event=APPROVE",
+        "-f",
+        f"body=Approved from the trusted local review attestation for commit {head_sha}.",
+    )
 
 
 def get_pull_request_workflow_runs(head_sha: str) -> list[dict]:
@@ -3336,7 +3441,21 @@ def process_pull_requests_with_label(
         pr_url = pull_request.get("url") if isinstance(pull_request.get("url"), str) else None
         pr_title = pull_request.get("title") if isinstance(pull_request.get("title"), str) else ""
         coordinates = extract_maven_coordinates(pr_title)
-        if not review_pull_request(
+        if has_trusted_local_review_attestation(pull_request):
+            print(
+                f"[Approving PR #{pr_number} from trusted local review attestation "
+                f"on {pull_request['headRefOid']}; no review agent launched.]"
+            )
+            try:
+                approve_pull_request_from_local_review_attestation(pull_request)
+            except Exception as exc:
+                print(
+                    f"ERROR: Failed attested approval for PR #{pr_number}: {exc!r}",
+                    file=sys.stderr,
+                )
+                failed_reviews.append(pr_number)
+                continue
+        elif not review_pull_request(
                 pr_number,
                 reachability_metadata_path,
                 pr_url,

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -131,6 +131,31 @@ def _pull_request_state(number: int, ci_state: str, mergeable: str = "MERGEABLE"
     }
 
 
+def _local_review_attestation_check(head_sha: str) -> dict:
+    return {
+        "__typename": "CheckRun",
+        "name": forge_metadata.LOCAL_REVIEW_ATTESTATION_CHECK_NAME,
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "checkSuite": {
+            "app": {"slug": forge_metadata.GITHUB_ACTIONS_APP_SLUG},
+            "commit": {"oid": head_sha},
+            "workflowRun": {
+                "event": "push",
+                "workflow": {"name": forge_metadata.FORGE_BRANCH_READY_WORKFLOW_NAME},
+                "file": {"path": forge_metadata.FORGE_BRANCH_READY_WORKFLOW_PATH},
+            },
+        },
+    }
+
+
+def _add_local_review_attestation(state: dict, check_run: dict | None = None) -> dict:
+    state["statusCheckRollup"]["contexts"] = {
+        "nodes": [check_run or _local_review_attestation_check(state["headRefOid"])],
+    }
+    return state
+
+
 def _preflight(
         *,
         issue_number: int = 1412,
@@ -2860,6 +2885,68 @@ class WorkQueueSchedulerTests(unittest.TestCase):
 
 
 class PullRequestReviewSelectionTests(unittest.TestCase):
+    def test_pull_request_state_loads_named_check_provenance(self) -> None:
+        payload = {
+            "data": {
+                "repository": {
+                    "pullRequest": _pull_request_state(9656, "SUCCESS"),
+                },
+            },
+        }
+        with patch.object(forge_metadata, "gh_json", return_value=payload) as gh_json:
+            forge_metadata.get_pull_request_state(9656)
+
+        query_argument = gh_json.call_args.args[-1]
+        self.assertIn("contexts(first: 100)", query_argument)
+        self.assertIn("checkSuite", query_argument)
+        self.assertIn("workflowRun", query_argument)
+        self.assertIn("commit", query_argument)
+
+    def test_trusted_current_head_attestation_is_accepted(self) -> None:
+        state = _add_local_review_attestation(_pull_request_state(9656, "SUCCESS"))
+        self.assertTrue(forge_metadata.has_trusted_local_review_attestation(state))
+
+    def test_non_current_or_untrusted_attestation_is_rejected(self) -> None:
+        cases = {
+            "older-sha": ("checkSuite", "commit", "oid", "older-head"),
+            "failed": (None, None, "conclusion", "FAILURE"),
+            "skipped": (None, None, "conclusion", "SKIPPED"),
+            "untrusted-app": ("checkSuite", "app", "slug", "other-app"),
+            "wrong-workflow": (
+                "checkSuite", "workflowRun", "workflow", {"name": "Other Workflow"},
+            ),
+            "wrong-workflow-path": (
+                "checkSuite",
+                "workflowRun",
+                "file",
+                {"path": ".github/workflows/other.yml"},
+            ),
+        }
+        for name, (outer, section, key, value) in cases.items():
+            with self.subTest(name=name):
+                state = _pull_request_state(9656, "SUCCESS")
+                check_run = _local_review_attestation_check(state["headRefOid"])
+                if outer is None:
+                    check_run[key] = value
+                else:
+                    check_run[outer][section][key] = value
+                _add_local_review_attestation(state, check_run)
+                self.assertFalse(forge_metadata.has_trusted_local_review_attestation(state))
+
+        self.assertFalse(
+            forge_metadata.has_trusted_local_review_attestation(
+                _pull_request_state(9656, "SUCCESS")
+            )
+        )
+
+    def test_attested_approval_targets_exact_head_commit(self) -> None:
+        state = _pull_request_state(9656, "SUCCESS")
+        with patch.object(forge_metadata, "gh") as gh:
+            forge_metadata.approve_pull_request_from_local_review_attestation(state)
+
+        self.assertIn("commit_id=head-9656", gh.call_args.args)
+        self.assertIn("event=APPROVE", gh.call_args.args)
+
     def test_bulk_pull_request_list_omits_status_check_rollup(self) -> None:
         with patch.object(forge_metadata, "gh_json", return_value=[]) as gh_json:
             self.assertEqual(
@@ -2870,6 +2957,135 @@ class PullRequestReviewSelectionTests(unittest.TestCase):
         args = gh_json.call_args.args
         self.assertEqual("number,title,url,author,labels", args[-1])
         self.assertNotIn("statusCheckRollup", args)
+
+    def test_current_head_attestation_approves_without_agent(self) -> None:
+        pull_request = _pull_request(9656, [forge_metadata.LABEL_LIBRARY_NEW])
+        state = _add_local_review_attestation(_pull_request_state(9656, "SUCCESS"))
+
+        with patch.object(forge_metadata, "get_pull_requests_with_labels", return_value=[]), \
+                patch.object(
+                    forge_metadata,
+                    "get_pull_requests_with_label",
+                    return_value=[pull_request],
+                ), \
+                patch.object(forge_metadata, "get_pull_request_state", return_value=state), \
+                patch.object(
+                    forge_metadata,
+                    "approve_pull_request_from_local_review_attestation",
+                ) as approve, \
+                patch.object(forge_metadata, "review_pull_request") as review, \
+                patch.object(
+                    forge_metadata,
+                    "reconcile_reviewed_pull_request",
+                    return_value=True,
+                ) as reconcile:
+            forge_metadata.process_pull_requests_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                1,
+                "/tmp/reachability",
+                "automation-user",
+            )
+
+        approve.assert_called_once()
+        self.assertEqual(9656, approve.call_args.args[0]["number"])
+        review.assert_not_called()
+        reconcile.assert_called_once_with(9656, "/tmp/reachability")
+
+    def test_non_attested_cases_use_agent(self) -> None:
+        missing = _pull_request_state(9656, "SUCCESS")
+        older = _pull_request_state(9656, "SUCCESS")
+        _add_local_review_attestation(older, _local_review_attestation_check("older-head"))
+        skipped = _pull_request_state(9656, "SUCCESS")
+        skipped_check = _local_review_attestation_check(skipped["headRefOid"])
+        skipped_check["conclusion"] = "SKIPPED"
+        _add_local_review_attestation(skipped, skipped_check)
+        failed = _pull_request_state(9656, "SUCCESS")
+        failed_check = _local_review_attestation_check(failed["headRefOid"])
+        failed_check["conclusion"] = "FAILURE"
+        _add_local_review_attestation(failed, failed_check)
+        untrusted = _pull_request_state(9656, "SUCCESS")
+        untrusted_check = _local_review_attestation_check(untrusted["headRefOid"])
+        untrusted_check["checkSuite"]["app"]["slug"] = "other-app"
+        _add_local_review_attestation(untrusted, untrusted_check)
+        malformed = _pull_request_state(9656, "SUCCESS")
+        _add_local_review_attestation(malformed, {"name": "malformed"})
+
+        cases = {
+            "missing": missing,
+            "older-sha": older,
+            "skipped": skipped,
+            "failed": failed,
+            "untrusted": untrusted,
+            "malformed": malformed,
+        }
+        for name, state in cases.items():
+            with self.subTest(name=name):
+                pull_request = _pull_request(9656, [forge_metadata.LABEL_LIBRARY_NEW])
+                with patch.object(
+                        forge_metadata,
+                        "get_pull_requests_with_labels",
+                        return_value=[],
+                ), patch.object(
+                        forge_metadata,
+                        "get_pull_requests_with_label",
+                        return_value=[pull_request],
+                ), patch.object(
+                        forge_metadata,
+                        "get_pull_request_state",
+                        return_value=state,
+                ), patch.object(
+                        forge_metadata,
+                        "approve_pull_request_from_local_review_attestation",
+                ) as approve, patch.object(
+                        forge_metadata,
+                        "review_pull_request",
+                        return_value=True,
+                ) as review, patch.object(
+                        forge_metadata,
+                        "reconcile_reviewed_pull_request",
+                        return_value=True,
+                ):
+                    forge_metadata.process_pull_requests_with_label(
+                        forge_metadata.LABEL_LIBRARY_NEW,
+                        1,
+                        "/tmp/reachability",
+                        "automation-user",
+                    )
+
+                approve.assert_not_called()
+                review.assert_called_once()
+
+    def test_direct_approval_failure_stops_review_processing(self) -> None:
+        pull_request = _pull_request(9656, [forge_metadata.LABEL_LIBRARY_NEW])
+        state = _add_local_review_attestation(_pull_request_state(9656, "SUCCESS"))
+
+        with patch.object(forge_metadata, "get_pull_requests_with_labels", return_value=[]), \
+                patch.object(
+                    forge_metadata,
+                    "get_pull_requests_with_label",
+                    return_value=[pull_request],
+                ), \
+                patch.object(forge_metadata, "get_pull_request_state", return_value=state), \
+                patch.object(
+                    forge_metadata,
+                    "approve_pull_request_from_local_review_attestation",
+                    side_effect=RuntimeError("approval failed"),
+                ), \
+                patch.object(forge_metadata, "review_pull_request") as review, \
+                patch.object(
+                    forge_metadata,
+                    "reconcile_reviewed_pull_request",
+                ) as reconcile, \
+                self.assertRaisesRegex(SystemExit, "1"):
+            forge_metadata.process_pull_requests_with_label(
+                forge_metadata.LABEL_LIBRARY_NEW,
+                1,
+                "/tmp/reachability",
+                "automation-user",
+            )
+
+        review.assert_not_called()
+        reconcile.assert_not_called()
 
     def test_process_pull_requests_fetches_state_only_after_cheap_filters(self) -> None:
         buried_pull_requests = [

--- a/forge/tests/test_forge_pr_publisher_attestation.py
+++ b/forge/tests/test_forge_pr_publisher_attestation.py
@@ -1,0 +1,158 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cover trusted local-review attestation publication. §FS-automated-pr-review"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUBLISHER_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "publisher.py",
+)
+HEAD_SHA = "a" * 40
+BRANCH = "ai/kimeta/example-forge-9656-20260831120000-0123456789ab"
+
+
+def _load_publisher() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "forge_pr_publisher_attestation", PUBLISHER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+publisher = _load_publisher()
+
+
+def _safe_descriptor() -> dict[str, Any]:
+    return {
+        "local_review": {
+            "status": "completed",
+            "decision": "approved",
+            "repair_reverted": False,
+        },
+        "local_ci_verification": {"status": "success"},
+    }
+
+
+def _validated(descriptor: dict[str, Any] | None = None) -> Any:
+    return publisher.ValidatedPublication(
+        _safe_descriptor() if descriptor is None else descriptor,
+        "stats/org.example/demo/1.0.0/forge-publication.json",
+        HEAD_SHA,
+    )
+
+
+def _main_argv() -> list[str]:
+    return [
+        "publisher.py",
+        "validate",
+        "--sha",
+        HEAD_SHA,
+        "--branch",
+        BRANCH,
+        "--actor",
+        "kimeta",
+        "--repository",
+        publisher.REPOSITORY,
+    ]
+
+
+class LocalReviewAttestationPublisherTests(unittest.TestCase):
+    def test_safe_validated_descriptor_is_eligible(self) -> None:
+        self.assertTrue(publisher.local_review_attestation_eligible(_validated()))
+
+    def test_unsafe_local_review_or_ci_is_not_eligible(self) -> None:
+        cases = {
+            "unavailable": ("local_review", "status", "unavailable"),
+            "changes-requested": ("local_review", "decision", "changes_requested"),
+            "repair-reverted": ("local_review", "repair_reverted", True),
+            "failed-local-ci": ("local_ci_verification", "status", "failure"),
+        }
+        for name, (section, key, value) in cases.items():
+            with self.subTest(name=name):
+                descriptor = _safe_descriptor()
+                descriptor[section][key] = value
+                self.assertFalse(
+                    publisher.local_review_attestation_eligible(_validated(descriptor))
+                )
+
+        self.assertFalse(publisher.local_review_attestation_eligible(_validated({})))
+
+    def test_strictly_validated_publication_outputs_attestation(self) -> None:
+        validated = _validated()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "github-output")
+            with (
+                    patch.object(sys, "argv", _main_argv()),
+                    patch.dict(os.environ, {"GITHUB_OUTPUT": output_path}),
+                    patch.object(publisher, "find_existing_publication", return_value=None),
+                    patch.object(publisher, "validate_publication", return_value=validated),
+                    patch.object(publisher, "render_publication", return_value=("title", "body")),
+                    patch.object(publisher, "write_evidence"),
+            ):
+                result = publisher.main()
+
+            self.assertEqual(0, result)
+            with open(output_path, "r", encoding="utf-8") as output_file:
+                self.assertEqual("local_review_attestation=true\n", output_file.read())
+
+    def test_descriptor_not_changed_in_head_outputs_no_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "github-output")
+            with (
+                    patch.object(sys, "argv", _main_argv()),
+                    patch.dict(os.environ, {"GITHUB_OUTPUT": output_path}),
+                    patch.object(publisher, "find_existing_publication", return_value=None),
+                    patch.object(
+                        publisher,
+                        "validate_publication",
+                        side_effect=ValueError(
+                            "Exactly one tip-committed forge-publication.json is required"
+                        ),
+                    ),
+            ):
+                result = publisher.main()
+
+            self.assertEqual(1, result)
+            with open(output_path, "r", encoding="utf-8") as output_file:
+                self.assertEqual("local_review_attestation=false\n", output_file.read())
+
+    def test_existing_publication_noop_outputs_no_attestation(self) -> None:
+        pull_request = {
+            "number": 9656,
+            "html_url": f"https://github.com/{publisher.REPOSITORY}/pull/9656",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "github-output")
+            with (
+                    patch.object(sys, "argv", _main_argv()),
+                    patch.dict(os.environ, {"GITHUB_OUTPUT": output_path}),
+                    patch.object(
+                        publisher,
+                        "find_existing_publication",
+                        return_value=pull_request,
+                    ),
+                    patch.object(publisher, "write_existing_publication_evidence"),
+                    patch.object(publisher, "validate_publication") as validate_publication,
+            ):
+                result = publisher.main()
+
+            self.assertEqual(0, result)
+            validate_publication.assert_not_called()
+            with open(output_path, "r", encoding="utf-8") as output_file:
+                self.assertEqual("local_review_attestation=false\n", output_file.read())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9656

## What this does

Forge currently launches a second review agent even when the local reviewer approved the exact tree that was published. This adds a trusted, SHA-bound `Forge Local Review Attestation` check and reuses it only for the current PR head; missing, stale, skipped, malformed, or untrusted checks keep the existing agent path. [§FS-automated-pr-review](https://github.com/oracle/graalvm-reachability-metadata/blob/reuse-local-review-attestation/forge/docs/functional-spec/publication.md#fs-automated-pr-review-automated-pull-request-review)

The direct approval targets `headRefOid` explicitly, then enters the existing reconciliation and merge gates. A failed approval remains a review-processing failure.