### PR TITLE
Make Forge console output concise

### DIFF
--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -54,9 +54,11 @@ the backstop (§PRCPL-prefer-algorithmic).
   `metadata/<group>/<artifact>/index.json`,
   `stats/<group>/<artifact>/<version>/` (stats and execution metrics), and
   `tests/src/<group>/<artifact>/<version>/`, plus an allowed-Docker-image
-  entry only when the test requires it. Build logic, workflows, other
-  coordinates, and generated sources outside the target test directory do not
-  belong in the contribution.
+  entry only when the test requires it. A Forge-generated contribution may also
+  update `forge/FINDINGS.md` when it records that contribution's local review
+  finding (§forge/FS-local-branch-review). No other Forge path belongs in the
+  contribution. Build logic, workflows, other coordinates, and generated
+  sources outside the target test directory do not belong in the contribution.
 - **Single metadata format.** The only accepted metadata file is
   `reachability-metadata.json`. Legacy split-config files (`reflect-config.json`,
   `resource-config.json`, `proxy-config.json`, `serialization-config.json`,

--- a/forge/README.md
+++ b/forge/README.md
@@ -19,11 +19,13 @@ script before the next cycle.
 §AR-do-work-loop
 
 Before self-update or queue processing, and again at the start of every
-work-starting `forge_metadata.py` invocation, Forge prints and validates the
-deterministic host requirements for the tools, environment variables, filesystem
-and network permissions, GitHub repository/project access, Docker, and agent
-authentication its mode needs. A failed required check exits before Forge claims
-or reviews anything; a `--review-pr` run is never asked for a GraalVM.
+work-starting `forge_metadata.py` invocation, Forge validates the deterministic
+host requirements for the tools, environment variables, filesystem and network
+permissions, GitHub repository/project access, Docker, and agent authentication
+its mode needs. Normal output prints only the check's start and outcome;
+`--verbose` or a failure prints the complete report. A failed required check
+exits before Forge claims or reviews anything; a `--review-pr` run is never
+asked for a GraalVM.
 §FS-forge-host-requirements
 
 The 25.0.x validation lane is pinned in `graalvm-versions.json`; update that
@@ -55,6 +57,8 @@ Common options:
 - `--graalvm-version-check {strict,warn,off}`: how a GraalVM version mismatch is treated. Default: `strict`.
 - `--once`: run a single update/work cycle through `do_up_to_date_work.sh` and exit.
 - `--fail-fast`: return nonzero on the first unsuccessful work cycle.
+- `-v`, `--verbose`: restore deterministic narration hidden by compact output
+  and enable verbose output in the selected workflow agents.
 - `--analysis-agent COMMAND --analysis-family FAMILY`: choose the analysis executable and adapter family.
 - `--setup-agent COMMAND --setup-family FAMILY`: choose the executable and adapter family for artifact-URL
   discovery and library preflight, independently of the analysis role.

--- a/forge/ai_workflows/agents/agent.py
+++ b/forge/ai_workflows/agents/agent.py
@@ -4,12 +4,27 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 import os
 import shutil
+import sys
 import tempfile
+import threading
+import time
+from collections.abc import Iterator
 
 from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import display_log_path, resolve_task_log_dir
+
+
+class AgentTimeoutError(RuntimeError):
+    """Agent timeout carrying the action and durable log needed by failure output."""
+
+    def __init__(self, action: str, timeout_seconds: int, log_path: str | None) -> None:
+        self.action = action
+        self.timeout_seconds = timeout_seconds
+        self.log_path = log_path
+        super().__init__(f"Agent {action} timed out after {_format_elapsed(timeout_seconds)}")
 
 
 class Agent(ABC):
@@ -92,14 +107,23 @@ class Agent(ABC):
         """Print the session log location once per agent instance."""
         if getattr(self, "_session_log_announced", False):
             return
-        print(f"[{agent_name} session log: {display_log_path(log_path)}]", flush=True)
+        log_stage("agent", f"{agent_name} session log: {display_log_path(log_path)}")
         self._session_log_announced = True
 
     def _print_live_status(self, agent_name: str, detail: str) -> None:
-        """Render a single-line live status update without advancing the console."""
+        """Render one quiet elapsed-time heartbeat for an active agent turn."""
+        del detail
+        if not self._live_status_enabled():
+            return
+        action = self._current_agent_action()
+        started_at = float(getattr(self, "_agent_activity_started_at", time.monotonic()))
+        elapsed_seconds = int(time.monotonic() - started_at)
+        if elapsed_seconds == getattr(self, "_last_live_status_second", None):
+            return
+        self._last_live_status_second = elapsed_seconds
         terminal_width = shutil.get_terminal_size(fallback=(120, 20)).columns
         max_message_length = max(terminal_width - 1, 20)
-        message = f"[{agent_name}] {detail}".replace("\n", " ").strip()
+        message = f"[agent] Running {action} — {_format_elapsed(elapsed_seconds)}"
         if len(message) > max_message_length:
             message = f"{message[:max_message_length - 3]}..."
         previous_length = int(getattr(self, "_live_status_length", 0) or 0)
@@ -114,6 +138,94 @@ class Agent(ABC):
             return
         print(f"\r{' ' * previous_length}\r", end="", flush=True)
         self._live_status_length = 0
+        self._last_live_status_second = None
+
+    def send_prompt_for_action(self, prompt: str, action: str) -> str:
+        """Send one prompt with the workflow action shown in live progress."""
+        previous_action = getattr(self, "_pending_agent_action", None)
+        self._pending_agent_action = action
+        try:
+            return self.send_prompt(prompt)
+        finally:
+            self._pending_agent_action = previous_action
+
+    @contextmanager
+    def _agent_activity(self, agent_name: str) -> Iterator[None]:
+        """Announce one agent turn and collapse its live output into a heartbeat.
+
+        Full prompts and responses remain in the durable session log while the
+        terminal shows only start, elapsed time, and outcome.
+        §FS-forge-run-output-legibility.3 §FS-durable-generation-logs
+        """
+        action = self._current_agent_action()
+        self._agent_activity_started_at = time.monotonic()
+        log_path = getattr(self, "_session_log_path", None)
+        log_suffix = f" (log: {display_log_path(log_path)})" if log_path else ""
+        log_stage("agent", f"Running {action}{log_suffix}")
+        heartbeat_stop, heartbeat = self._start_heartbeat(agent_name)
+        try:
+            yield
+        except Exception as exc:
+            elapsed_seconds = int(time.monotonic() - self._agent_activity_started_at)
+            self._stop_heartbeat(heartbeat_stop, heartbeat)
+            self._clear_live_status()
+            outcome = "timed out" if _is_timeout_exception(exc) else "failed"
+            current_log_path = getattr(self, "_session_log_path", None)
+            current_log_suffix = (
+                f" (log: {display_log_path(current_log_path)})" if current_log_path else ""
+            )
+            log_stage(
+                "agent",
+                f"{action} {outcome} after {_format_elapsed(elapsed_seconds)}{current_log_suffix}",
+            )
+            raise
+        else:
+            elapsed_seconds = int(time.monotonic() - self._agent_activity_started_at)
+            self._stop_heartbeat(heartbeat_stop, heartbeat)
+            self._clear_live_status()
+            current_log_path = getattr(self, "_session_log_path", None)
+            current_log_suffix = (
+                f" (log: {display_log_path(current_log_path)})" if current_log_path else ""
+            )
+            log_stage(
+                "agent",
+                f"{action} completed in {_format_elapsed(elapsed_seconds)}{current_log_suffix}",
+            )
+
+    def _current_agent_action(self) -> str:
+        configured = getattr(self, "_pending_agent_action", None)
+        if isinstance(configured, str) and configured:
+            return configured
+        task_type = str(getattr(self, "_task_type", "agent-task"))
+        return f"{task_type.replace('-', '_')}()"
+
+    @staticmethod
+    def _live_status_enabled() -> bool:
+        try:
+            parallelism = int(os.environ.get("FORGE_PARALLELISM", "1"))
+        except ValueError:
+            parallelism = 1
+        return sys.stdout.isatty() and parallelism == 1
+
+    def _start_heartbeat(self, agent_name: str) -> tuple[threading.Event | None, threading.Thread | None]:
+        if not self._live_status_enabled():
+            return None, None
+        stop = threading.Event()
+
+        def heartbeat() -> None:
+            while not stop.wait(1):
+                self._print_live_status(agent_name, "")
+
+        thread = threading.Thread(target=heartbeat, daemon=True)
+        thread.start()
+        return stop, thread
+
+    @staticmethod
+    def _stop_heartbeat(stop: threading.Event | None, thread: threading.Thread | None) -> None:
+        if stop is None or thread is None:
+            return
+        stop.set()
+        thread.join(timeout=2)
 
     @abstractmethod
     def send_prompt(self, prompt: str) -> str:
@@ -150,3 +262,33 @@ class Agent(ABC):
             result = self.send_prompt(f"/graphify {extra_dir} --update")
         log_stage("graphify", "Knowledge graph context initialized")
         return result
+
+
+def send_agent_prompt(agent: object, prompt: str, action: str) -> str:
+    """Send a prompt with an action name when the adapter supports it."""
+    send_for_action = getattr(agent, "send_prompt_for_action", None)
+    if callable(send_for_action):
+        return str(send_for_action(prompt, action))
+    send_prompt = getattr(agent, "send_prompt")
+    return str(send_prompt(prompt))
+
+
+def _format_elapsed(seconds: int | float) -> str:
+    total_seconds = max(int(seconds), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, remaining_seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours:02d}:{minutes:02d}:{remaining_seconds:02d}"
+    return f"{minutes:02d}:{remaining_seconds:02d}"
+
+
+def _is_timeout_exception(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, (AgentTimeoutError, TimeoutError)):
+            return True
+        if "timed out" in str(current).lower():
+            return True
+        cause = current.__cause__
+        current = cause if isinstance(cause, BaseException) else None
+    return False

--- a/forge/ai_workflows/agents/agent.py
+++ b/forge/ai_workflows/agents/agent.py
@@ -17,14 +17,27 @@ from utility_scripts.stage_logger import log_stage
 from utility_scripts.task_logs import display_log_path, resolve_task_log_dir
 
 
-class AgentTimeoutError(RuntimeError):
+class AgentFailureError(RuntimeError):
+    """Agent failure carrying the durable log needed by terminal output.
+
+    §FS-forge-run-output-legibility.2
+    """
+
+    def __init__(self, message: str, log_path: str | None) -> None:
+        self.log_path = log_path
+        super().__init__(message)
+
+
+class AgentTimeoutError(AgentFailureError):
     """Agent timeout carrying the action and durable log needed by failure output."""
 
     def __init__(self, action: str, timeout_seconds: int, log_path: str | None) -> None:
         self.action = action
         self.timeout_seconds = timeout_seconds
-        self.log_path = log_path
-        super().__init__(f"Agent {action} timed out after {_format_elapsed(timeout_seconds)}")
+        super().__init__(
+            f"Agent {action} timed out after {_format_elapsed(timeout_seconds)}",
+            log_path,
+        )
 
 
 class Agent(ABC):

--- a/forge/ai_workflows/agents/agent.py
+++ b/forge/ai_workflows/agents/agent.py
@@ -13,7 +13,7 @@ import threading
 import time
 from collections.abc import Iterator
 
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.task_logs import display_log_path, resolve_task_log_dir
 
 
@@ -120,7 +120,7 @@ class Agent(ABC):
         """Print the session log location once per agent instance."""
         if getattr(self, "_session_log_announced", False):
             return
-        log_stage("agent", f"{agent_name} session log: {display_log_path(log_path)}")
+        log_detail("agent", f"{agent_name} session log: {display_log_path(log_path)}")
         self._session_log_announced = True
 
     def _print_live_status(self, agent_name: str, detail: str) -> None:
@@ -174,7 +174,7 @@ class Agent(ABC):
         self._agent_activity_started_at = time.monotonic()
         log_path = getattr(self, "_session_log_path", None)
         log_suffix = f" (log: {display_log_path(log_path)})" if log_path else ""
-        log_stage("agent", f"Running {action}{log_suffix}")
+        log_detail("agent", f"Running {action}{log_suffix}")
         heartbeat_stop, heartbeat = self._start_heartbeat(agent_name)
         try:
             yield
@@ -200,7 +200,7 @@ class Agent(ABC):
             current_log_suffix = (
                 f" (log: {display_log_path(current_log_path)})" if current_log_path else ""
             )
-            log_stage(
+            log_detail(
                 "agent",
                 f"{action} completed in {_format_elapsed(elapsed_seconds)}{current_log_suffix}",
             )
@@ -268,12 +268,12 @@ class Agent(ABC):
         """Send graphify prompts to the agent session to build a merged knowledge graph context."""
         if not source_dirs:
             return ""
-        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        log_detail("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
         result = self.send_prompt(f"/graphify {source_dirs[0]} --include-local")
         for extra_dir in source_dirs[1:]:
-            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            log_detail("graphify", f"Merging graph from {display_log_path(extra_dir)}")
             result = self.send_prompt(f"/graphify {extra_dir} --update")
-        log_stage("graphify", "Knowledge graph context initialized")
+        log_detail("graphify", "Knowledge graph context initialized")
         return result
 
 

--- a/forge/ai_workflows/agents/agent_runtime.py
+++ b/forge/ai_workflows/agents/agent_runtime.py
@@ -72,6 +72,7 @@ class AgentRunResult:
     output_tokens: int = 0
     cached_input_tokens: int | None = None
     session_log_path: str | None = None
+    failure_message: str | None = None
 
 
 def agent_process_environment(
@@ -319,7 +320,13 @@ def run_agent_task(
         timed_out = "timed out" in str(exc).lower()
         with open(log_path, "a", encoding="utf-8") as log_file:
             log_file.write(f"Agent failure: {exc}\n")
-        return AgentRunResult(1, log_path, timed_out, **_agent_usage(agent))
+        return AgentRunResult(
+            1,
+            log_path,
+            timed_out,
+            failure_message=str(exc),
+            **_agent_usage(agent),
+        )
 
     with open(log_path, "w", encoding="utf-8") as log_file:
         log_file.write(response)

--- a/forge/ai_workflows/agents/agent_runtime.py
+++ b/forge/ai_workflows/agents/agent_runtime.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 import os
 
-from ai_workflows.agents.agent import Agent
+from ai_workflows.agents.agent import Agent, send_agent_prompt
 from utility_scripts.task_logs import build_task_log_path
 
 
@@ -313,7 +313,8 @@ def run_agent_task(
         environment=environment,
     )
     try:
-        response = agent.send_prompt(prompt)
+        action = f"{task_type.replace('-', '_')}()"
+        response = send_agent_prompt(agent, prompt, action)
     except (OSError, RuntimeError) as exc:
         timed_out = "timed out" in str(exc).lower()
         with open(log_path, "a", encoding="utf-8") as log_file:

--- a/forge/ai_workflows/agents/claude_code_agent.py
+++ b/forge/ai_workflows/agents/claude_code_agent.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import uuid
 
-from ai_workflows.agents.agent import Agent
+from ai_workflows.agents.agent import Agent, AgentTimeoutError
 from ai_workflows.agents.agent_runtime import agent_process_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 
@@ -62,34 +62,37 @@ class ClaudeCodeAgent(Agent):
 
     def send_prompt(self, prompt: str) -> str:
         self._print_session_log_once("Claude Code", self._session_log_path)
-        command = self._build_command(prompt)
-        try:
-            result = subprocess.run(
-                command,
-                cwd=self._working_dir,
-                env=self._environment,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                timeout=self._timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            self._append_log(prompt, exc.stdout or "")
-            raise RuntimeError("Claude Code prompt timed out.") from exc
-        self._append_log(prompt, result.stdout)
-        if result.returncode != 0:
-            raise RuntimeError(f"Claude Code command failed with exit code {result.returncode}.")
-        payload = self._parse_result(result.stdout)
-        self._session_id = str(payload.get("session_id") or self._session_id or "") or None
-        usage = payload.get("usage") or {}
-        self._total_tokens_sent += int(usage.get("input_tokens", 0) or 0)
-        self._total_tokens_received += int(usage.get("output_tokens", 0) or 0)
-        self._cached_input_tokens_used += int(usage.get("cache_read_input_tokens", 0) or 0)
-        response = str(payload.get("result") or "")
-        if not response:
-            raise RuntimeError("Claude Code command completed without an assistant result.")
-        return response
+        with self._agent_activity("Claude Code"):
+            command = self._build_command(prompt)
+            try:
+                result = subprocess.run(
+                    command,
+                    cwd=self._working_dir,
+                    env=self._environment,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=self._timeout,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                self._append_log(prompt, exc.stdout or "")
+                raise AgentTimeoutError(
+                    self._current_agent_action(), self._timeout, self._session_log_path,
+                ) from exc
+            self._append_log(prompt, result.stdout)
+            if result.returncode != 0:
+                raise RuntimeError(f"Claude Code command failed with exit code {result.returncode}.")
+            payload = self._parse_result(result.stdout)
+            self._session_id = str(payload.get("session_id") or self._session_id or "") or None
+            usage = payload.get("usage") or {}
+            self._total_tokens_sent += int(usage.get("input_tokens", 0) or 0)
+            self._total_tokens_received += int(usage.get("output_tokens", 0) or 0)
+            self._cached_input_tokens_used += int(usage.get("cache_read_input_tokens", 0) or 0)
+            response = str(payload.get("result") or "")
+            if not response:
+                raise RuntimeError("Claude Code command completed without an assistant result.")
+            return response
 
     def _build_command(self, prompt: str, fork: bool = False) -> list[str]:
         command = [

--- a/forge/ai_workflows/agents/codex_agent.py
+++ b/forge/ai_workflows/agents/codex_agent.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import tempfile
 import time
-from ai_workflows.agents.agent import Agent
+from ai_workflows.agents.agent import Agent, AgentTimeoutError
 from ai_workflows.agents.agent_runtime import (
     CODEX_BYPASS_APPROVALS_AND_SANDBOX_FLAG,
     agent_process_environment,
@@ -176,29 +176,29 @@ class CodexAgent(Agent):
 
     def send_prompt(self, prompt: str) -> str:
         self._print_session_log_once("Codex", self._session_log_path)
-        original_thread_id = self._thread_id
-        cmd = self._build_exec_command(prompt)
-        try:
-            returncode, output = self._run_codex_command(cmd)
-        except subprocess.TimeoutExpired as exc:
-            self._write_turn_log(original_thread_id, prompt, exc.output or "")
-            print(f"[Codex] Timed out after {self._timeout}s.", flush=True)
-            raise RuntimeError("Codex prompt timed out.") from exc
+        with self._agent_activity("Codex"):
+            original_thread_id = self._thread_id
+            cmd = self._build_exec_command(prompt)
+            try:
+                returncode, output = self._run_codex_command(cmd)
+            except subprocess.TimeoutExpired as exc:
+                self._write_turn_log(original_thread_id, prompt, exc.output or "")
+                raise AgentTimeoutError(
+                    self._current_agent_action(), self._timeout, self._session_log_path,
+                ) from exc
 
-        self._record_token_usage(prompt, output)
-        if self._thread_id is None:
-            self._thread_id = self._extract_thread_id(output)
-        self._write_turn_log(self._thread_id or original_thread_id, prompt, output)
-        if returncode != 0:
-            print("[Codex] Failed.", flush=True)
-            raise RuntimeError(f"Codex command failed with exit code {returncode}.")
-        if self._thread_id is None:
-            raise RuntimeError("Codex command completed without a thread id.")
-        response = self._extract_last_message(output)
-        if not response:
-            raise RuntimeError("Codex command completed without an assistant message.")
-        print("[Codex] Done.", flush=True)
-        return response
+            self._record_token_usage(prompt, output)
+            if self._thread_id is None:
+                self._thread_id = self._extract_thread_id(output)
+            self._write_turn_log(self._thread_id or original_thread_id, prompt, output)
+            if returncode != 0:
+                raise RuntimeError(f"Codex command failed with exit code {returncode}.")
+            if self._thread_id is None:
+                raise RuntimeError("Codex command completed without a thread id.")
+            response = self._extract_last_message(output)
+            if not response:
+                raise RuntimeError("Codex command completed without an assistant message.")
+            return response
 
     def _run_codex_command(self, cmd: list[str]) -> tuple[int, str]:
         start_time = time.monotonic()

--- a/forge/ai_workflows/agents/codex_agent.py
+++ b/forge/ai_workflows/agents/codex_agent.py
@@ -162,16 +162,16 @@ class CodexAgent(Agent):
 
     def graphify(self, source_dirs: list[str]) -> str:
         """Send $graphify to the Codex session to build a merged knowledge graph context."""
-        from utility_scripts.stage_logger import log_stage
+        from utility_scripts.stage_logger import log_detail
         from utility_scripts.task_logs import display_log_path
         if not source_dirs:
             return ""
-        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        log_detail("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
         result = self.send_prompt(f"$graphify {source_dirs[0]}")
         for extra_dir in source_dirs[1:]:
-            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            log_detail("graphify", f"Merging graph from {display_log_path(extra_dir)}")
             result = self.send_prompt(f"$graphify {extra_dir} --update")
-        log_stage("graphify", "Knowledge graph context initialized")
+        log_detail("graphify", "Knowledge graph context initialized")
         return result
 
     def send_prompt(self, prompt: str) -> str:

--- a/forge/ai_workflows/agents/opencode_agent.py
+++ b/forge/ai_workflows/agents/opencode_agent.py
@@ -8,7 +8,7 @@ import json
 import os
 import subprocess
 
-from ai_workflows.agents.agent import Agent
+from ai_workflows.agents.agent import Agent, AgentTimeoutError
 from ai_workflows.agents.agent_runtime import agent_process_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
 
@@ -91,7 +91,8 @@ class OpenCodeAgent(Agent):
         return self._cached_input_tokens_used
 
     def send_prompt(self, prompt: str) -> str:
-        return self._run_prompt(prompt, fork=False)
+        with self._agent_activity("OpenCode"):
+            return self._run_prompt(prompt, fork=False)
 
     def _run_prompt(self, prompt: str, fork: bool) -> str:
         self._print_session_log_once("OpenCode", self._session_log_path)
@@ -120,7 +121,9 @@ class OpenCodeAgent(Agent):
             )
         except subprocess.TimeoutExpired as exc:
             self._append_log(prompt, exc.stdout or "")
-            raise RuntimeError("OpenCode prompt timed out.") from exc
+            raise AgentTimeoutError(
+                self._current_agent_action(), self._timeout, self._session_log_path,
+            ) from exc
         self._append_log(prompt, result.stdout)
         if result.returncode != 0:
             raise RuntimeError(f"OpenCode command failed with exit code {result.returncode}.")

--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -95,7 +95,7 @@ class PiAgent(Agent):
         return result
 
     def send_prompt(self, prompt: str) -> str:
-        self._ensure_failure_log_path()
+        self._ensure_session_log_path()
         self._print_session_log_once("Pi", self._session_log_path)
         with self._agent_activity("Pi"):
             original_session_path = self._session_path
@@ -116,8 +116,6 @@ class PiAgent(Agent):
             finally:
                 self._clear_live_status()
             self._session_path = result.session_file
-            if self._session_path != original_session_path:
-                self._set_session_log_path(self._build_generation_log_path())
             self._update_token_counters(result.session_stats)
             self._print_session_log_once("Pi", self._session_log_path)
             self._write_turn_log(self._session_path or original_session_path, prompt, result)
@@ -423,8 +421,11 @@ class PiAgent(Agent):
         self._session_log_path = log_path
         self._session_log_announced = False
 
-    def _ensure_failure_log_path(self) -> None:
-        """Ensure failures are written to a generation log file."""
+    def _ensure_session_log_path(self) -> None:
+        """Choose the stable log path used by every turn of this agent instance.
+
+        §FS-durable-generation-logs
+        """
         if self._session_log_path is not None:
             return
         self._set_session_log_path(self._build_generation_log_path())

--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -7,7 +7,7 @@ import json
 import os
 from datetime import datetime, timezone
 
-from ai_workflows.agents.agent import Agent
+from ai_workflows.agents.agent import Agent, AgentTimeoutError
 from ai_workflows.agents.agent_runtime import agent_process_environment
 from ai_workflows.agents.pi_rpc_client import PiRpcClient, PiRpcError, PromptResult
 from utility_scripts.gradle_test_runner import run_gradle_test_command
@@ -95,27 +95,33 @@ class PiAgent(Agent):
         return result
 
     def send_prompt(self, prompt: str) -> str:
-        original_session_path = self._session_path
-        try:
-            result = self._rpc_client.run_prompt(
-                prompt,
-                session=self._session_path,
-                progress_callback=lambda detail: self._print_live_status("Pi", detail),
-            )
-        except PiRpcError as exc:
-            self._ensure_failure_log_path()
-            self._print_session_log_once("Pi", self._session_log_path)
-            self._write_failure_log(original_session_path, prompt, exc)
-            raise
-        finally:
-            self._clear_live_status()
-        self._session_path = result.session_file
-        if self._session_log_path is None or self._session_path != original_session_path:
-            self._set_session_log_path(self._build_generation_log_path())
-        self._update_token_counters(result.session_stats)
+        self._ensure_failure_log_path()
         self._print_session_log_once("Pi", self._session_log_path)
-        self._write_turn_log(self._session_path or original_session_path, prompt, result)
-        return result.text
+        with self._agent_activity("Pi"):
+            original_session_path = self._session_path
+            try:
+                result = self._rpc_client.run_prompt(
+                    prompt,
+                    session=self._session_path,
+                    progress_callback=lambda detail: self._print_live_status("Pi", detail),
+                )
+            except (PiRpcError, RuntimeError) as exc:
+                logged_error = exc if isinstance(exc, PiRpcError) else PiRpcError(str(exc))
+                self._write_failure_log(original_session_path, prompt, logged_error)
+                if "timed out" in str(exc).lower():
+                    raise AgentTimeoutError(
+                        self._current_agent_action(), self._timeout, self._session_log_path,
+                    ) from exc
+                raise
+            finally:
+                self._clear_live_status()
+            self._session_path = result.session_file
+            if self._session_path != original_session_path:
+                self._set_session_log_path(self._build_generation_log_path())
+            self._update_token_counters(result.session_stats)
+            self._print_session_log_once("Pi", self._session_log_path)
+            self._write_turn_log(self._session_path or original_session_path, prompt, result)
+            return result.text
 
     def fork(self, prompt: str) -> "PiAgent":
         if self._session_path is None:

--- a/forge/ai_workflows/agents/pi_agent.py
+++ b/forge/ai_workflows/agents/pi_agent.py
@@ -82,16 +82,16 @@ class PiAgent(Agent):
 
     def graphify(self, source_dirs: list[str]) -> str:
         """Send /skill:graphify to the Pi session to build a merged knowledge graph context."""
-        from utility_scripts.stage_logger import log_stage
+        from utility_scripts.stage_logger import log_detail
         from utility_scripts.task_logs import display_log_path
         if not source_dirs:
             return ""
-        log_stage("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
+        log_detail("graphify", f"Initializing knowledge graph context for {len(source_dirs)} source(s)")
         result = self.send_prompt(f"/skill:graphify {source_dirs[0]}")
         for extra_dir in source_dirs[1:]:
-            log_stage("graphify", f"Merging graph from {display_log_path(extra_dir)}")
+            log_detail("graphify", f"Merging graph from {display_log_path(extra_dir)}")
             result = self.send_prompt(f"/skill:graphify {extra_dir} --update")
-        log_stage("graphify", "Knowledge graph context initialized")
+        log_detail("graphify", "Knowledge graph context initialized")
         return result
 
     def send_prompt(self, prompt: str) -> str:

--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -15,12 +15,13 @@ from utility_scripts.run_location import (
     STEP_NATIVE_TRACE_GATE,
     RunLocation,
     enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail
 
 
 BASIC_ITERATIVE_PERSISTENT_INSTRUCTIONS_PATH = "prompt_templates/persistent/basic_iterative_rules.md"
@@ -118,11 +119,11 @@ class BasicIterativeStrategy(WorkflowStrategy):
 
     @staticmethod
     def _print_message(message: str) -> None:
-        log_stage("basic-iterative", message)
+        log_detail("basic-iterative", message)
 
     @classmethod
     def _print_detail(cls, message: str, indent_level: int = 1) -> None:
-        log_stage("basic-iterative", message, indent_level=indent_level)
+        log_detail("basic-iterative", message, indent_level=indent_level)
 
     def _commit_test_sources(self, message: str) -> str:
         tests_dir = os.path.join(
@@ -180,6 +181,17 @@ class BasicIterativeStrategy(WorkflowStrategy):
         unittest_number = 0
 
         while failed_iterations < self.max_failed_generations and unittest_number < self.max_successful_generations:
+            generation_number = unittest_number + 1
+            generation_label = (
+                f"retry after failed generation {failed_iterations}/{self.max_failed_generations}"
+                if failed_iterations > 0
+                else f"generation {generation_number}/{self.max_successful_generations}"
+            )
+            log_step_progress(
+                RUN_PHASE_EXPLORE,
+                STEP_GENERATE_TESTS,
+                f"Generating tests: unguided {generation_label}",
+            )
             self._print_message(
                 "successful generation {generation}/{max_generations}, failed attempts {attempt}/{max_attempts}".format(
                     generation=unittest_number,
@@ -211,6 +223,12 @@ class BasicIterativeStrategy(WorkflowStrategy):
             )
             reached_native_test = False
             for test_iter in range(self.max_test_iterations):
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Running test {test_iter + 1}/{self.max_test_iterations}",
+                    indent_level=1,
+                )
                 self._print_detail(
                     "test {test_iteration}/{max_test_iterations}".format(
                         test_iteration=test_iter + 1,
@@ -225,6 +243,18 @@ class BasicIterativeStrategy(WorkflowStrategy):
                 )
                 test_output = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
                 failed_task = self._get_first_failed_task(test_output)
+                if failed_task == "nativeTest":
+                    test_outcome = "reached nativeTest"
+                elif failed_task is None:
+                    test_outcome = "passed"
+                else:
+                    test_outcome = f"failed at {failed_task}"
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Test {test_iter + 1}/{self.max_test_iterations} {test_outcome}",
+                    indent_level=1,
+                )
                 self._print_detail(
                     "test: complete (failed task: {failed_task})".format(
                         failed_task=failed_task or "none",
@@ -249,6 +279,12 @@ class BasicIterativeStrategy(WorkflowStrategy):
                     "agent: test failed before nativeTest; sending failure output back to agent",
                     indent_level=2,
                 )
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Running feedback fix after {failed_task}",
+                    indent_level=2,
+                )
                 send_agent_prompt(
                     agent,
                     f"The following test command failed:\n./gradlew test -Pcoordinates={self.library}\n\nOutput:\n{test_output}",
@@ -262,6 +298,11 @@ class BasicIterativeStrategy(WorkflowStrategy):
                 continue
 
             failed_iterations += 1
+            log_step_progress(
+                RUN_PHASE_EXPLORE,
+                STEP_GENERATE_TESTS,
+                "Generation failed before nativeTest; reverting generated tests",
+            )
             self._print_detail("result: failed before reaching nativeTest, reverting to checkpoint")
             subprocess.run(["git", "reset", "--hard", checkpoint_commit_hash], check=False)
 

--- a/forge/ai_workflows/core/basic_iterative_strategy.py
+++ b/forge/ai_workflows/core/basic_iterative_strategy.py
@@ -6,6 +6,7 @@
 import os
 import subprocess
 
+from ai_workflows.agents.agent import send_agent_prompt
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.run_location import (
@@ -190,11 +191,17 @@ class BasicIterativeStrategy(WorkflowStrategy):
             with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand=self.library):
                 if failed_iterations > 0:
                     self._print_detail("agent: running failed-iteration prompt")
-                    agent.send_prompt(self.prompt_after_failed)
+                    send_agent_prompt(
+                        agent, self.prompt_after_failed, "failed_iteration()",
+                    )
                 else:
                     prompt_name = "initial" if unittest_number < 1 else "successful-iteration"
                     self._print_detail(f"agent: running {prompt_name} prompt")
-                    agent.send_prompt(self.prompt_initial if unittest_number < 1 else self.prompt_after_success)
+                    send_agent_prompt(
+                        agent,
+                        self.prompt_initial if unittest_number < 1 else self.prompt_after_success,
+                        "initial_generation()" if unittest_number < 1 else "successful_iteration()",
+                    )
                 self._print_detail("agent: complete")
 
             global_iterations += 1
@@ -242,8 +249,10 @@ class BasicIterativeStrategy(WorkflowStrategy):
                     "agent: test failed before nativeTest; sending failure output back to agent",
                     indent_level=2,
                 )
-                agent.send_prompt(
-                    f"The following test command failed:\n./gradlew test -Pcoordinates={self.library}\n\nOutput:\n{test_output}"
+                send_agent_prompt(
+                    agent,
+                    f"The following test command failed:\n./gradlew test -Pcoordinates={self.library}\n\nOutput:\n{test_output}",
+                    "feedback_fix()",
                 )
                 self._print_detail("agent: complete", indent_level=2)
                 global_iterations += 1

--- a/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
@@ -20,6 +20,7 @@ from utility_scripts.run_location import (
     STEP_NATIVE_TRACE_GATE,
     RunLocation,
     enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
@@ -33,7 +34,7 @@ from utility_scripts.dynamic_access_report import (
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
-from utility_scripts.stage_logger import log_detail, log_stage
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
@@ -138,12 +139,25 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
 
         for iteration in range(self.max_bulk_iterations):
             agent.clear_context()
+            uncovered_calls = current_report.total_calls - current_report.covered_calls
+            uncovered_classes = sum(1 for c in current_report.classes if c.uncovered_calls > 0)
+            log_step_progress(
+                RUN_PHASE_EXPLORE,
+                STEP_GENERATE_TESTS,
+                "Generating tests: bulk iteration {current}/{maximum}, "
+                "{calls} uncovered across {classes} classes".format(
+                    current=iteration + 1,
+                    maximum=self.max_bulk_iterations,
+                    calls=uncovered_calls,
+                    classes=uncovered_classes,
+                ),
+            )
             self._print_message(
                 "iteration {current}/{max} — {uncovered} uncovered across {classes} classes".format(
                     current=iteration + 1,
                     max=self.max_bulk_iterations,
-                    uncovered=current_report.total_calls - current_report.covered_calls,
-                    classes=sum(1 for c in current_report.classes if c.uncovered_calls > 0),
+                    uncovered=uncovered_calls,
+                    classes=uncovered_classes,
                 )
             )
 
@@ -171,6 +185,12 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
             last_test_output = ""
             last_failed_task = None
             for test_iteration in range(self.max_test_iterations):
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Running test {test_iteration + 1}/{self.max_test_iterations}",
+                    indent_level=1,
+                )
                 self._print_detail(
                     "test {current}/{max}: running ./gradlew test -Pcoordinates={library}".format(
                         current=test_iteration + 1,
@@ -183,6 +203,18 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                 failed_task = self._get_first_failed_task(test_output)
                 last_test_output = test_output
                 last_failed_task = failed_task
+                if failed_task == "nativeTest":
+                    test_outcome = "reached nativeTest"
+                elif failed_task is None:
+                    test_outcome = "passed"
+                else:
+                    test_outcome = f"failed at {failed_task}"
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Test {test_iteration + 1}/{self.max_test_iterations} {test_outcome}",
+                    indent_level=1,
+                )
                 self._print_detail(
                     "test: complete (failed task: {failed_task})".format(
                         failed_task=failed_task or "none",
@@ -192,6 +224,12 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                 if failed_task in {"nativeTest", None}:
                     reached_native_test = True
                     break
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Running feedback fix after {failed_task}",
+                    indent_level=2,
+                )
                 self._print_detail("agent: test failed; sending failure output back", indent_level=2)
                 send_agent_prompt(
                     agent,
@@ -205,6 +243,11 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                 prompt_iterations += 1
 
             if not reached_native_test:
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Bulk iteration {iteration + 1} failed before nativeTest",
+                )
                 self._print_detail("result: failed, reverting to checkpoint")
                 self._print_failure_analysis(
                     "gradle_test_failed",
@@ -219,6 +262,13 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
             if current_report is None:
                 self._print_detail("result: dynamic-access report unavailable after test run")
                 break
+
+            log_step_progress(
+                RUN_PHASE_EXPLORE,
+                STEP_GENERATE_TESTS,
+                f"Bulk iteration {iteration + 1} completed: "
+                f"{current_report.covered_calls}/{current_report.total_calls} covered",
+            )
 
             self._commit_test_sources(
                 "Bulk dynamic-access coverage ({covered}/{total})".format(
@@ -468,7 +518,7 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
 
     @staticmethod
     def _print_message(message: str) -> None:
-        log_stage("bulk-da", message)
+        log_detail("bulk-da", message)
 
     @classmethod
     def _print_detail(cls, message: str, indent_level: int = 1) -> None:

--- a/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
@@ -6,6 +6,7 @@
 import os
 import subprocess
 
+from ai_workflows.agents.agent import send_agent_prompt
 from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_FAILURE,
@@ -161,7 +162,7 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
             )
             with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand=self.library):
                 self._print_detail("agent: sending bulk prompt")
-                agent.send_prompt(prompt)
+                send_agent_prompt(agent, prompt, "bulk_dynamic_access_iteration()")
                 self._print_detail("agent: complete")
             prompt_iterations += 1
 
@@ -192,11 +193,13 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                     reached_native_test = True
                     break
                 self._print_detail("agent: test failed; sending failure output back", indent_level=2)
-                agent.send_prompt(
+                send_agent_prompt(
+                    agent,
                     "When `./gradlew test -Pcoordinates={library}` is ran this is the error:\n{error_output}".format(
                         library=self.library,
                         error_output=test_output,
-                    )
+                    ),
+                    "feedback_fix()",
                 )
                 self._print_detail("agent: complete", indent_level=2)
                 prompt_iterations += 1
@@ -393,7 +396,6 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                 issue=self._summarize_gradle_issue(result.stdout),
                 exit_code=result.returncode,
             )
-            print(result.stdout)
             return None
         try:
             report = load_dynamic_access_coverage_report(

--- a/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
@@ -33,7 +33,7 @@ from utility_scripts.dynamic_access_report import (
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.metadata_index import resolve_test_version
 from utility_scripts.native_test_verification import global_output_dir
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
@@ -472,7 +472,7 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
 
     @classmethod
     def _print_detail(cls, message: str, indent_level: int = 1) -> None:
-        log_stage("bulk-da", message, indent_level=indent_level)
+        log_detail("bulk-da", message, indent_level=indent_level)
 
     @classmethod
     def _print_failure_analysis(cls, stage: str, issue: str, indent_level: int = 1, **details) -> None:

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -30,10 +30,11 @@ from utility_scripts.run_location import (
     STEP_NATIVE_TRACE_GATE,
     RunLocation,
     enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
@@ -374,6 +375,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     class_name=class_name,
                 )
             )
+            log_step_progress(
+                RUN_PHASE_EXPLORE,
+                STEP_GENERATE_TESTS,
+                f"Generating tests for class {progress_text}: {class_name}",
+            )
             self._print_dynamic_access_detail(
                 "coverage: {covered}/{total}".format(
                     covered=active_class.covered_calls,
@@ -385,6 +391,13 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             class_committed = False
             gate_failed = False
             while class_attempts < self.max_class_iterations:
+                if class_attempts > 0:
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Retrying test generation for class {progress_text}: {class_name} "
+                        f"(attempt {class_attempts + 1}/{self.max_class_iterations})",
+                    )
                 self._print_dynamic_access_detail(
                     "attempt {attempt}/{max_attempts}".format(
                         attempt=class_attempts + 1,
@@ -414,6 +427,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 last_test_output = ""
                 last_failed_task = None
                 for test_iteration in range(self.max_class_test_iterations):
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Running test {test_iteration + 1}/{self.max_class_test_iterations}",
+                        indent_level=1,
+                    )
                     self._print_dynamic_access_detail(
                         "test {current}/{maximum}: running ./gradlew test -Pcoordinates={library}".format(
                             current=test_iteration + 1,
@@ -426,6 +445,18 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     failed_task = self._get_first_failed_task(test_output)
                     last_test_output = test_output
                     last_failed_task = failed_task
+                    if failed_task == "nativeTest":
+                        test_outcome = "reached nativeTest"
+                    elif failed_task is None:
+                        test_outcome = "passed"
+                    else:
+                        test_outcome = f"failed at {failed_task}"
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Test {test_iteration + 1}/{self.max_class_test_iterations} {test_outcome}",
+                        indent_level=1,
+                    )
                     self._print_dynamic_access_detail(
                         "test: complete (failed task: {failed_task})".format(
                             failed_task=failed_task or "none",
@@ -435,6 +466,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     if failed_task in {"nativeTest", None}:
                         reached_native_test = True
                         break
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Running feedback fix after {failed_task}",
+                        indent_level=2,
+                    )
                     self._print_dynamic_access_detail(
                         "agent: test failed before nativeTest; sending failure output back to agent",
                         indent_level=2,
@@ -462,12 +499,22 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         class_name=class_name,
                     )
                     subprocess.run(["git", "reset", "--hard", class_checkpoint], check=False)
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Class {class_name} failed before nativeTest",
+                    )
                     class_failed = True
                     break
 
                 previous_report = current_report
                 current_report = self._generate_dynamic_access_report(indent_level=2)
                 if current_report is None:
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Class {class_name} failed: dynamic-access report unavailable",
+                    )
                     self._print_dynamic_access_detail(
                         "result: dynamic-access report unavailable after test run",
                         indent_level=2,
@@ -548,6 +595,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         ),
                         indent_level=2,
                     )
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Class {class_name} partially covered: "
+                        f"{updated_class.covered_calls}/{updated_class.total_calls}",
+                    )
                     class_checkpoint = self._commit_test_sources(
                         f"Partial dynamic-access coverage for {class_name} "
                         f"({updated_class.covered_calls}/{updated_class.total_calls})"
@@ -567,6 +620,12 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         updated_class = current_report.get_class(class_name) or updated_class
                     self._save_dynamic_access_exhaust_report()
                 else:
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Class {class_name} gained no coverage; "
+                        f"{updated_class.uncovered_calls} calls remain",
+                    )
                     self._print_dynamic_access_detail(
                         "result: no new coverage, {remaining} {call_label} still uncovered".format(
                             remaining=updated_class.uncovered_calls,
@@ -626,6 +685,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         self._locate_explore_failure(class_name)
                         return False, prompt_iterations
                     self._last_phase_status = RUN_STATUS_CHUNK_READY
+                    log_step_progress(
+                        RUN_PHASE_EXPLORE,
+                        STEP_GENERATE_TESTS,
+                        f"Exploration chunk ready after {len(terminal_classes_this_part)} classes",
+                    )
                     self._print_dynamic_access_message(
                         "Chunked dynamic-access boundary reached after {count} terminal class(es).".format(
                             count=len(terminal_classes_this_part),
@@ -647,6 +711,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     "final: exhausted after {attempts} attempts".format(
                         attempts=self.max_class_iterations,
                     )
+                )
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Class {class_name} exhausted after {self.max_class_iterations} attempts",
                 )
                 self._print_failure_analysis(
                     "class_iteration_exhausted",
@@ -682,6 +751,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     self._locate_explore_failure(class_name)
                     return False, prompt_iterations
                 self._last_phase_status = RUN_STATUS_CHUNK_READY
+                log_step_progress(
+                    RUN_PHASE_EXPLORE,
+                    STEP_GENERATE_TESTS,
+                    f"Exploration chunk ready after {len(terminal_classes_this_part)} classes",
+                )
                 self._print_dynamic_access_message(
                     "Chunked dynamic-access boundary reached after {count} terminal class(es).".format(
                         count=len(terminal_classes_this_part),
@@ -972,6 +1046,19 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             current_report,
     ) -> None:
         remaining_calls = max(current_report.total_calls - current_report.covered_calls, 0)
+        log_step_progress(
+            RUN_PHASE_EXPLORE,
+            STEP_GENERATE_TESTS,
+            "Finished class {class_name}: classes {completed}/{total} processed; "
+            "coverage {covered}/{call_total} ({remaining} remaining)".format(
+                class_name=class_name,
+                completed=completed_class_count,
+                total=total_class_count,
+                covered=current_report.covered_calls,
+                call_total=current_report.total_calls,
+                remaining=remaining_calls,
+            ),
+        )
         cls._print_dynamic_access_message(cls.PROGRESS_DIVIDER)
         cls._print_dynamic_access_message(
             "Progress after {class_name}: classes {completed}/{total} complete; "
@@ -1243,15 +1330,15 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
 
     @staticmethod
     def _print_dynamic_access_message(message: str) -> None:
-        log_stage("dynamic-access", message)
+        log_detail("dynamic-access", message)
 
     @classmethod
     def _print_dynamic_access_detail(cls, message: str, indent_level: int = 1) -> None:
-        log_stage("dynamic-access", message, indent_level=indent_level)
+        log_detail("dynamic-access", message, indent_level=indent_level)
 
     @staticmethod
     def _print_issue_requested_metadata_message(message: str) -> None:
-        log_stage("issue-requested-metadata", message)
+        log_detail("issue-requested-metadata", message)
 
     @classmethod
     def _print_failure_analysis(cls, stage: str, issue: str, indent_level: int = 1, **details) -> None:

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -6,6 +6,7 @@
 import os
 import subprocess
 
+from ai_workflows.agents.agent import send_agent_prompt
 from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_FAILURE,
@@ -163,7 +164,11 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         prompt_iterations = 1
         with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand="reporter-requested metadata"):
             self._print_issue_requested_metadata_message("agent: running reporter-requested metadata prompt")
-            agent.send_prompt(self._render_prompt("issue-requested-metadata"))
+            send_agent_prompt(
+                agent,
+                self._render_prompt("issue-requested-metadata"),
+                "issue_requested_metadata()",
+            )
             self._print_issue_requested_metadata_message("agent: complete")
 
         last_test_output = ""
@@ -193,11 +198,13 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
             self._print_issue_requested_metadata_message(
                 "agent: test failed before nativeTest; sending failure output back to agent"
             )
-            agent.send_prompt(
+            send_agent_prompt(
+                agent,
                 "When `./gradlew test -Pcoordinates={library}` is ran this is the error:\n{error_output}".format(
                     library=self.library,
                     error_output=test_output,
-                )
+                ),
+                "feedback_fix()",
             )
             self._print_issue_requested_metadata_message("agent: complete")
             prompt_iterations += 1
@@ -394,7 +401,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 )
                 with run_step(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, operand=class_name):
                     self._print_dynamic_access_detail("agent: running dynamic-access prompt", indent_level=2)
-                    agent.send_prompt(dynamic_prompt)
+                    send_agent_prompt(agent, dynamic_prompt, "dynamic_access_iteration()")
                     self._print_dynamic_access_detail("agent: complete", indent_level=2)
                 prompt_iterations += 1
                 save_phase_update(
@@ -432,11 +439,13 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         "agent: test failed before nativeTest; sending failure output back to agent",
                         indent_level=2,
                     )
-                    agent.send_prompt(
+                    send_agent_prompt(
+                        agent,
                         "When `./gradlew test -Pcoordinates={library}` is ran this is the error:\n{error_output}".format(
                             library=self.library,
                             error_output=test_output,
-                        )
+                        ),
+                        "feedback_fix()",
                     )
                     self._print_dynamic_access_detail("agent: complete", indent_level=2)
                     prompt_iterations += 1
@@ -1122,7 +1131,6 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 indent_level=indent_level,
                 exit_code=result.returncode,
             )
-            print(result.stdout)
             return None
         try:
             report = load_dynamic_access_coverage_report(

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -13,6 +13,7 @@ from ai_workflows.core.workflow_strategy import (
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.dynamic_access_report import BulkDynamicAccessProgress, DynamicAccessCoverageReport
 from utility_scripts.java_fix_coverage_follow_up import uncovered_dynamic_access_class_count
+from utility_scripts.stage_logger import log_detail
 
 
 @WorkflowStrategy.register("increase_dynamic_access_coverage")
@@ -48,7 +49,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
 
     @staticmethod
     def _print_message(message: str) -> None:
-        print(f"[composition-workflow] {message}")
+        log_detail("composition-workflow", message)
 
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -12,10 +12,12 @@ from utility_scripts.run_location import (
     STEP_NATIVE_TRACE_GATE,
     RunLocation,
     enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
 from utility_scripts.native_test_verification import global_output_dir
+from utility_scripts.stage_logger import log_detail
 
 
 """
@@ -91,11 +93,11 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         return "agent: test failed before nativeTest; sending failure output back to agent"
 
     def _print_message(self, message: str) -> None:
-        print(f"[{self._log_prefix}] {message}")
+        log_detail(self._log_prefix, message)
 
     @classmethod
     def _print_detail(cls, message: str, indent_level: int = 1) -> None:
-        print(f"{'  ' * indent_level}{message}")
+        log_detail("fix", message, indent_level=indent_level)
 
     def run(self, agent):
         save_phase_update(
@@ -106,8 +108,25 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
         workflow_status = RUN_STATUS_FAILURE
 
         with run_step(RUN_PHASE_FIX, STEP_FIX_REPORTED_FAILURE, operand=self.library):
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                f"Fixing reported failure for {self.library}",
+            )
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                "Reproducing reported failure",
+                indent_level=1,
+            )
             self._print_message("running initial gradle test to collect errors")
             initial_error = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                "Running initial agent fix",
+                indent_level=1,
+            )
             self._print_message("running agent...")
             send_agent_prompt(
                 agent,
@@ -121,6 +140,12 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.record_iteration(PHASE_FIX, test_iter + 1),
+            )
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                f"Running test {test_iter + 1}/{self.max_test_iterations}",
+                indent_level=1,
             )
             self._print_message(
                 "test {test_iteration}/{max_test_iterations}".format(
@@ -136,6 +161,18 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             )
             test_output = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
             failed_task = self._get_first_failed_task(test_output)
+            if failed_task == "nativeTest":
+                test_outcome = "reached nativeTest"
+            elif failed_task is None:
+                test_outcome = "passed"
+            else:
+                test_outcome = f"failed at {failed_task}"
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                f"Test {test_iter + 1}/{self.max_test_iterations} {test_outcome}",
+                indent_level=1,
+            )
             self._print_detail(
                 "test: complete (failed task: {failed_task})".format(
                     failed_task=failed_task or "none",
@@ -152,6 +189,12 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
                 break
 
             global_iterations += 1
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                f"Running feedback fix after {failed_task}",
+                indent_level=2,
+            )
             self._print_detail(
                 self._retry_detail_message,
                 indent_level=2,
@@ -183,6 +226,11 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
                 ),
             )
         else:
+            log_step_progress(
+                RUN_PHASE_FIX,
+                STEP_FIX_REPORTED_FAILURE,
+                f"Reported failure could not be fixed for {self.library}",
+            )
             save_phase_update(
                 self.continuation_marker_path,
                 lambda marker: marker.mark_phase_pending(PHASE_FIX, iteration=global_iterations),

--- a/forge/ai_workflows/core/java_fix_iterative_strategy.py
+++ b/forge/ai_workflows/core/java_fix_iterative_strategy.py
@@ -3,6 +3,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+from ai_workflows.agents.agent import send_agent_prompt
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS, WorkflowStrategy
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.run_location import (
@@ -108,7 +109,11 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
             self._print_message("running initial gradle test to collect errors")
             initial_error = agent.run_test_command(f"./gradlew test -Pcoordinates={self.library}")
             self._print_message("running agent...")
-            agent.send_prompt(self._render_prompt("initial", initial_error=initial_error))
+            send_agent_prompt(
+                agent,
+                self._render_prompt("initial", initial_error=initial_error),
+                "initial_fix()",
+            )
             self._print_message("agent complete")
         global_iterations = 1
 
@@ -151,8 +156,10 @@ class _JavaTestFixIterativeBase(WorkflowStrategy):
                 self._retry_detail_message,
                 indent_level=2,
             )
-            agent.send_prompt(
-                f"{self._retry_prompt_title}\n./gradlew test -Pcoordinates={self.library}\n\nOutput:\n{test_output}"
+            send_agent_prompt(
+                agent,
+                f"{self._retry_prompt_title}\n./gradlew test -Pcoordinates={self.library}\n\nOutput:\n{test_output}",
+                "feedback_fix()",
             )
             self._print_detail("agent: complete", indent_level=2)
 

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 from typing import Callable
 
+from ai_workflows.agents.agent import AgentFailureError
 from ai_workflows.core.metadata_fix import run_metadata_fix
 from ai_workflows.core.post_generation_fix import (
     DEFAULT_MAX_TEST_OUTPUT_CHARS,
@@ -200,6 +201,13 @@ class WorkflowStrategy(ABC):
                 f"native-test gate FAILED{label_suffix} after {result.iterations_used} cycles "
                 f"(last log: {log_path})",
             )
+            # Preserve the agent cause and log through the terminal boundary.
+            # §FS-forge-run-output-legibility.2
+            if result.failure_detail is not None:
+                raise AgentFailureError(
+                    f"native-trace-gate agent failed with: {result.failure_detail}",
+                    result.failure_log_path,
+                )
             return False
         log_stage(
             "native-test-verify",

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -28,6 +28,7 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.workflow_setup import build_graalvm_environment
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.gradle_test_runner import run_gradle_test_command
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.run_location import (
     PHASE_FINALIZATION as RUN_PHASE_FINALIZATION,
     STEP_AGENT_FIX,
@@ -396,24 +397,24 @@ class WorkflowStrategy(ABC):
             libraries.append(metadata_library)
         return libraries
 
-    def _run_gradle_command_with_output(self, command: list[str]) -> subprocess.CompletedProcess[str]:
-        """Run a Gradle command in the reachability repo and capture combined output."""
+    def _run_gradle_command_with_output(self, command: list[str]) -> LoggedCommandResult:
+        """Run a Gradle command quietly and retain complete durable output."""
         require_complete_reachability_repo(self.reachability_repo_path)
-        return subprocess.run(
+        action = command[1] if len(command) > 1 else "gradle"
+        return run_logged_command(
             command,
             cwd=self.reachability_repo_path,
+            task_type="gradle",
+            subject=self.library,
+            action=action,
             env=gradle_command_environment(self.reachability_repo_path),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=False,
+            stage="gradle",
         )
 
     def _run_gradle_command(self, command: list[str]) -> bool:
         """Run a Gradle command in the reachability repo, returning True on success."""
         result = self._run_gradle_command_with_output(command)
         if result.returncode != 0:
-            print(result.stdout)
             return False
         return True
 
@@ -525,11 +526,9 @@ class WorkflowStrategy(ABC):
             new_packages = missing_packages - seen_packages
             if not new_packages:
                 log_stage("check-metadata-files", "No new TypeReached packages found in checkMetadataFiles output")
-                print(result.stdout)
                 return False
             log_stage("allowed-packages", f"Adding allowed-packages for {library}: {', '.join(sorted(new_packages))}")
             if not self._append_allowed_packages_to_metadata_index(new_packages):
-                print(result.stdout)
                 return False
             seen_packages.update(new_packages)
 

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -34,6 +34,8 @@ from utility_scripts.run_location import (
     PHASE_FINALIZATION as RUN_PHASE_FINALIZATION,
     STEP_AGENT_FIX,
     STEP_FINALIZE_RUN,
+    current_run_location,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
@@ -54,7 +56,7 @@ from utility_scripts.issue_requested_metadata import NO_REPORTER_METADATA_CONTEX
 from utility_scripts.task_logs import display_log_path
 from utility_scripts.library_preparation_preflight import NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.strategy_loader import load_persistent_instructions, load_prompt_template
 
 RUN_STATUS_SUCCESS = "success"
@@ -182,7 +184,15 @@ class WorkflowStrategy(ABC):
     ) -> bool:
         """Run the shared native-test gate (§FS-native-test-verification-gate)."""
         label_suffix: str = f" for {label}" if label else ""
-        log_stage(
+        gate_target = label or self.library
+        location = current_run_location()
+        if location is not None:
+            log_step_progress(
+                location.phase,
+                location.step,
+                f"Running native trace gate for {gate_target}",
+            )
+        log_detail(
             "native-test-verify",
             f"native-test gate: starting{label_suffix} output_dir={output_dir} "
             f"budget={self.max_native_test_verification_iterations}",
@@ -196,7 +206,24 @@ class WorkflowStrategy(ABC):
         )
         if result.status == NATIVE_TEST_GATE_FAILED:
             log_path: str = result.last_native_test_log_path or "(none)"
-            log_stage(
+            last_exit: str = (
+                str(result.last_native_test_exit_code)
+                if result.last_native_test_exit_code is not None
+                else "unknown"
+            )
+            failure_cause = result.failure_detail or (
+                f"native test did not pass after {result.iterations_used} cycles; "
+                f"last binary exit {last_exit}"
+            )
+            if location is not None:
+                displayed_log = display_log_path(log_path) if log_path != "(none)" else log_path
+                log_step_progress(
+                    location.phase,
+                    location.step,
+                    f"Native trace gate failed for {gate_target}: {failure_cause} "
+                    f"(log: {displayed_log})",
+                )
+            log_detail(
                 "native-test-verify",
                 f"native-test gate FAILED{label_suffix} after {result.iterations_used} cycles "
                 f"(last log: {log_path})",
@@ -209,7 +236,14 @@ class WorkflowStrategy(ABC):
                     result.failure_log_path,
                 )
             return False
-        log_stage(
+        status_text = result.status.lower().replace("_", " ")
+        if location is not None:
+            log_step_progress(
+                location.phase,
+                location.step,
+                f"Native trace gate {status_text} for {gate_target}",
+            )
+        log_detail(
             "native-test-verify",
             f"native-test gate {result.status}{label_suffix} after {result.iterations_used} cycles",
         )

--- a/forge/ai_workflows/core/workflow_strategy.py
+++ b/forge/ai_workflows/core/workflow_strategy.py
@@ -311,16 +311,33 @@ class WorkflowStrategy(ABC):
         repo_path = getattr(self, "reachability_repo_path", os.getcwd())
         final_status = RUN_STATUS_SUCCESS
 
+        # Lanes are the visible units; their commands remain verbose narration.
+        # §FS-forge-run-output-legibility.1 §FS-forge-run-output-legibility.5
         def run_lane(
+                lane_number: int,
+                lane_name: str,
                 stage_name: str,
                 command_runner: Callable[[], str],
                 reproduction_command: str,
                 command_env: dict[str, str] | None,
         ) -> str:
-            log_stage("post-generation-test", f"Running {stage_name} for {library}")
+            lane_target = f"native-test lane {lane_number}/3 for {library}: {lane_name}"
+            log_step_progress(
+                RUN_PHASE_FINALIZATION,
+                STEP_FINALIZE_RUN,
+                f"Running {lane_target}",
+                indent_level=1,
+            )
+            log_detail("post-generation-test", f"Running {stage_name} for {library}")
             test_output = command_runner()
             if self._get_first_failed_task(test_output) is None:
-                log_stage("post-generation-test", f"{stage_name} passed for {library}")
+                log_step_progress(
+                    RUN_PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    f"Passed {lane_target}",
+                    indent_level=1,
+                )
+                log_detail("post-generation-test", f"{stage_name} passed for {library}")
                 return RUN_STATUS_SUCCESS
 
             def record_lane_failure() -> str:
@@ -331,7 +348,12 @@ class WorkflowStrategy(ABC):
             # Repairing a failed post-generation lane is the finalization phase's
             # agent fix. §FS-forge-run-location-reporting.2
             with run_step(RUN_PHASE_FINALIZATION, STEP_AGENT_FIX, operand=f"{library} {stage_name}"):
-                log_stage("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
+                log_step_progress(
+                    RUN_PHASE_FINALIZATION,
+                    STEP_AGENT_FIX,
+                    f"Running agent fix for {lane_target}",
+                )
+                log_detail("metadata-fix", f"Running metadata fix workflow for {library} after {stage_name} failure")
                 codex_env = gradle_command_environment(repo_path, command_env)
                 codex_rc, codex_log_path, codex_timed_out = run_metadata_fix(
                     repo_path,
@@ -344,10 +366,26 @@ class WorkflowStrategy(ABC):
                 if not codex_timed_out and codex_rc == 0:
                     recovery_test_output = command_runner()
                     if self._get_first_failed_task(recovery_test_output) is None:
-                        log_stage("post-generation-test", f"{stage_name} passed for {library} after metadata fix")
+                        log_step_progress(
+                            RUN_PHASE_FINALIZATION,
+                            STEP_AGENT_FIX,
+                            f"Agent fix passed {lane_target}",
+                        )
+                        log_detail(
+                            "post-generation-test",
+                            f"{stage_name} passed for {library} after metadata fix",
+                        )
                         return RUN_STATUS_SUCCESS
 
-                log_stage("post-generation-fix", f"Running post generation fix for {library} after {stage_name} failure")
+                log_step_progress(
+                    RUN_PHASE_FINALIZATION,
+                    STEP_AGENT_FIX,
+                    f"Retrying agent fix for {lane_target}",
+                )
+                log_detail(
+                    "post-generation-fix",
+                    f"Running post generation fix for {library} after {stage_name} failure",
+                )
                 pi_rc, intervention_path, pi_timed_out = run_post_generation_fix(
                     reachability_metadata_path=repo_path,
                     coordinates=library,
@@ -363,11 +401,28 @@ class WorkflowStrategy(ABC):
                     ),
                 )
                 if pi_timed_out or pi_rc != 0:
+                    reason = "timed out" if pi_timed_out else f"failed with exit code {pi_rc}"
+                    log_step_progress(
+                        RUN_PHASE_FINALIZATION,
+                        STEP_AGENT_FIX,
+                        f"Agent fix for {lane_target} {reason} "
+                        f"(log: {display_log_path(intervention_path)})",
+                    )
                     return record_lane_failure()
 
                 rerun_output = command_runner()
                 if self._get_first_failed_task(rerun_output) is not None:
+                    log_step_progress(
+                        RUN_PHASE_FINALIZATION,
+                        STEP_AGENT_FIX,
+                        f"Agent fix did not pass {lane_target}",
+                    )
                     return record_lane_failure()
+                log_step_progress(
+                    RUN_PHASE_FINALIZATION,
+                    STEP_AGENT_FIX,
+                    f"Agent fix passed {lane_target}",
+                )
 
             with open(intervention_path, "r", encoding="utf-8") as intervention_file:
                 intervention_markdown = intervention_file.read().strip()
@@ -383,6 +438,8 @@ class WorkflowStrategy(ABC):
             return SUCCESS_WITH_INTERVENTION_STATUS
 
         regular_status = run_lane(
+            1,
+            "latest GraalVM, current defaults",
             "current-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd),
             test_cmd,
@@ -396,6 +453,8 @@ class WorkflowStrategy(ABC):
         future_defaults_env = dict(os.environ)
         future_defaults_env["GVM_TCK_NATIVE_IMAGE_MODE"] = "future-defaults-all"
         future_defaults_status = run_lane(
+            2,
+            "latest GraalVM, future defaults",
             "future-defaults latest GRAALVM test",
             lambda: self._run_command_with_env(test_cmd, future_defaults_env),
             f"GVM_TCK_NATIVE_IMAGE_MODE=future-defaults-all {test_cmd}",
@@ -415,6 +474,8 @@ class WorkflowStrategy(ABC):
         current_defaults_25_env = build_graalvm_environment(os.environ["GRAALVM_HOME_25_0"])
         current_defaults_25_env.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
         current_defaults_25_status = run_lane(
+            3,
+            "GraalVM 25, current defaults",
             "current-defaults GraalVM 25 test",
             lambda: self._run_command_with_env(test_cmd, current_defaults_25_env),
             f'GRAALVM_HOME="$GRAALVM_HOME_25_0" JAVA_HOME="$GRAALVM_HOME_25_0" {test_cmd}',
@@ -592,6 +653,17 @@ class WorkflowStrategy(ABC):
         # it still names its location. §FS-forge-run-location-reporting.2
         with run_step(RUN_PHASE_FINALIZATION, STEP_FINALIZE_RUN, operand=self.library):
             finalize_status, _ = self._finalize_successful_iteration(base_commit=base_commit)
+            if finalize_status == SUCCESS_WITH_INTERVENTION_STATUS:
+                outcome = f"Finalization completed with agent intervention for {self.library}"
+            elif finalize_status == RUN_STATUS_SUCCESS:
+                outcome = f"Finalization completed for {self.library}"
+            else:
+                outcome = f"Finalization failed for {self.library}"
+            log_step_progress(
+                RUN_PHASE_FINALIZATION,
+                STEP_FINALIZE_RUN,
+                outcome,
+            )
         finalize_succeeded = finalize_status in {RUN_STATUS_SUCCESS, SUCCESS_WITH_INTERVENTION_STATUS}
         if not finalize_succeeded:
             record_step_failure(operand=self.library)
@@ -640,6 +712,12 @@ class WorkflowStrategy(ABC):
             group, artifact, library_version = coordinate_parts(library)
             if library_version is None:
                 return RUN_STATUS_FAILURE, None
+            log_step_progress(
+                RUN_PHASE_FINALIZATION,
+                STEP_FINALIZE_RUN,
+                f"Running final repository checks for {library}",
+                indent_level=1,
+            )
             if not run_library_finalization(
                 repo_path=self.reachability_repo_path,
                 library=library,
@@ -648,8 +726,20 @@ class WorkflowStrategy(ABC):
                 library_version=library_version,
                 base_commit=base_commit,
             ):
+                log_step_progress(
+                    RUN_PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    f"Final repository checks failed for {library}",
+                    indent_level=1,
+                )
                 return RUN_STATUS_FAILURE, None
-        log_stage("commit-iteration", f"Running commit iteration for {self.library}")
+            log_step_progress(
+                RUN_PHASE_FINALIZATION,
+                STEP_FINALIZE_RUN,
+                f"Final repository checks passed for {library}",
+                indent_level=1,
+            )
+        log_detail("commit-iteration", f"Running commit iteration for {self.library}")
         if not self._commit_library_iteration():
             return RUN_STATUS_FAILURE, None
         checkpoint_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -394,9 +394,9 @@ def write_add_new_library_support_metrics(run_metrics, metrics_repo_dir, is_benc
     record instead of appending a run entry.
     """
     if not is_benchmark_mode:
-        log_stage("schema-validation", "Validating schema")
+        log_detail("schema-validation", "Validating schema")
         metrics_writer.write_workflow_run_metrics(run_metrics, metrics_repo_dir, metrics_repo_root, METRICS_TASK_TYPE)
-        log_stage("schema-validation", "Schema validated")
+        log_detail("schema-validation", "Schema validated")
         return
 
     metrics_json = os.path.join(metrics_repo_dir, f"{METRICS_TASK_TYPE}.json")
@@ -426,9 +426,9 @@ def write_add_new_library_support_metrics(run_metrics, metrics_repo_dir, is_benc
         json.dump(data, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
-    log_stage("schema-validation", "Validating schema")
+    log_detail("schema-validation", "Validating schema")
     validate_benchmark_run_metrics(metrics_json)
-    log_stage("schema-validation", "Schema validated")
+    log_detail("schema-validation", "Schema validated")
 
 
 def _should_create_failure_run_metrics(
@@ -710,9 +710,9 @@ def main(argv=None):
 
     ending_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     if workflow_status == RUN_STATUS_SUCCESS:
-        log_stage("status", "Test generation successful")
+        log_detail("status", "Test generation successful")
     elif workflow_status == SUCCESS_WITH_INTERVENTION_STATUS:
-        log_stage("status", "Test generation produced PR-eligible post-generation intervention output")
+        log_detail("status", "Test generation produced PR-eligible post-generation intervention output")
     else:
         log_stage("status", "Test generation failed")
 

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -55,6 +55,7 @@ from utility_scripts.library_preparation_preflight import (
     apply_library_preparation_setup,
     prepare_library_preparation_preflight,
 )
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.metadata_index import is_not_for_native_image, write_not_for_native_image_marker
 from utility_scripts.native_image_artifact import evaluate_native_image_eligibility
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -296,30 +297,33 @@ def prepare_native_image_eligible_artifact(reachability_repo_path: str, library:
     return False
 
 
-def _metadata_already_exists(scaffold_proc: subprocess.CompletedProcess) -> bool:
+def _metadata_already_exists(scaffold_proc: LoggedCommandResult) -> bool:
     """Return True when Gradle reports that metadata for the library already exists."""
-    output = "\n".join(
-        value for value in (scaffold_proc.stdout, scaffold_proc.stderr) if value
-    )
+    output = scaffold_proc.stdout
     return "already exists" in output and "Use --force to overwrite existing metadata" in output
 
 
 def run_scaffold(library: str) -> bool:
-    require_complete_reachability_repo(os.getcwd())
-    log_stage("scaffold", f"Running scaffold for {library}")
-    # Run scaffold for the given coordinates
-    scaffold_proc = subprocess.run(
-        f"./gradlew scaffold --coordinates={library} --rerun-tasks",
-        shell=True,
-        env=gradle_command_environment(os.getcwd()),
-        capture_output=True,
-        text=True
+    """Run scaffold quietly while preserving its complete output.
+
+    §FS-forge-run-output-legibility §FS-durable-generation-logs
+    """
+    repo_path = os.getcwd()
+    require_complete_reachability_repo(repo_path)
+    scaffold_proc = run_logged_command(
+        ["./gradlew", "scaffold", f"--coordinates={library}", "--rerun-tasks"],
+        cwd=repo_path,
+        task_type="scaffold",
+        subject=library,
+        action="scaffold",
+        env=gradle_command_environment(repo_path),
+        stage="scaffold",
     )
     if scaffold_proc.returncode == 0:
         return True
     if _metadata_already_exists(scaffold_proc):
         return False
-    raise ScaffoldError(scaffold_proc.stderr or scaffold_proc.stdout or "Gradle scaffold task failed")
+    raise ScaffoldError(scaffold_proc.stdout or "Gradle scaffold task failed")
 
 
 def init_agent(

--- a/forge/ai_workflows/drivers/add_new_library_support.py
+++ b/forge/ai_workflows/drivers/add_new_library_support.py
@@ -41,7 +41,11 @@ from ai_workflows.core.workflow_strategy import (
     strategy_skips_initial_fix_phase,
 )
 from ai_workflows.core.workflow_strategy import WorkflowStrategy
-from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    switch_branch_quietly,
+)
 from utility_scripts import metrics_writer
 from utility_scripts.continuation_marker import (
     PHASE_FINALIZATION,
@@ -62,6 +66,8 @@ from utility_scripts.repo_path_resolver import require_complete_reachability_rep
 from utility_scripts.run_location import (
     STEP_NORMAL_SETUP,
     STEP_RUN_WORKFLOW_ENGINE,
+    enter_phase,
+    log_step_progress,
     record_step_failure,
     report_run_failure,
     resolve_failure_location,
@@ -75,7 +81,8 @@ from utility_scripts.source_context import (
     prepare_source_contexts,
     resolve_test_source_layout,
 )
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
+from utility_scripts.task_logs import display_log_path
 from utility_scripts.test_quality_checks import (
     cleanup_scaffold_placeholder_tests,
     collect_generated_test_validity_issues,
@@ -259,10 +266,7 @@ def create_feature_branch_for_library(group, artifact, library_version):
 
     new_branch = build_ai_branch_name(f"add-lib-support-{group}-{artifact}-{library_version}")
     delete_remote_branch_if_exists(new_branch)
-    subprocess.run(
-        ["git", "switch", "-C", new_branch],
-        check=True,
-    )
+    switch_branch_quietly(new_branch)
 
 
 def prepare_native_image_eligible_artifact(reachability_repo_path: str, library: str) -> bool:
@@ -318,11 +322,17 @@ def run_scaffold(library: str) -> bool:
         action="scaffold",
         env=gradle_command_environment(repo_path),
         stage="scaffold",
+        failure_is_detail=True,
     )
     if scaffold_proc.returncode == 0:
         return True
     if _metadata_already_exists(scaffold_proc):
         return False
+    log_stage(
+        "scaffold",
+        f"scaffold failed with exit code {scaffold_proc.returncode} "
+        f"(log: {display_log_path(scaffold_proc.log_path)})",
+    )
     raise ScaffoldError(scaffold_proc.stdout or "Gradle scaffold task failed")
 
 
@@ -350,7 +360,7 @@ def init_agent(
         print("ERROR: Strategy is missing required field: agent", file=sys.stderr)
         sys.exit(1)
 
-    log_stage("init-agent", f"Initializing {strategy_agent} agent")
+    log_detail("init-agent", f"Initializing {strategy_agent} agent")
     agent_class = Agent.get_class(strategy_agent)
     return agent_class(
         model_name=model_name,
@@ -467,6 +477,7 @@ def main(argv=None):
     resume_from = None if continuation_marker is None else continuation_marker.continue_from
     resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
     resume_finalization = resume_from == PHASE_FINALIZATION
+    enter_phase(PHASE_SETUP)
 
     # Resolve repository locations (possibly cloning)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
@@ -492,7 +503,7 @@ def main(argv=None):
         )
     resolve_graalvm_java_home()
 
-    log_stage("setup", f"Selected strategy: {strategy_name}")
+    log_detail("setup", f"Selected strategy: {strategy_name}")
     model_name = strategy.get("model") or DEFAULT_MODEL_NAME
     workflow_name = strategy.get("workflow")
     if not workflow_name:
@@ -506,6 +517,7 @@ def main(argv=None):
         # Branching and scaffolding is the run's model-free setup.
         # §FS-forge-run-location-reporting.2
         with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
+            log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Scaffolding {library}")
             create_feature_branch_for_library(package, artifact, library_version)
             try:
                 if not prepare_native_image_eligible_artifact(reachability_repo_path, library):
@@ -526,7 +538,8 @@ def main(argv=None):
                 ),
             )
     else:
-        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
+        log_detail("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
+        log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Reusing prepared workspace for {library}")
     source_context_types = normalize_source_context_types(strategy.get("parameters", {}).get("source-context-types"))
     prepared_source_context = prepare_source_contexts(
         repo_root=get_repo_root(),
@@ -582,7 +595,7 @@ def main(argv=None):
         subprocess.run(["git", "add", directory_path, index_json_path, *docker_setup_targets], check=False)
         subprocess.run(["git", "commit", "-m", f"Scaffold {library}"], check=False, capture_output=True, text=True)
     checkpoint_commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    log_stage("scaffold", f"Checkpoint at {checkpoint_commit_hash}")
+    log_detail("scaffold", f"Checkpoint at {checkpoint_commit_hash}")
 
     editable_files = list_all_files(test_source_layout.source_root)
     build_gradle_file = os.path.join(
@@ -620,12 +633,23 @@ def main(argv=None):
         ]
         agent.graphify(graphify_dirs)
 
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Setup ready for {library}")
     if resume_finalization:
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_RUN_WORKFLOW_ENGINE,
+            f"Reusing completed workflow for {strategy_name}",
+        )
         workflow_status = RUN_STATUS_SUCCESS
         global_iterations = 0
         unittest_number = 1
     else:
         with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_RUN_WORKFLOW_ENGINE,
+                f"Starting workflow {strategy_name} for {library}",
+            )
             workflow_status, global_iterations, unittest_number = strategy_obj.run(
                 agent=agent,
                 checkpoint_commit_hash=checkpoint_commit_hash,

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -35,6 +35,7 @@ from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
 )
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.native_test_verification import global_output_dir
@@ -125,17 +126,26 @@ def run_fix_test_native_image_run(
         reachability_metadata_path: str,
         current_coordinates: str,
         new_version: str,
-) -> subprocess.CompletedProcess[str]:
-    """Run the fixTestNativeImageRun Gradle task."""
+) -> LoggedCommandResult:
+    """Run the fixTestNativeImageRun task with durable quiet output.
+
+    §FS-forge-run-output-legibility §FS-durable-generation-logs
+    """
     require_complete_reachability_repo(reachability_metadata_path)
-    return subprocess.run(
+    group, artifact, _ = current_coordinates.split(":", 2)
+    library = f"{group}:{artifact}:{new_version}"
+    return run_logged_command(
         [
             "./gradlew", "fixTestNativeImageRun",
             f"-PtestLibraryCoordinates={current_coordinates}",
             f"-PnewLibraryVersion={new_version}",
         ],
         cwd=reachability_metadata_path,
+        task_type="native-image-run-fix",
+        subject=library,
+        action="fixTestNativeImageRun",
         env=gradle_command_environment(reachability_metadata_path),
+        stage="native-image-run-fix",
     )
 
 
@@ -175,20 +185,23 @@ def commit_checkpoint(reachability_metadata_path: str, library: str) -> str:
 def run_dynamic_access_coverage_report(
         reachability_metadata_path: str,
         library: str,
-) -> subprocess.CompletedProcess[str]:
-    """Generate the dynamic-access coverage report for the new coordinate."""
+) -> LoggedCommandResult:
+    """Generate the dynamic-access report with durable quiet output.
+
+    §FS-forge-run-output-legibility §FS-durable-generation-logs
+    """
     require_complete_reachability_repo(reachability_metadata_path)
-    return subprocess.run(
+    return run_logged_command(
         [
             "./gradlew", "generateDynamicAccessCoverageReport",
             f"-Pcoordinates={library}",
         ],
         cwd=reachability_metadata_path,
+        task_type="dynamic-access-report",
+        subject=library,
+        action="generateDynamicAccessCoverageReport",
         env=gradle_command_environment(reachability_metadata_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        stage="dynamic-access",
     )
 
 
@@ -204,7 +217,6 @@ def should_explore_new_version(reachability_metadata_path: str, group: str, arti
     result = run_dynamic_access_coverage_report(reachability_metadata_path, library)
     if result.returncode != 0:
         log_stage("coverage-gate", f"Dynamic-access report unavailable for {library}; skipping exploration")
-        print(result.stdout)
         return False
 
     test_version = resolve_test_version(reachability_metadata_path, group, artifact, version)

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -20,7 +20,11 @@ from ai_workflows.core.workflow_strategy import (
     WorkflowStrategy,
 )
 from ai_workflows.drivers.improve_library_coverage import prepare_library_update_target
-from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    switch_branch_quietly,
+)
 from utility_scripts import metrics_writer
 from utility_scripts.continuation_marker import (
     PHASE_EXPLORE,
@@ -44,6 +48,8 @@ from utility_scripts.run_location import (
     STEP_NORMAL_SETUP,
     STEP_RUN_WORKFLOW_ENGINE,
     clear_recorded_failure,
+    enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
@@ -53,7 +59,7 @@ from utility_scripts.source_context import (
     prepare_source_contexts,
     resolve_test_source_layout,
 )
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import (
     list_all_files,
@@ -152,11 +158,7 @@ def run_fix_test_native_image_run(
 def create_or_switch_branch(reachability_metadata_path: str, branch: str) -> None:
     """Reset the workflow branch to the current detached HEAD."""
     delete_remote_branch_if_exists(branch, cwd=reachability_metadata_path)
-    subprocess.run(
-        ["git", "switch", "-C", branch],
-        cwd=reachability_metadata_path,
-        check=True,
-    )
+    switch_branch_quietly(branch, cwd=reachability_metadata_path)
 
 
 def commit_checkpoint(reachability_metadata_path: str, library: str) -> str:
@@ -216,7 +218,7 @@ def should_explore_new_version(reachability_metadata_path: str, group: str, arti
     library = f"{group}:{artifact}:{version}"
     result = run_dynamic_access_coverage_report(reachability_metadata_path, library)
     if result.returncode != 0:
-        log_stage("coverage-gate", f"Dynamic-access report unavailable for {library}; skipping exploration")
+        log_detail("coverage-gate", f"Dynamic-access report unavailable for {library}; skipping exploration")
         return False
 
     test_version = resolve_test_version(reachability_metadata_path, group, artifact, version)
@@ -228,12 +230,12 @@ def should_explore_new_version(reachability_metadata_path: str, group: str, arti
     try:
         report = load_dynamic_access_coverage_report(report_path)
     except FileNotFoundError:
-        log_stage("coverage-gate", f"Dynamic-access report file missing for {library}; skipping exploration")
+        log_detail("coverage-gate", f"Dynamic-access report file missing for {library}; skipping exploration")
         return False
 
     uncovered_calls = max(report.total_calls - report.covered_calls, 0)
     if not report.has_dynamic_access or report.total_calls == 0 or uncovered_calls == 0:
-        log_stage(
+        log_detail(
             "coverage-gate",
             "No uncovered dynamic-access calls for {library} "
             "(hasDynamicAccess={has}, {covered}/{total} covered); skipping exploration".format(
@@ -245,7 +247,7 @@ def should_explore_new_version(reachability_metadata_path: str, group: str, arti
         )
         return False
 
-    log_stage(
+    log_detail(
         "coverage-gate",
         "{uncovered} uncovered dynamic-access call(s) for {library}; preparing exploration".format(
             uncovered=uncovered_calls,
@@ -365,6 +367,7 @@ def main(argv=None) -> int:
     resume_from = None if continuation_marker is None else continuation_marker.continue_from
     resume_existing_tree = resume_from in {"fix", PHASE_EXPLORE, PHASE_FINALIZATION, "publication"}
     resume_finalization = resume_from == PHASE_FINALIZATION
+    enter_phase(PHASE_SETUP)
     # Apply deterministic preflight setup into the resolved worktree before
     # generation; only advisory guidance reaches the prompt context.
     library_preparation_preflight, library_preparation_preflight_context = (
@@ -382,8 +385,8 @@ def main(argv=None) -> int:
             ),
         )
     if library_preparation_preflight is not None:
-        print("[pipeline] Library preparation preflight:")
-        print(library_preparation_preflight_context)
+        log_detail("pipeline", "Library preparation preflight:")
+        log_detail("pipeline", library_preparation_preflight_context)
 
     resolve_graalvm_java_home()
     validate_repo_paths(reachability_metadata_path, metrics_repo_dir)
@@ -399,14 +402,23 @@ def main(argv=None) -> int:
     agent: Agent | None = None
     model_name: str | None = None
     tests_root: str | None = None
+    setup_action = (
+        "Reusing prepared native-image workspace"
+        if resume_existing_tree
+        else "Preparing native-image workspace"
+    )
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"{setup_action} for {library}")
     if not resume_existing_tree:
         # Branching and the deterministic native-image fix are the run's
         # model-free setup. §FS-forge-run-location-reporting.2
         with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
-            print(f"[pipeline] Creating branch: {branch}")
+            log_detail("pipeline", f"Creating branch: {branch}")
             create_or_switch_branch(reachability_metadata_path, branch)
 
-            print(f"[pipeline] Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}")
+            log_detail(
+                "pipeline",
+                f"Running fixTestNativeImageRun for: {current_coordinates} -> {new_version}",
+            )
             result = run_fix_test_native_image_run(
                 reachability_metadata_path=reachability_metadata_path,
                 current_coordinates=current_coordinates,
@@ -459,13 +471,13 @@ def main(argv=None) -> int:
                 ),
             )
     else:
-        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
+        log_detail("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
         checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
     # Coverage gate: explore only when the new version has uncovered calls.
     explore = not resume_finalization and should_explore_new_version(reachability_metadata_path, group, artifact, new_version)
     if explore:
-        print(f"[pipeline] Preparing version-specific test-suite for {library}")
+        log_detail("pipeline", f"Preparing version-specific test-suite for {library}")
         prepare_library_update_target(reachability_metadata_path, group, artifact, new_version)
 
     if strategy_obj is None or explore:
@@ -483,11 +495,16 @@ def main(argv=None) -> int:
     assert agent is not None
     assert model_name is not None
     assert tests_root is not None
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Setup ready for {library}")
 
     iterations = 0
     if explore:
-        print(f"[pipeline] Running dynamic-access exploration for {library}")
         with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=args.strategy_name):
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_RUN_WORKFLOW_ENGINE,
+                f"Starting workflow {args.strategy_name} for {library}",
+            )
             run_result = strategy_obj.run(agent=agent, checkpoint_commit_hash=checkpoint)
         explore_status, iterations = run_result[0], run_result[1]
         # Best-effort: a partial or failed explore must not abort. The seed is
@@ -511,6 +528,11 @@ def main(argv=None) -> int:
                 continuation_marker_path=args.continuation_marker_path,
             )
     else:
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_RUN_WORKFLOW_ENGINE,
+            f"Dynamic-access workflow not needed for {library}",
+        )
         save_phase_update(
             args.continuation_marker_path,
             lambda marker: marker.mark_phase_skipped(PHASE_EXPLORE),

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -41,7 +41,13 @@ from ai_workflows.core.workflow_strategy import (
     WorkflowStrategy,
     strategy_skips_initial_fix_phase,
 )
-from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated, load_library_stats
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    ensure_gh_authenticated,
+    load_library_stats,
+    switch_branch_quietly,
+)
 from utility_scripts import metrics_writer
 from utility_scripts.continuation_marker import (
     PHASE_FINALIZATION,
@@ -73,6 +79,8 @@ from utility_scripts.run_location import (
     STEP_NORMAL_SETUP,
     STEP_RUN_WORKFLOW_ENGINE,
     RunLocation,
+    enter_phase,
+    log_step_progress,
     record_step_failure,
     run_step,
 )
@@ -83,7 +91,7 @@ from utility_scripts.source_context import (
     resolve_test_source_layout,
     source_context_urls_available,
 )
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import (
     list_all_files,
@@ -534,7 +542,7 @@ def prepare_library_update_target(
     )
     if must_split_shared_target and target.matched_entry is not None:
         clone_library_update_support(repo_path, group, artifact, requested_version, target.matched_entry)
-        log_stage(
+        log_detail(
             "library-update-target",
             "Split {group}:{artifact}:{requested_version} from shared metadata-version {metadata_version} "
             "for version-specific library-update coverage".format(
@@ -560,7 +568,7 @@ def prepare_library_update_target(
     baseline = resolve_version_backfill_baseline(repo_path, group, artifact, requested_version)
     if baseline is not None:
         clone_library_update_support(repo_path, group, artifact, requested_version, baseline.entry)
-        log_stage(
+        log_detail(
             "library-update-target",
             "Cloned support for {group}:{artifact}:{requested_version} from {baseline_coordinates}; "
             "reason: {reason}".format(
@@ -573,7 +581,7 @@ def prepare_library_update_target(
         )
     else:
         coordinate = f"{group}:{artifact}:{requested_version}"
-        log_stage("library-update-target", f"No compatible support found; scaffolding {coordinate}")
+        log_detail("library-update-target", f"No compatible support found; scaffolding {coordinate}")
         _run_scaffold(repo_path, coordinate)
 
     return target
@@ -675,6 +683,7 @@ def main(argv=None) -> int:
     resume_from = None if continuation_marker is None else continuation_marker.continue_from
     resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
     resume_finalization = resume_from == PHASE_FINALIZATION
+    enter_phase(PHASE_SETUP)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
@@ -700,7 +709,13 @@ def main(argv=None) -> int:
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
     os.chdir(reachability_repo_path)
 
-    log_stage("setup", f"Selected strategy: {strategy_name}")
+    log_detail("setup", f"Selected strategy: {strategy_name}")
+    setup_action = (
+        "Reusing prepared coverage workspace"
+        if resume_existing_tree
+        else "Preparing coverage workspace"
+    )
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"{setup_action} for {library}")
     update_target = prepare_library_update_target(
         reachability_repo_path,
         group,
@@ -709,7 +724,7 @@ def main(argv=None) -> int:
         issue_requested_metadata_context=issue_requested_metadata_context,
     )
     if update_target.match_type != MATCH_NEW_VERSION:
-        log_stage(
+        log_detail(
             "library-update-target",
             (
                 f"Using {update_target.match_type} target: "
@@ -724,9 +739,9 @@ def main(argv=None) -> int:
         with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=library):
             new_branch = build_ai_branch_name(f"improve-coverage-{group}-{artifact}-{version}")
             delete_remote_branch_if_exists(new_branch)
-            subprocess.run(["git", "switch", "-C", new_branch], check=True)
+            switch_branch_quietly(new_branch)
     else:
-        log_stage("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
+        log_detail("continuation", f"Resuming {library} from preserved branch at phase {resume_from}")
 
     # Commit existing state as checkpoint
     test_version = update_target.resolved_test_version
@@ -748,7 +763,7 @@ def main(argv=None) -> int:
         record_step_failure(location=RunLocation(PHASE_SETUP, STEP_NORMAL_SETUP, library))
         return 1
     if test_version != version:
-        log_stage(
+        log_detail(
             "setup",
             "Using indexed test directory tests/src/{group}/{artifact}/{test_version} for {library}".format(
                 group=group,
@@ -768,7 +783,7 @@ def main(argv=None) -> int:
             )
             record_step_failure(location=RunLocation(PHASE_SETUP, STEP_NORMAL_SETUP, library))
             return 1
-        log_stage("setup", f"Reusing cached baseline snapshot from {BASELINE_STATS_FILENAME}")
+        log_detail("setup", f"Reusing cached baseline snapshot from {BASELINE_STATS_FILENAME}")
     else:
         # Snapshot baseline stats and metadata entry counts before the workflow modifies them.
         baseline_stats = load_library_stats(reachability_repo_path, library)
@@ -781,7 +796,7 @@ def main(argv=None) -> int:
         }
         with open(baseline_stats_path, "w", encoding="utf-8") as f:
             json.dump(baseline_snapshot, f, indent=2)
-        log_stage("setup", f"Saved baseline snapshot to {BASELINE_STATS_FILENAME}")
+        log_detail("setup", f"Saved baseline snapshot to {BASELINE_STATS_FILENAME}")
     if not resume_existing_tree:
         subprocess.run(["git", "add", tests_dir, index_json], check=False)
         subprocess.run(
@@ -789,7 +804,7 @@ def main(argv=None) -> int:
             capture_output=True, text=True, check=False,
         )
     checkpoint_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    log_stage("setup", f"Checkpoint commit: {checkpoint_commit}")
+    log_detail("setup", f"Checkpoint commit: {checkpoint_commit}")
     if not resume_existing_tree:
         save_phase_update(
             continuation_marker_path,
@@ -806,7 +821,7 @@ def main(argv=None) -> int:
     ):
         populate_artifact_urls(reachability_repo_path, library)
     else:
-        log_stage(
+        log_detail(
             "populate-artifact-urls",
             f"Skipping artifact URL population for resumed {library}; index.json already has requested source-context URLs.",
         )
@@ -863,7 +878,7 @@ def main(argv=None) -> int:
     read_only_files = list_all_files(docs_path) if docs_path else []
     read_only_files.extend(prepared_source_context.read_only_files)
 
-    log_stage("init-agent", f"Initializing {strategy_agent} agent")
+    log_detail("init-agent", f"Initializing {strategy_agent} agent")
     agent_class = Agent.get_class(strategy_agent)
     agent = agent_class(
         model_name=model_name,
@@ -880,11 +895,22 @@ def main(argv=None) -> int:
         agent_name=strategy.get("agent-command"),
     )
 
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Setup ready for {library}")
     if resume_finalization:
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_RUN_WORKFLOW_ENGINE,
+            f"Reusing completed workflow for {strategy_name}",
+        )
         workflow_status = RUN_STATUS_SUCCESS
         iterations = 0
     else:
         with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_RUN_WORKFLOW_ENGINE,
+                f"Starting workflow {strategy_name} for {library}",
+            )
             run_result = strategy_obj.run(
                 agent=agent,
                 checkpoint_commit_hash=checkpoint_commit,

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -943,9 +943,9 @@ def main(argv=None) -> int:
         )
     else:
         if workflow_status == SUCCESS_WITH_INTERVENTION_STATUS:
-            log_stage("status", "Coverage improvement produced PR-eligible post-generation intervention output")
+            log_detail("status", "Coverage improvement produced PR-eligible post-generation intervention output")
         else:
-            log_stage("status", "Coverage improvement succeeded")
+            log_detail("status", "Coverage improvement succeeded")
         run_metrics = metrics_writer.create_run_metrics_output_json(
             repo_path=reachability_repo_path,
             package=group,

--- a/forge/ai_workflows/drivers/improve_library_coverage.py
+++ b/forge/ai_workflows/drivers/improve_library_coverage.py
@@ -50,6 +50,7 @@ from utility_scripts.continuation_marker import (
     save_phase_update,
 )
 from utility_scripts.dynamic_access_exhaust_report import resolve_workflow_exhaust_report
+from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.issue_requested_metadata import (
     NO_REPORTER_METADATA_CONTEXT,
     format_issue_requested_test_requirements,
@@ -58,6 +59,7 @@ from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
 )
 from utility_scripts.library_stats import stats_artifact_dir
+from utility_scripts.logged_command import run_logged_command
 from utility_scripts.metadata_index import (
     MATCH_NEW_VERSION,
     LibraryUpdateTarget,
@@ -420,16 +422,25 @@ def _write_index_entries(repo_path: str, group: str, artifact: str, entries: lis
 
 
 def _run_scaffold(repo_path: str, coordinate: str) -> None:
-    """Run the Gradle scaffold task with a clear failure message."""
+    """Run scaffold quietly with a durable log and clear failure.
+
+    §FS-forge-run-output-legibility §FS-durable-generation-logs
+    """
     command = ["./gradlew", "scaffold", "--coordinates", coordinate]
-    log_stage("library-update-target", f"Running scaffold command: {' '.join(command)}")
-    try:
-        subprocess.run(command, cwd=repo_path, check=True)
-    except subprocess.CalledProcessError as error:
+    result = run_logged_command(
+        command,
+        cwd=repo_path,
+        task_type="library-update-target",
+        subject=coordinate,
+        action="scaffold",
+        env=gradle_command_environment(repo_path),
+        stage="library-update-target",
+    )
+    if result.returncode != 0:
         raise RuntimeError(
             "Failed to scaffold library-update target "
-            f"{coordinate}; command exited with status {error.returncode}: {' '.join(command)}"
-        ) from error
+            f"{coordinate}; command exited with status {result.returncode}: {' '.join(command)}"
+        )
 
 
 def clone_library_update_support(

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -23,7 +23,12 @@ from ai_workflows.core.workflow_strategy import (
     SUCCESS_WITH_INTERVENTION_STATUS,
     WorkflowStrategy,
 )
-from git_scripts.common_git import build_ai_branch_name, delete_remote_branch_if_exists, ensure_gh_authenticated
+from git_scripts.common_git import (
+    build_ai_branch_name,
+    delete_remote_branch_if_exists,
+    ensure_gh_authenticated,
+    switch_branch_quietly,
+)
 from utility_scripts import metrics_writer
 from utility_scripts.continuation_marker import (
     PHASE_FINALIZATION,
@@ -39,13 +44,20 @@ from utility_scripts.logged_command import run_logged_command
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
-from utility_scripts.run_location import STEP_NORMAL_SETUP, STEP_RUN_WORKFLOW_ENGINE, run_step
+from utility_scripts.run_location import (
+    STEP_NORMAL_SETUP,
+    STEP_RUN_WORKFLOW_ENGINE,
+    enter_phase,
+    log_step_progress,
+    run_step,
+)
 from utility_scripts.source_context import (
     normalize_source_context_types,
     populate_artifact_urls,
     prepare_source_contexts,
     resolve_test_source_layout,
 )
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.strategy_loader import require_strategy_by_name
 from utility_scripts.workflow_setup import (
     list_all_files,
@@ -230,7 +242,7 @@ def copy_and_prepare_project_dir(
         raise FileNotFoundError(f"Missing source test project directory: {src_dir}")
 
     if _same_filesystem_path(src_dir, dst_dir):
-        print(f"[project-prep] Source and destination test project are the same: {dst_dir}")
+        log_detail("project-prep", f"Source and destination test project are the same: {dst_dir}")
     else:
         os.makedirs(dst_dir, exist_ok=True)
         shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
@@ -296,10 +308,7 @@ def create_project_prep_checkpoint(config: JavaFailWorkflowConfig, group, artifa
         f"{config.branch_prefix}-{group}-{artifact}-{updated_library_version}",
     )
     delete_remote_branch_if_exists(new_branch)
-    subprocess.run(
-        ["git", "switch", "-C", new_branch],
-        check=True,
-    )
+    switch_branch_quietly(new_branch)
 
     candidate_paths = [
         os.path.join("tests", "src", group, artifact, updated_library_version),
@@ -310,7 +319,7 @@ def create_project_prep_checkpoint(config: JavaFailWorkflowConfig, group, artifa
 
     has_staged_changes = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
     if has_staged_changes.returncode == 0:
-        print("[project-prep] No project preparation changes to commit.")
+        log_detail("project-prep", "No project preparation changes to commit.")
         return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
     subprocess.run(
@@ -425,7 +434,7 @@ def init_agent(
         print("ERROR: Strategy is missing required field: agent", file=sys.stderr)
         sys.exit(1)
 
-    print(f"[Initializing {strategy_agent} agent...]")
+    log_detail("init-agent", f"Initializing {strategy_agent} agent")
     agent_class = Agent.get_class(strategy_agent)
     return agent_class(
         model_name=model_name,
@@ -480,6 +489,7 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     resume_from = None if continuation_marker is None else continuation_marker.continue_from
     resume_existing_tree = resume_from in {"fix", "explore", PHASE_FINALIZATION, "publication"}
     resume_finalization = resume_from == PHASE_FINALIZATION
+    enter_phase(PHASE_SETUP)
     reachability_repo_path, metrics_repo_dir, metrics_repo_root = resolve_workflow_repo_paths(
         explicit_repo_path,
         explicit_metrics_repo_path,
@@ -492,6 +502,13 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
             reachability_repo_path,
         )
     )
+    updated_library = f"{group}:{artifact}:{updated_library_version}"
+    setup_action = (
+        "Reusing prepared repair workspace"
+        if resume_existing_tree
+        else "Preparing repair workspace"
+    )
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"{setup_action} for {updated_library}")
     if not resume_existing_tree:
         save_phase_update(
             continuation_marker_path,
@@ -536,9 +553,8 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
                 lambda marker: marker.mark_setup_done(),
             )
     else:
-        log_stage("continuation", f"Resuming {group}:{artifact}:{updated_library_version} from phase {resume_from}")
+        log_detail("continuation", f"Resuming {updated_library} from phase {resume_from}")
         commit_checkpoint = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    updated_library = f"{group}:{artifact}:{updated_library_version}"
     if not resume_existing_tree:
         populate_artifact_urls(reachability_repo_path, updated_library)
 
@@ -599,11 +615,22 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
         persistent_instructions=strategy_obj.persistent_instructions,
     )
 
+    log_step_progress(PHASE_SETUP, STEP_NORMAL_SETUP, f"Setup ready for {updated_library}")
     if resume_finalization:
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_RUN_WORKFLOW_ENGINE,
+            f"Reusing completed workflow for {strategy_name}",
+        )
         workflow_status = RUN_STATUS_SUCCESS
         iterations = 0
     else:
         with run_step(PHASE_SETUP, STEP_RUN_WORKFLOW_ENGINE, operand=strategy_name):
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_RUN_WORKFLOW_ENGINE,
+                f"Starting workflow {strategy_name} for {updated_library}",
+            )
             workflow_status, iterations = strategy_obj.run(
                 agent=agent,
             )

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -35,6 +35,7 @@ from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
 )
+from utility_scripts.logged_command import run_logged_command
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -244,11 +245,24 @@ def copy_and_prepare_project_dir(
 
 
 def run_gradle_task(task: str, coordinates: str) -> None:
-    """Run a Gradle task for the provided dependency coordinates."""
+    """Run a Gradle task quietly with durable output for the coordinates.
+
+    §FS-forge-run-output-legibility §FS-durable-generation-logs
+    """
     repo_path = os.getcwd()
     require_complete_reachability_repo(repo_path)
-    command = f"./gradlew {task} -Pcoordinates={coordinates}"
-    subprocess.run(command, shell=True, env=gradle_command_environment(repo_path), check=True)
+    command = ["./gradlew", task, f"-Pcoordinates={coordinates}"]
+    result = run_logged_command(
+        command,
+        cwd=repo_path,
+        task_type="java-fail-setup",
+        subject=coordinates,
+        action=task,
+        env=gradle_command_environment(repo_path),
+        stage="java-fail-setup",
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout)
 
 
 def update_metadata_index_json(

--- a/forge/do_up_to_date_work.sh
+++ b/forge/do_up_to_date_work.sh
@@ -43,6 +43,7 @@ USER_REQUESTED_ONLY="${FORGE_USER_REQUESTED_ISSUES_ONLY:-0}"
 # §FS-forge-run-requirements.2
 TAKE_BLOCKED_ISSUES="${FORGE_TAKE_BLOCKED_ISSUES:-0}"
 GRAALVM_VERSION_CHECK="${FORGE_GRAALVM_VERSION_CHECK:-strict}"
+VERBOSE="${FORGE_VERBOSE:-0}"
 WORK_STRATEGY_NAME="${FORGE_STRATEGY_NAME:-optimistic_dynamic_access_iterative_pi_gpt-5.6-sol}"
 GITHUB_RATE_LIMIT_EXIT_CODE=75
 GRADLE_BOOTSTRAP_EXIT_CODE=76
@@ -90,6 +91,9 @@ Options:
       Run one update/work cycle and exit without sleeping.
   --fail-fast
       Exit nonzero when the first work cycle is unsuccessful.
+  -v, --verbose
+      Show deterministic narration hidden by the compact default output and
+      enable verbose output in the selected workflow agents.
   --stop
       Request Forge do-work loops to exit. Without a branch argument this
       creates the global stop marker ~/.metadata-forge-stop. With --branch or
@@ -223,6 +227,8 @@ Environment:
   FORGE_GRAALVM_VERSION_CHECK
       Default --graalvm-version-check mode: strict, warn, or off. Defaults to
       strict.
+  FORGE_VERBOSE
+      Set to 1 for the same behavior as --verbose. Defaults to 0.
 
 Examples:
   $0
@@ -485,6 +491,7 @@ export_work_configuration() {
     export FORGE_USER_REQUESTED_ISSUES_ONLY="$USER_REQUESTED_ONLY"
     export FORGE_TAKE_BLOCKED_ISSUES="$TAKE_BLOCKED_ISSUES"
     export FORGE_GRAALVM_VERSION_CHECK="$GRAALVM_VERSION_CHECK"
+    export FORGE_VERBOSE="$VERBOSE"
 
     if [[ -n "$AGENT_FAMILY" ]]; then
         export FORGE_AGENT_FAMILY="$AGENT_FAMILY"
@@ -540,6 +547,9 @@ process_work_queues() {
     if [[ "$TAKE_BLOCKED_ISSUES" == "1" ]]; then
         forge_metadata_args+=("--take-blocked-issues")
     fi
+    if [[ "$VERBOSE" == "1" ]]; then
+        forge_metadata_args+=("--verbose")
+    fi
 
     run_step "Processing configured work queues via forge_metadata." \
         "$PYTHON_BIN" "$SCRIPT_DIR/forge_metadata.py" "${forge_metadata_args[@]}"
@@ -563,7 +573,10 @@ run_host_requirements() {
         return 1
     fi
 
-    log "Validating Forge host requirements before any work starts."
+    if [[ "$VERBOSE" == "1" ]]; then
+        log "Validating Forge host requirements before any work starts."
+        host_requirements_args+=(--verbose)
+    fi
     # The gate takes no review model or shared family: --agent-family already
     # reaches it as --analysis-family, and PR review runs on the analysis role
     # (§FS-forge-agent-runtime-selection).
@@ -843,6 +856,10 @@ while [[ "$#" -gt 0 ]]; do
             FAIL_FAST=1
             shift
             ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
         --user-requested-only)
             USER_REQUESTED_ONLY=1
             shift
@@ -1018,6 +1035,11 @@ if [[ "$GRAALVM_VERSION_CHECK" != "strict" \
         && "$GRAALVM_VERSION_CHECK" != "warn" \
         && "$GRAALVM_VERSION_CHECK" != "off" ]]; then
     echo "--graalvm-version-check must be strict, warn, or off." >&2
+    exit 1
+fi
+
+if [[ "$VERBOSE" != "0" && "$VERBOSE" != "1" ]]; then
+    echo "FORGE_VERBOSE must be 0 or 1." >&2
     exit 1
 fi
 

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -986,9 +986,12 @@ boundary nearest the error owns the line and the rest add nothing.
 process-wide verbose level, enabled by `--verbose`/`FORGE_VERBOSE`; the older
 `FORGE_DEBUG_LOGGING` switch remains an alias. The worker forwards the setting
 to its host-check and workflow-driver processes rather than threading a boolean
-through workflow functions. Git commands capture their output and replay it
-only on failure or under verbose output, so the default failed-run output is the
-location, the error, and the preserved branch
+through workflow functions. Normal detail follows the phase most recently
+announced by `enter_phase()`, rather than the outer Python call stack, because
+`run_workflow_engine()` changes from compact `setup` into `fix` or `explore`
+before returning to its driver. Git commands capture their output and replay it
+only on failure or under verbose output, so the default failed-run output is
+the location, the error, and the preserved branch
 (§FS-forge-run-location-reporting.4, §FS-forge-run-output-legibility.5).
 
 ## AR-forge-control-plane: Worker loop and dispatcher own queue control

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -937,8 +937,10 @@ because more than one phase runs `generate_tests()` and `native_trace_gate()`.
 
 **Steps are marked, not narrated.** A step is entered through the `run_step()`
 context manager — or the `pipeline_step()` decorator, which is the same thing
-applied to a whole function. Entering prints the progress line and pushes the
-location onto a run-local stack; leaving pops it. Nothing at a raise site
+applied to a whole function. Entering pushes the location onto a run-local
+stack; leaving pops it. A compact phase prints its normal start and outcome
+through `log_step_progress()`, which derives `(n/total)` from the same table,
+while the method-style entry line is verbose narration. Nothing at a raise site
 mentions a step name, because a raise site does not know which step it is in.
 The decorator resolves its operand from the call's arguments **by parameter
 name**, binding the wrapped signature rather than indexing `args`, so a keyword
@@ -980,12 +982,14 @@ several boundaries on the way out — the driver's status code, the workflow run
 result, the failed-issue handler. The reporter is idempotent for the run, so the
 boundary nearest the error owns the line and the rest add nothing.
 
-**Debug narration is separate from failure output.** `stage_logger` gains a
-debug level, enabled by `FORGE_DEBUG_LOGGING`, and the human-intervention
-handoff's git narration moves onto it. The git commands themselves capture their
-output and replay it only on failure or under debug, so the default failed-run
-output is the location, the error, and the preserved branch
-(§FS-forge-run-location-reporting.4).
+**Verbose narration is separate from failure output.** `stage_logger` owns the
+process-wide verbose level, enabled by `--verbose`/`FORGE_VERBOSE`; the older
+`FORGE_DEBUG_LOGGING` switch remains an alias. The worker forwards the setting
+to its host-check and workflow-driver processes rather than threading a boolean
+through workflow functions. Git commands capture their output and replay it
+only on failure or under verbose output, so the default failed-run output is the
+location, the error, and the preserved branch
+(§FS-forge-run-location-reporting.4, §FS-forge-run-output-legibility.5).
 
 ## AR-forge-control-plane: Worker loop and dispatcher own queue control
 

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -989,9 +989,10 @@ to its host-check and workflow-driver processes rather than threading a boolean
 through workflow functions. Normal detail follows the phase most recently
 announced by `enter_phase()`, rather than the outer Python call stack, because
 `run_workflow_engine()` changes from compact `setup` into `fix` or `explore`
-before returning to its driver. Git commands capture their output and replay it
-only on failure or under verbose output, so the default failed-run output is
-the location, the error, and the preserved branch
+before returning to its driver, and every successful driver later enters compact
+`finalization`. Git commands capture their output and replay it only on failure
+or under verbose output, so the default failed-run output is the location, the
+error, and the preserved branch
 (§FS-forge-run-location-reporting.4, §FS-forge-run-output-legibility.5).
 
 ## AR-forge-control-plane: Worker loop and dispatcher own queue control

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -461,11 +461,14 @@ does. This is the live counterpart of the durable record required by
 §FS-durable-generation-logs, and it keeps the loop short as called for by
 §GOAL-shorten-issue-to-shipped-metadata.
 
-1. **Every step announces itself once.** On entering a pipeline step, the run
-   prints one line naming the phase and the step (`setup/neural_setup`,
-   `explore/native_trace_gate`, `finalization/local_ci_check`, …) and the
-   operand it is working on. The reader must never have to infer the current
-   step from incidental output such as a Gradle banner or an agent's prose.
+1. **Every step locates its state.** On entering a pipeline step, the normal
+   output prints one concise line naming the phase, the work and its operand,
+   plus the step's derived position as `(n/total)`
+   (`setup/neural_setup`, `explore/native_trace_gate`,
+   `finalization/local_ci_check`, …). A completed step or unit adds one outcome
+   line under the same position instead of narrating its intermediate work. The
+   reader must never have to infer the current step from incidental output such
+   as a Gradle banner or an agent's prose.
 2. **Every failure names its location and its cause.** A failing run states the
    phase, the step, the operand, and the concrete reason it stopped, in that
    order, before any surrounding detail — the same pair required everywhere a
@@ -482,6 +485,11 @@ does. This is the live counterpart of the durable record required by
    run output prints the path to the relevant log instead of reproducing it, so
    a maintainer can escalate from the summary to the evidence in one step
    (§FS-durable-generation-logs).
+5. **Verbose mode restores narration.** `--verbose` adds the intermediate
+   operations hidden by normal output, including the registered method-style
+   step announcement and deterministic setup details. It never replaces the
+   concise progress and outcome lines. A failed gate prints the detail needed
+   to diagnose that failure even when verbose mode is off.
 
 ## FS-forge-run-metrics: Per-run metrics record
 §GOAL-minimize-generation-cost

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -2,7 +2,8 @@
 
 This spec realizes the Forge direction set out in §GOAL-forge-direction, in
 service of §GOAL-maximize-library-coverage and
-§GOAL-shorten-issue-to-shipped-metadata.
+§GOAL-shorten-issue-to-shipped-metadata. Repository-specific terms used by the
+spec are defined in §FS-forge-glossary.
 
 ## FS-forge-issue-resolution-goal: Forge issue resolution goal
 
@@ -452,44 +453,53 @@ the current implementation is §ROADMAP-forge-dispatcher-owned-run-preconditions
 
 ### FS-forge-run-output-legibility: Legible run output
 
-The run's own output is an output of the run. Whoever is running generation
-watches it live, so it must answer two questions at a glance: which concrete
-step the run is in right now, and — when the run stops — what exactly failed.
-Clarity is the requirement, not volume: a wall of text that has to be read
-backwards to locate the current step fails this section as surely as silence
-does. This is the live counterpart of the durable record required by
-§FS-durable-generation-logs, and it keeps the loop short as called for by
-§GOAL-shorten-issue-to-shipped-metadata.
+The run's own output is one of the run outputs defined by §FS-forge-outputs.
+Whoever is running generation watches it live, so it must answer two questions
+at a glance: which concrete step the run is in right now, and — when the run
+stops — what exactly failed. Clarity is the requirement, not volume: a wall of
+text that has to be read backwards to locate the current step fails this section
+as surely as silence does. This is the live counterpart of the durable record
+required by §FS-durable-generation-logs, and it keeps the loop short as called
+for by §GOAL-shorten-issue-to-shipped-metadata.
 
-1. **Every step locates its state.** On entering a pipeline step, the normal
-   output prints one concise line naming the phase, the work and its operand,
-   plus the step's derived position as `(n/total)`
-   (`setup/neural_setup`, `explore/native_trace_gate`,
-   `finalization/local_ci_check`, …). A completed step or unit adds one outcome
-   line under the same position instead of narrating its intermediate work. The
-   reader must never have to infer the current step from incidental output such
-   as a Gradle banner or an agent's prose.
-2. **Every failure names its location and its cause.** A failing run states the
-   phase, the step, the operand, and the concrete reason it stopped, in that
-   order, before any surrounding detail — the same pair required everywhere a
-   failure surfaces by §ROADMAP-forge-failure-locates-phase-and-step. A failure
-   reported only as a status, a stack trace, or a generic message does not
-   satisfy this requirement.
-3. **The inside of a step stays quiet.** Work within a step is reported by
-   outcome, not by narration: one line per completed unit (a generated class, a
-   passed gate, a trace cycle) and nothing per intermediate operation. Repeated
-   or retried work says that it is a retry and which attempt it is, so a
-   stalled loop is visible as a loop.
-4. **Detail lives in the logs, not in the terminal.** Full agent conversations,
-   Gradle output, and native-image output are written to the durable logs; the
-   run output prints the path to the relevant log instead of reproducing it, so
-   a maintainer can escalate from the summary to the evidence in one step
-   (§FS-durable-generation-logs).
-5. **Verbose mode restores narration.** `--verbose` adds the intermediate
-   operations hidden by normal output, including the registered method-style
-   step announcement and deterministic setup details. It never replaces the
-   concise progress and outcome lines. A failed gate prints the detail needed
-   to diagnose that failure even when verbose mode is off.
+#### 1. Every step locates its state
+
+On entering a pipeline step, the normal output prints one concise line naming
+the phase, the work and its operand, plus the step's derived position as
+`(n/total)` (`setup/neural_setup`, `explore/native_trace_gate`,
+`finalization/local_ci_check`, …). A completed step or unit adds one outcome
+line under the same position instead of narrating its intermediate work. The
+reader must never have to infer the current step from incidental output such as
+a Gradle banner or an agent's prose.
+
+#### 2. Every failure names its location and its cause
+
+A failing run states the phase, the step, the operand, and the concrete reason
+it stopped, in that order, before any surrounding detail — the same pair
+required everywhere a failure surfaces by
+§ROADMAP-forge-failure-locates-phase-and-step. A failure reported only as a
+status, a stack trace, or a generic message does not satisfy this requirement.
+
+#### 3. The inside of a step stays quiet
+
+Work within a step is reported by outcome, not by narration: one line per
+completed unit (a generated class, a passed gate, a trace cycle) and nothing per
+intermediate operation. Repeated or retried work says that it is a retry and
+which attempt it is, so a stalled loop is visible as a loop.
+
+#### 4. Detail lives in the logs, not in the terminal
+
+Full agent conversations, Gradle output, and native-image output are written to
+the durable logs; the run output prints the path to the relevant log instead of
+reproducing it, so a maintainer can escalate from the summary to the evidence in
+one step (§FS-durable-generation-logs).
+
+#### 5. Verbose mode restores narration
+
+`--verbose` adds the intermediate operations hidden by normal output, including
+the registered method-style step announcement and deterministic setup details.
+It never replaces the concise progress and outcome lines. A failed gate prints
+the detail needed to diagnose that failure even when verbose mode is off.
 
 For `setup`, normal output reduces the phase to three visible states under the
 registered positions: library preflight starts and reports its decision,

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -499,6 +499,18 @@ paths, command start/success lines, branch commands, source downloads,
 checkpoints, and report refreshes are verbose narration. A failed command or a
 degraded preflight remains visible with its cause and durable log path.
 
+For `fix` and `explore`, normal output names the diagram step and only the unit
+that advances it. Test generation identifies either the selected class and its
+`current/total` class position, a bulk iteration, or an unguided generation
+attempt. Beneath that state, tests report their bounded attempt, terminal task,
+and whether `nativeTest` was reached; an agent retry is one indented `feedback
+fix` state. The native-trace gate reports start, terminal status, and a nested
+`agent_fix` state only when deterministic tracing cannot converge. Agent session
+announcements, static start/completion lines, Gradle commands, report refreshes,
+trace directories, metadata paths, cycle internals, and failure-log excerpts
+are verbose narration. The in-place agent heartbeat remains the normal live
+timer. Terminal failures still name their cause and durable log.
+
 ## FS-forge-run-metrics: Per-run metrics record
 §GOAL-minimize-generation-cost
 

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -511,6 +511,17 @@ trace directories, metadata paths, cycle internals, and failure-log excerpts
 are verbose narration. The in-place agent heartbeat remains the normal live
 timer. Terminal failures still name their cause and durable log.
 
+For `finalization`, normal output shows the terminal native-trace gate, then
+the three native-test lanes with their `current/total` lane position, toolchain,
+and Native Image mode. The remaining deterministic production work is one
+`final repository checks` state per coordinate, followed by the finalization
+outcome. An agent entered by a failed native lane, metadata check, or Checkstyle
+check is reported as the separate `agent_fix` step with its attempt and target.
+Metadata splitting, individual validation and style tasks, statistics and
+metrics generation, schema validation, Gradle commands, paths, and timings are
+verbose narration. A failed command or agent remains visible with its cause and
+durable log path.
+
 ## FS-forge-run-metrics: Per-run metrics record
 §GOAL-minimize-generation-cost
 

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -491,6 +491,14 @@ does. This is the live counterpart of the durable record required by
    concise progress and outcome lines. A failed gate prints the detail needed
    to diagnose that failure even when verbose mode is off.
 
+For `setup`, normal output reduces the phase to three visible states under the
+registered positions: library preflight starts and reports its decision,
+deterministic workspace preparation names its current unit and reports it
+ready, and workflow-engine dispatch names the strategy it starts. Agent session
+paths, command start/success lines, branch commands, source downloads,
+checkpoints, and report refreshes are verbose narration. A failed command or a
+degraded preflight remains visible with its cause and durable log path.
+
 ## FS-forge-run-metrics: Per-run metrics record
 §GOAL-minimize-generation-cost
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -210,6 +210,7 @@ from utility_scripts.run_location import (
     bind_run_context,
     enter_phase,
     format_run_failure_line,
+    log_step_progress,
     marker_failure_location,
     pipeline_step,
     record_step_failure,
@@ -219,7 +220,14 @@ from utility_scripts.run_location import (
     run_step,
 )
 from utility_scripts.source_context import GradleBootstrapFailure
-from utility_scripts.stage_logger import log_debug, log_failure_banner, log_stage, log_success_banner
+from utility_scripts.stage_logger import (
+    debug_logging_enabled,
+    enable_verbose_logging,
+    log_debug,
+    log_failure_banner,
+    log_stage,
+    log_success_banner,
+)
 from utility_scripts.shutdown_signal import get_active_shutdown_signal_path, is_shutdown_requested
 from utility_scripts.strategy_loader import load_strategy_by_name, require_strategy_by_name
 from utility_scripts.task_logs import (
@@ -1823,9 +1831,8 @@ def get_project_item_state(issue_number: int) -> tuple[str | None, str | None]:
         STATUS_FIELD_NAME,
     )
     if item_id:
-        print()
         status_text = status if status is not None else "unknown"
-        log_stage(
+        log_debug(
             "project-item",
             (
                 f"Issue #{issue_number} is linked to GitHub project item {item_id} "
@@ -2157,13 +2164,11 @@ def resolve_authenticated_user(authenticated_user: str | None = None) -> str:
     if authenticated_user is not None:
         return authenticated_user
     if is_fixture_testing_enabled():
-        print()
-        log_stage("github-auth", f"Fixture authenticated as: {FIXTURE_AUTHENTICATED_USER}")
+        log_debug("github-auth", f"Fixture authenticated as: {FIXTURE_AUTHENTICATED_USER}")
         return FIXTURE_AUTHENTICATED_USER
     ensure_gh_authenticated()
     resolved_user = get_authenticated_user()
-    print()
-    log_stage("github-auth", f"Authenticated as: {resolved_user}")
+    log_debug("github-auth", f"Authenticated as: {resolved_user}")
     return resolved_user
 
 
@@ -3483,8 +3488,7 @@ def set_item_status(item_id: str, status: str) -> None:
     """
     Update the Status field of a project item to the given status option name.
     """
-    print()
-    log_stage("project-status", f"Setting project item {item_id} -> {status}")
+    log_debug("project-status", f"Setting project item {item_id} -> {status}")
     project_node_id, field_id, option_ids = get_cached_field_info()
     option_id = option_ids.get(status)
     run_github_command_with_retries(
@@ -5768,6 +5772,12 @@ def invoke_pipeline(
     (§AR-forge-workflow-boundary), receiving resolved coordinates, paths,
     strategy names, and chunk context.
     """
+    issue_number = claimed_issue.issue["number"]
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_ROUTE_TO_DRIVER,
+        f"Routing issue #{issue_number} to its workflow driver",
+    )
     require_claimed_issue_worktree(claimed_issue, "workflow execution")
     strategy_override = strategy_name
     if claimed_issue.continuation_marker is not None:
@@ -5790,6 +5800,11 @@ def invoke_pipeline(
         claimed_issue,
         library_update_route,
         strategy_override,
+    )
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_ROUTE_TO_DRIVER,
+        f"Issue #{issue_number} routed to {claimed_issue.label} with strategy {run_strategy_name}",
     )
     continuation_path = create_or_load_run_continuation_marker(
         claimed_issue,
@@ -5850,6 +5865,8 @@ def invoke_pipeline(
             library_update_route,
             continuation_path,
         )
+    if debug_logging_enabled() and "--verbose" not in invocation.argv:
+        invocation.argv.append("--verbose")
 
     print()
     log_stage(invocation.log_stage_name, invocation.log_message)
@@ -6086,8 +6103,14 @@ def get_review_queue_configs_from_environment() -> list[ReviewQueueConfig]:
     ]
 
 
+@pipeline_step(PHASE_CLAIM, STEP_CHECK_STRATEGY_AND_MODEL)
 def validate_work_queue_strategies(queue_configs: list[WorkQueueConfig]) -> None:
     """Validate strategy names configured for enabled issue queues."""
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_STRATEGY_AND_MODEL,
+        "Checking configured strategies",
+    )
     seen_strategy_names: set[str] = set()
     for queue_config in queue_configs:
         strategy_name = queue_config.strategy_name
@@ -6095,6 +6118,11 @@ def validate_work_queue_strategies(queue_configs: list[WorkQueueConfig]) -> None
             continue
         require_strategy_by_name(strategy_name)
         seen_strategy_names.add(strategy_name)
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_STRATEGY_AND_MODEL,
+        f"Configured strategies accepted: {len(seen_strategy_names)}",
+    )
 
 
 def run_pull_request_review_loop(
@@ -6240,13 +6268,13 @@ def fetch_issue_base_commit(repo_path: str) -> str:
     remote-tracking ref supplies repository state for issue work
     (§FS-forge-run-requirements.2).
     """
-    log_stage(
+    log_debug(
         "claim",
         f"Fetching newest origin/{DEFAULT_WORKTREE_BASE_REF} for the next issue claim",
     )
     remote_tracking_ref = fetch_default_base_ref(repo_path, "issue claim")
     commit = resolve_git_commit(repo_path, remote_tracking_ref)
-    log_stage(
+    log_debug(
         "claim",
         f"Pinned origin/{DEFAULT_WORKTREE_BASE_REF} at {commit[:12]}",
     )
@@ -6336,9 +6364,14 @@ def create_issue_workspace(
 
     §FS-forge-run-requirements.4
     """
-    log_stage(
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CREATE_ISSUE_WORKSPACE,
+        f"Creating workspace for issue #{issue_number} from newest master {issue_base_commit[:12]}",
+    )
+    log_debug(
         "claim",
-        f"Creating workspace for issue #{issue_number} from {issue_base_commit}",
+        f"Workspace base for issue #{issue_number}: {issue_base_commit}",
     )
     repo_root = get_repo_root()
     worktrees_root = os.path.join(repo_root, "local_repositories", SCRATCH_WORKTREE_DIRNAME)
@@ -6358,8 +6391,9 @@ def create_issue_workspace(
     except SystemExit:
         remove_worktree(base_reachability_metadata_path, worktree_path)
         raise
-    log_stage(
-        "claim",
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CREATE_ISSUE_WORKSPACE,
         f"Workspace created for issue #{issue_number}: {os.path.relpath(worktree_path, repo_root)}",
     )
 
@@ -6687,7 +6721,11 @@ def check_issue_form(
     (§FS-forge-run-requirements.3, §root/PRCPL-verify-inputs).
     """
     issue_number = issue["number"]
-    log_stage("claim", f"Checking issue #{issue_number} against the pinned issue workspace")
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_ISSUE_FORM,
+        f"Checking issue #{issue_number} against newest master in its pinned workspace",
+    )
 
     workflow_labels = sorted(
         label_name for label_name in get_issue_label_names(issue) if label_name in PIPELINE_LABELS
@@ -6775,7 +6813,11 @@ def check_issue_form(
             ),
         ))
 
-    log_stage("claim", f"Issue #{issue_number} accepted: {label} for {coordinate}")
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_ISSUE_FORM,
+        f"Issue #{issue_number} accepted: {label} for {coordinate}",
+    )
     return ISSUE_FORM_ACCEPTED
 
 
@@ -6921,22 +6963,34 @@ def claim_issue_for_processing(
     """
     enter_phase(PHASE_CLAIM)
     issue_number = issue["number"]
-    log_stage("claim", f"Claiming issue #{issue_number}")
+    log_step_progress(PHASE_CLAIM, STEP_CLAIM_ISSUE, f"Claiming issue #{issue_number}")
     if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
-        log_stage("claim", f"Issue #{issue_number} not claimed: live issue state is no longer eligible")
+        log_step_progress(
+            PHASE_CLAIM,
+            STEP_CLAIM_ISSUE,
+            f"Issue #{issue_number} not claimed: live issue state is no longer eligible",
+        )
         return None
 
     try:
         issue_base_commit = fetch_issue_base_commit(base_reachability_metadata_path)
     except BaseException as exc:
         if isinstance(exc, Exception):
-            log_stage("claim", f"Issue #{issue_number} not claimed: newest origin/master could not be pinned")
+            log_step_progress(
+                PHASE_CLAIM,
+                STEP_CLAIM_ISSUE,
+                f"Issue #{issue_number} not claimed: newest origin/master could not be pinned",
+            )
             return None
         raise
 
     item_id = try_claim_issue(issue, authenticated_user, label, take_blocked_issues)
     if not item_id:
-        log_stage("claim", f"Issue #{issue_number} not claimed: live claimability check did not pass")
+        log_step_progress(
+            PHASE_CLAIM,
+            STEP_CLAIM_ISSUE,
+            f"Issue #{issue_number} not claimed: live claimability check did not pass",
+        )
         return None
 
     worktree_path: str | None = None
@@ -8646,21 +8700,18 @@ def try_claim_issue_with_local_lock(
 
     try:
         # SET ourselves as the sole assignee
-        print()
-        log_stage("issue-claim", f"Setting issue #{number} assignee to {authenticated_user}")
+        log_debug("issue-claim", f"Setting issue #{number} assignee to {authenticated_user}")
         set_issue_assignee(number, authenticated_user)
 
         # Random wait so concurrent runners' SETs have time to land.
         backoff = random.uniform(CLAIM_BACKOFF_MIN, CLAIM_BACKOFF_MAX)
-        print()
-        log_stage("issue-claim", f"Waiting {backoff:.1f}s before verifying claim on issue #{number}")
+        log_debug("issue-claim", f"Waiting {backoff:.1f}s before verifying claim on issue #{number}")
         time.sleep(backoff)
 
         # Verify we are still the assignee
         assignees = get_issue_assignees(number)
         if assignees != [authenticated_user]:
-            print()
-            log_stage("issue-claim", f"Issue #{number}: assignee is now {assignees}, not us. Backing off.")
+            log_debug("issue-claim", f"Issue #{number}: assignee is now {assignees}, not us. Backing off.")
             if assignees:
                 record_issue_claim_cache_observations([
                     IssueClaimCacheObservation(
@@ -8679,8 +8730,8 @@ def try_claim_issue_with_local_lock(
                 project_status=STATUS_IN_PROGRESS,
             )
         ])
-        print()
-        log_stage("claim", f"Issue #{number} claimed; project status is In Progress")
+        log_step_progress(PHASE_CLAIM, STEP_CLAIM_ISSUE, f"Issue #{number} claimed")
+        log_debug("claim", f"Issue #{number} claimed; project status is In Progress")
         return item_id
     except BaseException as exc:
         revert_issue_claim_if_still_owned_by_user(
@@ -8738,8 +8789,7 @@ def log_issue_scan_start(label: str, offset: int, priority: str | None = None) -
         position = "draining the high, priority, then normal tiers in turn"
     else:
         position = f"from offset {offset}"
-    print()
-    log_stage("issue-scan", f"Starting issue scan for label '{label}' {position}")
+    log_debug("issue-scan", f"Starting issue scan for label '{label}' {position}")
 
 
 def log_issue_scan_progress(
@@ -8752,8 +8802,7 @@ def log_issue_scan_progress(
 ) -> None:
     """Log issue scan progress after another interval of candidates was inspected."""
     position = format_issue_scan_position(offset, current_offset, scan_state, priority)
-    print()
-    log_stage(
+    log_debug(
         "issue-scan",
         f"Looked through {scanned_count} issue(s) for label '{label}' ({position})",
     )
@@ -9059,8 +9108,7 @@ def process_issues_with_label(
     finally:
         executor.shutdown(wait=False, cancel_futures=True)
 
-    print()
-    log_stage("issue-scan", f"Scanned {scanned_count} issue(s) for label '{label}'")
+    log_debug("issue-scan", f"Scanned {scanned_count} issue(s) for label '{label}'")
     return processed_count
 
 
@@ -9113,12 +9161,10 @@ def process_work_queues(
             )
             return
         if queue_config.limit <= 0:
-            print()
-            log_stage("work-queue", f"Skipping issue queue '{queue_config.label}' because its limit is 0")
+            log_debug("work-queue", f"Skipping issue queue '{queue_config.label}' because its limit is 0")
             continue
 
-        print()
-        log_stage(
+        log_debug(
             "work-queue",
             f"Processing up to {queue_config.limit} issue(s) for label '{queue_config.label}'",
         )
@@ -9144,8 +9190,7 @@ def process_work_queues(
                 user_requested_only=user_requested_only,
                 **priority_kwargs,
             )
-            print()
-            log_stage(
+            log_debug(
                 "issue-scan",
                 f"Selected random start offset {issue_scan_offset} for label '{queue_config.label}'",
             )
@@ -9173,8 +9218,7 @@ def process_work_queues(
             )
             return
         if review_queue_config.limit <= 0:
-            print()
-            log_stage("work-queue", f"Skipping review queue '{review_queue_config.label}' because its limit is 0")
+            log_debug("work-queue", f"Skipping review queue '{review_queue_config.label}' because its limit is 0")
             continue
 
         authenticated_user = resolve_authenticated_user(authenticated_user)
@@ -9325,6 +9369,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_TAKE_BLOCKED_ISSUES,
         help="Claim issues even when GitHub shows open blocking issues. Defaults to disabled.",
     )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Show narration hidden by the compact default output.",
+    )
 
     args = parser.parse_args(argv)
     if args.period is not None and args.review_pr is None:
@@ -9375,8 +9424,7 @@ def process_single_issue(
     validate_issue_processing_environment()
 
     issue, label = get_issue_by_number(issue_number)
-    print()
-    log_stage("issue-scan", f"Issue #{issue_number} matched pipeline label: {label}")
+    log_debug("issue-scan", f"Issue #{issue_number} matched pipeline label: {label}")
 
     if is_fixture_testing_enabled():
         with fixture_issue_run_log(issue_number):
@@ -9473,15 +9521,24 @@ def require_host_requirements(args: argparse.Namespace, reachability_metadata_pa
     checkout this run selected, which `--reachability-metadata-path` can move away from
     the checkout that contains Forge (§FS-forge-host-requirements).
     """
-    log_stage("startup", "Checking host requirements")
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_HOST_REQUIREMENTS,
+        "Checking host requirements",
+    )
     ensure_host_requirements(
         FORGE_DIR,
         requirements=resolve_host_requirement_queues(args),
         graalvm_version_check=resolve_graalvm_version_check(args.graalvm_version_check),
         repo_dir=reachability_metadata_path,
         test_strategy_names=resolve_host_requirement_strategy_names(args),
+        verbose=args.verbose or debug_logging_enabled(),
     )
-    log_stage("startup", "Host requirements passed")
+    log_step_progress(
+        PHASE_CLAIM,
+        STEP_CHECK_HOST_REQUIREMENTS,
+        "Host requirements passed",
+    )
 
 
 def main() -> None:
@@ -9489,6 +9546,8 @@ def main() -> None:
     previous_sigint_handler = signal.getsignal(signal.SIGINT)
     signal.signal(signal.SIGINT, _handle_sigint)
     args = parse_args()
+    if args.verbose:
+        enable_verbose_logging()
     normal_exit = False
 
     try:
@@ -9519,7 +9578,17 @@ def main() -> None:
         require_host_requirements(args, reachability_metadata_path)
         if args.strategy_name:
             with run_step(PHASE_CLAIM, STEP_CHECK_STRATEGY_AND_MODEL, operand=args.strategy_name):
+                log_step_progress(
+                    PHASE_CLAIM,
+                    STEP_CHECK_STRATEGY_AND_MODEL,
+                    f"Checking strategy {args.strategy_name}",
+                )
                 require_strategy_by_name(args.strategy_name)
+                log_step_progress(
+                    PHASE_CLAIM,
+                    STEP_CHECK_STRATEGY_AND_MODEL,
+                    f"Strategy {args.strategy_name} accepted",
+                )
         metrics_repo_path = resolve_metrics_repo_root(reachability_metadata_path, None)
 
         if not PROJECT_NUMBER:
@@ -9579,8 +9648,10 @@ def main() -> None:
                     priority=args.priority,
                     user_requested_only=user_requested_only,
                 )
-                print()
-                log_stage("issue-scan", f"Selected random start offset {issue_scan_offset} for label '{args.label}'")
+                log_debug(
+                    "issue-scan",
+                    f"Selected random start offset {issue_scan_offset} for label '{args.label}'",
+                )
             process_issues_with_label(
                 args.label,
                 args.limit,

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -93,7 +93,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
 )
-from ai_workflows.agents.agent import AgentTimeoutError
+from ai_workflows.agents.agent import AgentFailureError
 from ai_workflows.agents.codex_agent import extract_codex_token_usage
 from ai_workflows.agents.agent_runtime import (
     analysis_agent_run,
@@ -7213,15 +7213,15 @@ def run_claimed_issue(
             raise KeyboardInterrupt from exc
         # The location the step annotated onto the exception leads its detail.
         # §FS-forge-run-location-reporting.3
-        error_detail = str(exc) if isinstance(exc, AgentTimeoutError) else (
+        error_detail = str(exc) if isinstance(exc, AgentFailureError) else (
             f"Issue #{claimed_issue.issue['number']} workflow raised an exception: {exc!r}"
         )
         report_run_failure(
             resolve_failure_location(exc),
             error_detail,
-            log_path=exc.log_path if isinstance(exc, AgentTimeoutError) else None,
+            log_path=exc.log_path if isinstance(exc, AgentFailureError) else None,
         )
-        if not isinstance(exc, AgentTimeoutError):
+        if not isinstance(exc, AgentFailureError):
             traceback.print_exc()
         success = False
         failure_was_external = is_external_failure_exception(exc)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -203,6 +203,7 @@ from utility_scripts.run_location import (
     STEP_CLAIM_ISSUE,
     STEP_CREATE_ISSUE_WORKSPACE,
     STEP_NEURAL_SETUP,
+    STEP_NORMAL_SETUP,
     STEP_PUBLISH_BRANCH,
     STEP_ROUTE_TO_DRIVER,
     RunLocation,
@@ -224,6 +225,7 @@ from utility_scripts.stage_logger import (
     debug_logging_enabled,
     enable_verbose_logging,
     log_debug,
+    log_detail,
     log_failure_banner,
     log_stage,
     log_success_banner,
@@ -5170,7 +5172,7 @@ def _generate_dispatcher_dynamic_access_report(claimed_issue: ClaimedIssue) -> N
         stage="dynamic-access",
     )
     if result.returncode != 0:
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             (
                 "Dispatcher dynamic-access report refresh failed for "
@@ -5242,7 +5244,7 @@ def _prepare_dispatcher_dynamic_access_report(claimed_issue: ClaimedIssue) -> bo
     built (§FS-forge-chunked-dynamic-access).
     """
     if _continuation_resumes_existing_tree(claimed_issue.continuation_marker):
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             (
                 f"Issue #{claimed_issue.issue['number']} resumes a preserved tree; "
@@ -5296,7 +5298,7 @@ def prepare_dynamic_access_chunking(
         chunk_boundary: int = threshold
         if active_chunk_remaining_budget is not None:
             chunk_boundary = min(chunk_boundary, active_chunk_remaining_budget)
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             "Deferring chunk selection for '{strategy}' until its bulk phase completes; "
             "uncovered_classes={uncovered}, class_boundary={boundary}.".format(
@@ -5309,7 +5311,7 @@ def prepare_dynamic_access_chunking(
 
     report = _load_dispatcher_dynamic_access_report(claimed_issue)
     if report is None:
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             (
                 f"No dispatcher dynamic-access report for issue #{claimed_issue.issue['number']} "
@@ -5335,7 +5337,7 @@ def prepare_dynamic_access_chunking(
         claimed_issue.continuation_marker,
     )
     if not already_chunked and len(current_uncovered_classes) <= threshold:
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             (
                 f"Chunking not selected for issue #{claimed_issue.issue['number']}: "
@@ -5353,7 +5355,7 @@ def prepare_dynamic_access_chunking(
     if active_chunk_remaining_budget is not None:
         current_chunk_class_count = min(current_chunk_class_count, active_chunk_remaining_budget)
     if current_chunk_class_count <= 0:
-        log_stage(
+        log_detail(
             "dynamic-access-chunking",
             (
                 f"No chunk selected for issue #{claimed_issue.issue['number']}: "
@@ -5373,7 +5375,7 @@ def prepare_dynamic_access_chunking(
         add_issue_label(claimed_issue.issue["number"], LABEL_CHUNKED_DYNAMIC_ACCESS)
         add_issue_label_to_payload(claimed_issue.issue, LABEL_CHUNKED_DYNAMIC_ACCESS)
 
-    log_stage(
+    log_detail(
         "dynamic-access-chunking",
         "Chunked dynamic-access selected for issue #{issue_number}: "
         "already_chunked={already_chunked}, total_uncovered_classes={uncovered_count}, "
@@ -5828,9 +5830,14 @@ def invoke_pipeline(
             claimed_issue,
             marker,
         )
-        log_stage(
+        log_detail(
             "continuation",
             f"Issue #{claimed_issue.issue['number']} skips completed setup preflight.",
+        )
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_NEURAL_SETUP,
+            f"Reusing completed library preflight for {claimed_issue.issue_coordinates}",
         )
     else:
         # The preflight agent is the run's neural setup, and it runs before the
@@ -5852,10 +5859,29 @@ def invoke_pipeline(
                     and library_update_route.selected_driver == ROUTE_IMPROVE_COVERAGE
             )
     ):
-        chunk_class_count = prepare_dynamic_access_chunking(
-            claimed_issue,
-            run_strategy_name,
-        )
+        with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand=claimed_issue.issue_coordinates):
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_NORMAL_SETUP,
+                f"Inspecting dynamic access for {claimed_issue.issue_coordinates}",
+            )
+            chunk_class_count = prepare_dynamic_access_chunking(
+                claimed_issue,
+                run_strategy_name,
+            )
+            uncovered_classes = _dispatcher_uncovered_class_count(claimed_issue)
+            budget_suffix = f", class budget {chunk_class_count}" if chunk_class_count is not None else ""
+            inspection_result = (
+                "report unavailable"
+                if uncovered_classes == "unavailable"
+                else f"{uncovered_classes} uncovered classes{budget_suffix}"
+            )
+            log_step_progress(
+                PHASE_SETUP,
+                STEP_NORMAL_SETUP,
+                f"Dynamic-access inspection ready for {claimed_issue.issue_coordinates}: "
+                f"{inspection_result}",
+            )
     invocation = build_workflow_driver_invocation(
             claimed_issue,
             strategy_override,
@@ -5868,8 +5894,7 @@ def invoke_pipeline(
     if debug_logging_enabled() and "--verbose" not in invocation.argv:
         invocation.argv.append("--verbose")
 
-    print()
-    log_stage(invocation.log_stage_name, invocation.log_message)
+    log_detail(invocation.log_stage_name, invocation.log_message)
     if is_fixture_testing_enabled():
         display_argv = list(invocation.argv)
         if "--issue-requested-metadata-context" in display_argv:

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -93,6 +93,7 @@ from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_SUCCESS,
     SUCCESS_WITH_INTERVENTION_STATUS,
 )
+from ai_workflows.agents.agent import AgentTimeoutError
 from ai_workflows.agents.codex_agent import extract_codex_token_usage
 from ai_workflows.agents.agent_runtime import (
     analysis_agent_run,
@@ -153,6 +154,7 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.dynamic_access_report import load_dynamic_access_coverage_report
 from utility_scripts.fixture_github import FixtureGitHubState, load_fixture_github_state
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.logged_command import run_logged_command
 from utility_scripts.library_stats import resolve_stats_file_path
 from utility_scripts.library_preparation_preflight import (
     LIBRARY_PREPARATION_PREFLIGHT_FILENAME,
@@ -5150,18 +5152,18 @@ def _prepare_library_update_dynamic_access_report(claimed_issue: ClaimedIssue) -
 
 def _generate_dispatcher_dynamic_access_report(claimed_issue: ClaimedIssue) -> None:
     """Generate or refresh the dynamic-access report used for dispatcher chunking."""
-    result = subprocess.run(
+    result = run_logged_command(
         [
             "./gradlew",
             "generateDynamicAccessCoverageReport",
             f"-Pcoordinates={claimed_issue.issue_coordinates}",
         ],
         cwd=claimed_issue.worktree_path,
+        task_type="dynamic-access-report",
+        subject=claimed_issue.issue_coordinates,
+        action="generateDynamicAccessCoverageReport",
         env=gradle_command_environment(claimed_issue.worktree_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        stage="dynamic-access",
     )
     if result.returncode != 0:
         log_stage(
@@ -6238,11 +6240,15 @@ def fetch_issue_base_commit(repo_path: str) -> str:
     remote-tracking ref supplies repository state for issue work
     (§FS-forge-run-requirements.2).
     """
+    log_stage(
+        "claim",
+        f"Fetching newest origin/{DEFAULT_WORKTREE_BASE_REF} for the next issue claim",
+    )
     remote_tracking_ref = fetch_default_base_ref(repo_path, "issue claim")
     commit = resolve_git_commit(repo_path, remote_tracking_ref)
     log_stage(
-        "issue-base",
-        f"Pinned origin/{DEFAULT_WORKTREE_BASE_REF} at {commit[:12]} for the next issue claim",
+        "claim",
+        f"Pinned origin/{DEFAULT_WORKTREE_BASE_REF} at {commit[:12]}",
     )
     return commit
 
@@ -6330,6 +6336,10 @@ def create_issue_workspace(
 
     §FS-forge-run-requirements.4
     """
+    log_stage(
+        "claim",
+        f"Creating workspace for issue #{issue_number} from {issue_base_commit}",
+    )
     repo_root = get_repo_root()
     worktrees_root = os.path.join(repo_root, "local_repositories", SCRATCH_WORKTREE_DIRNAME)
     os.makedirs(worktrees_root, exist_ok=True)
@@ -6348,6 +6358,10 @@ def create_issue_workspace(
     except SystemExit:
         remove_worktree(base_reachability_metadata_path, worktree_path)
         raise
+    log_stage(
+        "claim",
+        f"Workspace created for issue #{issue_number}: {os.path.relpath(worktree_path, repo_root)}",
+    )
 
     scratch_metrics_repo_path = os.path.join(worktree_path, get_forge_subdir_name())
     del canonical_metrics_repo_path, issue_number
@@ -6384,11 +6398,6 @@ def cleanup_issue_workspace(claimed_issue: ClaimedIssue, canonical_metrics_repo_
             )
 
 
-@pipeline_step(
-    PHASE_CLAIM,
-    STEP_CHECK_ISSUE_FORM,
-    operand=lambda arguments: f"issue #{arguments['issue']['number']}",
-)
 def build_claim_metadata(
         issue: dict,
         label: str,
@@ -6659,7 +6668,16 @@ class IssueFormVerdict:
 ISSUE_FORM_ACCEPTED = IssueFormVerdict()
 
 
-def check_issue_form(issue: dict, label: str, reachability_metadata_path: str) -> IssueFormVerdict:
+@pipeline_step(
+    PHASE_CLAIM,
+    STEP_CHECK_ISSUE_FORM,
+    operand=lambda arguments: f"issue #{arguments['issue']['number']}",
+)
+def check_issue_form(
+        issue: dict,
+        label: str,
+        reachability_metadata_path: str,
+) -> IssueFormVerdict:
     """Decide every issue-form rule from the payload and the repository.
 
     Runs inside the pinned issue-base worktree while the exclusive claim is held.
@@ -6669,6 +6687,7 @@ def check_issue_form(issue: dict, label: str, reachability_metadata_path: str) -
     (§FS-forge-run-requirements.3, §root/PRCPL-verify-inputs).
     """
     issue_number = issue["number"]
+    log_stage("claim", f"Checking issue #{issue_number} against the pinned issue workspace")
 
     workflow_labels = sorted(
         label_name for label_name in get_issue_label_names(issue) if label_name in PIPELINE_LABELS
@@ -6756,6 +6775,7 @@ def check_issue_form(issue: dict, label: str, reachability_metadata_path: str) -
             ),
         ))
 
+    log_stage("claim", f"Issue #{issue_number} accepted: {label} for {coordinate}")
     return ISSUE_FORM_ACCEPTED
 
 
@@ -6900,18 +6920,23 @@ def claim_issue_for_processing(
     §FS-forge-run-requirements.4).
     """
     enter_phase(PHASE_CLAIM)
+    issue_number = issue["number"]
+    log_stage("claim", f"Claiming issue #{issue_number}")
     if not refresh_issue_payload_for_claim(issue, label, authenticated_user):
+        log_stage("claim", f"Issue #{issue_number} not claimed: live issue state is no longer eligible")
         return None
 
     try:
         issue_base_commit = fetch_issue_base_commit(base_reachability_metadata_path)
     except BaseException as exc:
         if isinstance(exc, Exception):
+            log_stage("claim", f"Issue #{issue_number} not claimed: newest origin/master could not be pinned")
             return None
         raise
 
     item_id = try_claim_issue(issue, authenticated_user, label, take_blocked_issues)
     if not item_id:
+        log_stage("claim", f"Issue #{issue_number} not claimed: live claimability check did not pass")
         return None
 
     worktree_path: str | None = None
@@ -7188,11 +7213,16 @@ def run_claimed_issue(
             raise KeyboardInterrupt from exc
         # The location the step annotated onto the exception leads its detail.
         # §FS-forge-run-location-reporting.3
+        error_detail = str(exc) if isinstance(exc, AgentTimeoutError) else (
+            f"Issue #{claimed_issue.issue['number']} workflow raised an exception: {exc!r}"
+        )
         report_run_failure(
             resolve_failure_location(exc),
-            f"ERROR: Issue #{claimed_issue.issue['number']} workflow raised an exception: {exc!r}",
+            error_detail,
+            log_path=exc.log_path if isinstance(exc, AgentTimeoutError) else None,
         )
-        traceback.print_exc()
+        if not isinstance(exc, AgentTimeoutError):
+            traceback.print_exc()
         success = False
         failure_was_external = is_external_failure_exception(exc)
     if is_user_interrupt_requested():
@@ -8650,7 +8680,7 @@ def try_claim_issue_with_local_lock(
             )
         ])
         print()
-        log_stage("issue-claim", f"Claimed issue #{number} (-> In Progress)")
+        log_stage("claim", f"Issue #{number} claimed; project status is In Progress")
         return item_id
     except BaseException as exc:
         revert_issue_claim_if_still_owned_by_user(
@@ -9443,6 +9473,7 @@ def require_host_requirements(args: argparse.Namespace, reachability_metadata_pa
     checkout this run selected, which `--reachability-metadata-path` can move away from
     the checkout that contains Forge (§FS-forge-host-requirements).
     """
+    log_stage("startup", "Checking host requirements")
     ensure_host_requirements(
         FORGE_DIR,
         requirements=resolve_host_requirement_queues(args),
@@ -9450,6 +9481,7 @@ def require_host_requirements(args: argparse.Namespace, reachability_metadata_pa
         repo_dir=reachability_metadata_path,
         test_strategy_names=resolve_host_requirement_strategy_names(args),
     )
+    log_stage("startup", "Host requirements passed")
 
 
 def main() -> None:

--- a/forge/git_scripts/branch_publication.py
+++ b/forge/git_scripts/branch_publication.py
@@ -41,6 +41,7 @@ from utility_scripts.local_ci_verification import (
     fetch_pr_base_ref,
     run_local_ci_verification,
 )
+from utility_scripts.logged_command import run_logged_command
 from utility_scripts.continuation_marker import (
     CONTINUATION_MARKER_FILENAME,
     PHASE_PUBLICATION,
@@ -196,22 +197,23 @@ def _prepare_unpushed_publication_resume_branch(
 def _run_post_review_gradle_test(
         repo_path: str,
         coordinates: str,
+        lane_name: str,
         environment: dict[str, str],
 ) -> bool:
-    """Run one deterministic native test lane after a reviewer edit."""
-    result = subprocess.run(
+    """Run one post-review lane with output kept in its durable log.
+
+    §FS-forge-run-output-legibility.4 §FS-durable-generation-logs
+    """
+    result = run_logged_command(
         ["./gradlew", "test", f"-Pcoordinates={coordinates}"],
         cwd=repo_path,
         env=gradle_command_environment(repo_path, environment),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        task_type="post-review-finalization",
+        subject=coordinates,
+        action=lane_name,
+        stage="finalization",
     )
-    if result.returncode != 0:
-        print(result.stdout)
-        return False
-    return True
+    return result.returncode == 0
 
 
 def _run_standard_post_review_finalization(
@@ -235,12 +237,17 @@ def _run_standard_post_review_finalization(
     graalvm_25_environment["GRAALVM_HOME"] = graalvm_25_home
     graalvm_25_environment["JAVA_HOME"] = graalvm_25_home
     graalvm_25_environment.pop("GVM_TCK_NATIVE_IMAGE_MODE", None)
-    for environment in (
-            current_environment,
-            future_defaults_environment,
-            graalvm_25_environment,
+    for lane_name, environment in (
+            ("post-review current-defaults latest GraalVM test", current_environment),
+            ("post-review future-defaults latest GraalVM test", future_defaults_environment),
+            ("post-review current-defaults GraalVM 25 test", graalvm_25_environment),
     ):
-        if not _run_post_review_gradle_test(repo_path, coordinates, environment):
+        if not _run_post_review_gradle_test(
+                repo_path,
+                coordinates,
+                lane_name,
+                environment,
+        ):
             return False
 
     group, artifact, version = coordinates.split(":")

--- a/forge/git_scripts/common_git.py
+++ b/forge/git_scripts/common_git.py
@@ -12,6 +12,7 @@ import sys
 import time
 from typing import Any, Callable, Iterable, List
 from utility_scripts.library_stats import load_library_stats_entry
+from utility_scripts.stage_logger import debug_logging_enabled
 from utility_scripts.strategy_loader import load_strategy_by_name
 
 
@@ -475,6 +476,23 @@ def build_ai_branch_name(branch_suffix: str, cwd=None) -> str:
     """Build an AI branch name scoped to the authenticated GitHub login."""
     authenticated_login = get_authenticated_login(cwd=cwd)
     return f"ai/{authenticated_login}/{branch_suffix}"
+
+
+def switch_branch_quietly(branch: str, cwd: str | None = None) -> None:
+    """Reset a branch without leaking Git narration in compact output.
+
+    §FS-forge-run-output-legibility.5
+    """
+    result = subprocess.run(
+        ["git", "switch", "-C", branch],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )
+    if debug_logging_enabled() and result.stdout:
+        print(result.stdout, end="")
 
 
 def git_remote_branch_exists(branch: str, remote: str = "origin", cwd: str | None = None) -> bool:

--- a/forge/tests/test_agent_runtime.py
+++ b/forge/tests/test_agent_runtime.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import shlex
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
 
 from ai_workflows.agents import Agent
+from ai_workflows.agents.agent import AgentTimeoutError
 from ai_workflows.agents.claude_code_agent import ClaudeCodeAgent
 from ai_workflows.agents.codex_agent import CodexAgent
 from ai_workflows.agents.codex_app_server import CodexAppServerClient
@@ -39,6 +43,28 @@ class AgentRuntimeTests(unittest.TestCase):
             set(SUPPORTED_AGENT_BACKENDS),
             {name for name in SUPPORTED_AGENT_BACKENDS if Agent.get_class(name)},
         )
+
+    def test_agent_timeout_prints_named_quiet_activity_and_log(self) -> None:
+        with tempfile.TemporaryDirectory() as work_dir:
+            agent = CodexAgent(
+                model_name="gpt-5.6-luna",
+                working_dir=work_dir,
+                timeout=1200,
+                library="org.example:demo:1.0.0",
+                task_type="add-new-library-support",
+            )
+            timeout = subprocess.TimeoutExpired(["codex"], 1200, output="partial private output")
+            output = io.StringIO()
+            with patch.object(agent, "_run_codex_command", side_effect=timeout), \
+                    contextlib.redirect_stdout(output), self.assertRaises(AgentTimeoutError) as raised:
+                agent.send_prompt_for_action("prompt", "dynamic_access_iteration()")
+
+        rendered = output.getvalue()
+        self.assertIn("Running dynamic_access_iteration()", rendered)
+        self.assertIn("dynamic_access_iteration() timed out", rendered)
+        self.assertIn("log:", rendered)
+        self.assertNotIn("partial private output", rendered)
+        self.assertEqual(raised.exception.timeout_seconds, 1200)
 
     def test_the_environment_selects_the_analysis_role_only(self) -> None:
         """The worker configures analysis; a bundle owns the test role it declares."""

--- a/forge/tests/test_agent_runtime.py
+++ b/forge/tests/test_agent_runtime.py
@@ -10,7 +10,7 @@ import shlex
 import subprocess
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from ai_workflows.agents import Agent
 from ai_workflows.agents.agent import AgentTimeoutError
@@ -21,6 +21,7 @@ from ai_workflows.agents.opencode_agent import OpenCodeAgent
 from ai_workflows.agents.agent_runtime import PROVIDER_AWARE_BACKENDS, resolve_provider
 from ai_workflows.agents.agent_runtime import (
     CODEX_BYPASS_APPROVALS_AND_SANDBOX_FLAG,
+    AgentSelection,
     DEFAULT_AGENT,
     SUPPORTED_AGENT_BACKENDS,
     default_model_for_backend,
@@ -28,6 +29,7 @@ from ai_workflows.agents.agent_runtime import (
     get_setup_agent,
     agent_process_environment,
     normalize_backend_name,
+    run_agent_task,
 )
 from utility_scripts.source_context import url_fetch_agent_command
 from utility_scripts.strategy_loader import (
@@ -65,6 +67,41 @@ class AgentRuntimeTests(unittest.TestCase):
         self.assertIn("log:", rendered)
         self.assertNotIn("partial private output", rendered)
         self.assertEqual(raised.exception.timeout_seconds, 1200)
+
+    def test_one_shot_agent_failure_preserves_message(self) -> None:
+        failed_agent = Mock()
+        failed_agent.send_prompt_for_action.side_effect = AgentTimeoutError(
+            "native_test_verify()",
+            1800,
+            "/tmp/native-session.log",
+        )
+        failed_agent.total_tokens_sent = 0
+        failed_agent.total_tokens_received = 0
+        failed_agent.cached_input_tokens_used = 0
+        failed_agent._session_log_path = "/tmp/native-session.log"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            task_log_path = os.path.join(temp_dir, "native-task.log")
+            with patch(
+                    "ai_workflows.agents.agent_runtime.create_agent",
+                    return_value=failed_agent,
+            ), patch(
+                    "ai_workflows.agents.agent_runtime.build_task_log_path",
+                    return_value=task_log_path,
+            ):
+                result = run_agent_task(
+                    selection=AgentSelection(backend="codex", model="test-model"),
+                    working_dir=temp_dir,
+                    prompt="repair",
+                    task_type="native-test-verify",
+                    library="g:a:1.0",
+                    timeout=1800,
+                )
+
+        self.assertEqual(
+            result.failure_message,
+            "Agent native_test_verify() timed out after 30:00",
+        )
 
     def test_the_environment_selects_the_analysis_role_only(self) -> None:
         """The worker configures analysis; a bundle owns the test role it declares."""

--- a/forge/tests/test_agent_runtime.py
+++ b/forge/tests/test_agent_runtime.py
@@ -18,6 +18,8 @@ from ai_workflows.agents.claude_code_agent import ClaudeCodeAgent
 from ai_workflows.agents.codex_agent import CodexAgent
 from ai_workflows.agents.codex_app_server import CodexAppServerClient
 from ai_workflows.agents.opencode_agent import OpenCodeAgent
+from ai_workflows.agents.pi_agent import PiAgent
+from ai_workflows.agents.pi_rpc_client import PromptResult
 from ai_workflows.agents.agent_runtime import PROVIDER_AWARE_BACKENDS, resolve_provider
 from ai_workflows.agents.agent_runtime import (
     CODEX_BYPASS_APPROVALS_AND_SANDBOX_FLAG,
@@ -102,6 +104,36 @@ class AgentRuntimeTests(unittest.TestCase):
             result.failure_message,
             "Agent native_test_verify() timed out after 30:00",
         )
+
+    def test_pi_reuses_the_first_log_path_for_every_turn(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "pi-generation.log")
+            agent = PiAgent(
+                model_name="test-model",
+                working_dir=temp_dir,
+                library="g:a:1.0",
+                task_type="native-test-verify",
+            )
+            agent._rpc_client = Mock()
+            agent._rpc_client.run_prompt.side_effect = [
+                PromptResult("first", "/tmp/pi-session-1", {"tokens": {}}),
+                PromptResult("second", "/tmp/pi-session-2", {"tokens": {}}),
+            ]
+
+            with patch.object(
+                    agent,
+                    "_build_generation_log_path",
+                    return_value=log_path,
+            ) as build_log_path, contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(agent.send_prompt("first prompt"), "first")
+                self.assertEqual(agent.send_prompt("second prompt"), "second")
+
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                durable_log = log_file.read()
+
+        build_log_path.assert_called_once_with()
+        self.assertEqual(agent._session_log_path, log_path)
+        self.assertEqual(durable_log.count("Timestamp:"), 2)
 
     def test_the_environment_selects_the_analysis_role_only(self) -> None:
         """The worker configures analysis; a bundle owns the test role it declares."""

--- a/forge/tests/test_bulk_dynamic_access_strategy.py
+++ b/forge/tests/test_bulk_dynamic_access_strategy.py
@@ -3,7 +3,10 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import io
+import os
 import unittest
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 from ai_workflows.core.increase_dynamic_access_coverage_strategy import (
@@ -18,6 +21,7 @@ from utility_scripts.dynamic_access_report import (
     DynamicAccessCoverageReport,
     compute_bulk_dynamic_access_progress,
 )
+from utility_scripts.run_location import reset_run_location
 
 
 class BulkDynamicAccessChunkTests(unittest.TestCase):
@@ -244,9 +248,22 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
 class BulkDynamicAccessRunTests(unittest.TestCase):
     """The bulk loop must run on the report the run prepared for it."""
 
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
     def test_usable_report_starts_bulk_iterations_without_a_fallback(self) -> None:
         strategy, agent = self._runnable_strategy(reports=[self._usable_report()])
-        with patch.object(strategy, "_run_basic_iterative_fallback") as fallback:
+        output = io.StringIO()
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), patch.object(
+                strategy,
+                "_run_basic_iterative_fallback",
+        ) as fallback, redirect_stdout(output):
             status, iterations, generations = strategy.run(agent)
 
         fallback.assert_not_called()
@@ -254,6 +271,16 @@ class BulkDynamicAccessRunTests(unittest.TestCase):
         self.assertEqual(generations, 1)
         self.assertEqual(iterations, 1)
         self.assertEqual(len(agent.prompts), 1)
+        printed = output.getvalue()
+        self.assertIn(
+            "[explore] Generating tests: bulk iteration 1/3, "
+            "0 uncovered across 0 classes (1/3)",
+            printed,
+        )
+        self.assertIn("[explore]   Running test 1/2 (1/3)", printed)
+        self.assertIn("[explore]   Test 1/2 passed (1/3)", printed)
+        self.assertNotIn("[bulk-da]", printed)
+        self.assertNotIn("./gradlew", printed)
 
     def test_empty_report_bootstraps_through_the_fallback_then_runs_bulk(self) -> None:
         # A report only becomes usable once tests exist; the fallback creates

--- a/forge/tests/test_common_git.py
+++ b/forge/tests/test_common_git.py
@@ -23,6 +23,44 @@ class ForgeRevisionSectionTests(unittest.TestCase):
         self.assertIn("- Forge commit hash: `abc123`", section)
 
 
+class QuietBranchSwitchTests(unittest.TestCase):
+    def test_compact_output_hides_git_switch_narration(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["git"],
+            0,
+            stdout="Switched to a new branch 'ai/test'\n",
+            stderr="",
+        )
+        with patch.object(common_git.subprocess, "run", return_value=result) as run, \
+                patch.dict(os.environ, {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"}), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            common_git.switch_branch_quietly("ai/test", cwd="/repo")
+
+        self.assertEqual("", stdout.getvalue())
+        run.assert_called_once_with(
+            ["git", "switch", "-C", "ai/test"],
+            cwd="/repo",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=True,
+        )
+
+    def test_verbose_output_replays_git_switch_narration(self) -> None:
+        result = subprocess.CompletedProcess(
+            ["git"],
+            0,
+            stdout="Reset branch 'ai/test'\n",
+            stderr="",
+        )
+        with patch.object(common_git.subprocess, "run", return_value=result), \
+                patch.dict(os.environ, {"FORGE_VERBOSE": "1"}), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            common_git.switch_branch_quietly("ai/test")
+
+        self.assertEqual("Reset branch 'ai/test'\n", stdout.getvalue())
+
+
 class IssueLookupTests(unittest.TestCase):
     def test_find_issue_for_coordinates_uses_exact_coordinate_match(self) -> None:
         completed_process = subprocess.CompletedProcess(

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -16,9 +16,18 @@ from ai_workflows.core.dynamic_access_iterative_strategy import DynamicAccessIte
 from ai_workflows.core.workflow_strategy import RUN_STATUS_CHUNK_READY, RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS
 from utility_scripts.dynamic_access_report import DynamicAccessClass, DynamicAccessCoverageReport
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
+from utility_scripts.continuation_marker import PHASE_EXPLORE
+from utility_scripts.run_location import enter_phase, reset_run_location
 
 
 class DynamicAccessProgressLoggingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+        enter_phase(PHASE_EXPLORE)
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
     def test_class_completion_progress_prints_overall_coverage(self) -> None:
         report = DynamicAccessCoverageReport(
             coordinate="org.example:lib:1.0.0",
@@ -39,10 +48,8 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
 
         self.assertEqual(
             output.getvalue().strip(),
-            "[dynamic-access] ===================================================================================\n"
-            "[dynamic-access] Progress after org.example.SomeClass: "
-            "classes 5/35 complete; overall coverage 45/103 covered (58 remaining)\n"
-            "[dynamic-access] ===================================================================================",
+            "[explore] Finished class org.example.SomeClass: classes 5/35 processed; "
+            "coverage 45/103 (58 remaining) (1/3)",
         )
 
     def test_completed_class_count_includes_fully_covered_report_classes(self) -> None:

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -316,6 +316,59 @@ class FinalizeSuccessfulIssueTests(unittest.TestCase):
 
 
 class LibraryUpdateIssueTests(unittest.TestCase):
+    def test_compact_preflight_reports_completed_decision(self) -> None:
+        from utility_scripts import library_preparation_preflight as preflight_module
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            claimed_issue = SimpleNamespace(
+                scratch_metrics_repo_path=temp_dir,
+                preflight_info_path=temp_dir,
+            )
+            record = {
+                "status": "completed",
+                "action": "no_action",
+                "issue_number": 1412,
+                "library": "org.example:lib:1.0.0",
+                "deterministic_setup": [],
+            }
+            stdout = io.StringIO()
+            run_location.enter_phase(PHASE_SETUP)
+            with contextlib.redirect_stdout(stdout):
+                preflight_module._write_and_log_preflight(claimed_issue, record)
+            run_location.reset_run_location()
+
+        self.assertIn(
+            "[setup] Library preflight completed for org.example:lib:1.0.0: no action (1/3)",
+            stdout.getvalue(),
+        )
+        self.assertNotIn("Preflight decision", stdout.getvalue())
+
+    def test_degraded_preflight_keeps_cause_and_log_in_compact_output(self) -> None:
+        from utility_scripts import library_preparation_preflight as preflight_module
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            claimed_issue = SimpleNamespace(
+                scratch_metrics_repo_path=temp_dir,
+                preflight_info_path=temp_dir,
+            )
+            record = {
+                "status": "degraded",
+                "action": "no_action",
+                "issue_number": 1412,
+                "library": "org.example:lib:1.0.0",
+                "deterministic_setup": [],
+                "failure_reason": "Agent timed out",
+                "session_log_path": "/tmp/preflight-session.log",
+            }
+            stdout = io.StringIO()
+            run_location.enter_phase(PHASE_SETUP)
+            with contextlib.redirect_stdout(stdout):
+                preflight_module._write_and_log_preflight(claimed_issue, record)
+            run_location.reset_run_location()
+
+        self.assertIn("Library preflight degraded for org.example:lib:1.0.0: Agent timed out", stdout.getvalue())
+        self.assertIn("preflight-session.log", stdout.getvalue())
+
     def test_library_preflight_dispatches_without_a_strategy(self) -> None:
         claimed_issue = forge_metadata.ClaimedIssue(
             issue={"number": 1412, "title": "Update org.example:lib:1.0.0"},

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -2595,6 +2595,17 @@ class WorkQueueSchedulerTests(unittest.TestCase):
         self.assertFalse(default_args.take_blocked_issues)
         self.assertTrue(override_args.take_blocked_issues)
 
+    def test_verbose_output_is_disabled_by_default(self) -> None:
+        default_args = forge_metadata.parse_args(["--label", forge_metadata.LABEL_LIBRARY_NEW])
+        verbose_args = forge_metadata.parse_args([
+            "--label",
+            forge_metadata.LABEL_LIBRARY_NEW,
+            "--verbose",
+        ])
+
+        self.assertFalse(default_args.verbose)
+        self.assertTrue(verbose_args.verbose)
+
     def test_issue_queue_modes_accept_priority_tiers(self) -> None:
         for priority in forge_metadata.PRIORITY_CHOICES:
             with self.subTest(priority=priority):
@@ -3285,7 +3296,7 @@ class IssueClaimCacheTests(unittest.TestCase):
             ],
         )
 
-    def test_process_loop_logs_scan_start_and_progress(self) -> None:
+    def test_verbose_process_loop_logs_scan_start_and_progress(self) -> None:
         issues = [
             {
                 "number": issue_number,
@@ -3309,6 +3320,7 @@ class IssueClaimCacheTests(unittest.TestCase):
                         "claim_issue_for_processing",
                         return_value=None,
                     ), \
+                    patch.dict(os.environ, {"FORGE_VERBOSE": "1"}), \
                     patch("sys.stdout", new_callable=io.StringIO) as stdout:
                 self.assertEqual(
                     forge_metadata.process_issues_with_label(
@@ -3402,12 +3414,13 @@ class ProjectItemStatusTests(unittest.TestCase):
 
         gh_json.assert_called_once()
 
-    def test_forge_project_item_state_uses_combined_lookup(self) -> None:
+    def test_forge_project_item_state_is_quiet_in_compact_output(self) -> None:
         with patch.object(
                 forge_metadata,
                 "get_issue_project_item_status",
                 return_value=("project-item", forge_metadata.STATUS_TODO),
         ) as get_issue_project_item_status, \
+                patch.dict(os.environ, {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"}), \
                 patch("sys.stdout", new_callable=io.StringIO) as stdout:
             self.assertEqual(
                 forge_metadata.get_project_item_state(1412),
@@ -3420,6 +3433,17 @@ class ProjectItemStatusTests(unittest.TestCase):
             1412,
             forge_metadata.STATUS_FIELD_NAME,
         )
+        self.assertEqual("", stdout.getvalue())
+
+    def test_forge_project_item_state_is_available_in_verbose_output(self) -> None:
+        with patch.object(
+                forge_metadata,
+                "get_issue_project_item_status",
+                return_value=("project-item", forge_metadata.STATUS_TODO),
+        ), patch.dict(os.environ, {"FORGE_VERBOSE": "1"}), \
+                patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            forge_metadata.get_project_item_state(1412)
+
         self.assertIn(
             (
                 "[project-item] Issue #1412 is linked to GitHub project item project-item "
@@ -3542,7 +3566,9 @@ class IssueClaimLockTests(unittest.TestCase):
                     patch.object(forge_metadata, "set_issue_assignee") as set_issue_assignee, \
                     patch.object(forge_metadata, "set_item_status") as set_item_status, \
                     patch.object(forge_metadata.random, "uniform", return_value=0), \
-                    patch.object(forge_metadata.time, "sleep"):
+                    patch.object(forge_metadata.time, "sleep"), \
+                    patch.dict(os.environ, {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"}), \
+                    patch("sys.stdout", new_callable=io.StringIO) as stdout:
                 self.assertEqual(
                     forge_metadata.try_claim_issue(issue, "automation-user"),
                     "project-item",
@@ -3550,6 +3576,9 @@ class IssueClaimLockTests(unittest.TestCase):
 
         set_issue_assignee.assert_called_once_with(1412, "automation-user")
         set_item_status.assert_called_once_with("project-item", forge_metadata.STATUS_IN_PROGRESS)
+        self.assertIn("[claim] Issue #1412 claimed (3/6)", stdout.getvalue())
+        self.assertNotIn("Setting issue #1412 assignee", stdout.getvalue())
+        self.assertNotIn("Waiting", stdout.getvalue())
 
     def test_try_claim_issue_skips_chunked_dynamic_access_when_in_progress(self) -> None:
         issue = _search_issue(1412, [forge_metadata.LABEL_CHUNKED_DYNAMIC_ACCESS])

--- a/forge/tests/test_host_requirements.py
+++ b/forge/tests/test_host_requirements.py
@@ -57,6 +57,11 @@ def _graalvm_home(native_image: bool = True, schema: bool = True) -> Iterator[st
 
 
 class HostRequirementsTests(unittest.TestCase):
+    def test_host_cli_accepts_verbose_output(self) -> None:
+        args = parse_args(["--forge-dir", "/repo/forge", "--verbose"])
+
+        self.assertTrue(args.verbose)
+
     def test_invalid_queue_limit_prints_one_actionable_fix(self) -> None:
         stdout = io.StringIO()
         stderr = io.StringIO()
@@ -683,6 +688,36 @@ class HostRequirementsTests(unittest.TestCase):
         self.assertIn("No work was started", stdout.getvalue())
         self.assertEqual("", stderr.getvalue())
 
+    def test_successful_host_report_is_quiet_unless_verbose(self) -> None:
+        def run_host(verbose: bool) -> str:
+            host_requirements = HostRequirements(
+                "/repo/forge",
+                "python3",
+                {},
+                requirements=QueueRequirements(
+                    issue_work=False,
+                    review_work=False,
+                    github_work=False,
+                ),
+            )
+            stdout = io.StringIO()
+            with patch.object(host_requirements, "_check_tools"), \
+                    patch.object(host_requirements, "_check_environment"), \
+                    patch.object(host_requirements, "_check_write_permissions"), \
+                    patch.object(host_requirements, "_check_network"), \
+                    patch.object(host_requirements, "_check_github"), \
+                    patch.object(host_requirements, "_check_selected_agents"), \
+                    patch.object(host_requirements, "_check_docker"), \
+                    redirect_stdout(stdout):
+                self.assertTrue(host_requirements.run(verbose=verbose))
+            return stdout.getvalue()
+
+        self.assertEqual("", run_host(verbose=False))
+        verbose_output = run_host(verbose=True)
+        self.assertIn("[forge-host] Deterministic host requirements", verbose_output)
+        self.assertIn("[forge-host] Check results:", verbose_output)
+        self.assertIn("PASS: all required host checks succeeded", verbose_output)
+
     @patch("utility_scripts.host_requirements.resolve_executable", return_value="/usr/bin/docker")
     @patch("utility_scripts.host_requirements.run_command")
     def test_docker_daemon_check_does_not_require_docker_specific_template_fields(
@@ -887,6 +922,7 @@ class HostRequirementsTests(unittest.TestCase):
 
                 environment = dict(os.environ)
                 environment.pop("FORGE_TAKE_BLOCKED_ISSUES", None)
+                environment.pop("FORGE_VERBOSE", None)
                 environment.update({
                     "PYTHON_BIN": fake_python,
                     "PATH": f"{temp_dir}{os.pathsep}{environment['PATH']}",
@@ -918,6 +954,8 @@ class HostRequirementsTests(unittest.TestCase):
         self.assertNotIn("--take-blocked-issues", run_worker([]))
         self.assertIn("--take-blocked-issues", run_worker(["--take-blocked-issues"]))
         self.assertIn("--take-blocked-issues", run_worker([], "1"))
+        self.assertNotIn("--verbose", run_worker([]))
+        self.assertIn("--verbose", run_worker(["--verbose"]))
 
     def test_worker_propagates_the_analysis_role_selection(self) -> None:
         worker_path = Path(__file__).resolve().parents[1] / "do_up_to_date_work.sh"

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -8,9 +8,21 @@ import os
 import subprocess
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
-from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.library_finalization import (
+    _run_finalization_agent_fix,
+    run_library_finalization,
+)
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION,
+    STEP_AGENT_FIX,
+    STEP_FINALIZE_RUN,
+    failed_run_location,
+    reset_run_location,
+    run_step,
+)
 
 
 def _git(repo_path: str, *args: str) -> str:
@@ -32,6 +44,68 @@ def _commit_all(repo_path: str, message: str) -> str:
 
 
 class LibraryFinalizationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
+    def test_concise_metadata_repair_uses_agent_fix_step(self) -> None:
+        output = io.StringIO()
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), redirect_stdout(output):
+            with run_step(
+                    PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    operand="g:a:1.0",
+            ):
+                result = _run_finalization_agent_fix(
+                    "g:a:1.0",
+                    "metadata validation",
+                    1,
+                    3,
+                    lambda: True,
+                )
+
+        self.assertTrue(result)
+        printed = output.getvalue()
+        self.assertIn(
+            "[finalization] Running agent fix for metadata validation on g:a:1.0 "
+            "(attempt 1/3) (2/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization] Agent fix completed for metadata validation on g:a:1.0 "
+            "(attempt 1/3) (2/2)",
+            printed,
+        )
+
+    def test_last_failed_metadata_repair_records_agent_fix_location(self) -> None:
+        output = io.StringIO()
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), redirect_stdout(output):
+            with run_step(
+                    PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    operand="g:a:1.0",
+            ):
+                result = _run_finalization_agent_fix(
+                    "g:a:1.0",
+                    "metadata validation",
+                    3,
+                    3,
+                    lambda: False,
+                )
+
+        self.assertFalse(result)
+        location = failed_run_location()
+        self.assertIsNotNone(location)
+        self.assertEqual(location.step, STEP_AGENT_FIX)
+
     def test_rejects_legacy_test_resource_native_image_config_after_split(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path:
             _git(repo_path, "init")

--- a/forge/tests/test_library_update_alias_split.py
+++ b/forge/tests/test_library_update_alias_split.py
@@ -55,7 +55,7 @@ class LibraryUpdateAliasSplitTests(unittest.TestCase):
                 return_value=gradle_environment,
             ),
             patch(
-                "utility_scripts.library_update_alias_split.subprocess.run",
+                "utility_scripts.library_update_alias_split.run_logged_command",
                 side_effect=record_stats_generation,
             ) as run_command,
         ):
@@ -80,8 +80,11 @@ class LibraryUpdateAliasSplitTests(unittest.TestCase):
                 f"-Pcoordinates={successor_coordinates}",
             ],
             cwd="/repo",
+            task_type="library-update-alias-split",
+            subject=successor_coordinates,
+            action="generateLibraryStats",
             env=gradle_environment,
-            check=True,
+            stage="generate-library-stats",
         )
 
 

--- a/forge/tests/test_library_update_target.py
+++ b/forge/tests/test_library_update_target.py
@@ -724,10 +724,11 @@ class LibraryUpdateTargetTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as repo:
             _write_index(repo, [])
 
-            def fail_scaffold(command, **kwargs):  # type: ignore[no-untyped-def]
-                raise subprocess.CalledProcessError(17, command)
-
-            with patch("ai_workflows.drivers.improve_library_coverage.subprocess.run", side_effect=fail_scaffold):
+            failed_result = subprocess.CompletedProcess(["./gradlew"], 17)
+            with patch(
+                    "ai_workflows.drivers.improve_library_coverage.run_logged_command",
+                    return_value=failed_result,
+            ):
                 with self.assertRaisesRegex(
                         RuntimeError,
                         "Failed to scaffold library-update target org.example:demo:9.9.9",

--- a/forge/tests/test_logged_command.py
+++ b/forge/tests/test_logged_command.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 
 from ai_workflows.drivers import add_new_library_support, fix_ni_run, java_fail_workflow
 from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
+from utility_scripts.continuation_marker import PHASE_SETUP
+from utility_scripts.run_location import enter_phase, reset_run_location
 
 
 class LoggedCommandTests(unittest.TestCase):
@@ -17,6 +19,9 @@ class LoggedCommandTests(unittest.TestCase):
 
     §FS-forge-run-output-legibility.4 §FS-durable-generation-logs
     """
+
+    def tearDown(self) -> None:
+        reset_run_location()
 
     def test_success_keeps_command_output_out_of_terminal_and_in_log(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -68,6 +73,83 @@ class LoggedCommandTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("live debug output", terminal.getvalue())
         self.assertIn("live debug output", durable_output)
+
+    def test_compact_setup_hides_success_but_keeps_failure_and_log(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "command.log")
+            terminal = io.StringIO()
+            enter_phase(PHASE_SETUP)
+            with patch(
+                    "utility_scripts.logged_command.build_timestamped_task_log_path",
+                    return_value=log_path,
+            ), contextlib.redirect_stdout(terminal):
+                result = run_logged_command(
+                    [sys.executable, "-c", "raise SystemExit(7)"],
+                    cwd=temp_dir,
+                    task_type="setup-test",
+                    subject="org.example:demo:1.0.0",
+                    action="failingSetup",
+                )
+
+        self.assertEqual(result.returncode, 7)
+        self.assertNotIn("Running failingSetup", terminal.getvalue())
+        self.assertIn("failingSetup failed with exit code 7", terminal.getvalue())
+        self.assertIn("command.log", terminal.getvalue())
+
+    def test_compact_setup_hides_a_failure_the_caller_handles(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "command.log")
+            terminal = io.StringIO()
+            enter_phase(PHASE_SETUP)
+            with patch(
+                    "utility_scripts.logged_command.build_timestamped_task_log_path",
+                    return_value=log_path,
+            ), contextlib.redirect_stdout(terminal):
+                result = run_logged_command(
+                    [sys.executable, "-c", "raise SystemExit(1)"],
+                    cwd=temp_dir,
+                    task_type="setup-test",
+                    subject="org.example:demo:1.0.0",
+                    action="handledSetup",
+                    failure_is_detail=True,
+                )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual("", terminal.getvalue())
+
+    def test_scaffold_only_reports_unhandled_failure_in_compact_setup(self) -> None:
+        already_exists = LoggedCommandResult(
+            args=["./gradlew"],
+            returncode=1,
+            stdout="metadata already exists. Use --force to overwrite existing metadata",
+            log_path="/tmp/scaffold.log",
+            timed_out=False,
+            duration_seconds=1.0,
+        )
+        terminal = io.StringIO()
+        enter_phase(PHASE_SETUP)
+        with patch.object(add_new_library_support, "require_complete_reachability_repo"), \
+                patch.object(add_new_library_support, "run_logged_command", return_value=already_exists), \
+                contextlib.redirect_stdout(terminal):
+            self.assertFalse(add_new_library_support.run_scaffold("g:a:1.0"))
+        self.assertEqual("", terminal.getvalue())
+
+        failed = LoggedCommandResult(
+            args=["./gradlew"],
+            returncode=1,
+            stdout="unexpected scaffold failure",
+            log_path="/tmp/scaffold.log",
+            timed_out=False,
+            duration_seconds=1.0,
+        )
+        terminal = io.StringIO()
+        with patch.object(add_new_library_support, "require_complete_reachability_repo"), \
+                patch.object(add_new_library_support, "run_logged_command", return_value=failed), \
+                contextlib.redirect_stdout(terminal), \
+                self.assertRaises(add_new_library_support.ScaffoldError):
+            add_new_library_support.run_scaffold("g:a:1.0")
+        self.assertIn("scaffold failed with exit code 1", terminal.getvalue())
+        self.assertIn("scaffold.log", terminal.getvalue())
 
     def test_remaining_driver_gradle_commands_use_durable_logging(self) -> None:
         successful_result = LoggedCommandResult(

--- a/forge/tests/test_logged_command.py
+++ b/forge/tests/test_logged_command.py
@@ -8,7 +8,8 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from utility_scripts.logged_command import run_logged_command
+from ai_workflows.drivers import add_new_library_support, fix_ni_run, java_fail_workflow
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 
 
 class LoggedCommandTests(unittest.TestCase):
@@ -67,6 +68,74 @@ class LoggedCommandTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("live debug output", terminal.getvalue())
         self.assertIn("live debug output", durable_output)
+
+    def test_remaining_driver_gradle_commands_use_durable_logging(self) -> None:
+        successful_result = LoggedCommandResult(
+            args=["./gradlew"],
+            returncode=0,
+            stdout="",
+            log_path="/tmp/gradle.log",
+            timed_out=False,
+            duration_seconds=0.0,
+        )
+        with patch.object(
+                add_new_library_support,
+                "require_complete_reachability_repo",
+        ), patch.object(
+                add_new_library_support,
+                "gradle_command_environment",
+                return_value={},
+        ), patch.object(
+                add_new_library_support,
+                "run_logged_command",
+                return_value=successful_result,
+        ) as new_library_command, patch.object(
+                add_new_library_support.os,
+                "getcwd",
+                return_value="/repo",
+        ):
+            self.assertTrue(add_new_library_support.run_scaffold("g:a:1.0"))
+
+        self.assertEqual(new_library_command.call_args.kwargs["task_type"], "scaffold")
+        self.assertEqual(new_library_command.call_args.kwargs["subject"], "g:a:1.0")
+
+        with patch.object(
+                fix_ni_run,
+                "require_complete_reachability_repo",
+        ), patch.object(
+                fix_ni_run,
+                "gradle_command_environment",
+                return_value={},
+        ), patch.object(
+                fix_ni_run,
+                "run_logged_command",
+                return_value=successful_result,
+        ) as native_fix_command:
+            fix_ni_run.run_fix_test_native_image_run("/repo", "g:a:1.0", "2.0")
+
+        self.assertEqual(native_fix_command.call_args.kwargs["task_type"], "native-image-run-fix")
+        self.assertEqual(native_fix_command.call_args.kwargs["subject"], "g:a:2.0")
+
+        with patch.object(
+                java_fail_workflow,
+                "require_complete_reachability_repo",
+        ), patch.object(
+                java_fail_workflow,
+                "gradle_command_environment",
+                return_value={},
+        ), patch.object(
+                java_fail_workflow,
+                "run_logged_command",
+                return_value=successful_result,
+        ) as java_fail_command, patch.object(
+                java_fail_workflow.os,
+                "getcwd",
+                return_value="/repo",
+        ):
+            java_fail_workflow.run_gradle_task("addLibraryMetadataIndexJson", "g:a:2.0")
+
+        self.assertEqual(java_fail_command.call_args.kwargs["task_type"], "java-fail-setup")
+        self.assertEqual(java_fail_command.call_args.kwargs["subject"], "g:a:2.0")
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_logged_command.py
+++ b/forge/tests/test_logged_command.py
@@ -1,0 +1,73 @@
+# Copyright and related rights waived via CC0
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from utility_scripts.logged_command import run_logged_command
+
+
+class LoggedCommandTests(unittest.TestCase):
+    """Concise command output backed by complete durable logs.
+
+    §FS-forge-run-output-legibility.4 §FS-durable-generation-logs
+    """
+
+    def test_success_keeps_command_output_out_of_terminal_and_in_log(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "command.log")
+            terminal = io.StringIO()
+            with patch(
+                    "utility_scripts.logged_command.build_timestamped_task_log_path",
+                    return_value=log_path,
+            ), contextlib.redirect_stdout(terminal):
+                result = run_logged_command(
+                    [sys.executable, "-c", "print('private command output')"],
+                    cwd=temp_dir,
+                    task_type="test",
+                    subject="org.example:demo:1.0.0",
+                    action="exampleTask",
+                )
+
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                durable_output = log_file.read()
+
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("private command output", terminal.getvalue())
+        self.assertIn("Running exampleTask", terminal.getvalue())
+        self.assertIn("exampleTask completed", terminal.getvalue())
+        self.assertIn("private command output", durable_output)
+
+    def test_debug_mode_tees_raw_output_while_preserving_log(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "command.log")
+            terminal = io.StringIO()
+            with patch(
+                    "utility_scripts.logged_command.build_timestamped_task_log_path",
+                    return_value=log_path,
+            ), patch.dict(
+                    os.environ,
+                    {"FORGE_DEBUG_LOGGING": "1"},
+            ), contextlib.redirect_stdout(terminal):
+                result = run_logged_command(
+                    [sys.executable, "-c", "print('live debug output')"],
+                    cwd=temp_dir,
+                    task_type="test",
+                    subject="org.example:demo:1.0.0",
+                    action="exampleTask",
+                )
+
+            with open(log_path, "r", encoding="utf-8") as log_file:
+                durable_output = log_file.read()
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("live debug output", terminal.getvalue())
+        self.assertIn("live debug output", durable_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -29,6 +29,12 @@ _FORGE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_FORGE_ROOT))
 
 from utility_scripts import native_test_verification as ntv  # noqa: E402
+from utility_scripts.run_location import (  # noqa: E402
+    PHASE_EXPLORE,
+    STEP_NATIVE_TRACE_GATE,
+    reset_run_location,
+    run_step,
+)
 
 
 class ParseBinaryExitCodeTests(unittest.TestCase):
@@ -417,6 +423,11 @@ class MetadataAggregationTests(unittest.TestCase):
 class PrintCollectedMetadataTests(unittest.TestCase):
     """Readable logging of per-cycle trace metadata."""
 
+    def setUp(self) -> None:
+        verbose = patch.dict(os.environ, {"FORGE_VERBOSE": "1"})
+        verbose.start()
+        self.addCleanup(verbose.stop)
+
     def test_prints_metadata_summary_without_json_contents(self) -> None:
         run_dir = tempfile.mkdtemp(prefix="trace-run-")
         self.addCleanup(_rmtree, run_dir)
@@ -467,6 +478,11 @@ class GateRoutingTests(unittest.TestCase):
     """
 
     def setUp(self) -> None:
+        verbose = patch.dict(os.environ, {"FORGE_VERBOSE": "1"})
+        verbose.start()
+        self.addCleanup(verbose.stop)
+        reset_run_location()
+        self.addCleanup(reset_run_location)
         self.repo = tempfile.mkdtemp(prefix="repo-")
         self.addCleanup(_rmtree, self.repo)
         _make_complete_reachability_repo(self.repo)
@@ -1134,6 +1150,76 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(len([call for call in calls if "runNativeTraceImage" in call]), 1)
         self.assertEqual(len(result.intervention_records), 1)
         self.assertEqual(result.intervention_records[0].kind, "codex")
+
+    def test_concise_output_names_the_native_trace_agent_fix(self) -> None:
+        fake, _calls = self._fake_run_factory([1])
+        output = io.StringIO()
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), patch(
+                "utility_scripts.native_test_verification.subprocess.run",
+                side_effect=fake,
+        ), patch(
+                "utility_scripts.native_test_verification.run_native_test_fix",
+                return_value=(0, "/tmp/codex.log", False, None),
+        ), redirect_stdout(output):
+            with run_step(
+                    PHASE_EXPLORE,
+                    STEP_NATIVE_TRACE_GATE,
+                    operand="g:a:1.0",
+            ):
+                result = ntv.verify_native_test_passes(
+                    reachability_repo_path=self.repo,
+                    coordinate="g:a:1.0",
+                    output_dir=self.output_dir,
+                    max_iterations=5,
+                )
+
+        self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
+        printed = output.getvalue()
+        self.assertIn(
+            "[explore] Running native-trace agent fix for g:a:1.0:",
+            printed,
+        )
+        self.assertIn(
+            "[explore] Native-trace agent fix completed for g:a:1.0 (3/3)",
+            printed,
+        )
+        self.assertNotIn("[native-test-verify]", printed)
+        self.assertNotIn("./gradlew", printed)
+
+    def test_concise_agent_fix_failure_keeps_error_and_log(self) -> None:
+        fake, _calls = self._fake_run_factory([1])
+        output = io.StringIO()
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), patch(
+                "utility_scripts.native_test_verification.subprocess.run",
+                side_effect=fake,
+        ), patch(
+                "utility_scripts.native_test_verification.run_native_test_fix",
+                return_value=(2, "/tmp/codex.log", False, "Agent repair failed"),
+        ), redirect_stdout(output):
+            with run_step(
+                    PHASE_EXPLORE,
+                    STEP_NATIVE_TRACE_GATE,
+                    operand="g:a:1.0",
+            ):
+                result = ntv.verify_native_test_passes(
+                    reachability_repo_path=self.repo,
+                    coordinate="g:a:1.0",
+                    output_dir=self.output_dir,
+                    max_iterations=5,
+                )
+
+        self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertIn(
+            "[explore] Native-trace agent fix failed for g:a:1.0: "
+            "Agent repair failed (log: ../../codex.log) (3/3)",
+            output.getvalue(),
+        )
 
     def test_routes_to_codex_with_same_graalvm_home_as_gate_commands(self) -> None:
         graalvm_home = tempfile.mkdtemp(prefix="gate-graalvm-")

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -147,7 +147,7 @@ class NativeTestFixPromptTests(unittest.TestCase):
 
     def test_runs_the_central_analysis_agent_without_overrides(self) -> None:
         environment = {"FORGE_ANALYSIS_AGENT": "pi"}
-        agent_result = Mock(return_code=0, log_path="/tmp/analysis.log", timed_out=False)
+        agent_result = Mock(return_code=0, log_path="/tmp/analysis.log", timed_out=False, failure_message=None)
 
         with patch(
                 "utility_scripts.native_test_verification.analysis_agent_run",
@@ -160,7 +160,7 @@ class NativeTestFixPromptTests(unittest.TestCase):
                 env=environment,
             )
 
-        self.assertEqual(result, (0, "/tmp/analysis.log", False))
+        self.assertEqual(result, (0, "/tmp/analysis.log", False, None))
         call_kwargs = analysis_run.call_args.kwargs
         self.assertEqual(call_kwargs["environment"], environment)
         self.assertNotIn("model", call_kwargs)
@@ -663,7 +663,7 @@ class GateRoutingTests(unittest.TestCase):
         )
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -752,7 +752,7 @@ class GateRoutingTests(unittest.TestCase):
                 side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -878,7 +878,7 @@ class GateRoutingTests(unittest.TestCase):
             side_effect=merge_fails,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -907,7 +907,7 @@ class GateRoutingTests(unittest.TestCase):
             side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -953,7 +953,7 @@ class GateRoutingTests(unittest.TestCase):
             side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1005,7 +1005,7 @@ class GateRoutingTests(unittest.TestCase):
             side_effect=_fake_run,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ), redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1029,7 +1029,7 @@ class GateRoutingTests(unittest.TestCase):
         fake, _calls = self._fake_run_factory([172, 172])
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1059,7 +1059,7 @@ class GateRoutingTests(unittest.TestCase):
         output = io.StringIO()
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock, redirect_stdout(output):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1085,7 +1085,7 @@ class GateRoutingTests(unittest.TestCase):
         fake, calls = self._fake_run_factory([1], generate_metadata_rc=1)
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1101,7 +1101,7 @@ class GateRoutingTests(unittest.TestCase):
         fake, calls = self._fake_run_factory([], test_rc=1, test_failed_task="compileTestJava")
         with patch("utility_scripts.native_test_verification.subprocess.run", side_effect=fake), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1120,7 +1120,7 @@ class GateRoutingTests(unittest.TestCase):
                 side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as analysis_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1146,7 +1146,7 @@ class GateRoutingTests(unittest.TestCase):
                 side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(0, "/tmp/codex.log", False),
+            return_value=(0, "/tmp/codex.log", False, None),
         ) as codex_mock:
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1167,7 +1167,7 @@ class GateRoutingTests(unittest.TestCase):
                 side_effect=fake,
         ), patch(
             "utility_scripts.native_test_verification.run_native_test_fix",
-            return_value=(2, "/tmp/codex.log", False),
+            return_value=(2, "/tmp/codex.log", False, "Agent repair failed"),
         ):
             result = ntv.verify_native_test_passes(
                 reachability_repo_path=self.repo,
@@ -1176,6 +1176,8 @@ class GateRoutingTests(unittest.TestCase):
                 max_iterations=5,
             )
         self.assertEqual(result.status, ntv.STATUS_FAILED)
+        self.assertEqual(result.failure_detail, "Agent repair failed")
+        self.assertEqual(result.failure_log_path, "/tmp/codex.log")
 
 def _command_property(command: str, property_name: str) -> str:
     prefix = f"{property_name}="

--- a/forge/tests/test_native_test_verification.py
+++ b/forge/tests/test_native_test_verification.py
@@ -96,7 +96,7 @@ class ReadExitFileTests(unittest.TestCase):
 class FailureLogTailTests(unittest.TestCase):
     """Native failure diagnostics print the tail of the Gradle log."""
 
-    def test_extracts_last_300_lines(self) -> None:
+    def test_extracts_last_20_lines(self) -> None:
         fd, path = tempfile.mkstemp(suffix=".log")
         os.close(fd)
         self.addCleanup(os.unlink, path)
@@ -107,8 +107,8 @@ class FailureLogTailTests(unittest.TestCase):
 
         excerpt = ntv._extract_failure_log_tail(path)
 
-        self.assertNotIn("line-49", excerpt)
-        self.assertIn("line-50", excerpt)
+        self.assertNotIn("line-329", excerpt)
+        self.assertIn("line-330", excerpt)
         self.assertIn("line-349", excerpt)
 
 
@@ -417,7 +417,7 @@ class MetadataAggregationTests(unittest.TestCase):
 class PrintCollectedMetadataTests(unittest.TestCase):
     """Readable logging of per-cycle trace metadata."""
 
-    def test_prints_pretty_json_metadata(self) -> None:
+    def test_prints_metadata_summary_without_json_contents(self) -> None:
         run_dir = tempfile.mkdtemp(prefix="trace-run-")
         self.addCleanup(_rmtree, run_dir)
         metadata_file = Path(run_dir) / "reachability-metadata.json"
@@ -432,8 +432,8 @@ class PrintCollectedMetadataTests(unittest.TestCase):
 
         printed = output.getvalue()
         self.assertIn("cycle 2: collected metadata from 1 file(s)", printed)
-        self.assertIn("reachability-metadata.json:", printed)
-        self.assertIn('"type": "com.example.Foo"', printed)
+        self.assertNotIn("reachability-metadata.json:", printed)
+        self.assertNotIn('"type": "com.example.Foo"', printed)
 
     def test_prints_none_for_empty_trace_dir(self) -> None:
         run_dir = tempfile.mkdtemp(prefix="trace-run-")
@@ -1016,12 +1016,13 @@ class GateRoutingTests(unittest.TestCase):
         self.assertEqual(result.status, ntv.STATUS_PASSED_WITH_INTERVENTION)
         self.assertEqual(result.iterations_used, 1)
         printed = output.getvalue()
-        self.assertIn("reachability-metadata.json:", printed)
-        self.assertIn("{}", printed)
+        self.assertIn("collected metadata from 1 file(s)", printed)
+        self.assertNotIn("reachability-metadata.json:", printed)
+        self.assertNotIn("{}", printed)
         self.assertIn("produced no usable trace metadata", printed)
-        self.assertIn("failure log tail (last 300 lines)", printed)
-        self.assertNotIn("native log line 5\n", printed)
-        self.assertIn("native log line 6\n", printed)
+        self.assertIn("failure log tail (last 20 lines)", printed)
+        self.assertNotIn("native log line 285\n", printed)
+        self.assertIn("native log line 286\n", printed)
         self.assertIn("MissingResourceRegistrationError: missing resource", printed)
 
     def test_routes_to_codex_when_budget_exhausted_with_only_172(self) -> None:

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -7,6 +7,7 @@ import contextlib
 import io
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from utility_scripts import run_location
 from utility_scripts.continuation_marker import (
@@ -32,6 +33,7 @@ from utility_scripts.run_location import (
     bind_run_context,
     clear_recorded_failure,
     format_run_failure_line,
+    log_step_progress,
     marker_failure_location,
     pipeline_step,
     record_step_failure,
@@ -95,6 +97,40 @@ class ProgressOutputTests(unittest.TestCase):
             f"Running step {STEP_NATIVE_TRACE_GATE} ({position}/{total}) of phase {PHASE_EXPLORE} on com.acme.Thing",
             stdout,
         )
+
+    def test_compact_claim_progress_keeps_the_derived_step_count(self) -> None:
+        def enter() -> None:
+            with run_step(PHASE_CLAIM, STEP_CHECK_HOST_REQUIREMENTS):
+                log_step_progress(
+                    PHASE_CLAIM,
+                    STEP_CHECK_HOST_REQUIREMENTS,
+                    "Checking host requirements",
+                )
+
+        with patch.dict(
+                "os.environ",
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ):
+            stdout, _ = _captured(enter)
+
+        position, total = step_position(PHASE_CLAIM, STEP_CHECK_HOST_REQUIREMENTS)
+        self.assertIn(f"[claim] Checking host requirements ({position}/{total})", stdout)
+        self.assertNotIn(f"Running step {STEP_CHECK_HOST_REQUIREMENTS}", stdout)
+
+    def test_verbose_claim_progress_restores_the_registered_step_line(self) -> None:
+        def enter() -> None:
+            with run_step(PHASE_CLAIM, STEP_CHECK_HOST_REQUIREMENTS):
+                log_step_progress(
+                    PHASE_CLAIM,
+                    STEP_CHECK_HOST_REQUIREMENTS,
+                    "Checking host requirements",
+                )
+
+        with patch.dict("os.environ", {"FORGE_VERBOSE": "1"}):
+            stdout, _ = _captured(enter)
+
+        self.assertIn(f"Running step {STEP_CHECK_HOST_REQUIREMENTS}", stdout)
+        self.assertIn("[claim] Checking host requirements", stdout)
 
     def test_phase_banner_prints_once_per_transition(self) -> None:
         bind_run_context("issue #1412 org.example:demo:1.0.0")

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -44,7 +44,7 @@ from utility_scripts.run_location import (
     run_step,
     step_position,
 )
-from utility_scripts.stage_logger import log_detail
+from utility_scripts.stage_logger import log_detail, log_plain_detail
 
 
 def _captured(callable_under_test):
@@ -144,6 +144,7 @@ class ProgressOutputTests(unittest.TestCase):
                     "Scaffolding org.example:lib:1.0.0",
                 )
                 log_detail("scaffold", "internal setup narration")
+                log_plain_detail("plain setup narration")
 
         with patch.dict(
                 "os.environ",
@@ -155,6 +156,7 @@ class ProgressOutputTests(unittest.TestCase):
         self.assertIn(f"[setup] Scaffolding org.example:lib:1.0.0 ({position}/{total})", stdout)
         self.assertNotIn(f"Running step {STEP_NORMAL_SETUP}", stdout)
         self.assertNotIn("internal setup narration", stdout)
+        self.assertNotIn("plain setup narration", stdout)
 
     def test_verbose_setup_restores_detail_and_registered_step(self) -> None:
         def enter() -> None:
@@ -165,21 +167,27 @@ class ProgressOutputTests(unittest.TestCase):
                     "Scaffolding org.example:lib:1.0.0",
                 )
                 log_detail("scaffold", "internal setup narration")
+                log_plain_detail("plain setup narration")
 
         with patch.dict("os.environ", {"FORGE_VERBOSE": "1"}):
             stdout, _ = _captured(enter)
 
         self.assertIn(f"Running step {STEP_NORMAL_SETUP}", stdout)
         self.assertIn("internal setup narration", stdout)
+        self.assertIn("plain setup narration", stdout)
+        self.assertNotIn("[] plain setup narration", stdout)
 
-    def test_entering_finalization_restores_normal_detail_after_compact_phases(self) -> None:
+    def test_finalization_is_compact_and_publication_restores_detail(self) -> None:
         def transition() -> None:
             run_location.enter_phase(PHASE_SETUP)
             log_detail("setup-detail", "hidden setup detail")
             run_location.enter_phase(PHASE_EXPLORE)
             log_detail("explore-detail", "hidden explore detail")
             run_location.enter_phase(PHASE_FINALIZATION)
-            log_detail("finalization-detail", "visible finalization detail")
+            log_detail("finalization-detail", "hidden finalization detail")
+            log_plain_detail("hidden plain finalization detail")
+            run_location.enter_phase(PHASE_PUBLICATION)
+            log_detail("publication-detail", "visible publication detail")
 
         with patch.dict(
                 "os.environ",
@@ -189,7 +197,9 @@ class ProgressOutputTests(unittest.TestCase):
 
         self.assertNotIn("hidden setup detail", stdout)
         self.assertNotIn("hidden explore detail", stdout)
-        self.assertIn("visible finalization detail", stdout)
+        self.assertNotIn("hidden finalization detail", stdout)
+        self.assertNotIn("hidden plain finalization detail", stdout)
+        self.assertIn("visible publication detail", stdout)
 
     def test_phase_banner_prints_once_per_transition(self) -> None:
         bind_run_context("issue #1412 org.example:demo:1.0.0")

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -88,12 +88,13 @@ class ProgressOutputTests(unittest.TestCase):
     def tearDown(self) -> None:
         reset_run_location()
 
-    def test_step_entry_prints_the_running_step_line(self) -> None:
+    def test_verbose_explore_prints_the_registered_step_line(self) -> None:
         def enter() -> None:
             with run_step(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE, operand="com.acme.Thing"):
                 pass
 
-        stdout, _ = _captured(enter)
+        with patch.dict("os.environ", {"FORGE_VERBOSE": "1"}):
+            stdout, _ = _captured(enter)
         position, total = step_position(PHASE_EXPLORE, STEP_NATIVE_TRACE_GATE)
         self.assertIn(
             f"Running step {STEP_NATIVE_TRACE_GATE} ({position}/{total}) of phase {PHASE_EXPLORE} on com.acme.Thing",
@@ -171,12 +172,14 @@ class ProgressOutputTests(unittest.TestCase):
         self.assertIn(f"Running step {STEP_NORMAL_SETUP}", stdout)
         self.assertIn("internal setup narration", stdout)
 
-    def test_entering_explore_restores_normal_detail_after_setup(self) -> None:
+    def test_entering_finalization_restores_normal_detail_after_compact_phases(self) -> None:
         def transition() -> None:
             run_location.enter_phase(PHASE_SETUP)
             log_detail("setup-detail", "hidden setup detail")
             run_location.enter_phase(PHASE_EXPLORE)
-            log_detail("explore-detail", "visible explore detail")
+            log_detail("explore-detail", "hidden explore detail")
+            run_location.enter_phase(PHASE_FINALIZATION)
+            log_detail("finalization-detail", "visible finalization detail")
 
         with patch.dict(
                 "os.environ",
@@ -185,7 +188,8 @@ class ProgressOutputTests(unittest.TestCase):
             stdout, _ = _captured(transition)
 
         self.assertNotIn("hidden setup detail", stdout)
-        self.assertIn("visible explore detail", stdout)
+        self.assertNotIn("hidden explore detail", stdout)
+        self.assertIn("visible finalization detail", stdout)
 
     def test_phase_banner_prints_once_per_transition(self) -> None:
         bind_run_context("issue #1412 org.example:demo:1.0.0")

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -131,7 +131,10 @@ class FailureLocationTests(unittest.TestCase):
         _, stderr = _captured(fail)
         lines = [line for line in stderr.splitlines() if line]
         self.assertEqual(lines[0], "run failed in explore/generate_tests()[com.acme.Thing]")
-        self.assertEqual(lines[1], "ERROR: boom")
+        self.assertEqual(lines[1], "Phase failed: explore")
+        self.assertEqual(lines[2], "Step failed: generate_tests()")
+        self.assertEqual(lines[3], "Class: com.acme.Thing")
+        self.assertEqual(lines[4], "Error: boom")
 
     def test_innermost_step_wins_and_survives_an_intermediate_handler(self) -> None:
         def fail() -> None:

--- a/forge/tests/test_run_location.py
+++ b/forge/tests/test_run_location.py
@@ -23,6 +23,7 @@ from utility_scripts.run_location import (
     PHASE_SETUP,
     STEP_CHECK_HOST_REQUIREMENTS,
     STEP_GENERATE_TESTS,
+    STEP_NORMAL_SETUP,
     STEP_NATIVE_TRACE_GATE,
     STEP_PUBLISH_BRANCH,
     UNLOCATED_FAILURE_DEFECT,
@@ -43,6 +44,7 @@ from utility_scripts.run_location import (
     run_step,
     step_position,
 )
+from utility_scripts.stage_logger import log_detail
 
 
 def _captured(callable_under_test):
@@ -131,6 +133,59 @@ class ProgressOutputTests(unittest.TestCase):
 
         self.assertIn(f"Running step {STEP_CHECK_HOST_REQUIREMENTS}", stdout)
         self.assertIn("[claim] Checking host requirements", stdout)
+
+    def test_compact_setup_hides_detail_but_keeps_state_and_count(self) -> None:
+        def enter() -> None:
+            with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand="org.example:lib:1.0.0"):
+                log_step_progress(
+                    PHASE_SETUP,
+                    STEP_NORMAL_SETUP,
+                    "Scaffolding org.example:lib:1.0.0",
+                )
+                log_detail("scaffold", "internal setup narration")
+
+        with patch.dict(
+                "os.environ",
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ):
+            stdout, _ = _captured(enter)
+
+        position, total = step_position(PHASE_SETUP, STEP_NORMAL_SETUP)
+        self.assertIn(f"[setup] Scaffolding org.example:lib:1.0.0 ({position}/{total})", stdout)
+        self.assertNotIn(f"Running step {STEP_NORMAL_SETUP}", stdout)
+        self.assertNotIn("internal setup narration", stdout)
+
+    def test_verbose_setup_restores_detail_and_registered_step(self) -> None:
+        def enter() -> None:
+            with run_step(PHASE_SETUP, STEP_NORMAL_SETUP, operand="org.example:lib:1.0.0"):
+                log_step_progress(
+                    PHASE_SETUP,
+                    STEP_NORMAL_SETUP,
+                    "Scaffolding org.example:lib:1.0.0",
+                )
+                log_detail("scaffold", "internal setup narration")
+
+        with patch.dict("os.environ", {"FORGE_VERBOSE": "1"}):
+            stdout, _ = _captured(enter)
+
+        self.assertIn(f"Running step {STEP_NORMAL_SETUP}", stdout)
+        self.assertIn("internal setup narration", stdout)
+
+    def test_entering_explore_restores_normal_detail_after_setup(self) -> None:
+        def transition() -> None:
+            run_location.enter_phase(PHASE_SETUP)
+            log_detail("setup-detail", "hidden setup detail")
+            run_location.enter_phase(PHASE_EXPLORE)
+            log_detail("explore-detail", "visible explore detail")
+
+        with patch.dict(
+                "os.environ",
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ):
+            stdout, _ = _captured(transition)
+
+        self.assertNotIn("hidden setup detail", stdout)
+        self.assertIn("visible explore detail", stdout)
 
     def test_phase_banner_prints_once_per_transition(self) -> None:
         bind_run_context("issue #1412 org.example:demo:1.0.0")

--- a/forge/tests/test_style_checks.py
+++ b/forge/tests/test_style_checks.py
@@ -3,19 +3,38 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import io
+import os
 import subprocess
 import unittest
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 from utility_scripts.style_checks import run_style_fix_and_checks
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION,
+    STEP_FINALIZE_RUN,
+    reset_run_location,
+    run_step,
+)
 
 
 class StyleChecksTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
     def test_checkstyle_failure_passes_after_first_analysis_repair(self) -> None:
         failed = subprocess.CompletedProcess([], 1, stdout="checkstyle failure")
         passed = subprocess.CompletedProcess([], 0, stdout="BUILD SUCCESSFUL")
+        output = io.StringIO()
 
-        with patch("utility_scripts.style_checks._run_gradle_task", return_value=True), \
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), patch("utility_scripts.style_checks._run_gradle_task", return_value=True), \
                 patch(
                     "utility_scripts.style_checks._run_checkstyle",
                     side_effect=[failed, passed],
@@ -25,13 +44,29 @@ class StyleChecksTests(unittest.TestCase):
                 ) as analysis_fix, patch(
                     "utility_scripts.style_checks._run_test",
                     return_value=passed,
-                ) as coordinate_test:
-            result = run_style_fix_and_checks("/repo", "g:a:1.0")
+                ) as coordinate_test, redirect_stdout(output):
+            with run_step(
+                    PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    operand="g:a:1.0",
+            ):
+                result = run_style_fix_and_checks("/repo", "g:a:1.0")
 
         self.assertTrue(result)
         analysis_fix.assert_called_once()
         self.assertEqual(checkstyle.call_count, 2)
         coordinate_test.assert_called_once()
+        printed = output.getvalue()
+        self.assertIn(
+            "[finalization] Running agent fix for Checkstyle on g:a:1.0 "
+            "(attempt 1/3) (2/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization] Agent fix completed for Checkstyle on g:a:1.0 "
+            "(attempt 1/3) (2/2)",
+            printed,
+        )
 
     def test_failed_checkstyle_reruns_use_all_three_repairs(self) -> None:
         failed = subprocess.CompletedProcess([], 1, stdout="still failing")

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from ai_workflows.agents.agent import AgentFailureError
 from ai_workflows.core.workflow_strategy import (
     RUN_STATUS_CHUNK_READY,
     RUN_STATUS_FAILURE,
@@ -17,6 +18,7 @@ from ai_workflows.core.workflow_strategy import (
     SUCCESS_WITH_INTERVENTION_STATUS,
     WorkflowStrategy,
 )
+from utility_scripts.native_test_verification import NativeTestVerificationResult
 
 
 class _TestWorkflowStrategy(WorkflowStrategy):
@@ -25,6 +27,33 @@ class _TestWorkflowStrategy(WorkflowStrategy):
 
 
 class WorkflowStrategyTests(unittest.TestCase):
+    def test_native_gate_agent_failure_reaches_terminal_reporter(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        strategy.library = "org.example:demo:1.0.0"
+        failed_result = NativeTestVerificationResult(
+            status="FAILED",
+            output_dir="/tmp/output",
+            iterations_used=1,
+            failure_detail="Agent native_test_verify() timed out after 30:00",
+            failure_log_path="/tmp/native-agent.log",
+        )
+
+        with patch(
+                "ai_workflows.core.workflow_strategy.verify_native_test_passes",
+                return_value=failed_result,
+        ), self.assertRaises(AgentFailureError) as raised:
+            strategy.verify_native_test_gate("/tmp/output")
+
+        self.assertEqual(
+            str(raised.exception),
+            "native-trace-gate agent failed with: Agent native_test_verify() timed out after 30:00",
+        )
+        self.assertEqual(raised.exception.log_path, "/tmp/native-agent.log")
+
     def test_post_generation_tests_run_latest_and_graalvm_25_current_defaults_lanes(self) -> None:
         strategy = _TestWorkflowStrategy(
             {"model": "test-model"},

--- a/forge/tests/test_workflow_strategy.py
+++ b/forge/tests/test_workflow_strategy.py
@@ -3,11 +3,13 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+import io
 import os
 import json
 import subprocess
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from unittest.mock import patch
 
 from ai_workflows.agents.agent import AgentFailureError
@@ -19,6 +21,13 @@ from ai_workflows.core.workflow_strategy import (
     WorkflowStrategy,
 )
 from utility_scripts.native_test_verification import NativeTestVerificationResult
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION,
+    STEP_FINALIZE_RUN,
+    enter_phase,
+    reset_run_location,
+    run_step,
+)
 
 
 class _TestWorkflowStrategy(WorkflowStrategy):
@@ -27,6 +36,12 @@ class _TestWorkflowStrategy(WorkflowStrategy):
 
 
 class WorkflowStrategyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_run_location()
+
+    def tearDown(self) -> None:
+        reset_run_location()
+
     def test_native_gate_agent_failure_reaches_terminal_reporter(self) -> None:
         strategy = _TestWorkflowStrategy(
             {"model": "test-model"},
@@ -90,6 +105,152 @@ class WorkflowStrategyTests(unittest.TestCase):
         self.assertEqual(commands[2][1]["GRAALVM_HOME"], "/dev/graalvm-25")
         self.assertEqual(commands[2][1]["JAVA_HOME"], "/dev/graalvm-25")
         self.assertNotIn("GVM_TCK_NATIVE_IMAGE_MODE", commands[2][1])
+
+    def test_concise_finalization_output_names_the_three_native_test_lanes(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        strategy._run_command_with_env = lambda *_args, **_kwargs: "BUILD SUCCESSFUL"
+        output = io.StringIO()
+
+        with patch.dict(
+                os.environ,
+                {
+                    "FORGE_VERBOSE": "0",
+                    "FORGE_DEBUG_LOGGING": "0",
+                    "GRAALVM_HOME": "/dev/graalvm",
+                    "JAVA_HOME": "/dev/graalvm",
+                    "GRAALVM_HOME_25_0": "/dev/graalvm-25",
+                },
+                clear=True,
+        ), redirect_stdout(output):
+            enter_phase(PHASE_FINALIZATION)
+            with run_step(
+                    PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    operand="org.example:demo:1.0.0",
+            ):
+                status = strategy._run_test_with_retry("org.example:demo:1.0.0")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        printed = output.getvalue()
+        self.assertIn(
+            "[finalization]   Running native-test lane 1/3 for "
+            "org.example:demo:1.0.0: latest GraalVM, current defaults (1/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization]   Running native-test lane 2/3 for "
+            "org.example:demo:1.0.0: latest GraalVM, future defaults (1/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization]   Running native-test lane 3/3 for "
+            "org.example:demo:1.0.0: GraalVM 25, current defaults (1/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization]   Passed native-test lane 3/3 for "
+            "org.example:demo:1.0.0: GraalVM 25, current defaults (1/2)",
+            printed,
+        )
+        self.assertNotIn("[post-generation-test]", printed)
+        self.assertNotIn("./gradlew", printed)
+
+    def test_verbose_finalization_restores_native_test_lane_narration(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+        )
+        strategy._run_command_with_env = lambda *_args, **_kwargs: "BUILD SUCCESSFUL"
+        output = io.StringIO()
+
+        with patch.dict(
+                os.environ,
+                {
+                    "FORGE_VERBOSE": "1",
+                    "GRAALVM_HOME": "/dev/graalvm",
+                    "JAVA_HOME": "/dev/graalvm",
+                    "GRAALVM_HOME_25_0": "/dev/graalvm-25",
+                },
+                clear=True,
+        ), redirect_stdout(output):
+            enter_phase(PHASE_FINALIZATION)
+            with run_step(
+                    PHASE_FINALIZATION,
+                    STEP_FINALIZE_RUN,
+                    operand="org.example:demo:1.0.0",
+            ):
+                status = strategy._run_test_with_retry("org.example:demo:1.0.0")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        self.assertIn(
+            "[post-generation-test] Running current-defaults latest GRAALVM test "
+            "for org.example:demo:1.0.0",
+            output.getvalue(),
+        )
+
+    def test_concise_finalization_groups_repository_checks(self) -> None:
+        strategy = _TestWorkflowStrategy(
+            {"model": "test-model"},
+            reachability_repo_path="/tmp/reachability",
+            library="org.example:demo:1.0.0",
+            metadata_version="1.0.0",
+            test_version="1.0.0",
+        )
+        strategy.group = "org.example"
+        strategy.artifact = "demo"
+        strategy.library = "org.example:demo:1.0.0"
+        strategy.version = "1.0.0"
+        strategy.reachability_repo_path = "/tmp/reachability"
+        output = io.StringIO()
+
+        with patch.dict(
+                os.environ,
+                {"FORGE_VERBOSE": "0", "FORGE_DEBUG_LOGGING": "0"},
+        ), patch.object(
+                strategy,
+                "verify_native_test_gate",
+                return_value=True,
+        ), patch.object(
+                strategy,
+                "_run_test_with_retry",
+                return_value=RUN_STATUS_SUCCESS,
+        ), patch.object(
+                strategy,
+                "_commit_library_iteration",
+                return_value=True,
+        ), patch(
+                "ai_workflows.core.workflow_strategy.run_library_finalization",
+                return_value=True,
+        ), patch(
+                "ai_workflows.core.workflow_strategy.subprocess.check_output",
+                return_value="checkpoint\n",
+        ), redirect_stdout(output):
+            status = strategy.finalize_run("base")
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        printed = output.getvalue()
+        self.assertIn(
+            "[finalization]   Running final repository checks for "
+            "org.example:demo:1.0.0 (1/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization]   Final repository checks passed for "
+            "org.example:demo:1.0.0 (1/2)",
+            printed,
+        )
+        self.assertIn(
+            "[finalization] Finalization completed for org.example:demo:1.0.0 (1/2)",
+            printed,
+        )
+        self.assertNotIn("splitTestOnlyMetadata", printed)
+        self.assertNotIn("checkMetadataFiles", printed)
+        self.assertNotIn("generateLibraryStats", printed)
 
     def test_commit_library_iteration_stages_resolved_test_version(self) -> None:
         with tempfile.TemporaryDirectory() as repo:

--- a/forge/utility_scripts/gradle_test_runner.py
+++ b/forge/utility_scripts/gradle_test_runner.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import time
 
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -46,7 +46,7 @@ def run_gradle_test_command(
     resolved_library = library or _extract_coordinates(test_cmd)
     resolved_timeout = timeout_seconds or _timeout_from_environment()
     log_path = build_timestamped_task_log_path("gradle-test", resolved_library, "gradle-test")
-    log_stage(
+    log_detail(
         "gradle-test",
         "$ {command}  (log: {log_path}, timeout: {timeout}s)".format(
             command=test_cmd,

--- a/forge/utility_scripts/host_requirements.py
+++ b/forge/utility_scripts/host_requirements.py
@@ -301,11 +301,10 @@ class HostRequirements:
         """Return whether this run operates on a checkout other than the one holding Forge."""
         return os.path.realpath(self.repo_dir) != os.path.realpath(self.forge_repo_dir)
 
-    def run(self) -> bool:
-        """Run all selected checks, print the report, and return whether they passed."""
+    def run(self, verbose: bool = False) -> bool:
+        """Run selected checks, printing details when requested or work is blocked."""
         if self.requirements.issue_work and self.graalvm_version_check != "off":
             self.graalvm_versions = self._resolve_graalvm_versions()
-        self._print_manifest()
         self._check_tools()
         self._check_environment()
         self._check_write_permissions()
@@ -313,8 +312,13 @@ class HostRequirements:
         self._check_github()
         self._check_selected_agents()
         self._check_docker()
-        self._print_results()
-        return not any(result.blocks_work for result in self.results)
+        passed = not any(result.blocks_work for result in self.results)
+        if verbose or not passed:
+            self._print_manifest()
+            self._print_results()
+        elif any(result.status == "WARN" for result in self.results):
+            self._print_warnings()
+        return passed
 
     def _print_manifest(self) -> None:
         issue_text = "enabled" if self.requirements.issue_work else "disabled"
@@ -1288,6 +1292,14 @@ query($owner: String!, $name: String!, $project: Int!) {
         else:
             print("[forge-host] PASS: all required host checks succeeded; work may start.")
 
+    def _print_warnings(self) -> None:
+        """Print only non-blocking warnings when the successful report is compact."""
+        warnings = [result for result in self.results if result.status == "WARN"]
+        print("[forge-host] Host requirement warnings:")
+        for result in warnings:
+            print(f"  [WARN] {result.category}: {result.name} — {result.detail}")
+        print(f"[forge-host] PASS with {len(warnings)} warning(s); work may start.")
+
 
 def check_graalvm_installation(
         graalvm_home: str,
@@ -1399,6 +1411,7 @@ def verify_host_requirements(
         repo_dir: str | None = None,
         test_strategy_name: str | None = None,
         test_strategy_names: Sequence[str] | None = None,
+        verbose: bool = False,
 ) -> bool:
     """Run every host requirement selected by this run and report whether work may start.
 
@@ -1415,7 +1428,7 @@ def verify_host_requirements(
         test_strategy_name=test_strategy_name,
         test_strategy_names=test_strategy_names,
     )
-    return host_requirements.run()
+    return host_requirements.run(verbose=verbose)
 
 
 def ensure_host_requirements(
@@ -1427,6 +1440,7 @@ def ensure_host_requirements(
         repo_dir: str | None = None,
         test_strategy_name: str | None = None,
         test_strategy_names: Sequence[str] | None = None,
+        verbose: bool = False,
 ) -> None:
     """Stop the process with a non-zero exit when a required host capability is missing.
 
@@ -1441,6 +1455,7 @@ def ensure_host_requirements(
         repo_dir,
         test_strategy_name,
         test_strategy_names,
+        verbose,
     )
     if not passed:
         sys.exit(1)
@@ -1883,6 +1898,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--setup-model", default=None)
     parser.add_argument("--setup-provider", default=None)
     parser.add_argument("--test-strategy", action="append", default=None)
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print the complete host report.")
     parser.add_argument(
         "--graalvm-version-check",
         choices=GRAALVM_VERSION_CHECK_MODES,
@@ -1925,7 +1941,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    return 0 if host_requirements.run() else 1
+    return 0 if host_requirements.run(verbose=args.verbose) else 1
 
 
 if __name__ == "__main__":

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Callable
 
 from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_agent
 from utility_scripts.gradle_environment import gradle_command_environment
@@ -19,7 +20,15 @@ from utility_scripts.native_image_config_policy import (
     format_legacy_test_native_image_config_error,
 )
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION,
+    STEP_AGENT_FIX,
+    current_run_location,
+    log_step_progress,
+    record_step_failure,
+    run_step,
+)
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.task_logs import display_log_path
 from utility_scripts.test_quality_checks import (
     collect_generated_test_validity_issues,
@@ -28,6 +37,41 @@ from utility_scripts.test_quality_checks import (
 
 CHECK_METADATA_FIX_TIMEOUT_SECONDS = 1200
 MAX_CHECK_METADATA_FIX_ATTEMPTS = 3
+
+
+def _run_finalization_agent_fix(
+        library: str,
+        target: str,
+        attempt: int,
+        maximum_attempts: int,
+        operation: Callable[[], bool],
+) -> bool:
+    """Run one repair with concise finalization progress when phase-bound.
+
+    §FS-forge-run-output-legibility.1 §FS-forge-run-output-legibility.5
+    """
+    location = current_run_location()
+    if location is None or location.phase != PHASE_FINALIZATION:
+        return operation()
+
+    with run_step(PHASE_FINALIZATION, STEP_AGENT_FIX, operand=f"{library} {target}"):
+        log_step_progress(
+            PHASE_FINALIZATION,
+            STEP_AGENT_FIX,
+            f"Running agent fix for {target} on {library} "
+            f"(attempt {attempt}/{maximum_attempts})",
+        )
+        fixed = operation()
+        outcome = "completed" if fixed else "failed"
+        log_step_progress(
+            PHASE_FINALIZATION,
+            STEP_AGENT_FIX,
+            f"Agent fix {outcome} for {target} on {library} "
+            f"(attempt {attempt}/{maximum_attempts})",
+        )
+        if not fixed and attempt == maximum_attempts:
+            record_step_failure()
+        return fixed
 
 
 def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> LoggedCommandResult:
@@ -191,7 +235,7 @@ def _append_allowed_packages_to_metadata_index(
         json.dump(index_entries, index_file, indent=2)
         index_file.write("\n")
 
-    log_stage("allowed-packages", f"Updated {index_path_display}: {', '.join(added_packages)}")
+    log_detail("allowed-packages", f"Updated {index_path_display}: {', '.join(added_packages)}")
     return True
 
 
@@ -204,21 +248,21 @@ def _run_check_metadata_files_with_allowed_packages_fix(
         log_stage_name: str,
 ) -> tuple[bool, str]:
     """Run checkMetadataFiles and update missing allowed-packages when the task reports them."""
-    log_stage(log_stage_name, f"Running checkMetadataFiles for {library}")
+    log_detail(log_stage_name, f"Running checkMetadataFiles for {library}")
     seen_packages: set[str] = set()
     for attempt in range(1, 4):
-        log_stage(log_stage_name, f"Running checkMetadataFiles attempt {attempt}/3 for {library}")
+        log_detail(log_stage_name, f"Running checkMetadataFiles attempt {attempt}/3 for {library}")
         metadata_valid, metadata_output = _run_check_metadata_files(repo_path, library, log_stage_name)
         if metadata_valid:
             return (True, metadata_output)
 
-        log_stage(log_stage_name, f"checkMetadataFiles failed for {library}; resolving missing allowed-packages")
+            log_detail(log_stage_name, f"checkMetadataFiles failed for {library}; resolving missing allowed-packages")
         missing_packages = _extract_missing_allowed_packages(metadata_output)
         new_packages = missing_packages - seen_packages
         if not new_packages:
-            log_stage(log_stage_name, "No new TypeReached packages found in checkMetadataFiles output")
+            log_detail(log_stage_name, "No new TypeReached packages found in checkMetadataFiles output")
             return (False, metadata_output)
-        log_stage("allowed-packages", f"Adding allowed-packages for {library}: {', '.join(sorted(new_packages))}")
+        log_detail("allowed-packages", f"Adding allowed-packages for {library}: {', '.join(sorted(new_packages))}")
         if not _append_allowed_packages_to_metadata_index(
             repo_path=repo_path,
             library=library,
@@ -241,7 +285,7 @@ def _run_check_metadata_files(repo_path: str, library: str, log_stage_name: str)
         ["./gradlew", "checkMetadataFiles", f"-Pcoordinates={library}"],
     )
     if result.returncode == 0:
-        log_stage(log_stage_name, f"checkMetadataFiles passed for {library}")
+        log_detail(log_stage_name, f"checkMetadataFiles passed for {library}")
         return (True, result.stdout)
     return (False, result.stdout)
 
@@ -260,7 +304,7 @@ def run_library_finalization(
     §AR-forge-driver-finalization
     """
     del log_prefix
-    log_stage("split-test-only-metadata", f"Running splitTestOnlyMetadata for {library}")
+    log_detail("split-test-only-metadata", f"Running splitTestOnlyMetadata for {library}")
     if not _run_gradle_command(repo_path, ["./gradlew", "splitTestOnlyMetadata", f"-Pcoordinates={library}"]):
         return False
     legacy_test_config_paths = set(
@@ -279,7 +323,7 @@ def run_library_finalization(
         "check-metadata-files",
     )
     if not metadata_valid:
-        log_stage("route-foreign-metadata", f"Running routeForeignMetadata after validation failed for {library}")
+        log_detail("route-foreign-metadata", f"Running routeForeignMetadata after validation failed for {library}")
         if _run_gradle_command(repo_path, ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"]):
             metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
                 repo_path=repo_path,
@@ -291,11 +335,17 @@ def run_library_finalization(
             )
     if not metadata_valid:
         for attempt in range(1, MAX_CHECK_METADATA_FIX_ATTEMPTS + 1):
-            log_stage(
+            log_detail(
                 "check-metadata-files",
                 f"Running analysis metadata fix attempt {attempt}/{MAX_CHECK_METADATA_FIX_ATTEMPTS} for {library}",
             )
-            if not _run_check_metadata_fix(repo_path, library, metadata_failure_output):
+            if not _run_finalization_agent_fix(
+                    library,
+                    "metadata validation",
+                    attempt,
+                    MAX_CHECK_METADATA_FIX_ATTEMPTS,
+                    lambda: _run_check_metadata_fix(repo_path, library, metadata_failure_output),
+            ):
                 continue
             metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
                 repo_path=repo_path,
@@ -309,7 +359,7 @@ def run_library_finalization(
                 break
         else:
             return False
-    log_stage("style-checks", f"Running style checks for {library}")
+    log_detail("style-checks", f"Running style checks for {library}")
     if not run_style_fix_and_checks(repo_path, library):
         return False
     test_source_root = os.path.join(repo_path, "tests", "src", group, artifact, library_version, "src", "test")
@@ -322,7 +372,7 @@ def run_library_finalization(
                 f"{format_generated_test_validity_issue(issue, repo_path)}",
             )
         return False
-    log_stage("generate-library-stats", f"Running generateLibraryStats for {library}")
+    log_detail("generate-library-stats", f"Running generateLibraryStats for {library}")
     if not _run_gradle_command(repo_path, ["./gradlew", "generateLibraryStats", f"-Pcoordinates={library}"]):
         return False
     return True

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -6,11 +6,11 @@
 import json
 import os
 import re
-import subprocess
 import sys
 
 from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_agent
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.metadata_index import find_index_entry_for_version
 from utility_scripts.style_checks import run_style_fix_and_checks
 from utility_scripts.native_image_config_policy import (
@@ -30,17 +30,22 @@ CHECK_METADATA_FIX_TIMEOUT_SECONDS = 1200
 MAX_CHECK_METADATA_FIX_ATTEMPTS = 3
 
 
-def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run a Gradle command in the reachability repo and capture combined output."""
+def _run_gradle_command_with_output(repo_path: str, command: list[str]) -> LoggedCommandResult:
+    """Run a finalization Gradle command quietly with durable output."""
     require_complete_reachability_repo(repo_path)
-    return subprocess.run(
+    action = command[1] if len(command) > 1 else "gradle"
+    coordinate_argument = next(
+        (argument for argument in command if argument.startswith("-Pcoordinates=")),
+        "-Pcoordinates=unknown",
+    )
+    return run_logged_command(
         command,
         cwd=repo_path,
+        task_type="finalization",
+        subject=coordinate_argument.removeprefix("-Pcoordinates="),
+        action=action,
         env=gradle_command_environment(repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        stage="finalization",
     )
 
 
@@ -48,7 +53,6 @@ def _run_gradle_command(repo_path: str, command: list[str]) -> bool:
     """Run a Gradle command in the reachability repo, returning True on success."""
     result = _run_gradle_command_with_output(repo_path, command)
     if result.returncode != 0:
-        print(result.stdout)
         return False
     return True
 
@@ -213,7 +217,6 @@ def _run_check_metadata_files_with_allowed_packages_fix(
         new_packages = missing_packages - seen_packages
         if not new_packages:
             log_stage(log_stage_name, "No new TypeReached packages found in checkMetadataFiles output")
-            print(metadata_output)
             return (False, metadata_output)
         log_stage("allowed-packages", f"Adding allowed-packages for {library}: {', '.join(sorted(new_packages))}")
         if not _append_allowed_packages_to_metadata_index(
@@ -224,7 +227,6 @@ def _run_check_metadata_files_with_allowed_packages_fix(
             library_version=library_version,
             packages=new_packages,
         ):
-            print(metadata_output)
             return (False, metadata_output)
         seen_packages.update(new_packages)
 

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -15,7 +15,13 @@ from utility_scripts.metadata_index import (
     resolve_test_dir,
 )
 from ai_workflows.agents.agent_runtime import AgentRunResult, get_setup_agent, setup_agent_run
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.run_location import (
+    PHASE_SETUP,
+    STEP_NEURAL_SETUP,
+    log_step_progress,
+)
+from utility_scripts.stage_logger import log_detail
+from utility_scripts.task_logs import display_log_path
 
 LIBRARY_PREPARATION_PREFLIGHT_FILENAME = ".library_preparation_preflight.json"
 NO_LIBRARY_PREPARATION_PREFLIGHT_CONTEXT = (
@@ -425,10 +431,29 @@ def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
     failure_reason = record.get("failure_reason")
     if failure_reason:
         detail += f" reason={failure_reason}"
-    log_stage(
+    log_detail(
         "library-preflight",
         f"Preflight decision for issue #{record.get('issue_number')}: {detail}",
     )
+    library = str(record.get("library") or "unknown library")
+    if record.get("status") == "completed":
+        outcome = str(record.get("action") or "no_action").replace("_", " ")
+        if setup_count:
+            outcome += f", {setup_count} deterministic setup item(s)"
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_NEURAL_SETUP,
+            f"Library preflight completed for {library}: {outcome}",
+        )
+    else:
+        log_path = record.get("session_log_path")
+        log_suffix = f" (log: {display_log_path(str(log_path))})" if log_path else ""
+        failure_text = str(failure_reason or "no usable decision")
+        log_step_progress(
+            PHASE_SETUP,
+            STEP_NEURAL_SETUP,
+            f"Library preflight degraded for {library}: {failure_text}{log_suffix}",
+        )
     return write_library_preparation_preflight(_preflight_artifact_root(claimed_issue), record)
 
 
@@ -448,7 +473,12 @@ def run_library_preparation_preflight(
         claimed_issue,
         issue_body_provider,
     )
-    log_stage(
+    log_step_progress(
+        PHASE_SETUP,
+        STEP_NEURAL_SETUP,
+        f"Running library preflight for {input_bundle.get('library')}",
+    )
+    log_detail(
         "library-preflight",
         (
             f"Running preflight for issue #{claimed_issue.issue['number']} "
@@ -709,7 +739,7 @@ def prepare_library_preparation_preflight(
                 f"{item.get('kind')}:{item.get('result')}"
                 for item in applied if isinstance(item, dict)
             )
-            log_stage("library-preflight", f"Applied deterministic setup: {summary}")
+            log_detail("library-preflight", f"Applied deterministic setup: {summary}")
     context = format_library_preparation_preflight_context(preflight)
     return preflight, context
 

--- a/forge/utility_scripts/library_update_alias_split.py
+++ b/forge/utility_scripts/library_update_alias_split.py
@@ -21,6 +21,7 @@ from git_scripts.common_git import (
     stage_and_commit as stage_and_commit_common,
 )
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.logged_command import run_logged_command
 from utility_scripts.metadata_index import (
     index_path,
     load_index_entries,
@@ -345,20 +346,28 @@ def _apply_alias_split(
     entries.insert(target_index, successor_entry)
     _write_index_entries(repo_path, group, artifact, entries)
     successor_coordinates = f"{group}:{artifact}:{failed_version}"
-    log_stage(
-        "generate-library-stats",
-        f"Running generateLibraryStats for split successor {successor_coordinates}",
-    )
-    subprocess.run(
-        [
-            "./gradlew",
-            "generateLibraryStats",
-            f"-Pcoordinates={successor_coordinates}",
-        ],
+    stats_command = [
+        "./gradlew",
+        "generateLibraryStats",
+        f"-Pcoordinates={successor_coordinates}",
+    ]
+    # Keep split finalization quiet without losing its evidence.
+    # §FS-forge-run-output-legibility §FS-durable-generation-logs
+    stats_result = run_logged_command(
+        stats_command,
         cwd=repo_path,
+        task_type="library-update-alias-split",
+        subject=successor_coordinates,
+        action="generateLibraryStats",
         env=gradle_command_environment(repo_path),
-        check=True,
+        stage="generate-library-stats",
     )
+    if stats_result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            stats_result.returncode,
+            stats_command,
+            output=stats_result.stdout,
+        )
 
     return {
         "requested_coordinates": requested_coordinates,

--- a/forge/utility_scripts/logged_command.py
+++ b/forge/utility_scripts/logged_command.py
@@ -1,0 +1,135 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Quiet subprocess execution backed by durable per-task logs.
+
+Command output belongs in the durable log by default; debug mode tees the same
+bytes to the terminal while the process runs. §FS-forge-run-output-legibility.4
+§FS-durable-generation-logs
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import shlex
+import subprocess
+import sys
+import threading
+import time
+
+from utility_scripts.stage_logger import debug_logging_enabled, log_stage
+from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+
+
+@dataclass(frozen=True)
+class LoggedCommandResult:
+    """Captured command outcome and its durable evidence path."""
+
+    args: list[str]
+    returncode: int
+    stdout: str
+    log_path: str
+    timed_out: bool
+    duration_seconds: float
+
+
+def run_logged_command(
+        command: list[str],
+        *,
+        cwd: str,
+        task_type: str,
+        subject: str | None,
+        action: str,
+        env: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+        stage: str = "command",
+) -> LoggedCommandResult:
+    """Run one command quietly, teeing live output only in debug mode."""
+    log_path = build_timestamped_task_log_path(task_type, subject, action)
+    displayed_log_path = display_log_path(log_path)
+    log_stage(stage, f"Running {action} (log: {displayed_log_path})")
+    started_at = time.monotonic()
+    output_chunks: list[str] = []
+    timed_out = False
+
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(f"Command: {shlex.join(command)}\n")
+        log_file.write(f"Working directory: {os.path.abspath(cwd)}\n")
+        log_file.write("\n--- output ---\n")
+        log_file.flush()
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except OSError as exc:
+            message = f"Failed to start command: {exc}\n"
+            log_file.write(message)
+            duration_seconds = time.monotonic() - started_at
+            log_stage(stage, f"{action} failed to start (log: {displayed_log_path})")
+            return LoggedCommandResult(
+                command, 1, message, log_path, False, duration_seconds,
+            )
+
+        output_lock = threading.Lock()
+
+        def copy_output() -> None:
+            if process.stdout is None:
+                return
+            while True:
+                chunk = process.stdout.read(4096)
+                if not chunk:
+                    return
+                with output_lock:
+                    output_chunks.append(chunk)
+                    log_file.write(chunk)
+                    log_file.flush()
+                if debug_logging_enabled():
+                    print(chunk, end="", file=sys.stdout, flush=True)
+
+        output_thread = threading.Thread(target=copy_output, daemon=True)
+        output_thread.start()
+        try:
+            returncode = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            process.kill()
+            returncode = process.wait()
+            timeout_message = f"\nCommand exceeded {timeout_seconds}s timeout\n"
+            with output_lock:
+                output_chunks.append(timeout_message)
+                log_file.write(timeout_message)
+                log_file.flush()
+        finally:
+            output_thread.join()
+            if process.stdout is not None:
+                process.stdout.close()
+
+    duration_seconds = time.monotonic() - started_at
+    output = "".join(output_chunks)
+    duration = _format_duration(duration_seconds)
+    if returncode == 0 and not timed_out:
+        log_stage(stage, f"{action} completed in {duration} (log: {displayed_log_path})")
+    else:
+        reason = "timed out" if timed_out else f"failed with exit code {returncode}"
+        log_stage(stage, f"{action} {reason} after {duration} (log: {displayed_log_path})")
+    return LoggedCommandResult(
+        command, returncode, output, log_path, timed_out, duration_seconds,
+    )
+
+
+def _format_duration(duration_seconds: float) -> str:
+    total_seconds = max(int(duration_seconds), 0)
+    minutes, seconds = divmod(total_seconds, 60)
+    if minutes >= 60:
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes:02d}:{seconds:02d}"

--- a/forge/utility_scripts/logged_command.py
+++ b/forge/utility_scripts/logged_command.py
@@ -20,7 +20,7 @@ import sys
 import threading
 import time
 
-from utility_scripts.stage_logger import debug_logging_enabled, log_stage
+from utility_scripts.stage_logger import debug_logging_enabled, log_detail, log_stage
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 
@@ -46,11 +46,12 @@ def run_logged_command(
         env: dict[str, str] | None = None,
         timeout_seconds: int | None = None,
         stage: str = "command",
+        failure_is_detail: bool = False,
 ) -> LoggedCommandResult:
     """Run one command quietly, teeing live output only in debug mode."""
     log_path = build_timestamped_task_log_path(task_type, subject, action)
     displayed_log_path = display_log_path(log_path)
-    log_stage(stage, f"Running {action} (log: {displayed_log_path})")
+    log_detail(stage, f"Running {action} (log: {displayed_log_path})")
     started_at = time.monotonic()
     output_chunks: list[str] = []
     timed_out = False
@@ -74,7 +75,8 @@ def run_logged_command(
             message = f"Failed to start command: {exc}\n"
             log_file.write(message)
             duration_seconds = time.monotonic() - started_at
-            log_stage(stage, f"{action} failed to start (log: {displayed_log_path})")
+            failure_logger = log_detail if failure_is_detail else log_stage
+            failure_logger(stage, f"{action} failed to start (log: {displayed_log_path})")
             return LoggedCommandResult(
                 command, 1, message, log_path, False, duration_seconds,
             )
@@ -117,10 +119,11 @@ def run_logged_command(
     output = "".join(output_chunks)
     duration = _format_duration(duration_seconds)
     if returncode == 0 and not timed_out:
-        log_stage(stage, f"{action} completed in {duration} (log: {displayed_log_path})")
+        log_detail(stage, f"{action} completed in {duration} (log: {displayed_log_path})")
     else:
         reason = "timed out" if timed_out else f"failed with exit code {returncode}"
-        log_stage(stage, f"{action} {reason} after {duration} (log: {displayed_log_path})")
+        failure_logger = log_detail if failure_is_detail else log_stage
+        failure_logger(stage, f"{action} {reason} after {duration} (log: {displayed_log_path})")
     return LoggedCommandResult(
         command, returncode, output, log_path, timed_out, duration_seconds,
     )

--- a/forge/utility_scripts/metrics_writer.py
+++ b/forge/utility_scripts/metrics_writer.py
@@ -25,6 +25,7 @@ from utility_scripts.native_image_config_policy import (
     format_legacy_test_native_image_config_error,
 )
 from utility_scripts.source_context import resolve_test_source_layout
+from utility_scripts.stage_logger import log_plain_detail
 from utility_scripts.strategy_loader import load_strategy_by_name
 from git_scripts.common_git import GitTransportError, git_remote_exists, run_git_transport
 
@@ -398,8 +399,15 @@ def collect_and_print_metrics(
     if test_only_metadata_entries > 0:
         test_metadata_suffix = f" Test-Only Metadata Entries: {test_only_metadata_entries}"
 
-    print(
-        f"Iterations: {global_iterations}  Input Tokens: {input_tokens_used}{cached_tokens_suffix} Output Tokens: {output_tokens_used} Metadata Entries: {total_entries}{test_metadata_suffix} Coverage: {coverage_percent:.2f}% Generated LOC: {generated_loc} Cost: {total_cost_usd:.4f} Library lines covered: {lines_covered}")
+    # Persisted metrics stay available without becoming finalization progress.
+    # §FS-forge-run-output-legibility.5
+    log_plain_detail(
+        f"Iterations: {global_iterations}  Input Tokens: {input_tokens_used}"
+        f"{cached_tokens_suffix} Output Tokens: {output_tokens_used} "
+        f"Metadata Entries: {total_entries}{test_metadata_suffix} "
+        f"Coverage: {coverage_percent:.2f}% Generated LOC: {generated_loc} "
+        f"Cost: {total_cost_usd:.4f} Library lines covered: {lines_covered}",
+    )
 
     metrics = {
         "coverage_percent": coverage_percent,

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -82,6 +82,8 @@ class NativeTestVerificationResult:
     last_native_test_exit_code: int | None = None
     accepted_run_dirs: list[str] = field(default_factory=list)
     intervention_records: list[InterventionRecord] = field(default_factory=list)
+    failure_detail: str | None = None
+    failure_log_path: str | None = None
 
 
 DEFAULT_CYCLE_TIMEOUT_SECONDS = 30 * 60
@@ -98,12 +100,12 @@ def run_native_test_fix(
         env: dict[str, str],
         graalvm_home: str | None = None,
         failure_log_path: str | None = None,
-) -> tuple[int, str, bool]:
+) -> tuple[int, str, bool, str | None]:
     """Run a quick analysis-agent fixup for a failing native test.
 
-    Returns ``(return_code, log_path, timed_out)``. The reproduction command and
-    GraalVM home are pinned to the environment that produced the failed native
-    run so the repair uses the exact same distribution.
+    Returns ``(return_code, log_path, timed_out, failure_message)``. The
+    reproduction command and GraalVM home are pinned to the environment that
+    produced the failed native run so the repair uses the exact same distribution.
     """
     prompt = _build_native_test_fix_prompt(
         coordinates, reproduction_command, graalvm_home, failure_log_path
@@ -121,7 +123,12 @@ def run_native_test_fix(
             f"ERROR: Native-test fix failed for {coordinates}. "
             f"See {display_log_path(result.log_path)}.",
         )
-    return (result.return_code, result.log_path, result.timed_out)
+    return (
+        result.return_code,
+        result.log_path,
+        result.timed_out,
+        result.failure_message,
+    )
 
 
 def _build_native_test_fix_prompt(
@@ -209,7 +216,12 @@ def verify_native_test_passes(
     last_log_path: str | None = None
     last_binary_rc: int | None = None
 
-    def _make_result(status: str, iterations_used: int) -> NativeTestVerificationResult:
+    def _make_result(
+            status: str,
+            iterations_used: int,
+            failure_detail: str | None = None,
+            failure_log_path: str | None = None,
+    ) -> NativeTestVerificationResult:
         return NativeTestVerificationResult(
             status=status,
             output_dir=output_dir,
@@ -218,6 +230,8 @@ def verify_native_test_passes(
             last_native_test_exit_code=last_binary_rc,
             accepted_run_dirs=list(accepted_run_dirs),
             intervention_records=intervention_records,
+            failure_detail=failure_detail,
+            failure_log_path=failure_log_path,
         )
 
     def _route_to_analysis_agent(
@@ -238,7 +252,7 @@ def verify_native_test_passes(
             f"{stage}: {reason}; routing to the analysis agent (terminal)",
         )
         require_complete_reachability_repo(reachability_repo_path)
-        fix_rc, fix_log_path, fix_timed_out = run_native_test_fix(
+        fix_rc, fix_log_path, fix_timed_out, fix_failure_message = run_native_test_fix(
             reachability_repo_path,
             coordinate,
             reproduction_command=reproduction_command,
@@ -259,7 +273,15 @@ def verify_native_test_passes(
                 f"{analysis_backend} did not converge "
                 f"(timed_out={fix_timed_out}, rc={fix_rc}); FAILED",
             )
-            return _make_result(STATUS_FAILED, iterations_used)
+            failure_detail = fix_failure_message or (
+                f"{analysis_backend} agent failed with exit code {fix_rc}"
+            )
+            return _make_result(
+                STATUS_FAILED,
+                iterations_used,
+                failure_detail=failure_detail,
+                failure_log_path=fix_log_path,
+            )
         require_complete_reachability_repo(reachability_repo_path)
         log_stage(
             _GATE_STAGE,

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -58,7 +58,7 @@ _LOG_TASK_TYPE = "native-test-verify"
 _EXIT_VALUE_PATTERN = re.compile(r"exit\s+value\s+(\d+)", re.IGNORECASE)
 _TRACE_SENTINEL_FILE_NAMES = frozenset({"binary-exit-code"})
 _AGGREGATED_METADATA_FILE_NAME = "reachability-metadata.json"
-_FAILURE_LOG_TAIL_LINE_LIMIT = 300
+_FAILURE_LOG_TAIL_LINE_LIMIT = 20
 _FAILED_TASK_PATTERN = re.compile(r"> Task :(\S+) FAILED")
 
 
@@ -924,11 +924,6 @@ def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
         f"cycle {cycle_number}: collected metadata from {len(metadata_files)} file(s) ({run_dir})",
         indent_level=1,
     )
-    for metadata_file in metadata_files:
-        relative = os.path.relpath(metadata_file, run_dir)
-        log_stage(_GATE_STAGE, f"{relative}:", indent_level=2)
-        for line in _format_metadata_file(metadata_file).splitlines():
-            log_stage(_GATE_STAGE, line, indent_level=3)
 
 
 def _print_failure_log_tail(log_path: str, cycle_number: int) -> None:
@@ -1169,32 +1164,24 @@ def _merge_metadata_dirs(
         f"-PinputDirs={','.join(input_dirs)}",
         f"-PoutputDir={output_dir}",
     ]
-    log_stage(_GATE_STAGE, f"$ {' '.join(cmd)}", indent_level=1)
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=reachability_repo_path,
-            env=env or gradle_command_environment(reachability_repo_path),
-            check=False,
-            timeout=_MERGE_TIMEOUT_SECONDS,
-        )
-        if result.returncode != 0:
-            log_stage(
-                _GATE_STAGE,
-                f"mergeNativeTraceMetadata failed with exit code {result.returncode}",
-                indent_level=1,
-            )
-            return False
-        if print_output_path:
-            _print_aggregated_metadata_path(output_dir)
-        return True
-    except subprocess.TimeoutExpired:
+    merge_log_path = _gate_log_path("native-trace", 0, "mergeNativeTraceMetadata")
+    result = _run_logged_gradle_command(
+        reachability_repo_path=reachability_repo_path,
+        cmd=cmd,
+        log_path=merge_log_path,
+        timeout_seconds=_MERGE_TIMEOUT_SECONDS,
+        env=env or gradle_command_environment(reachability_repo_path),
+    )
+    if result.returncode != 0:
         log_stage(
             _GATE_STAGE,
-            f"mergeNativeTraceMetadata exceeded {_MERGE_TIMEOUT_SECONDS}s timeout",
+            f"mergeNativeTraceMetadata failed with exit code {result.returncode}",
             indent_level=1,
         )
         return False
+    if print_output_path:
+        _print_aggregated_metadata_path(output_dir)
+    return True
 
 
 def _print_aggregated_metadata_path(output_dir: str) -> None:

--- a/forge/utility_scripts/native_test_verification.py
+++ b/forge/utility_scripts/native_test_verification.py
@@ -31,7 +31,15 @@ from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_a
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import resolve_metadata_version
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.run_location import (
+    PHASE_STEPS,
+    STEP_AGENT_FIX,
+    RunLocation,
+    current_run_location,
+    log_step_progress,
+    run_step,
+)
+from utility_scripts.stage_logger import log_detail, log_stage
 from utility_scripts.task_logs import (
     build_timestamped_task_log_path,
     display_log_path,
@@ -205,7 +213,7 @@ def verify_native_test_passes(
     trace_metadata_dir = os.path.join(output_dir, "trace")
     trace_condition_packages: list[str] | None = list(condition_packages) if condition_packages else None
 
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"start coordinate={coordinate} output_dir={output_dir} budget={max_iterations}",
     )
@@ -247,47 +255,77 @@ def verify_native_test_passes(
         failed native command.
         """
         analysis_backend = get_analysis_agent(command_env).backend
-        log_stage(
+        log_detail(
             _GATE_STAGE,
             f"{stage}: {reason}; routing to the analysis agent (terminal)",
         )
-        require_complete_reachability_repo(reachability_repo_path)
-        fix_rc, fix_log_path, fix_timed_out, fix_failure_message = run_native_test_fix(
-            reachability_repo_path,
-            coordinate,
-            reproduction_command=reproduction_command,
-            env=command_env,
-            graalvm_home=required_graalvm_home,
-            failure_log_path=last_log_path,
-        )
-        intervention_records.append(
-            InterventionRecord(
-                stage=f"{stage}-analysis-agent",
-                kind=analysis_backend,
-                log_path=fix_log_path,
+
+        def _run_agent_fix(location: RunLocation | None) -> NativeTestVerificationResult:
+            if location is not None:
+                log_step_progress(
+                    location.phase,
+                    STEP_AGENT_FIX,
+                    f"Running native-trace agent fix for {coordinate}: {reason}",
+                )
+            require_complete_reachability_repo(reachability_repo_path)
+            fix_rc, fix_log_path, fix_timed_out, fix_failure_message = run_native_test_fix(
+                reachability_repo_path,
+                coordinate,
+                reproduction_command=reproduction_command,
+                env=command_env,
+                graalvm_home=required_graalvm_home,
+                failure_log_path=last_log_path,
             )
-        )
-        if fix_timed_out or fix_rc != 0:
-            log_stage(
+            intervention_records.append(
+                InterventionRecord(
+                    stage=f"{stage}-analysis-agent",
+                    kind=analysis_backend,
+                    log_path=fix_log_path,
+                )
+            )
+            if fix_timed_out or fix_rc != 0:
+                failure_detail = fix_failure_message or (
+                    f"{analysis_backend} agent failed with exit code {fix_rc}"
+                )
+                if location is not None:
+                    log_step_progress(
+                        location.phase,
+                        STEP_AGENT_FIX,
+                        f"Native-trace agent fix failed for {coordinate}: {failure_detail} "
+                        f"(log: {display_log_path(fix_log_path)})",
+                    )
+                log_detail(
+                    _GATE_STAGE,
+                    f"{analysis_backend} did not converge "
+                    f"(timed_out={fix_timed_out}, rc={fix_rc}); FAILED",
+                )
+                return _make_result(
+                    STATUS_FAILED,
+                    iterations_used,
+                    failure_detail=failure_detail,
+                    failure_log_path=fix_log_path,
+                )
+            require_complete_reachability_repo(reachability_repo_path)
+            if location is not None:
+                log_step_progress(
+                    location.phase,
+                    STEP_AGENT_FIX,
+                    f"Native-trace agent fix completed for {coordinate}",
+                )
+            log_detail(
                 _GATE_STAGE,
-                f"{analysis_backend} did not converge "
-                f"(timed_out={fix_timed_out}, rc={fix_rc}); FAILED",
+                f"{analysis_backend} exited successfully; PASSED_WITH_INTERVENTION",
             )
-            failure_detail = fix_failure_message or (
-                f"{analysis_backend} agent failed with exit code {fix_rc}"
-            )
-            return _make_result(
-                STATUS_FAILED,
-                iterations_used,
-                failure_detail=failure_detail,
-                failure_log_path=fix_log_path,
-            )
-        require_complete_reachability_repo(reachability_repo_path)
-        log_stage(
-            _GATE_STAGE,
-            f"{analysis_backend} exited successfully; PASSED_WITH_INTERVENTION",
-        )
-        return _make_result(STATUS_PASSED_WITH_INTERVENTION, iterations_used)
+            return _make_result(STATUS_PASSED_WITH_INTERVENTION, iterations_used)
+
+        active_location = current_run_location()
+        if (
+                active_location is not None
+                and STEP_AGENT_FIX in PHASE_STEPS[active_location.phase]
+        ):
+            with run_step(active_location.phase, STEP_AGENT_FIX, operand=coordinate):
+                return _run_agent_fix(active_location)
+        return _run_agent_fix(None)
 
     def _finalize_and_verify_durable_metadata(
             metadata_dirs: list[str],
@@ -315,7 +353,7 @@ def verify_native_test_passes(
         )
         last_log_path = finalized_test_log_path
         if test_rc == 0:
-            log_stage(_GATE_STAGE, "finalized durable metadata passed native tests")
+            log_detail(_GATE_STAGE, "finalized durable metadata passed native tests")
             return None
 
         failed_task_display = failed_task or "unknown"
@@ -341,11 +379,11 @@ def verify_native_test_passes(
     agent_metadata_dirs = [agent_metadata_dir] if generate_metadata_rc == 0 else []
     if generate_metadata_rc != 0:
         failure_reason = _summarize_gradle_failure_reason(generate_metadata_log_path)
-        log_stage(
+        log_detail(
             _GATE_STAGE,
             f"generateMetadata failed (exit={generate_metadata_rc}); starting native trace fallback",
         )
-        log_stage(_GATE_STAGE, f"generateMetadata failure reason: {failure_reason}", indent_level=1)
+        log_detail(_GATE_STAGE, f"generateMetadata failure reason: {failure_reason}", indent_level=1)
     else:
         test_log_path = _gate_log_path(coordinate, 0, "test")
         test_rc, failed_task = _run_coordinate_test(
@@ -358,7 +396,7 @@ def verify_native_test_passes(
         )
         last_log_path = test_log_path
         if test_rc == 0:
-            log_stage(_GATE_STAGE, "JVM-agent metadata made native tests pass")
+            log_detail(_GATE_STAGE, "JVM-agent metadata made native tests pass")
             finalized_result = _finalize_and_verify_durable_metadata(
                 [agent_metadata_dir],
                 0,
@@ -376,18 +414,18 @@ def verify_native_test_passes(
                 iterations_used=0,
             )
 
-        log_stage(_GATE_STAGE, "nativeTest still fails after JVM-agent metadata; starting native trace fallback")
+        log_detail(_GATE_STAGE, "nativeTest still fails after JVM-agent metadata; starting native trace fallback")
 
     if trace_condition_packages is None:
         trace_condition_packages = _default_condition_packages(reachability_repo_path, coordinate)
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"trace condition packages: {','.join(trace_condition_packages)}",
         indent_level=1,
     )
 
     for cycle in range(max_iterations):
-        log_stage(_GATE_STAGE, f"cycle {cycle + 1}/{max_iterations}")
+        log_detail(_GATE_STAGE, f"cycle {cycle + 1}/{max_iterations}")
 
         run_dir = os.path.join(runs_dir, f"cycle-{cycle}")
         os.makedirs(run_dir, exist_ok=True)
@@ -409,7 +447,7 @@ def verify_native_test_passes(
         usable_metadata_files = _usable_metadata_files(run_dir)
 
         if binary_rc == 0:
-            log_stage(
+            log_detail(
                 _GATE_STAGE,
                 f"cycle {cycle + 1}: binary passed (exit 0); merging trace dirs",
             )
@@ -434,7 +472,7 @@ def verify_native_test_passes(
 
         if binary_rc == MISSING_METADATA_EXIT_CODE:
             if not usable_metadata_files:
-                log_stage(
+                log_detail(
                     _GATE_STAGE,
                     f"cycle {cycle + 1}: binary exited 172 but produced no usable trace metadata",
                 )
@@ -471,7 +509,7 @@ def verify_native_test_passes(
                     ),
                     iterations_used=cycle + 1,
                 )
-            log_stage(
+            log_detail(
                 _GATE_STAGE,
                 f"cycle {cycle + 1}: binary exited 172 (missing metadata); "
                 f"adding {os.path.basename(run_dir)} to config_dirs "
@@ -495,7 +533,7 @@ def verify_native_test_passes(
             iterations_used=cycle + 1,
         )
 
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"FAILED after {max_iterations} cycles "
         f"(metadata-gap-exhausted; last binary_exit={last_binary_rc})",
@@ -756,7 +794,7 @@ def _run_logged_gradle_command(
         env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a Gradle command and write stdout/stderr to ``log_path``."""
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"$ {' '.join(cmd)}  (log: {display_log_path(log_path)})",
         indent_level=1,
@@ -897,7 +935,7 @@ def _run_native_trace_image(
     ]
     if metadata_config_dirs:
         cmd.append(f"-PmetadataConfigDirs={','.join(metadata_config_dirs)}")
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"$ {' '.join(cmd)}  (log: {display_log_path(log_path)})",
         indent_level=1,
@@ -934,14 +972,14 @@ def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
     """Print the trace metadata collected in ``run_dir`` for one gate cycle."""
     metadata_files = _metadata_files(run_dir)
     if not metadata_files:
-        log_stage(
+        log_detail(
             _GATE_STAGE,
             f"cycle {cycle_number}: collected metadata: none ({run_dir})",
             indent_level=1,
         )
         return
 
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"cycle {cycle_number}: collected metadata from {len(metadata_files)} file(s) ({run_dir})",
         indent_level=1,
@@ -950,13 +988,13 @@ def _print_collected_metadata(run_dir: str, cycle_number: int) -> None:
 
 def _print_failure_log_tail(log_path: str, cycle_number: int) -> None:
     """Print the native trace failure log tail."""
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"cycle {cycle_number}: failure log tail (last {_FAILURE_LOG_TAIL_LINE_LIMIT} lines) from {log_path}:",
         indent_level=1,
     )
     for line in _extract_failure_log_tail(log_path).splitlines():
-        log_stage(_GATE_STAGE, line, indent_level=2)
+        log_detail(_GATE_STAGE, line, indent_level=2)
 
 
 def _print_metadata_progress(
@@ -966,7 +1004,7 @@ def _print_metadata_progress(
         reason: str,
 ) -> None:
     """Print trace-loop progress before a no-progress failure."""
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         (
             f"metadata progress stalled ({reason}): "
@@ -978,9 +1016,9 @@ def _print_metadata_progress(
     )
     if not accepted_run_dirs:
         return
-    log_stage(_GATE_STAGE, "accepted run dirs:", indent_level=1)
+    log_detail(_GATE_STAGE, "accepted run dirs:", indent_level=1)
     for run_dir in accepted_run_dirs:
-        log_stage(_GATE_STAGE, run_dir, indent_level=2)
+        log_detail(_GATE_STAGE, run_dir, indent_level=2)
 
 
 def _extract_failure_log_tail(log_path: str) -> str:
@@ -1208,7 +1246,7 @@ def _merge_metadata_dirs(
 
 def _print_aggregated_metadata_path(output_dir: str) -> None:
     """Print only the path to the merged reachability metadata file."""
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         os.path.join(output_dir, _AGGREGATED_METADATA_FILE_NAME),
         indent_level=1,
@@ -1224,7 +1262,7 @@ def _finalize_staged_metadata(
     """Merge staged agent/trace metadata into the durable library metadata file."""
     staged_metadata_dirs = _existing_metadata_dirs(metadata_dirs)
     if not staged_metadata_dirs:
-        log_stage(_GATE_STAGE, "no staged reachability-metadata.json to finalize")
+        log_detail(_GATE_STAGE, "no staged reachability-metadata.json to finalize")
         return True
 
     try:
@@ -1272,7 +1310,7 @@ def _finalize_staged_metadata(
                     durable_metadata_path,
                     merged_metadata_path,
             ):
-                log_stage(_GATE_STAGE, "native trace metadata already present in durable metadata")
+                log_detail(_GATE_STAGE, "native trace metadata already present in durable metadata")
                 return True
 
             os.makedirs(durable_metadata_dir, exist_ok=True)
@@ -1280,7 +1318,7 @@ def _finalize_staged_metadata(
     except OSError as exc:
         log_stage(_GATE_STAGE, f"failed to aggregate native trace metadata: {exc}", indent_level=1)
         return False
-    log_stage(
+    log_detail(
         _GATE_STAGE,
         f"finalized staged metadata into {os.path.relpath(durable_metadata_path, reachability_repo_path)}",
     )

--- a/forge/utility_scripts/repo_path_resolver.py
+++ b/forge/utility_scripts/repo_path_resolver.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 
 from git_scripts.common_git import GitTransportError, run_git_transport
+from utility_scripts.stage_logger import log_debug
 
 REACHABILITY_REPO_CLONE_URL = "git@github.com:oracle/graalvm-reachability-metadata.git"
 
@@ -238,7 +239,7 @@ def metrics_json_repo_relative_path(
 
 def resolve_reachability_repo_root(explicit_reachability_path: str | None) -> str:
     """Resolve and validate the reachability repository a run operates on."""
-    print("[Resolving graalvm-reachability-metadata root path...]")
+    log_debug("startup", "Resolving graalvm-reachability-metadata root path")
     if explicit_reachability_path:
         resolved_reachability_root = explicit_reachability_path
     else:
@@ -249,7 +250,7 @@ def resolve_reachability_repo_root(explicit_reachability_path: str | None) -> st
 
 def resolve_metrics_repo_root(reachability_root: str, explicit_metrics_repo_path: str | None) -> str:
     """Resolve the Forge metrics root used alongside a resolved reachability repository."""
-    print("[Resolving Forge metrics root path...]")
+    log_debug("startup", "Resolving Forge metrics root path")
     if explicit_metrics_repo_path:
         return ensure_in_repo_metrics_root(explicit_metrics_repo_path)
     return resolve_in_repo_metrics_root(reachability_root)

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -30,6 +30,7 @@ from utility_scripts.continuation_marker import (
     save_phase_update,
 )
 from utility_scripts.stage_logger import log_phase_banner, log_stage
+from utility_scripts.task_logs import display_log_path
 
 # The dispatcher-side segment that runs before a run — and therefore before any
 # continuation state — exists. §FS-forge-run-location-reporting.1
@@ -69,9 +70,9 @@ PHASE_STEPS: dict[str, tuple[str, ...]] = {
     PHASE_CLAIM: (
         STEP_CHECK_HOST_REQUIREMENTS,
         STEP_CHECK_STRATEGY_AND_MODEL,
-        STEP_CHECK_ISSUE_FORM,
         STEP_CLAIM_ISSUE,
         STEP_CREATE_ISSUE_WORKSPACE,
+        STEP_CHECK_ISSUE_FORM,
         STEP_ROUTE_TO_DRIVER,
     ),
     PHASE_SETUP: (
@@ -352,7 +353,11 @@ def format_run_failure_line(location: RunLocation) -> str:
     return f"{FAILURE_LINE_PREFIX}{location}"
 
 
-def report_run_failure(location: RunLocation, detail: str | None = None) -> str:
+def report_run_failure(
+        location: RunLocation,
+        detail: str | None = None,
+        log_path: str | None = None,
+) -> str:
     """Print the failure location once per run, then its error detail.
 
     A run has one terminal failure, so the first reporter on the way out owns the
@@ -367,9 +372,37 @@ def report_run_failure(location: RunLocation, detail: str | None = None) -> str:
     print(line, file=sys.stderr)
     if not location.is_located:
         print(UNLOCATED_FAILURE_DEFECT, file=sys.stderr)
+    print(file=sys.stderr)
+    print(f"Phase failed: {location.phase}", file=sys.stderr)
+    print(f"Step failed: {location.step}", file=sys.stderr)
+    if location.operand is not None:
+        print(f"{_failure_operand_label(location)}: {location.operand}", file=sys.stderr)
     if detail:
-        print(detail, file=sys.stderr)
+        print(f"Error: {_normalize_failure_detail(detail)}", file=sys.stderr)
+    if log_path:
+        print(f"Log: {display_log_path(log_path)}", file=sys.stderr)
     return line
+
+
+def _failure_operand_label(location: RunLocation) -> str:
+    """Return the operator-facing label for a failed step's operand."""
+    operand = location.operand or ""
+    if (
+            location.step in {STEP_GENERATE_TESTS, STEP_NATIVE_TRACE_GATE}
+            and ":" not in operand and "." in operand and " " not in operand
+    ):
+        return "Class"
+    if ":" in operand:
+        return "Coordinate"
+    return "Operand"
+
+
+def _normalize_failure_detail(detail: str) -> str:
+    """Remove the legacy error prefix before rendering structured failure output."""
+    normalized = detail.strip()
+    if normalized.startswith("ERROR: "):
+        return normalized[len("ERROR: "):]
+    return normalized
 
 
 def _record_failure_in_marker(location: RunLocation) -> None:

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -29,7 +29,12 @@ from utility_scripts.continuation_marker import (
     ContinuationMarker,
     save_phase_update,
 )
-from utility_scripts.stage_logger import log_debug, log_phase_banner, log_stage
+from utility_scripts.stage_logger import (
+    log_debug,
+    log_phase_banner,
+    log_stage,
+    set_compact_narration,
+)
 from utility_scripts.task_logs import display_log_path
 
 # The dispatcher-side segment that runs before a run — and therefore before any
@@ -103,7 +108,7 @@ PHASE_STEPS: dict[str, tuple[str, ...]] = {
 
 # Phases move to concise output one at a time. Their registered method-style
 # announcement remains available under --verbose. §FS-forge-run-output-legibility.5
-COMPACT_OUTPUT_PHASES: tuple[str, ...] = (PHASE_CLAIM,)
+COMPACT_OUTPUT_PHASES: tuple[str, ...] = (PHASE_CLAIM, PHASE_SETUP)
 
 UNLOCATED_STEP = "<unlocated-step>"
 LOCATION_ATTRIBUTE = "forge_run_location"
@@ -205,6 +210,7 @@ def reset_run_location() -> None:
     _STATE.phase = None
     _STATE.context = None
     _STATE.reported = False
+    set_compact_narration(False)
 
 
 def enter_phase(phase: str) -> None:
@@ -217,6 +223,7 @@ def enter_phase(phase: str) -> None:
     if _STATE.phase == phase:
         return
     _STATE.phase = phase
+    set_compact_narration(phase in COMPACT_OUTPUT_PHASES)
     log_phase_banner(phase, context=_STATE.context)
 
 

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -113,6 +113,7 @@ COMPACT_OUTPUT_PHASES: tuple[str, ...] = (
     PHASE_SETUP,
     PHASE_FIX,
     PHASE_EXPLORE,
+    PHASE_FINALIZATION,
 )
 
 UNLOCATED_STEP = "<unlocated-step>"

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -108,7 +108,12 @@ PHASE_STEPS: dict[str, tuple[str, ...]] = {
 
 # Phases move to concise output one at a time. Their registered method-style
 # announcement remains available under --verbose. §FS-forge-run-output-legibility.5
-COMPACT_OUTPUT_PHASES: tuple[str, ...] = (PHASE_CLAIM, PHASE_SETUP)
+COMPACT_OUTPUT_PHASES: tuple[str, ...] = (
+    PHASE_CLAIM,
+    PHASE_SETUP,
+    PHASE_FIX,
+    PHASE_EXPLORE,
+)
 
 UNLOCATED_STEP = "<unlocated-step>"
 LOCATION_ATTRIBUTE = "forge_run_location"
@@ -262,10 +267,15 @@ def announce_step(phase: str, step: str, operand: str | None = None) -> RunLocat
     return RunLocation(phase=phase, step=step, operand=operand)
 
 
-def log_step_progress(phase: str, step: str, message: str) -> None:
+def log_step_progress(
+        phase: str,
+        step: str,
+        message: str,
+        indent_level: int = 0,
+) -> None:
     """Print one concise step transition with its derived phase position."""
     position, total = step_position(phase, step)
-    log_stage(phase, f"{message} ({position}/{total})")
+    log_stage(phase, f"{message} ({position}/{total})", indent_level=indent_level)
 
 
 def pipeline_step(

--- a/forge/utility_scripts/run_location.py
+++ b/forge/utility_scripts/run_location.py
@@ -29,7 +29,7 @@ from utility_scripts.continuation_marker import (
     ContinuationMarker,
     save_phase_update,
 )
-from utility_scripts.stage_logger import log_phase_banner, log_stage
+from utility_scripts.stage_logger import log_debug, log_phase_banner, log_stage
 from utility_scripts.task_logs import display_log_path
 
 # The dispatcher-side segment that runs before a run — and therefore before any
@@ -100,6 +100,10 @@ PHASE_STEPS: dict[str, tuple[str, ...]] = {
         STEP_LOCAL_CI_CHECK,
     ),
 }
+
+# Phases move to concise output one at a time. Their registered method-style
+# announcement remains available under --verbose. §FS-forge-run-output-legibility.5
+COMPACT_OUTPUT_PHASES: tuple[str, ...] = (PHASE_CLAIM,)
 
 UNLOCATED_STEP = "<unlocated-step>"
 LOCATION_ATTRIBUTE = "forge_run_location"
@@ -243,8 +247,18 @@ def announce_step(phase: str, step: str, operand: str | None = None) -> RunLocat
     position, total = step_position(phase, step)
     enter_phase(phase)
     suffix = "" if operand is None else f" on {operand}"
-    log_stage(phase, f"Running step {step} ({position}/{total}) of phase {phase}{suffix}")
+    message = f"Running step {step} ({position}/{total}) of phase {phase}{suffix}"
+    if phase in COMPACT_OUTPUT_PHASES:
+        log_debug(phase, message)
+    else:
+        log_stage(phase, message)
     return RunLocation(phase=phase, step=step, operand=operand)
+
+
+def log_step_progress(phase: str, step: str, message: str) -> None:
+    """Print one concise step transition with its derived phase position."""
+    position, total = step_position(phase, step)
+    log_stage(phase, f"{message} ({position}/{total})")
 
 
 def pipeline_step(

--- a/forge/utility_scripts/source_context.py
+++ b/forge/utility_scripts/source_context.py
@@ -37,7 +37,7 @@ from ai_workflows.agents.agent_runtime import (
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.metadata_index import find_index_entry_for_version, is_not_for_native_image_entry
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
-from utility_scripts.stage_logger import log_stage
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.task_logs import build_task_log_path, display_log_path
 
 SOURCE_CONTEXT_FIELD_BY_TYPE = {
@@ -268,7 +268,7 @@ def populate_artifact_urls(
     require_complete_reachability_repo(reachability_repo_path)
     log_path = build_task_log_path("populate-artifact-urls", coordinate, "populate_artifact_urls.log")
     log_path_display = display_log_path(log_path)
-    log_stage("populate-artifact-urls", f"Populating artifact URLs for {coordinate}; output: {log_path_display}")
+    log_detail("populate-artifact-urls", f"Populating artifact URLs for {coordinate}; output: {log_path_display}")
     command = [
         "./gradlew",
         "populateArtifactURLs",
@@ -292,7 +292,7 @@ def populate_artifact_urls(
             file=sys.stderr,
         )
         raise SystemExit(1)
-    log_stage("populate-artifact-urls", f"Artifact URLs populated for {coordinate}")
+    log_detail("populate-artifact-urls", f"Artifact URLs populated for {coordinate}")
 
 
 def source_context_urls_available(
@@ -328,7 +328,7 @@ def discover_artifact_metadata(
     require_complete_reachability_repo(reachability_repo_path)
     log_path = build_task_log_path("discover-artifact-metadata", coordinate, "discover_artifact_metadata.log")
     log_path_display = display_log_path(log_path)
-    log_stage("discover-artifact-metadata", f"Discovering artifact metadata for {coordinate}; output: {log_path_display}")
+    log_detail("discover-artifact-metadata", f"Discovering artifact metadata for {coordinate}; output: {log_path_display}")
     effective_agent_command = _effective_agent_command(agent_command)
     command = _discover_artifact_metadata_command(coordinate, effective_agent_command)
     command_env = agent_process_environment(gradle_command_environment(reachability_repo_path))
@@ -342,7 +342,7 @@ def discover_artifact_metadata(
             effective_agent_command,
             diagnostics=True,
         )
-        log_stage(
+        log_detail(
             "discover-artifact-metadata",
             (
                 f"Gradle bootstrap failed for {coordinate}; retrying once with "
@@ -366,7 +366,7 @@ def discover_artifact_metadata(
             file=sys.stderr,
         )
         raise SystemExit(1)
-    log_stage("discover-artifact-metadata", f"Artifact metadata discovered for {coordinate}")
+    log_detail("discover-artifact-metadata", f"Artifact metadata discovered for {coordinate}")
 
 
 def _discover_artifact_metadata_command(
@@ -481,7 +481,7 @@ def prepare_source_contexts(
         field_name = SOURCE_CONTEXT_FIELD_BY_TYPE[source_type]
         url = render_url_template(normalize_url_value(index_entry.get(field_name)), requested_version)
         if url is None:
-            log_stage("source-context", f"{source_type}: unavailable, no URL in index.json")
+            log_detail("source-context", f"{source_type}: unavailable, no URL in index.json")
             artifacts.append(SourceArtifactContext(source_type, None, None, [], False, "no URL in index.json"))
             continue
         artifacts.append(download_source_artifact(base_dir, source_type, url))
@@ -492,7 +492,7 @@ def prepare_source_contexts(
         artifacts=artifacts,
     )
     available_artifacts = [artifact for artifact in prepared_context.artifacts if artifact.available]
-    log_stage(
+    log_detail(
         "source-context",
         "Ready for {coordinate}: {available}/{total} artifact types available".format(
             coordinate=coordinate,
@@ -589,7 +589,7 @@ def render_url_template(url: str | None, version: str) -> str | None:
 
 
 def download_source_artifact(base_dir: str, source_type: str, url: str) -> SourceArtifactContext:
-    log_stage("source-context", f"Downloading {source_type} from {url}")
+    log_detail("source-context", f"Downloading {source_type} from {url}")
     target_dir = os.path.join(base_dir, source_type)
     if os.path.isdir(target_dir):
         shutil.rmtree(target_dir)
@@ -600,10 +600,10 @@ def download_source_artifact(base_dir: str, source_type: str, url: str) -> Sourc
         headers = _download_file(url, download_path)
         extracted_files = extract_downloaded_artifact(download_path, target_dir, headers)
     except Exception as exc:  # noqa: BLE001
-        log_stage("source-context", f"{source_type}: unavailable ({exc})")
+        log_detail("source-context", f"{source_type}: unavailable ({exc})")
         return SourceArtifactContext(source_type, url, None, [], False, str(exc))
 
-    log_stage(
+    log_detail(
         "source-context",
         "{source_type}: ready with {count} files at {target_dir}".format(
             source_type=source_type,

--- a/forge/utility_scripts/stage_logger.py
+++ b/forge/utility_scripts/stage_logger.py
@@ -64,6 +64,16 @@ def log_detail(stage: str, message: str, indent_level: int = 0) -> None:
     log_stage(stage, message, indent_level)
 
 
+def log_plain_detail(message: str) -> None:
+    """Print unprefixed narration unless the compact phase hides it.
+
+    §FS-forge-run-output-legibility.5
+    """
+    if _NARRATION_STATE.compact and not debug_logging_enabled():
+        return
+    print(message)
+
+
 def log_debug(stage: str, message: str, indent_level: int = 0) -> None:
     """Print verbose narration that is debugging detail, not normal run output.
 

--- a/forge/utility_scripts/stage_logger.py
+++ b/forge/utility_scripts/stage_logger.py
@@ -14,11 +14,25 @@ ANSI_BOLD_RED = "\033[1;31m"
 ANSI_BOLD_CYAN = "\033[1;36m"
 BANNER_WIDTH = 88
 DEBUG_LOGGING_ENV_VAR = "FORGE_DEBUG_LOGGING"
+VERBOSE_LOGGING_ENV_VAR = "FORGE_VERBOSE"
+
+
+def _environment_flag_enabled(variable: str) -> bool:
+    """Return True when an environment flag carries a conventional true value."""
+    return os.environ.get(variable, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def enable_verbose_logging() -> None:
+    """Enable narration-level logging for this process and its children."""
+    os.environ[VERBOSE_LOGGING_ENV_VAR] = "1"
 
 
 def debug_logging_enabled() -> bool:
     """Return True when narration-level logging is switched on."""
-    return os.environ.get(DEBUG_LOGGING_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+    return (
+        _environment_flag_enabled(VERBOSE_LOGGING_ENV_VAR)
+        or _environment_flag_enabled(DEBUG_LOGGING_ENV_VAR)
+    )
 
 
 def log_stage(stage: str, message: str, indent_level: int = 0) -> None:
@@ -28,10 +42,10 @@ def log_stage(stage: str, message: str, indent_level: int = 0) -> None:
 
 
 def log_debug(stage: str, message: str, indent_level: int = 0) -> None:
-    """Print narration that is debugging detail, not run output.
+    """Print verbose narration that is debugging detail, not normal run output.
 
     Keeps the human-intervention handoff's git narration out of failure output
-    unless debug logging is enabled. §FS-forge-run-location-reporting.4
+    unless verbose logging is enabled. §FS-forge-run-location-reporting.4
     """
     if debug_logging_enabled():
         log_stage(stage, message, indent_level)

--- a/forge/utility_scripts/stage_logger.py
+++ b/forge/utility_scripts/stage_logger.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import threading
 from typing import TextIO
 
 
@@ -15,6 +16,16 @@ ANSI_BOLD_CYAN = "\033[1;36m"
 BANNER_WIDTH = 88
 DEBUG_LOGGING_ENV_VAR = "FORGE_DEBUG_LOGGING"
 VERBOSE_LOGGING_ENV_VAR = "FORGE_VERBOSE"
+
+
+class _NarrationState(threading.local):
+    """Per-run phase state deciding whether normal detail is suppressed."""
+
+    def __init__(self) -> None:
+        self.compact: bool = False
+
+
+_NARRATION_STATE = _NarrationState()
 
 
 def _environment_flag_enabled(variable: str) -> bool:
@@ -39,6 +50,18 @@ def log_stage(stage: str, message: str, indent_level: int = 0) -> None:
     """Print a workflow log line that starts with the current stage."""
     indent = "  " * indent_level
     print(f"[{stage}] {indent}{message}")
+
+
+def set_compact_narration(compact: bool) -> None:
+    """Select whether the current thread's announced phase hides detail."""
+    _NARRATION_STATE.compact = compact
+
+
+def log_detail(stage: str, message: str, indent_level: int = 0) -> None:
+    """Print narration unless the current compact phase hides it."""
+    if _NARRATION_STATE.compact and not debug_logging_enabled():
+        return
+    log_stage(stage, message, indent_level)
 
 
 def log_debug(stage: str, message: str, indent_level: int = 0) -> None:

--- a/forge/utility_scripts/style_checks.py
+++ b/forge/utility_scripts/style_checks.py
@@ -4,17 +4,62 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import sys
+from collections.abc import Callable
 
 from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_agent
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
+from utility_scripts.run_location import (
+    PHASE_FINALIZATION,
+    STEP_AGENT_FIX,
+    current_run_location,
+    log_step_progress,
+    record_step_failure,
+    run_step,
+)
+from utility_scripts.stage_logger import log_detail
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
 DEFAULT_STYLE_FIX_TIMEOUT_SECONDS = 600
 MAX_CHECKSTYLE_OUTPUT_CHARS = 12000
 MAX_TEST_OUTPUT_CHARS = 12000
 MAX_CHECKSTYLE_FIX_ATTEMPTS = 3
+
+
+def _run_finalization_agent_fix(
+        coordinates: str,
+        target: str,
+        attempt: int,
+        terminal_on_failure: bool,
+        operation: Callable[[], bool],
+) -> bool:
+    """Run one style repair with concise finalization progress when bound.
+
+    §FS-forge-run-output-legibility.1 §FS-forge-run-output-legibility.5
+    """
+    location = current_run_location()
+    if location is None or location.phase != PHASE_FINALIZATION:
+        return operation()
+
+    with run_step(PHASE_FINALIZATION, STEP_AGENT_FIX, operand=f"{coordinates} {target}"):
+        log_step_progress(
+            PHASE_FINALIZATION,
+            STEP_AGENT_FIX,
+            f"Running agent fix for {target} on {coordinates} "
+            f"(attempt {attempt}/{MAX_CHECKSTYLE_FIX_ATTEMPTS})",
+        )
+        fixed = operation()
+        outcome = "completed" if fixed else "failed"
+        log_step_progress(
+            PHASE_FINALIZATION,
+            STEP_AGENT_FIX,
+            f"Agent fix {outcome} for {target} on {coordinates} "
+            f"(attempt {attempt}/{MAX_CHECKSTYLE_FIX_ATTEMPTS})",
+        )
+        if not fixed and terminal_on_failure:
+            record_step_failure()
+        return fixed
 
 
 def _run_logged_style_command(repo_path: str, command: list[str]) -> LoggedCommandResult:
@@ -184,20 +229,27 @@ def run_style_fix_and_checks(
 
     print(f"[checkstyle] Gradle command failed: ./gradlew checkstyle {coordinate_arg}", file=sys.stderr)
     log_path = _build_checkstyle_log_path(coordinates)
-    print(f"[checkstyle] Analysis-agent output: {display_log_path(log_path)}")
+    log_detail("checkstyle", f"Analysis-agent output: {display_log_path(log_path)}")
 
     for attempt in range(1, MAX_CHECKSTYLE_FIX_ATTEMPTS + 1):
-        print(
-            "[checkstyle] Attempting analysis-agent Checkstyle fix "
-            f"({attempt}/{MAX_CHECKSTYLE_FIX_ATTEMPTS})..."
+        log_detail(
+            "checkstyle",
+            "Attempting analysis-agent Checkstyle fix "
+            f"({attempt}/{MAX_CHECKSTYLE_FIX_ATTEMPTS})...",
         )
-        if not _run_analysis_checkstyle_fix(
-            repo_path,
+        if not _run_finalization_agent_fix(
             coordinates,
-            checkstyle_result.stdout,
-            log_path,
+            "Checkstyle",
             attempt,
-            timeout_seconds,
+            attempt == MAX_CHECKSTYLE_FIX_ATTEMPTS,
+            lambda: _run_analysis_checkstyle_fix(
+                repo_path,
+                coordinates,
+                checkstyle_result.stdout,
+                log_path,
+                attempt,
+                timeout_seconds,
+            ),
         ):
             continue
 
@@ -207,7 +259,7 @@ def run_style_fix_and_checks(
 
         test_result = _run_test(repo_path, coordinate_arg)
         if test_result.returncode == 0:
-            print("[checkstyle] Analysis-agent Checkstyle fix succeeded")
+            log_detail("checkstyle", "Analysis-agent Checkstyle fix succeeded")
             return True
 
         print(
@@ -215,14 +267,20 @@ def run_style_fix_and_checks(
             "attempting analysis-agent recovery...",
             file=sys.stderr,
         )
-        if not _run_analysis_test_fix_after_checkstyle(
-            repo_path=repo_path,
-            coordinates=coordinates,
-            checkstyle_output=checkstyle_result.stdout,
-            test_output=test_result.stdout,
-            log_path=log_path,
-            attempt=attempt,
-            timeout_seconds=timeout_seconds,
+        if not _run_finalization_agent_fix(
+            coordinates,
+            "test after Checkstyle repair",
+            attempt,
+            True,
+            lambda: _run_analysis_test_fix_after_checkstyle(
+                repo_path=repo_path,
+                coordinates=coordinates,
+                checkstyle_output=checkstyle_result.stdout,
+                test_output=test_result.stdout,
+                log_path=log_path,
+                attempt=attempt,
+                timeout_seconds=timeout_seconds,
+            ),
         ):
             return False
 
@@ -233,7 +291,7 @@ def run_style_fix_and_checks(
 
         checkstyle_result = _run_checkstyle(repo_path, coordinate_arg)
         if checkstyle_result.returncode == 0:
-            print("[checkstyle] Analysis-agent Checkstyle fix succeeded")
+            log_detail("checkstyle", "Analysis-agent Checkstyle fix succeeded")
             return True
 
     print("[checkstyle] ERROR: Checkstyle still fails after analysis repair.", file=sys.stderr)

--- a/forge/utility_scripts/style_checks.py
+++ b/forge/utility_scripts/style_checks.py
@@ -3,11 +3,11 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
-import subprocess
 import sys
 
 from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_agent
 from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
 from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
 
@@ -17,49 +17,40 @@ MAX_TEST_OUTPUT_CHARS = 12000
 MAX_CHECKSTYLE_FIX_ATTEMPTS = 3
 
 
-def _run_gradle_task(repo_path: str, command: list[str]) -> bool:
+def _run_logged_style_command(repo_path: str, command: list[str]) -> LoggedCommandResult:
     require_complete_reachability_repo(repo_path)
-    result = subprocess.run(
+    coordinate_argument = next(
+        (argument for argument in command if argument.startswith("-Pcoordinates=")),
+        "-Pcoordinates=unknown",
+    )
+    return run_logged_command(
         command,
         cwd=repo_path,
+        task_type="style-checks",
+        subject=coordinate_argument.removeprefix("-Pcoordinates="),
+        action=command[1],
         env=gradle_command_environment(repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        stage="style-checks",
     )
-    if result.returncode == 0:
-        return True
-    print(f"ERROR: Gradle command failed: {' '.join(command)}", file=sys.stderr)
-    print(result.stdout)
-    return False
 
 
-def _run_checkstyle(repo_path: str, coordinate_arg: str) -> subprocess.CompletedProcess:
-    """Run the checkstyle Gradle task and return the CompletedProcess."""
-    require_complete_reachability_repo(repo_path)
-    return subprocess.run(
+def _run_gradle_task(repo_path: str, command: list[str]) -> bool:
+    return _run_logged_style_command(repo_path, command).returncode == 0
+
+
+def _run_checkstyle(repo_path: str, coordinate_arg: str) -> LoggedCommandResult:
+    """Run the checkstyle Gradle task and return its logged result."""
+    return _run_logged_style_command(
+        repo_path,
         ["./gradlew", "checkstyle", coordinate_arg],
-        cwd=repo_path,
-        env=gradle_command_environment(repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
     )
 
 
-def _run_test(repo_path: str, coordinate_arg: str) -> subprocess.CompletedProcess:
-    """Run the test Gradle task and return the CompletedProcess."""
-    require_complete_reachability_repo(repo_path)
-    return subprocess.run(
+def _run_test(repo_path: str, coordinate_arg: str) -> LoggedCommandResult:
+    """Run the test Gradle task and return its logged result."""
+    return _run_logged_style_command(
+        repo_path,
         ["./gradlew", "test", coordinate_arg],
-        cwd=repo_path,
-        env=gradle_command_environment(repo_path),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
     )
 
 
@@ -238,7 +229,6 @@ def run_style_fix_and_checks(
         retry_test_result = _run_test(repo_path, coordinate_arg)
         if retry_test_result.returncode != 0:
             print("ERROR: ./gradlew test still fails after post-Checkstyle repair.", file=sys.stderr)
-            print(retry_test_result.stdout)
             return False
 
         checkstyle_result = _run_checkstyle(repo_path, coordinate_arg)
@@ -247,5 +237,4 @@ def run_style_fix_and_checks(
             return True
 
     print("[checkstyle] ERROR: Checkstyle still fails after analysis repair.", file=sys.stderr)
-    print(checkstyle_result.stdout)
     return False

--- a/forge/utility_scripts/workflow_setup.py
+++ b/forge/utility_scripts/workflow_setup.py
@@ -4,7 +4,6 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import os
-import subprocess
 import sys
 
 from utility_scripts.gradle_environment import gradle_command_environment, pin_gradle_java_home
@@ -14,6 +13,7 @@ from utility_scripts.host_requirements import (
     require_graalvm_home_env,
 )
 from utility_scripts.library_finalization import run_library_finalization
+from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo, resolve_repo_roots
 from utility_scripts.stage_logger import log_stage
 
@@ -86,17 +86,17 @@ def build_graalvm_environment(graalvm_home: str, base_env: dict[str, str] | None
     return env
 
 
-def run_gradle_test_with_graalvm(repo_path: str, library: str, graalvm_home: str) -> subprocess.CompletedProcess[str]:
+def run_gradle_test_with_graalvm(repo_path: str, library: str, graalvm_home: str) -> LoggedCommandResult:
     """Run the library test task with a specific GraalVM/JAVA_HOME."""
     require_complete_reachability_repo(repo_path)
-    return subprocess.run(
+    return run_logged_command(
         ["./gradlew", "test", f"-Pcoordinates={library}"],
         cwd=repo_path,
+        task_type="post-generation-test",
+        subject=library,
+        action="test",
         env=gradle_command_environment(repo_path, build_graalvm_environment(graalvm_home)),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        check=False,
+        stage="post-generation-test",
     )
 
 
@@ -130,7 +130,6 @@ def run_metadata_fix_until_tests_pass(
                     return False
             return True
 
-        print(result.stdout)
         if attempt == max_attempts:
             break
 


### PR DESCRIPTION
Closes #9647

## Why this change

Forge's primary console stream mixed phase and step progress with raw Gradle output and agent transcripts. That made it difficult to tell what was running, whether setup transitions had completed, and exactly where a terminal failure occurred.

This makes the concise phase/step/operand view required by [§FS-forge-run-output-legibility](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/concise-forge-console-output/forge/docs/functional-spec/functional-spec.md#fs-forge-run-output-legibility-legible-run-output) the default while preserving complete evidence in durable logs as required by [§FS-durable-generation-logs](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/concise-forge-console-output/forge/docs/functional-spec/functional-spec.md#fs-durable-generation-logs-durable-generation-and-session-logs).

## What operators see

- Claiming now reports the issue number, newest pinned master, claimed/not-claimed outcome, workspace creation transition, and issue-form acceptance.
- Agent turns report a named action, elapsed activity, completion/failure/timeout, and the session log without printing the transcript. A single interactive run also gets a one-line heartbeat.
- Gradle-backed workflow commands write their full output to per-task logs. `FORGE_DEBUG_LOGGING=1` restores a live tee when detailed diagnosis is needed.
- Terminal errors use one canonical location vocabulary, including the phase, failed step, operand, error, and durable log path, following [§FS-forge-run-location-reporting](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/concise-forge-console-output/forge/docs/functional-spec/functional-spec.md#fs-forge-run-location-reporting-run-location-in-progress-and-failure-output) and [§AR-forge-run-location](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/concise-forge-console-output/forge/docs/architecture/architecture.md#ar-forge-run-location-one-run-location-for-progress-and-failure).

Focused unit coverage exercises quiet command logging, agent activity and timeouts, native trace summaries, and canonical run failures.
