### PR TITLE
Unify failed-CI handling during Forge PR review

### DIFF
--- a/forge/docs/architecture/orchestration-scripts.md
+++ b/forge/docs/architecture/orchestration-scripts.md
@@ -194,8 +194,9 @@ then selects for review only PRs whose CI checks all completed successfully,
 which are not authored by the authenticated review user, and which are not
 still blocked by `human-intervention`. The loaded current-head state retains
 named check-run details and their Actions workflow provenance. Running checks
-wait, while failed checks enter deterministic retry or failure follow-up
-without launching an agent or consuming a review slot. PRs labeled
+wait. For a failed workflow run on the current head, orchestration reruns failed
+jobs while `run_attempt < 3`; at attempt `3` or above it skips review without
+mutating the pull request or any linked issue. PRs labeled
 `human-intervention` are skipped until a maintainer marks them
 `human-intervention-fixed`, at which point orchestration may dismiss stale
 requested-changes reviews and let normal merge gates proceed

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -393,11 +393,6 @@ states. Bulk can attribute only classes proven completed by its baseline/final
 report comparison and records only those; a composite carries the union of the
 states its two phases can attribute.
 
-If a non-final chunk PR has failing CI and no eligible job remains to rerun,
-Forge releases the linked issue so a replacement chunk can be generated —
-otherwise the coordinate would be stranded mid-sequence behind a chunk nobody
-will fix.
-
 Each chunk also records its publication identity and unique head branch in the
 exhaust report before the verified push, which is how a later chunk resolves the
 preceding PR without committing a GitHub-assigned number back to the branch. The

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -701,10 +701,8 @@ Chunked mode is automatic after the issue is marked with the
 `chunked-dynamic-access` label. The normal project status remains the run-state
 signal: `Todo` means Forge may claim the next chunk, `In Progress` means a chunk
 is currently being generated or reviewed, and the final PR's `Fixes: #<issue>`
-transition moves the issue to `Done`. If a non-final chunk PR has failed CI and
-no failed-job rerun remains available, Forge must move the issue back to `Todo`
-and mark that PR for human follow-up so a replacement chunk can be generated.
-Forge must not require an explicit resume-state CLI flag; the exhaust report
+transition moves the issue to `Done`. Forge must not require an explicit
+resume-state CLI flag; the exhaust report
 location must be derived from the coordinate and loaded automatically by the
 orchestration scripts, as specified by §AR-dynamic-access-exhaust-report. When
 the issue is being resumed from a preserved failed-run continuation marker,

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -710,6 +710,11 @@ Forge may proceed without a coordinate-local exhaust report and use
 `explore.exhaustedClasses` from the marker as the processed-class set for the
 resumed run (§FS-forge-run-continuation.2).
 
+When a non-final chunk PR merges, Forge releases the linked issue for the next
+chunk by moving it to `Todo`, clearing its assignees, and removing the
+`human-intervention` and `resumable` labels when present. It retains the
+`chunked-dynamic-access` label so the next claim stays in chunked mode.
+
 Chunk PRs use `Refs: #<issue>` until the final chunk. Only the final chunk PR
 may use `Fixes: #<issue>` and move the issue to `Done`. Non-final chunk PRs
 must commit enough exhaust-report state for the next run to skip classes already

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -552,8 +552,12 @@ from the phase that failed instead of regenerating from scratch
 
 Forge review automation processes open pull requests by their PR labels only
 after CI has completed successfully. A pull request with running checks waits;
-a pull request with failed checks is handled by deterministic CI-failure
-follow-up and must not launch a review agent. A generated branch is reviewed
+a pull request with failed checks must not launch a review agent. For every
+failed GitHub Actions workflow run on the current pull-request head, Forge
+reruns the failed jobs only while `run_attempt` is less than `3`. At attempt
+`3` or above, Forge skips review and takes no other action: it does not label
+the pull request, change a linked issue's status or assignees, or distinguish a
+chunked pull request from any other pull request. A generated branch is reviewed
 locally before the push, against evidence a post-push reviewer cannot see
 (§FS-local-branch-review). The published-PR workflow either reuses a trusted,
 current-head attestation of that approval or launches the existing second

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -2645,7 +2645,10 @@ def resolve_non_final_chunked_dynamic_access_issue(pr: dict) -> int | None:
 
 
 def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
-    """Move a merged non-final chunk issue back to Todo for the next chunk."""
+    """Restore a merged non-final chunk issue for a clean next chunk.
+
+    §FS-forge-chunked-dynamic-access
+    """
     issue_number = resolve_non_final_chunked_dynamic_access_issue(pr)
     if issue_number is None:
         return
@@ -2656,6 +2659,10 @@ def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
             f"Chunked dynamic-access PR #{pr.get('number')} references issue #{issue_number}, "
             f"but the issue is not linked to project {PROJECT_NUMBER}."
         )
+    issue: dict = get_issue_claim_payload(issue_number)
+    for label_name in (LABEL_HUMAN_INTERVENTION, LABEL_RESUMABLE):
+        if issue_has_label(issue, label_name):
+            remove_issue_label(issue_number, label_name)
     set_item_status(item_id, STATUS_TODO)
     clear_issue_assignees(issue_number)
     invalidate_issue_claim_cache_entry(issue_number)

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -2417,7 +2417,10 @@ def get_pull_request_workflow_runs(head_sha: str) -> list[dict]:
 
 
 def get_rerunnable_failed_workflow_run_ids(workflow_runs: list[dict]) -> list[int]:
-    """Return failed GitHub Actions run IDs below the automated rerun limit."""
+    """Return failed GitHub Actions run IDs below the automated rerun limit.
+
+    §FS-automated-pr-review
+    """
     run_ids: list[int] = []
     for workflow_run in workflow_runs:
         if not isinstance(workflow_run, dict):
@@ -2641,11 +2644,11 @@ def resolve_non_final_chunked_dynamic_access_issue(pr: dict) -> int | None:
     return int(match.group(1))
 
 
-def release_non_final_chunked_dynamic_access_issue(pr: dict, reason: str) -> int | None:
-    """Move a non-final chunk issue back to Todo and return the issue number."""
+def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
+    """Move a merged non-final chunk issue back to Todo for the next chunk."""
     issue_number = resolve_non_final_chunked_dynamic_access_issue(pr)
     if issue_number is None:
-        return None
+        return
 
     item_id = get_project_item_id(issue_number)
     if item_id is None:
@@ -2658,31 +2661,8 @@ def release_non_final_chunked_dynamic_access_issue(pr: dict, reason: str) -> int
     invalidate_issue_claim_cache_entry(issue_number)
     log_stage(
         "chunked-dynamic-access",
-        f"Released issue #{issue_number} for the next chunk after PR #{pr.get('number')} {reason}.",
+        f"Released issue #{issue_number} for the next chunk after PR #{pr.get('number')} merged.",
     )
-    return issue_number
-
-
-def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
-    """Move a merged non-final chunk issue back to Todo for the next chunk."""
-    release_non_final_chunked_dynamic_access_issue(pr, "merged")
-
-
-def apply_chunked_dynamic_access_failed_ci_follow_up(pr: dict) -> None:
-    """Release a non-final chunk issue when its PR has failed CI and no rerun remains."""
-    issue_number = release_non_final_chunked_dynamic_access_issue(pr, "failed CI")
-    if issue_number is None:
-        return
-    pr_number = pr.get("number")
-    if isinstance(pr_number, int):
-        add_pull_request_label(pr_number, LABEL_HUMAN_INTERVENTION)
-        log_stage(
-            "chunked-dynamic-access",
-            (
-                f"Marked failed non-final chunk PR #{pr_number} as "
-                f"'{LABEL_HUMAN_INTERVENTION}' after releasing issue #{issue_number}."
-            ),
-        )
 
 
 def apply_unblocked_issue_merge_follow_up(pr: dict) -> None:
@@ -2850,7 +2830,10 @@ def resolve_pull_request_merge_conflict(
 
 
 def reconcile_failed_ci_pull_request(pull_request: dict) -> None:
-    """Handle failed CI deterministically without launching a review agent."""
+    """Rerun failed CI below attempt three, otherwise skip review.
+
+    §FS-automated-pr-review
+    """
     pr_number = pull_request.get("number")
     head_sha = pull_request.get("headRefOid")
     if not isinstance(pr_number, int) or not isinstance(head_sha, str) or not head_sha:
@@ -2861,23 +2844,12 @@ def reconcile_failed_ci_pull_request(pull_request: dict) -> None:
         print(f"[Skipping failed-CI follow-up for PR #{pr_number}: CI state changed.]")
         return
 
-    chunked_issue = resolve_non_final_chunked_dynamic_access_issue(pull_request)
     rerun_count = rerun_failed_pull_request_workflow_jobs(pr_number, head_sha)
     if rerun_count:
-        if chunked_issue is not None:
-            print(
-                f"[Reran failed GitHub Actions job(s) in {rerun_count} workflow run(s) "
-                f"for chunked PR #{pr_number}; keeping the backing issue in progress for this pass.]"
-            )
-        else:
-            print(
-                f"[Reran failed GitHub Actions job(s) in {rerun_count} workflow run(s) "
-                f"for PR #{pr_number}; review waits for successful CI.]"
-            )
-        return
-
-    if chunked_issue is not None:
-        apply_chunked_dynamic_access_failed_ci_follow_up(pull_request)
+        print(
+            f"[Reran failed GitHub Actions job(s) in {rerun_count} workflow run(s) "
+            f"for PR #{pr_number}; review waits for successful CI.]"
+        )
         return
 
     print(

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -4651,14 +4651,59 @@ class PullRequestReviewTests(unittest.TestCase):
         with patch.object(forge_metadata, "get_pull_request_changed_index_files", return_value=[]), \
                 patch.object(forge_metadata, "gh"), \
                 patch.object(forge_metadata, "get_project_item_id", return_value="project-item"), \
+                patch.object(
+                    forge_metadata,
+                    "get_issue_claim_payload",
+                    return_value={
+                        "labels": [
+                            {"name": forge_metadata.LABEL_CHUNKED_DYNAMIC_ACCESS},
+                            {"name": forge_metadata.LABEL_HUMAN_INTERVENTION},
+                            {"name": forge_metadata.LABEL_RESUMABLE},
+                        ],
+                    },
+                ), \
+                patch.object(forge_metadata, "remove_issue_label") as remove_issue_label, \
                 patch.object(forge_metadata, "set_item_status") as set_item_status, \
                 patch.object(forge_metadata, "clear_issue_assignees") as clear_issue_assignees, \
                 patch.object(forge_metadata, "invalidate_issue_claim_cache_entry") as invalidate_cache:
             forge_metadata.merge_pull_request(pr, "/repo")
 
+        self.assertEqual(
+            remove_issue_label.call_args_list,
+            [
+                call(1412, forge_metadata.LABEL_HUMAN_INTERVENTION),
+                call(1412, forge_metadata.LABEL_RESUMABLE),
+            ],
+        )
         set_item_status.assert_called_once_with("project-item", forge_metadata.STATUS_TODO)
         clear_issue_assignees.assert_called_once_with(1412)
         invalidate_cache.assert_called_once_with(1412)
+
+    def test_merge_pull_request_keeps_clean_chunk_issue_labels(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "body": "Refs: #1412\n\nSummary:\n- Chunked dynamic-access: yes\n",
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_changed_index_files", return_value=[]), \
+                patch.object(forge_metadata, "gh"), \
+                patch.object(forge_metadata, "get_project_item_id", return_value="project-item"), \
+                patch.object(
+                    forge_metadata,
+                    "get_issue_claim_payload",
+                    return_value={
+                        "labels": [{"name": forge_metadata.LABEL_CHUNKED_DYNAMIC_ACCESS}],
+                    },
+                ), \
+                patch.object(forge_metadata, "remove_issue_label") as remove_issue_label, \
+                patch.object(forge_metadata, "set_item_status"), \
+                patch.object(forge_metadata, "clear_issue_assignees"), \
+                patch.object(forge_metadata, "invalidate_issue_claim_cache_entry"):
+            forge_metadata.merge_pull_request(pr, "/repo")
+
+        remove_issue_label.assert_not_called()
 
     def test_merge_pull_request_does_not_release_final_chunked_dynamic_access_issue(self) -> None:
         pr = {

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -4759,6 +4759,41 @@ class PullRequestReviewTests(unittest.TestCase):
         rerun_failed_jobs.assert_called_once_with(3513, "abc123")
         merge_pull_request.assert_not_called()
 
+    def test_reconcile_failed_ci_treats_chunked_and_regular_prs_the_same_after_cap(self) -> None:
+        outputs: list[str] = []
+        pull_request_bodies = (
+            "",
+            "Refs: #1412\n\nSummary:\n- Chunked dynamic-access: yes\n",
+        )
+
+        for body in pull_request_bodies:
+            pull_request = {
+                "number": 3513,
+                "headRefOid": "abc123",
+                "body": body,
+                "statusCheckRollup": {"state": "FAILURE"},
+            }
+            output = io.StringIO()
+            with self.subTest(body=body), contextlib.redirect_stdout(output), \
+                    patch.object(
+                        forge_metadata,
+                        "rerun_failed_pull_request_workflow_jobs",
+                        return_value=0,
+                    ) as rerun_failed_jobs, \
+                    patch.object(forge_metadata, "add_pull_request_label") as add_label, \
+                    patch.object(forge_metadata, "set_item_status") as set_item_status, \
+                    patch.object(forge_metadata, "clear_issue_assignees") as clear_assignees:
+                forge_metadata.reconcile_failed_ci_pull_request(pull_request)
+
+            rerun_failed_jobs.assert_called_once_with(3513, "abc123")
+            add_label.assert_not_called()
+            set_item_status.assert_not_called()
+            clear_assignees.assert_not_called()
+            outputs.append(output.getvalue())
+
+        self.assertEqual(outputs[0], outputs[1])
+        self.assertIn("Skipping review for PR #3513", outputs[0])
+
     def test_reconcile_approved_conflicting_pr_resolves_the_conflict_instead_of_merging(self) -> None:
         pr = {
             "number": 3513,
@@ -4827,6 +4862,7 @@ class PullRequestReviewTests(unittest.TestCase):
             {"id": 103, "conclusion": "failure", "run_attempt": 3},
             {"id": 104, "conclusion": "success", "run_attempt": 1},
             {"id": 105, "conclusion": None, "run_attempt": 1},
+            {"id": 106, "conclusion": "failure", "run_attempt": 4},
         ]
 
         with patch.object(forge_metadata, "get_pull_request_workflow_runs", return_value=workflow_runs), \


### PR DESCRIPTION
Closes #9635

## What this does

Forge capped automatic CI reruns at attempt three, but the terminal behavior depended on PR shape: an exhausted non-final chunk released its linked issue and gained `human-intervention`, while an ordinary PR only skipped review. The decision here is to use the GitHub Actions `run_attempt` as the single authority and apply one rule to every PR, as specified by [§forge/FS-automated-pr-review](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/unify-failed-ci-retries/forge/docs/functional-spec/publication.md#fs-automated-pr-review-automated-pull-request-review).

## Failed-CI decision

| Current-head workflow state | Forge action |
| --- | --- |
| Running | Wait; do not review |
| Failed with `run_attempt < 3` | Rerun failed jobs; do not review |
| Failed with `run_attempt >= 3` | Skip review; make no PR or issue mutation |
| Successful | Continue through the existing review path |

At the retry cap Forge no longer parses chunk state, adds `human-intervention`, releases the linked issue, clears assignees, or invalidates its claim cache. Chunked and ordinary PRs now behave identically; the existing merge-time release of a completed non-final chunk remains unchanged.

The orchestration description now mirrors that uniform decision in [§forge/AR-forge-orchestration](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/unify-failed-ci-retries/forge/docs/architecture/orchestration-scripts.md#ar-forge-orchestration-forge-orchestration-scripts). The old failed-CI exception is removed from [§forge/FS-forge-chunked-dynamic-access](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/unify-failed-ci-retries/forge/docs/functional-spec/functional-spec.md#fs-forge-chunked-dynamic-access-chunked-dynamic-access-semantics) and [§forge/AR-chunked-dynamic-access-pr-linking](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/unify-failed-ci-retries/forge/docs/architecture/workflows.md#ar-chunked-dynamic-access-pr-linking-chunk-pr-linking). Regression coverage proves attempts three and four are not rerun and that capped chunked and ordinary PRs produce the same no-mutation outcome.