### PR TITLE
Resolve foreign metadata dependency owners

### DIFF
--- a/docs/functional-spec/metadata.md
+++ b/docs/functional-spec/metadata.md
@@ -94,22 +94,28 @@ Native tracing can observe an entry whose `condition.typeReached` belongs to a
 different artifact than the coordinate under test. After `checkMetadataFiles`
 reports such an entry outside the source artifact's `allowed-packages`, the
 metadata finalization flow invokes deterministic ownership routing before any
-allowed-package repair. The router resolves candidate owners from checked-in
-`allowed-packages`, and may move the entry only when the same tested version is
-mapped by exactly one supported artifact. If that tested version shares a
-metadata bucket with other versions, the task forks an exact version bucket by
-copying the inherited metadata before adding the new entry; older tested
-versions keep their original bucket unchanged. A successful metadata check
-never invokes ownership routing. When routing creates an exact metadata-version
-bucket, finalization also generates and commits that owner's matching library
-statistics using the bucket's resolved test version. If the inherited owner
-bucket is marked `latest`, the exact bucket takes ownership of `latest` and its
-automation fields; the inherited bucket relinquishes them.
+allowed-package repair. The router resolves the tested library's runtime
+dependency closure and locates `typeReached` in the runtime-visible view of
+those JARs. It may move the entry only when exactly one resolved dependency
+coordinate owns the class and that exact dependency version is listed in the
+owner's metadata index with a compatible `allowed-packages` entry.
 
-An entry with no unique supported owner remains untouched and routing fails.
-The router never deletes an entry merely because its condition is foreign, and
-`checkMetadataFiles` remains the independent, read-only enforcement gate that
-is rerun after a successful relocation.
+The resolved dependency version, rather than the source artifact's version,
+selects the destination. When it sits inside a shared metadata bucket, the task
+splits the bucket at that version's existing `tested-versions` position: earlier
+versions keep the inherited metadata, while the resolved version and every
+later list entry move together to a copied exact-version bucket. Finalization
+generates and commits that destination's matching library statistics using its
+resolved test version. If the inherited bucket is marked `latest`, the later
+bucket takes ownership of `latest` and its automation fields.
+
+A uniquely resolved owner whose artifact or exact version is unsupported is
+reported with that coordinate and remains untouched. An entry with no unique
+resolved owner also remains untouched, but carries no unsupported-owner report.
+Both cases fail routing. A successful metadata check never invokes ownership
+routing, the router never deletes an entry merely because its condition is
+foreign, and `checkMetadataFiles` remains the independent, read-only enforcement
+gate rerun after a successful relocation.
 §FS-repository-functional-spec.5.1
 
 ## 3. Provenance

--- a/forge/docs/architecture/drivers.md
+++ b/forge/docs/architecture/drivers.md
@@ -304,6 +304,15 @@ staging only artifact-scoped paths would drop them, and the next checkpoint rese
 would delete them. Test sources and stats stay scoped to the target coordinate.
 
 Per-coordinate finalization repairs missing allowed-packages deterministically.
+After `checkMetadataFiles` fails, it first runs `routeForeignMetadata`. When
+routing resolves an owner whose artifact is absent from repository metadata,
+Forge creates or reuses a `library-new-request`; when the artifact exists but
+the resolved version is unsupported, it creates or reuses a
+`library-update-request`. Routing remains failed, and Forge gives the original
+check output, routing output, resolved coordinate, and issue URL to the analysis
+agent. A passing initial metadata check does not run ownership routing.
+§FS-foreign-metadata-owner-follow-ups
+
 If metadata validation still fails, Forge gives its command and captured output
 to the analysis agent up to three times, rerunning validation after each repair
 and letting each deterministic result decide whether another attempt is needed.

--- a/forge/docs/functional-spec/README.md
+++ b/forge/docs/functional-spec/README.md
@@ -18,6 +18,7 @@ contract in [strategies.md](strategies.md), the benchmark contract in
 | [§FS-forge-functional-spec](functional-spec.md#fs-forge-functional-spec-forge-functional-specification) | Forge functional specification |
 | [§FS-forge-issue-resolution-goal](functional-spec.md#fs-forge-issue-resolution-goal-forge-issue-resolution-goal) | Forge issue resolution goal |
 | [§FS-forge-scope](functional-spec.md#fs-forge-scope-supported-issue-queues) | Supported issue queues |
+| [§FS-foreign-metadata-owner-follow-ups](functional-spec.md#fs-foreign-metadata-owner-follow-ups-foreign-metadata-owner-follow-ups) | Foreign metadata owner follow-ups |
 | [§FS-forge-glossary](functional-spec.md#fs-forge-glossary-glossary) | Glossary |
 | [§FS-forge-requirements](functional-spec.md#fs-forge-requirements-requirement-gates) | Requirement gates |
 | [§FS-forge-host-requirements](functional-spec.md#fs-forge-host-requirements-host-requirements) | Host requirements |

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -71,6 +71,23 @@ the stage that broke (`fails-javac-compile`, `fails-java-run`,
 issues; it never opens them. The producer's contract is the reachability repo's
 Library version update automation (§root/FS-library-version-update-automation).
 
+## FS-foreign-metadata-owner-follow-ups: Foreign metadata owner follow-ups
+
+§FS-forge-scope §root/FS-metadata
+
+When metadata finalization resolves a foreign condition to one runtime
+dependency coordinate that the reachability repo cannot yet host, Forge must
+create or reuse an open issue targeting that exact coordinate. A missing
+artifact uses `library-new-request`; an existing artifact missing the resolved
+version uses `library-update-request`.
+
+The routing operation and original metadata check remain failed. Forge gives
+the analysis agent their captured output, the resolved coordinate, the failure
+reason, and the follow-up issue URL. It must not treat the dependency package as
+owned by the source artifact. If ownership is absent or ambiguous, Forge creates
+no issue and gives the unresolved routing failure to the agent. A passing
+initial metadata check performs none of this work.
+
 ## FS-forge-glossary: Glossary
 
 | Term | Definition |

--- a/forge/tests/test_foreign_metadata_owner_issue.py
+++ b/forge/tests/test_foreign_metadata_owner_issue.py
@@ -1,0 +1,89 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from utility_scripts.foreign_metadata_owner_issue import (
+    ForeignMetadataOwnerFailure,
+    ensure_foreign_metadata_owner_issue,
+    failure_report_path,
+    load_foreign_metadata_owner_failure,
+)
+
+
+class ForeignMetadataOwnerIssueTests(unittest.TestCase):
+    def test_loads_only_two_field_ignored_report(self) -> None:
+        with tempfile.TemporaryDirectory() as repo_path:
+            report_path = failure_report_path(repo_path, "org.example:source:2.0.0")
+            os.makedirs(os.path.dirname(report_path))
+            with open(report_path, "w", encoding="utf-8") as report_file:
+                json.dump(
+                    {
+                        "reason": "owner-version-unsupported",
+                        "coordinate": "org.owner:dependency:1.0.0",
+                    },
+                    report_file,
+                )
+
+            failure = load_foreign_metadata_owner_failure(repo_path, "org.example:source:2.0.0")
+
+        self.assertEqual(
+            failure,
+            ForeignMetadataOwnerFailure("owner-version-unsupported", "org.owner:dependency:1.0.0"),
+        )
+        self.assertIn(os.path.join("build", "reports", "route-foreign-metadata"), report_path)
+
+    @patch("utility_scripts.foreign_metadata_owner_issue.resolve_github_repo_slug", return_value="oracle/repo")
+    @patch("utility_scripts.foreign_metadata_owner_issue.gh_json", return_value=[])
+    @patch("utility_scripts.foreign_metadata_owner_issue.gh")
+    def test_creates_new_library_issue_once(self, gh: Mock, _gh_json: Mock, _repo: Mock) -> None:
+        gh.return_value = subprocess.CompletedProcess([], 0, stdout="https://github.com/oracle/repo/issues/42\n")
+        failure = ForeignMetadataOwnerFailure(
+            "owner-library-unsupported",
+            "org.owner:dependency:1.0.0",
+        )
+
+        issue_url = ensure_foreign_metadata_owner_issue(
+            "/repo",
+            "org.example:source:2.0.0",
+            failure,
+        )
+
+        self.assertEqual(issue_url, "https://github.com/oracle/repo/issues/42")
+        arguments = gh.call_args.args
+        self.assertIn("library-new-request", arguments)
+        self.assertIn("Support for org.owner:dependency:1.0.0", arguments)
+
+    @patch("utility_scripts.foreign_metadata_owner_issue.resolve_github_repo_slug", return_value="oracle/repo")
+    @patch("utility_scripts.foreign_metadata_owner_issue.gh")
+    @patch("utility_scripts.foreign_metadata_owner_issue.gh_json")
+    def test_reuses_matching_open_issue(self, gh_json: Mock, gh: Mock, _repo: Mock) -> None:
+        gh_json.return_value = [{
+            "number": 7,
+            "url": "https://github.com/oracle/repo/issues/7",
+            "body": "<!-- forge-foreign-metadata-owner:owner-version-unsupported:org.owner:dependency:1.0.0 -->",
+        }]
+        failure = ForeignMetadataOwnerFailure(
+            "owner-version-unsupported",
+            "org.owner:dependency:1.0.0",
+        )
+
+        issue_url = ensure_foreign_metadata_owner_issue(
+            "/repo",
+            "org.example:source:2.0.0",
+            failure,
+        )
+
+        self.assertEqual(issue_url, "https://github.com/oracle/repo/issues/7")
+        gh.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_library_finalization.py
+++ b/forge/tests/test_library_finalization.py
@@ -4,13 +4,15 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import io
+import json
 import os
 import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from utility_scripts.foreign_metadata_owner_issue import failure_report_path
 from utility_scripts.library_finalization import (
     _run_finalization_agent_fix,
     run_library_finalization,
@@ -244,6 +246,10 @@ class LibraryFinalizationTests(unittest.TestCase):
                 "utility_scripts.library_finalization._run_gradle_command",
                 side_effect=run_gradle,
         ), patch(
+                "utility_scripts.library_finalization._run_route_foreign_metadata",
+                side_effect=lambda *_args: events.append("routeForeignMetadata")
+                or Mock(returncode=0, stdout=""),
+        ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],
         ), patch(
@@ -274,12 +280,12 @@ class LibraryFinalizationTests(unittest.TestCase):
         )
 
     def test_route_failure_falls_through_to_analysis_repair(self) -> None:
-        def run_gradle(_repo_path: str, command: list[str]) -> bool:
-            return command[1] != "routeForeignMetadata"
-
         with tempfile.TemporaryDirectory() as repo_path, patch(
                 "utility_scripts.library_finalization._run_gradle_command",
-                side_effect=run_gradle,
+                return_value=True,
+        ), patch(
+                "utility_scripts.library_finalization._run_route_foreign_metadata",
+                return_value=Mock(returncode=1, stdout="routing failed"),
         ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],
@@ -308,13 +314,78 @@ class LibraryFinalizationTests(unittest.TestCase):
             )
 
         self.assertTrue(result)
-        analysis_fix.assert_called_once_with(repo_path, "org.example:demo:1.0.0", "malformed metadata")
+        agent_evidence = analysis_fix.call_args.args[2]
+        self.assertIn("malformed metadata", agent_evidence)
+        self.assertIn("routing failed", agent_evidence)
         check_metadata.assert_called_once()
+
+    def test_unsupported_owner_issue_and_route_output_reach_agent(self) -> None:
+        library = "org.example:demo:1.0.0"
+        with tempfile.TemporaryDirectory() as repo_path:
+            report_path = failure_report_path(repo_path, library)
+            os.makedirs(os.path.dirname(report_path))
+            with open(report_path, "w", encoding="utf-8") as report_file:
+                json.dump(
+                    {
+                        "reason": "owner-version-unsupported",
+                        "coordinate": "org.owner:dependency:1.0.0",
+                    },
+                    report_file,
+                )
+
+            with patch(
+                    "utility_scripts.library_finalization._run_gradle_command",
+                    return_value=True,
+            ), patch(
+                    "utility_scripts.library_finalization._run_route_foreign_metadata",
+                    return_value=Mock(returncode=1, stdout="owner version is not supported"),
+            ), patch(
+                    "utility_scripts.library_finalization.ensure_foreign_metadata_owner_issue",
+                    return_value="https://github.com/oracle/repo/issues/42",
+            ) as ensure_issue, patch(
+                    "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
+                    return_value=[],
+            ), patch(
+                    "utility_scripts.library_finalization._run_check_metadata_files",
+                    side_effect=[(False, "foreign package"), (True, "BUILD SUCCESSFUL")],
+            ) as check_metadata, patch(
+                    "utility_scripts.library_finalization._run_check_metadata_files_with_allowed_packages_fix",
+            ) as allowed_packages_fix, patch(
+                    "utility_scripts.library_finalization._run_check_metadata_fix",
+                    return_value=True,
+            ) as analysis_fix, patch(
+                    "utility_scripts.library_finalization.run_style_fix_and_checks",
+                    return_value=True,
+            ), patch(
+                    "utility_scripts.library_finalization.collect_generated_test_validity_issues",
+                    return_value=[],
+            ):
+                result = run_library_finalization(
+                    repo_path=repo_path,
+                    library=library,
+                    group="org.example",
+                    artifact="demo",
+                    library_version="1.0.0",
+                )
+
+        self.assertTrue(result)
+        ensure_issue.assert_called_once()
+        allowed_packages_fix.assert_not_called()
+        self.assertEqual(check_metadata.call_count, 2)
+        agent_evidence = analysis_fix.call_args.args[2]
+        self.assertIn("foreign package", agent_evidence)
+        self.assertIn("owner-version-unsupported", agent_evidence)
+        self.assertIn("org.owner:dependency:1.0.0", agent_evidence)
+        self.assertIn("https://github.com/oracle/repo/issues/42", agent_evidence)
+        self.assertIn("owner version is not supported", agent_evidence)
 
     def test_metadata_validation_passes_after_first_analysis_repair(self) -> None:
         with tempfile.TemporaryDirectory() as repo_path, patch(
                 "utility_scripts.library_finalization._run_gradle_command",
                 return_value=True,
+        ), patch(
+                "utility_scripts.library_finalization._run_route_foreign_metadata",
+                return_value=Mock(returncode=0, stdout=""),
         ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],
@@ -356,6 +427,9 @@ class LibraryFinalizationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as repo_path, patch(
                 "utility_scripts.library_finalization._run_gradle_command",
                 return_value=True,
+        ), patch(
+                "utility_scripts.library_finalization._run_route_foreign_metadata",
+                return_value=Mock(returncode=0, stdout=""),
         ), patch(
                 "utility_scripts.library_finalization.find_uncommitted_legacy_test_native_image_config_files_for_coordinate",
                 return_value=[],

--- a/forge/utility_scripts/foreign_metadata_owner_issue.py
+++ b/forge/utility_scripts/foreign_metadata_owner_issue.py
@@ -1,0 +1,124 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Create idempotent follow-up issues for unsupported resolved metadata owners.
+
+§FS-forge-scope §AR-forge-driver-finalization
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+
+from git_scripts.common_git import gh, gh_json, resolve_github_repo_slug
+
+
+REASONS_TO_LABELS = {
+    "owner-library-unsupported": "library-new-request",
+    "owner-version-unsupported": "library-update-request",
+}
+
+
+@dataclass(frozen=True)
+class ForeignMetadataOwnerFailure:
+    """The complete two-field routeForeignMetadata failure contract."""
+
+    reason: str
+    coordinate: str
+
+
+def failure_report_path(repo_path: str, source_coordinate: str) -> str:
+    """Return the ignored build path for one routing failure report."""
+    file_name = source_coordinate.replace(":", "_") + ".json"
+    return os.path.join(repo_path, "build", "reports", "route-foreign-metadata", file_name)
+
+
+def load_foreign_metadata_owner_failure(
+        repo_path: str,
+        source_coordinate: str,
+) -> ForeignMetadataOwnerFailure | None:
+    """Load a valid unsupported-owner report, returning None for no report."""
+    report_path = failure_report_path(repo_path, source_coordinate)
+    if not os.path.isfile(report_path):
+        return None
+    try:
+        with open(report_path, "r", encoding="utf-8") as report_file:
+            report = json.load(report_file)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(report, dict) or set(report) != {"reason", "coordinate"}:
+        return None
+    reason = report.get("reason")
+    coordinate = report.get("coordinate")
+    if reason not in REASONS_TO_LABELS or not isinstance(coordinate, str) or not coordinate.strip():
+        return None
+    return ForeignMetadataOwnerFailure(reason=reason, coordinate=coordinate)
+
+
+def ensure_foreign_metadata_owner_issue(
+        repo_path: str,
+        source_coordinate: str,
+        failure: ForeignMetadataOwnerFailure,
+) -> str:
+    """Create or reuse the open queue issue for an unsupported owner coordinate."""
+    repo = resolve_github_repo_slug(repo_path=repo_path)
+    label = REASONS_TO_LABELS[failure.reason]
+    marker = _issue_marker(failure)
+    issues = gh_json(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--label",
+        label,
+        "--search",
+        f'"{failure.coordinate}" in:title,body',
+        "--json",
+        "number,title,body,url",
+        "--limit",
+        "50",
+    )
+    if isinstance(issues, list):
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            issue_text = f"{issue.get('title') or ''}\n{issue.get('body') or ''}"
+            if marker in issue_text or failure.coordinate in issue_text:
+                return str(issue["url"])
+
+    title = (
+        f"Support for {failure.coordinate}"
+        if label == "library-new-request"
+        else f"Update existing library: {failure.coordinate}"
+    )
+    body = (
+        f"Forge resolved metadata generated while testing `{source_coordinate}` to the runtime dependency "
+        f"`{failure.coordinate}`, which is not yet supported for this routing operation.\n\n"
+        f"{marker}\n"
+    )
+    result = gh(
+        "issue",
+        "create",
+        "--repo",
+        repo,
+        "--title",
+        title,
+        "--body",
+        body,
+        "--label",
+        label,
+    )
+    issue_url = result.stdout.strip()
+    if not issue_url:
+        raise RuntimeError(f"GitHub did not return a URL for the {failure.coordinate} follow-up issue")
+    return issue_url
+
+
+def _issue_marker(failure: ForeignMetadataOwnerFailure) -> str:
+    return f"<!-- forge-foreign-metadata-owner:{failure.reason}:{failure.coordinate} -->"

--- a/forge/utility_scripts/library_finalization.py
+++ b/forge/utility_scripts/library_finalization.py
@@ -10,6 +10,11 @@ import sys
 from collections.abc import Callable
 
 from ai_workflows.agents.agent_runtime import analysis_agent_run, get_analysis_agent
+from utility_scripts.foreign_metadata_owner_issue import (
+    ForeignMetadataOwnerFailure,
+    ensure_foreign_metadata_owner_issue,
+    load_foreign_metadata_owner_failure,
+)
 from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.metadata_index import find_index_entry_for_version
@@ -99,6 +104,46 @@ def _run_gradle_command(repo_path: str, command: list[str]) -> bool:
     if result.returncode != 0:
         return False
     return True
+
+
+def _run_route_foreign_metadata(repo_path: str, library: str) -> LoggedCommandResult:
+    """Run ownership routing while retaining its output for agent evidence."""
+    return _run_gradle_command_with_output(
+        repo_path,
+        ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"],
+    )
+
+
+def _unsupported_owner_agent_evidence(
+        failure: ForeignMetadataOwnerFailure,
+        issue_url: str,
+        routing_output: str,
+) -> str:
+    """Format the deterministic owner-resolution evidence for metadata repair."""
+    return "\n".join([
+        "routeForeignMetadata failed after resolving the foreign condition owner.",
+        f"Reason: {failure.reason}",
+        f"Resolved dependency coordinate: {failure.coordinate}",
+        f"Follow-up issue: {issue_url}",
+        "Do not add the resolved dependency package to the source artifact's allowed-packages.",
+        "",
+        "Captured routeForeignMetadata output:",
+        "```text",
+        routing_output,
+        "```",
+    ])
+
+
+def _routing_failure_agent_evidence(routing_output: str) -> str:
+    """Format a routing failure that did not resolve one unsupported owner."""
+    return "\n".join([
+        "routeForeignMetadata failed without a supported resolved dependency owner.",
+        "",
+        "Captured routeForeignMetadata output:",
+        "```text",
+        routing_output,
+        "```",
+    ])
 
 
 def _run_check_metadata_fix(repo_path: str, library: str, failure_output: str) -> bool:
@@ -322,9 +367,12 @@ def run_library_finalization(
         library,
         "check-metadata-files",
     )
+    routing_failure_evidence: str | None = None
+    unsupported_owner_reported = False
     if not metadata_valid:
         log_detail("route-foreign-metadata", f"Running routeForeignMetadata after validation failed for {library}")
-        if _run_gradle_command(repo_path, ["./gradlew", "routeForeignMetadata", f"-Pcoordinates={library}"]):
+        route_result = _run_route_foreign_metadata(repo_path, library)
+        if route_result.returncode == 0:
             metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
                 repo_path=repo_path,
                 library=library,
@@ -333,28 +381,48 @@ def run_library_finalization(
                 library_version=library_version,
                 log_stage_name="check-metadata-files",
             )
+        else:
+            owner_failure = load_foreign_metadata_owner_failure(repo_path, library)
+            if owner_failure is not None:
+                issue_url = ensure_foreign_metadata_owner_issue(repo_path, library, owner_failure)
+                routing_failure_evidence = _unsupported_owner_agent_evidence(
+                    owner_failure,
+                    issue_url,
+                    route_result.stdout,
+                )
+                unsupported_owner_reported = True
+            else:
+                routing_failure_evidence = _routing_failure_agent_evidence(route_result.stdout)
     if not metadata_valid:
         for attempt in range(1, MAX_CHECK_METADATA_FIX_ATTEMPTS + 1):
             log_detail(
                 "check-metadata-files",
                 f"Running analysis metadata fix attempt {attempt}/{MAX_CHECK_METADATA_FIX_ATTEMPTS} for {library}",
             )
+            agent_evidence = "\n\n".join(filter(None, [metadata_failure_output, routing_failure_evidence]))
             if not _run_finalization_agent_fix(
                     library,
                     "metadata validation",
                     attempt,
                     MAX_CHECK_METADATA_FIX_ATTEMPTS,
-                    lambda: _run_check_metadata_fix(repo_path, library, metadata_failure_output),
+                    lambda: _run_check_metadata_fix(repo_path, library, agent_evidence),
             ):
                 continue
-            metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
-                repo_path=repo_path,
-                library=library,
-                group=group,
-                artifact=artifact,
-                library_version=library_version,
-                log_stage_name="check-metadata-files",
-            )
+            if not unsupported_owner_reported:
+                metadata_valid, metadata_failure_output = _run_check_metadata_files_with_allowed_packages_fix(
+                    repo_path=repo_path,
+                    library=library,
+                    group=group,
+                    artifact=artifact,
+                    library_version=library_version,
+                    log_stage_name="check-metadata-files",
+                )
+            else:
+                metadata_valid, metadata_failure_output = _run_check_metadata_files(
+                    repo_path,
+                    library,
+                    "check-metadata-files",
+                )
             if metadata_valid:
                 break
         else:

--- a/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
+++ b/tests/tck-build-logic/src/main/groovy/org.graalvm.internal.tck.gradle
@@ -14,6 +14,7 @@ import org.graalvm.internal.tck.utils.NativeImageConfigUtils
 import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
 import org.graalvm.buildtools.gradle.tasks.NativeRunTask
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitivity
@@ -411,6 +412,48 @@ Closure<List<File>> resolveTestedLibraryJars = {
     return resolveTestedLibraryArtifacts().collect { ResolvedArtifact artifact -> artifact.file }
 }
 
+Closure<List<Map<String, String>>> resolveTestedLibraryDependencyArtifacts = {
+    String[] coordinates = libraryGAV.split(":")
+    if (coordinates.length < 3) {
+        throw new GradleException("Cannot resolve runtime dependencies without tested library coordinates.")
+    }
+
+    Set<ResolvedDependency> firstLevelDependencies =
+            configurations.testRuntimeClasspath.resolvedConfiguration.firstLevelModuleDependencies
+    ResolvedDependency testedLibrary = firstLevelDependencies.find { ResolvedDependency dependency ->
+        dependency.moduleGroup == coordinates[0] && dependency.moduleName == coordinates[1]
+    }
+    if (testedLibrary == null) {
+        testedLibrary = firstLevelDependencies.find { ResolvedDependency dependency ->
+            dependency.moduleName == coordinates[1] && dependency.moduleVersion == coordinates[2]
+        }
+    }
+    if (testedLibrary == null) {
+        throw new GradleException("Cannot find resolved runtime dependency root for ${libraryGAV}.")
+    }
+
+    List<ResolvedDependency> pending = [testedLibrary]
+    Set<String> visited = new LinkedHashSet<>()
+    List<Map<String, String>> artifacts = []
+    while (!pending.isEmpty()) {
+        ResolvedDependency dependency = pending.removeFirst()
+        String coordinate = "${dependency.moduleGroup}:${dependency.moduleName}:${dependency.moduleVersion}"
+        if (!visited.add(coordinate)) {
+            continue
+        }
+        dependency.moduleArtifacts
+                .findAll { ResolvedArtifact artifact -> artifact.file.isFile() && artifact.file.name.endsWith(".jar") }
+                .sort { ResolvedArtifact artifact -> artifact.file.absolutePath }
+                .each { ResolvedArtifact artifact ->
+                    artifacts.add([coordinate: coordinate, file: artifact.file.absolutePath])
+                }
+        pending.addAll(dependency.children.sort { ResolvedDependency child ->
+            "${child.moduleGroup}:${child.moduleName}:${child.moduleVersion}"
+        })
+    }
+    return artifacts
+}
+
 Closure<List<File>> resolveTestedLibraryMainJars = {
     List<ResolvedArtifact> mainArtifacts = resolveTestedLibraryArtifacts().findAll { ResolvedArtifact artifact ->
         JarUtils.isUnclassifiedMainJar(artifact.extension, artifact.classifier)
@@ -648,6 +691,16 @@ tasks.register("listLibraryJars") { task ->
     task.doLast {
         resolveTestedLibraryJars().each { File file ->
             println file.absolutePath
+        }
+    }
+}
+
+tasks.register("listRuntimeDependencyArtifacts") { task ->
+    task.setDescription("Lists resolved tested-library dependency artifacts for metadata ownership routing")
+    task.setGroup(JavaBasePlugin.VERIFICATION_GROUP)
+    task.doLast {
+        resolveTestedLibraryDependencyArtifacts().each { Map<String, String> artifact ->
+            println "TCK_RUNTIME_DEPENDENCY=${JsonOutput.toJson(artifact)}"
         }
     }
 }

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
@@ -28,14 +28,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.jar.JarFile;
 
 /**
  * Relocates foreign-condition metadata to an exact supported owner/version.
  *
- * Owner discovery uses checked-in {@code allowed-packages} and
- * {@code tested-versions}; it never guesses support or deletes unresolved
- * evidence. Shared buckets are forked before the new entry is added.
+ * Owner discovery locates {@code typeReached} in the tested library's resolved
+ * runtime dependency JARs. Checked-in {@code tested-versions} then decides
+ * whether that exact dependency version has a supported destination.
  * §FS-metadata
  */
 final class MetadataOwnershipRouter {
@@ -59,9 +59,13 @@ final class MetadataOwnershipRouter {
         this.logger = logger;
     }
 
-    Set<String> route(Path metadataRoot, Coordinates sourceCoordinates, ObjectNode sourceMetadata) throws IOException {
+    Set<String> route(
+            Path metadataRoot,
+            Coordinates sourceCoordinates,
+            ObjectNode sourceMetadata,
+            List<ResolvedDependencyArtifact> dependencyArtifacts
+    ) throws IOException {
         SourceSupport sourceSupport = resolveSourceSupport(metadataRoot, sourceCoordinates);
-        List<OwnerCandidate> ownerCatalog = loadOwnerCatalog(metadataRoot, sourceCoordinates.version());
         Map<OwnerKey, OwnerPlan> plans = new LinkedHashMap<>();
         List<ForeignEntry> foreignEntries = new ArrayList<>();
 
@@ -75,7 +79,13 @@ final class MetadataOwnershipRouter {
                     continue;
                 }
                 String typeReached = Objects.requireNonNull(MetadataEntryOwnership.typeReached(entry));
-                OwnerCandidate owner = resolveOwner(ownerCatalog, sourceCoordinates, typeReached, entry);
+                ResolvedDependencyArtifact dependencyOwner = resolveDependencyOwner(
+                        dependencyArtifacts,
+                        sourceCoordinates,
+                        typeReached,
+                        entry
+                );
+                OwnerCandidate owner = resolveSupportedOwner(metadataRoot, dependencyOwner.coordinate(), typeReached);
                 OwnerKey key = new OwnerKey(owner.artifactDirectory(), owner.entryIndex());
                 OwnerPlan plan = plans.computeIfAbsent(key, ignored -> new OwnerPlan(owner));
                 plan.add(sectionPath, entry);
@@ -89,13 +99,13 @@ final class MetadataOwnershipRouter {
 
         Set<String> touchedCoordinates = new LinkedHashSet<>();
         for (OwnerPlan plan : plans.values()) {
-            Destination destination = prepareDestination(plan.owner(), sourceCoordinates.version());
+            Destination destination = prepareDestination(plan.owner());
             mergeEntries(destination.metadata(), plan.entriesBySection());
             writeJson(destination.metadataFile(), destination.metadata());
             if (destination.indexChanged()) {
                 writeJson(destination.indexFile(), destination.index());
             }
-            String ownerCoordinate = plan.owner().group() + ":" + plan.owner().artifact() + ":" + sourceCoordinates.version();
+            String ownerCoordinate = plan.owner().coordinate();
             touchedCoordinates.add(ownerCoordinate);
             logger.lifecycle(
                     "Relocated {} foreign metadata entr{} from {} to {}",
@@ -125,85 +135,109 @@ final class MetadataOwnershipRouter {
         throw new GradleException("No index entry in " + indexFile + " supports " + coordinates.version());
     }
 
-    private List<OwnerCandidate> loadOwnerCatalog(Path metadataRoot, String testedVersion) throws IOException {
-        List<OwnerCandidate> candidates = new ArrayList<>();
-        if (!Files.isDirectory(metadataRoot)) {
-            return candidates;
-        }
-        try (Stream<Path> paths = Files.walk(metadataRoot, 3)) {
-            for (Path indexFile : paths
-                    .filter(path -> INDEX_FILE.equals(path.getFileName().toString()))
-                    .sorted()
-                    .toList()) {
-                Path artifactDirectory = indexFile.getParent();
-                Path relative = metadataRoot.relativize(artifactDirectory);
-                if (relative.getNameCount() != 2) {
-                    continue;
-                }
-                ArrayNode index = requireArray(objectMapper.readTree(indexFile.toFile()), indexFile);
-                for (int entryIndex = 0; entryIndex < index.size(); entryIndex++) {
-                    JsonNode rawEntry = index.get(entryIndex);
-                    if (!(rawEntry instanceof ObjectNode entry) || !supportsVersion(entry, testedVersion)) {
-                        continue;
-                    }
-                    List<String> allowedPackages = readStringArray(entry.get("allowed-packages"), "allowed-packages", indexFile);
-                    String metadataVersion = requiredText(entry, "metadata-version", indexFile);
-                    candidates.add(new OwnerCandidate(
-                            relative.getName(0).toString(),
-                            relative.getName(1).toString(),
-                            artifactDirectory,
-                            indexFile,
-                            index,
-                            entryIndex,
-                            entry,
-                            metadataVersion,
-                            allowedPackages
-                    ));
-                }
-            }
-        }
-        return candidates;
-    }
-
-    private OwnerCandidate resolveOwner(
-            List<OwnerCandidate> ownerCatalog,
+    private ResolvedDependencyArtifact resolveDependencyOwner(
+            List<ResolvedDependencyArtifact> dependencyArtifacts,
             Coordinates sourceCoordinates,
             String typeReached,
             JsonNode entry
-    ) {
-        List<OwnerCandidate> matches = ownerCatalog.stream()
-                .filter(candidate -> !candidate.group().equals(sourceCoordinates.group())
-                        || !candidate.artifact().equals(sourceCoordinates.artifact()))
-                .filter(candidate -> MetadataEntryOwnership.matchesAllowedPackage(typeReached, candidate.allowedPackages()))
+    ) throws IOException {
+        String classEntry = typeReached.replace('.', '/') + ".class";
+        List<ResolvedDependencyArtifact> matches = dependencyArtifacts.stream()
+                .filter(artifact -> jarContains(artifact.file(), classEntry))
                 .toList();
-        if (matches.size() == 1) {
-            return matches.getFirst();
+        Map<String, ResolvedDependencyArtifact> matchesByCoordinate = new LinkedHashMap<>();
+        for (ResolvedDependencyArtifact match : matches) {
+            matchesByCoordinate.putIfAbsent(match.coordinate(), match);
+        }
+        if (matchesByCoordinate.size() == 1) {
+            ResolvedDependencyArtifact owner = matchesByCoordinate.values().iterator().next();
+            Coordinates parsedOwner = Coordinates.parse(owner.coordinate());
+            if (parsedOwner.group().equals(sourceCoordinates.group())
+                    && parsedOwner.artifact().equals(sourceCoordinates.artifact())) {
+                throw new GradleException(
+                        "Foreign metadata entry " + MetadataEntryOwnership.describeEntry(entry)
+                                + " resolves to the source artifact " + owner.coordinate()
+                                + "; repair its allowed-packages instead of routing it"
+                );
+            }
+            return owner;
         }
 
         String entryDescription = MetadataEntryOwnership.describeEntry(entry);
-        if (matches.isEmpty()) {
+        if (matchesByCoordinate.isEmpty()) {
             throw new GradleException(
-                    "Cannot relocate metadata entry " + entryDescription + ": no supported artifact maps "
-                            + typeReached + " for tested version " + sourceCoordinates.version()
+                    "Cannot relocate metadata entry " + entryDescription
+                            + ": no resolved runtime dependency JAR contains " + typeReached
             );
         }
-        String owners = matches.stream()
-                .map(candidate -> candidate.group() + ":" + candidate.artifact())
-                .distinct()
+        String owners = matchesByCoordinate.keySet().stream()
                 .sorted()
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("<none>");
         throw new GradleException(
                 "Cannot relocate metadata entry " + entryDescription + ": " + typeReached
-                        + " has multiple supported owners for tested version " + sourceCoordinates.version() + ": " + owners
+                        + " occurs in multiple resolved runtime dependencies: " + owners
         );
     }
 
-    private Destination prepareDestination(OwnerCandidate owner, String testedVersion) throws IOException {
+    private boolean jarContains(Path jarFile, String classEntry) {
+        try (JarFile jar = new JarFile(jarFile.toFile())) {
+            return jar.getJarEntry(classEntry) != null;
+        } catch (IOException exception) {
+            throw new GradleException("Cannot inspect resolved dependency JAR " + jarFile, exception);
+        }
+    }
+
+    private OwnerCandidate resolveSupportedOwner(
+            Path metadataRoot,
+            String ownerCoordinate,
+            String typeReached
+    ) throws IOException {
+        Coordinates owner = Coordinates.parse(ownerCoordinate);
+        Path artifactDirectory = metadataRoot.resolve(owner.group()).resolve(owner.artifact());
+        Path indexFile = artifactDirectory.resolve(INDEX_FILE);
+        if (!Files.isRegularFile(indexFile)) {
+            throw new UnsupportedMetadataOwnerException("owner-library-unsupported", ownerCoordinate);
+        }
+
+        ArrayNode index = requireArray(objectMapper.readTree(indexFile.toFile()), indexFile);
+        for (int entryIndex = 0; entryIndex < index.size(); entryIndex++) {
+            JsonNode rawEntry = index.get(entryIndex);
+            if (!(rawEntry instanceof ObjectNode entry) || !supportsVersion(entry, owner.version())) {
+                continue;
+            }
+            List<String> allowedPackages = readStringArray(entry.get("allowed-packages"), "allowed-packages", indexFile);
+            if (!MetadataEntryOwnership.matchesAllowedPackage(typeReached, allowedPackages)) {
+                throw new GradleException(
+                        "Resolved owner " + ownerCoordinate + " does not allow condition type " + typeReached
+                );
+            }
+            return new OwnerCandidate(
+                    ownerCoordinate,
+                    owner.group(),
+                    owner.artifact(),
+                    owner.version(),
+                    artifactDirectory,
+                    indexFile,
+                    index,
+                    entryIndex,
+                    entry,
+                    requiredText(entry, "metadata-version", indexFile)
+            );
+        }
+        throw new UnsupportedMetadataOwnerException("owner-version-unsupported", ownerCoordinate);
+    }
+
+    private Destination prepareDestination(OwnerCandidate owner) throws IOException {
+        String testedVersion = owner.version();
         List<String> testedVersions = readStringArray(owner.entry().get("tested-versions"), "tested-versions", owner.indexFile());
         Path inheritedMetadataFile = owner.artifactDirectory().resolve(owner.metadataVersion()).resolve(METADATA_FILE);
         ObjectNode inheritedMetadata = readMetadata(inheritedMetadataFile);
-        if (testedVersions.size() == 1) {
+        int splitIndex = testedVersions.indexOf(testedVersion);
+        if (splitIndex < 0) {
+            throw new GradleException("Owner index no longer contains tested version " + testedVersion);
+        }
+        if (splitIndex == 0) {
             return new Destination(
                     inheritedMetadataFile,
                     inheritedMetadata,
@@ -212,13 +246,6 @@ final class MetadataOwnershipRouter {
                     false
             );
         }
-        if (owner.metadataVersion().equals(testedVersion)) {
-            throw new GradleException(
-                    "Cannot isolate " + testedVersion + " in shared metadata bucket " + owner.metadataVersion()
-                            + " for " + owner.group() + ":" + owner.artifact()
-            );
-        }
-
         Path exactMetadataFile = owner.artifactDirectory().resolve(testedVersion).resolve(METADATA_FILE);
         if (Files.exists(exactMetadataFile) || hasMetadataVersion(owner.index(), testedVersion)) {
             throw new GradleException(
@@ -229,7 +256,8 @@ final class MetadataOwnershipRouter {
 
         ObjectNode exactEntry = owner.entry().deepCopy();
         exactEntry.put("metadata-version", testedVersion);
-        exactEntry.putArray("tested-versions").add(testedVersion);
+        ArrayNode transferredVersions = exactEntry.putArray("tested-versions");
+        testedVersions.subList(splitIndex, testedVersions.size()).forEach(transferredVersions::add);
         if (!exactEntry.hasNonNull("test-version")) {
             exactEntry.put("test-version", owner.metadataVersion());
         }
@@ -240,9 +268,7 @@ final class MetadataOwnershipRouter {
         }
 
         ArrayNode retainedVersions = objectMapper.createArrayNode();
-        testedVersions.stream()
-                .filter(version -> !version.equals(testedVersion))
-                .forEach(retainedVersions::add);
+        testedVersions.subList(0, splitIndex).forEach(retainedVersions::add);
         owner.entry().set("tested-versions", retainedVersions);
         owner.index().insert(owner.entryIndex() + 1, exactEntry);
 
@@ -377,15 +403,16 @@ final class MetadataOwnershipRouter {
     }
 
     private record OwnerCandidate(
+            String coordinate,
             String group,
             String artifact,
+            String version,
             Path artifactDirectory,
             Path indexFile,
             ArrayNode index,
             int entryIndex,
             ObjectNode entry,
-            String metadataVersion,
-            List<String> allowedPackages
+            String metadataVersion
     ) {
     }
 

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/MetadataOwnershipRouter.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.jar.JarFile;
+import java.util.zip.ZipFile;
 
 /**
  * Relocates foreign-condition metadata to an exact supported owner/version.
@@ -181,7 +182,12 @@ final class MetadataOwnershipRouter {
     }
 
     private boolean jarContains(Path jarFile, String classEntry) {
-        try (JarFile jar = new JarFile(jarFile.toFile())) {
+        try (JarFile jar = new JarFile(
+                jarFile.toFile(),
+                true,
+                ZipFile.OPEN_READ,
+                JarFile.runtimeVersion()
+        )) {
             return jar.getJarEntry(classEntry) != null;
         } catch (IOException exception) {
             throw new GradleException("Cannot inspect resolved dependency JAR " + jarFile, exception);

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ResolvedDependencyArtifact.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/ResolvedDependencyArtifact.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import java.nio.file.Path;
+
+/**
+ * One JAR from the tested library's resolved runtime dependency closure.
+ * §FS-metadata
+ */
+record ResolvedDependencyArtifact(String coordinate, Path file) {
+}

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/RouteForeignMetadataTask.java
@@ -13,12 +13,18 @@ import org.graalvm.internal.tck.Coordinates;
 import org.graalvm.internal.tck.MetadataFilesCheckerTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecOperations;
 
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -29,8 +35,12 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
     private static final String REACHABILITY_METADATA_FILE = "reachability-metadata.json";
+    private static final String DEPENDENCY_PREFIX = "TCK_RUNTIME_DEPENDENCY=";
 
     private final ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Inject
+    public abstract ExecOperations getExecOperations();
 
     @TaskAction
     public void run() {
@@ -45,8 +55,13 @@ public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
             if (coordinate.startsWith("samples:") || coordinate.startsWith("org.example:")) {
                 continue;
             }
+            deleteFailureReport(coordinate);
             try {
                 routeMetadata(coordinate);
+            } catch (UnsupportedMetadataOwnerException exception) {
+                writeFailureReport(coordinate, exception);
+                failures.add(coordinate + ": " + exception.getMessage());
+                getLogger().error("routeForeignMetadata failed for {}: {}", coordinate, exception.getMessage());
             } catch (Exception exception) {
                 failures.add(coordinate + ": " + exception.getMessage());
                 getLogger().error("routeForeignMetadata failed for {}: {}", coordinate, exception.getMessage());
@@ -92,7 +107,8 @@ public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
         Set<String> relocatedOwners = ownershipRouter.route(
                 getProject().file("metadata").toPath(),
                 parsedCoordinates,
-                libraryMetadata
+                libraryMetadata,
+                resolveDependencyArtifacts(parsedCoordinates)
         );
         if (relocatedOwners.isEmpty()) {
             getLogger().lifecycle("No foreign-condition metadata entries found for {}", coordinate);
@@ -103,6 +119,85 @@ public abstract class RouteForeignMetadataTask extends CoordinatesAwareTask {
         ownershipRouter.writeJson(metadataFile, libraryMetadata);
         generateRelocatedOwnerStats(relocatedOwners);
         getLogger().lifecycle("routeForeignMetadata completed for {}; relocated owners: {}", coordinate, relocatedOwners);
+    }
+
+    protected List<ResolvedDependencyArtifact> resolveDependencyArtifacts(Coordinates coordinates) {
+        Path repositoryRoot = tckExtension.getRepoRoot().get().getAsFile().toPath();
+        Path testDirectory = tckExtension.getTestDir(coordinates.toString());
+        Path metadataDirectory = tckExtension.getMetadataDir(coordinates.toString());
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Map<String, String> environment = new HashMap<>(System.getenv());
+        environment.put("GVM_TCK_LC", coordinates.toString());
+        environment.put("GVM_TCK_LV", coordinates.version());
+        environment.put("GVM_TCK_EXCLUDE", "false");
+        environment.put("GVM_TCK_MD", metadataDirectory.toAbsolutePath().toString());
+        environment.put("GVM_TCK_TCKDIR", tckExtension.getTckRoot().get().getAsFile().toPath().toString());
+
+        int exitCode = getExecOperations().exec(spec -> {
+            spec.commandLine(repositoryRoot.resolve("gradlew").toString(), "--quiet", "listRuntimeDependencyArtifacts");
+            spec.workingDir(testDirectory.toFile());
+            spec.environment(environment);
+            spec.setStandardOutput(output);
+            spec.setErrorOutput(output);
+            spec.setIgnoreExitValue(true);
+        }).getExitValue();
+        String capturedOutput = output.toString(StandardCharsets.UTF_8);
+        if (exitCode != 0) {
+            throw new GradleException(
+                    "Cannot resolve runtime dependencies for " + coordinates + ":\n" + capturedOutput.strip()
+            );
+        }
+
+        List<ResolvedDependencyArtifact> artifacts = new ArrayList<>();
+        for (String line : capturedOutput.split("\\R")) {
+            if (!line.startsWith(DEPENDENCY_PREFIX)) {
+                continue;
+            }
+            try {
+                ObjectNode artifact = objectMapper.readTree(line.substring(DEPENDENCY_PREFIX.length()))
+                        instanceof ObjectNode objectNode ? objectNode : null;
+                if (artifact == null || !artifact.hasNonNull("coordinate") || !artifact.hasNonNull("file")) {
+                    throw new GradleException("Invalid resolved dependency artifact record: " + line);
+                }
+                artifacts.add(new ResolvedDependencyArtifact(
+                        artifact.get("coordinate").asText(),
+                        Path.of(artifact.get("file").asText())
+                ));
+            } catch (IOException exception) {
+                throw new GradleException("Cannot parse resolved dependency artifact record: " + line, exception);
+            }
+        }
+        if (artifacts.isEmpty()) {
+            throw new GradleException("No runtime dependency JARs resolved for " + coordinates);
+        }
+        return artifacts;
+    }
+
+    private void deleteFailureReport(String coordinate) {
+        try {
+            Files.deleteIfExists(failureReportPath(coordinate));
+        } catch (IOException exception) {
+            throw new GradleException("Cannot delete stale routeForeignMetadata report for " + coordinate, exception);
+        }
+    }
+
+    private void writeFailureReport(String sourceCoordinate, UnsupportedMetadataOwnerException exception) {
+        ObjectNode report = objectMapper.createObjectNode();
+        report.put("reason", exception.reason());
+        report.put("coordinate", exception.coordinate());
+        try {
+            Path reportPath = failureReportPath(sourceCoordinate);
+            Files.createDirectories(reportPath.getParent());
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(reportPath.toFile(), report);
+        } catch (IOException ioException) {
+            throw new GradleException("Cannot write routeForeignMetadata failure report", ioException);
+        }
+    }
+
+    private Path failureReportPath(String coordinate) {
+        return getProject().getLayout().getBuildDirectory()
+                .file("reports/route-foreign-metadata/" + coordinate.replace(':', '_') + ".json")
+                .get().getAsFile().toPath();
     }
 
     private void validateRelocatedOwners(Set<String> relocatedOwners) {

--- a/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/UnsupportedMetadataOwnerException.java
+++ b/tests/tck-build-logic/src/main/groovy/org/graalvm/internal/tck/harness/tasks/UnsupportedMetadataOwnerException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright and related rights waived via CC0
+ *
+ * You should have received a copy of the CC0 legalcode along with this
+ * work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+package org.graalvm.internal.tck.harness.tasks;
+
+import org.gradle.api.GradleException;
+
+/**
+ * Signals a resolved dependency owner that repository metadata cannot yet host.
+ * §FS-metadata
+ */
+final class UnsupportedMetadataOwnerException extends GradleException {
+    private final String reason;
+    private final String coordinate;
+
+    UnsupportedMetadataOwnerException(String reason, String coordinate) {
+        super(reason + ": " + coordinate);
+        this.reason = reason;
+        this.coordinate = coordinate;
+    }
+
+    String reason() {
+        return reason;
+    }
+
+    String coordinate() {
+        return coordinate;
+    }
+}

--- a/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
+++ b/tests/tck-build-logic/src/test/java/org/graalvm/internal/tck/harness/tasks/SplitTestOnlyMetadataTaskTests.java
@@ -8,6 +8,7 @@ package org.graalvm.internal.tck.harness.tasks;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graalvm.internal.tck.Coordinates;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,9 @@ import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -152,47 +155,11 @@ class SplitTestOnlyMetadataTaskTests {
     @Test
     void relocatesForeignConditionToExactSupportedOwner() throws IOException {
         String coordinate = "com.example:root:2.0.0";
+        String ownerCoordinate = "org.owner:engine:1.0.0";
         copyReachabilitySchemaFile();
         writeMinimalTestProject("com.example", "root", "2.0.0");
         writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
-        writeIndex("org.owner", "engine", "2.0.0", List.of("2.0.0"), List.of("org.owner"));
-        writeJson(
-                "metadata/com.example/root/2.0.0/reachability-metadata.json",
-                foreignSerializationMetadata()
-        );
-        writeJson(
-                "metadata/org.owner/engine/2.0.0/reachability-metadata.json",
-                """
-                {
-                  "reflection": [
-                    {
-                      "condition": {
-                        "typeReached": "org.owner.Engine"
-                      },
-                      "type": "org.owner.Engine"
-                    }
-                  ]
-                }
-                """
-        );
-
-        runRouteTask(coordinate);
-
-        JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
-        JsonNode ownerMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
-        assertThat(sourceMetadata.isEmpty()).isTrue();
-        assertThat(ownerMetadata.get("serialization"))
-                .extracting(entry -> entry.get("type").asText())
-                .containsExactly("org.owner.Engine$SerializedForm");
-    }
-
-    @Test
-    void forksSharedOwnerBucketBeforeRelocatingEntry() throws IOException {
-        String coordinate = "com.example:root:2.0.0";
-        copyReachabilitySchemaFile();
-        writeMinimalTestProject("com.example", "root", "2.0.0");
-        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
-        writeIndex("org.owner", "engine", "1.0.0", List.of("1.0.0", "2.0.0"), List.of("org.owner"));
+        writeIndex("org.owner", "engine", "1.0.0", List.of("1.0.0"), List.of("org.owner"));
         writeJson(
                 "metadata/com.example/root/2.0.0/reachability-metadata.json",
                 foreignSerializationMetadata()
@@ -213,10 +180,54 @@ class SplitTestOnlyMetadataTaskTests {
                 """
         );
 
-        RecordingRouteForeignMetadataTask task = runRouteTask(coordinate);
+        runRouteTask(coordinate, ownerCoordinate);
 
-        JsonNode inheritedMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
-        JsonNode exactMetadata = readJson("metadata/org.owner/engine/2.0.0/reachability-metadata.json");
+        JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
+        JsonNode ownerMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
+        assertThat(sourceMetadata.isEmpty()).isTrue();
+        assertThat(ownerMetadata.get("serialization"))
+                .extracting(entry -> entry.get("type").asText())
+                .containsExactly("org.owner.Engine$SerializedForm");
+    }
+
+    @Test
+    void forksSharedOwnerBucketBeforeRelocatingEntry() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        String ownerCoordinate = "org.owner:engine:1.0.0";
+        copyReachabilitySchemaFile();
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeIndex(
+                "org.owner",
+                "engine",
+                "0.9.0",
+                List.of("0.9.0", "1.0.0", "1.1.0", "2.0.0"),
+                List.of("org.owner")
+        );
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+        writeJson(
+                "metadata/org.owner/engine/0.9.0/reachability-metadata.json",
+                """
+                {
+                  "reflection": [
+                    {
+                      "condition": {
+                        "typeReached": "org.owner.Engine"
+                      },
+                      "type": "org.owner.Engine"
+                    }
+                  ]
+                }
+                """
+        );
+
+        RecordingRouteForeignMetadataTask task = runRouteTask(coordinate, ownerCoordinate);
+
+        JsonNode inheritedMetadata = readJson("metadata/org.owner/engine/0.9.0/reachability-metadata.json");
+        JsonNode exactMetadata = readJson("metadata/org.owner/engine/1.0.0/reachability-metadata.json");
         JsonNode ownerIndex = readJson("metadata/org.owner/engine/index.json");
         assertThat(inheritedMetadata.has("serialization")).isFalse();
         assertThat(exactMetadata.get("reflection")).isEqualTo(inheritedMetadata.get("reflection"));
@@ -225,25 +236,26 @@ class SplitTestOnlyMetadataTaskTests {
                 .containsExactly("org.owner.Engine$SerializedForm");
         assertThat(ownerIndex.get(0).get("tested-versions"))
                 .extracting(JsonNode::asText)
-                .containsExactly("1.0.0");
+                .containsExactly("0.9.0");
         assertThat(ownerIndex.get(0).has("latest")).isFalse();
         assertThat(ownerIndex.get(0).has("auto-update")).isFalse();
         assertThat(ownerIndex.get(0).has("high-priority")).isFalse();
-        assertThat(ownerIndex.get(1).get("metadata-version").asText()).isEqualTo("2.0.0");
-        assertThat(ownerIndex.get(1).get("test-version").asText()).isEqualTo("1.0.0");
+        assertThat(ownerIndex.get(1).get("metadata-version").asText()).isEqualTo("1.0.0");
+        assertThat(ownerIndex.get(1).get("test-version").asText()).isEqualTo("0.9.0");
         assertThat(ownerIndex.get(1).get("tested-versions"))
                 .extracting(JsonNode::asText)
-                .containsExactly("2.0.0");
+                .containsExactly("1.0.0", "1.1.0", "2.0.0");
         assertThat(ownerIndex.get(1).get("latest").asBoolean()).isTrue();
         assertThat(ownerIndex.get(1).get("auto-update").asBoolean()).isTrue();
         assertThat(ownerIndex.get(1).get("high-priority").asBoolean()).isTrue();
         assertThat(task.generatedStatsCoordinates())
-                .containsExactly("org.owner:engine:2.0.0");
+                .containsExactly("org.owner:engine:1.0.0");
     }
 
     @Test
-    void leavesUnresolvedForeignEntryUntouched() throws IOException {
+    void reportsResolvedUnsupportedOwnerWithoutChangingMetadata() throws IOException {
         String coordinate = "com.example:root:2.0.0";
+        String ownerCoordinate = "org.owner:engine:1.0.0";
         writeMinimalTestProject("com.example", "root", "2.0.0");
         writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
         writeJson(
@@ -251,14 +263,40 @@ class SplitTestOnlyMetadataTaskTests {
                 foreignSerializationMetadata()
         );
 
-        assertThatThrownBy(() -> runRouteTask(coordinate))
+        assertThatThrownBy(() -> runRouteTask(coordinate, ownerCoordinate))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("no supported artifact maps org.owner.Engine");
+                .hasMessageContaining("owner-library-unsupported: " + ownerCoordinate);
 
         JsonNode sourceMetadata = readJson("metadata/com.example/root/2.0.0/reachability-metadata.json");
         assertThat(sourceMetadata.get("serialization"))
                 .extracting(entry -> entry.get("type").asText())
                 .containsExactly("org.owner.Engine$SerializedForm");
+        JsonNode report = readJson("build/reports/route-foreign-metadata/com.example_root_2.0.0.json");
+        assertThat(report.fieldNames()).toIterable().containsExactly("reason", "coordinate");
+        assertThat(report.get("reason").asText()).isEqualTo("owner-library-unsupported");
+        assertThat(report.get("coordinate").asText()).isEqualTo(ownerCoordinate);
+    }
+
+    @Test
+    void reportsResolvedUnsupportedOwnerVersion() throws IOException {
+        String coordinate = "com.example:root:2.0.0";
+        String ownerCoordinate = "org.owner:engine:1.0.0";
+        writeMinimalTestProject("com.example", "root", "2.0.0");
+        writeIndex("com.example", "root", "2.0.0", List.of("2.0.0"), List.of("com.example"));
+        writeIndex("org.owner", "engine", "0.9.0", List.of("0.9.0"), List.of("org.owner"));
+        writeJson(
+                "metadata/com.example/root/2.0.0/reachability-metadata.json",
+                foreignSerializationMetadata()
+        );
+
+        assertThatThrownBy(() -> runRouteTask(coordinate, ownerCoordinate))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("owner-version-unsupported: " + ownerCoordinate);
+
+        JsonNode report = readJson("build/reports/route-foreign-metadata/com.example_root_2.0.0.json");
+        assertThat(report.fieldNames()).toIterable().containsExactly("reason", "coordinate");
+        assertThat(report.get("reason").asText()).isEqualTo("owner-version-unsupported");
+        assertThat(report.get("coordinate").asText()).isEqualTo(ownerCoordinate);
     }
 
     private void runSplitTask(String coordinate) {
@@ -272,7 +310,7 @@ class SplitTestOnlyMetadataTaskTests {
         task.run();
     }
 
-    private RecordingRouteForeignMetadataTask runRouteTask(String coordinate) {
+    private RecordingRouteForeignMetadataTask runRouteTask(String coordinate, String ownerCoordinate) throws IOException {
         Project project = ProjectBuilder.builder()
                 .withProjectDir(tempDir.toFile())
                 .build();
@@ -280,12 +318,26 @@ class SplitTestOnlyMetadataTaskTests {
                 .register("routeForeignMetadata", RecordingRouteForeignMetadataTask.class)
                 .get();
         task.setCoordinatesOverride(List.of(coordinate));
+        task.setDependencyArtifacts(List.of(new ResolvedDependencyArtifact(
+                ownerCoordinate,
+                writeJar("resolved/" + ownerCoordinate.replace(':', '_') + ".jar", "org/owner/Engine.class")
+        )));
         task.run();
         return task;
     }
 
     public abstract static class RecordingRouteForeignMetadataTask extends RouteForeignMetadataTask {
         private final Set<String> generatedStatsCoordinates = new LinkedHashSet<>();
+        private List<ResolvedDependencyArtifact> dependencyArtifacts = List.of();
+
+        void setDependencyArtifacts(List<ResolvedDependencyArtifact> dependencyArtifacts) {
+            this.dependencyArtifacts = dependencyArtifacts;
+        }
+
+        @Override
+        protected List<ResolvedDependencyArtifact> resolveDependencyArtifacts(Coordinates coordinates) {
+            return dependencyArtifacts;
+        }
 
         @Override
         protected void generateRelocatedOwnerStats(Set<String> relocatedOwners) {
@@ -377,6 +429,17 @@ class SplitTestOnlyMetadataTaskTests {
         Path file = tempDir.resolve(relativePath);
         Files.createDirectories(file.getParent());
         Files.writeString(file, content.stripIndent(), StandardCharsets.UTF_8);
+    }
+
+    private Path writeJar(String relativePath, String classEntry) throws IOException {
+        Path file = tempDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(file))) {
+            output.putNextEntry(new ZipEntry(classEntry));
+            output.write(new byte[] {0});
+            output.closeEntry();
+        }
+        return file;
     }
 
     private void writeJson(String relativePath, String content) throws IOException {


### PR DESCRIPTION
## What this does

Foreign-condition routing currently guesses an owner from checked-in package prefixes and assumes that the source artifact version is also the dependency version. That breaks as soon as, for example, `source:2.0.0` resolves `dependency:1.0.0`.

This change takes the owner coordinate from the tested library runtime dependency graph and confirms it by locating `condition.typeReached` in the resolved JAR. JAR lookup uses the active runtime view, so classes available only through a compatible multi-release entry are handled without enumerating JAR contents. Routing still runs only after `checkMetadataFiles` fails.

## How ownership is decided

```text
checkMetadataFiles failure
  -> resolve the tested library runtime dependency closure
  -> find the unique JAR containing typeReached
  -> use that selected group:artifact:version
  -> route only when that exact owner version is supported
```

When the resolved version sits inside a shared metadata bucket, the bucket splits at its existing `tested-versions` position. Earlier versions remain on the inherited metadata; the resolved version and every later list entry move together to the copied exact-version bucket.

## When owner support is missing

| Resolved state | Outcome |
| --- | --- |
| Artifact is absent | Create or reuse a `library-new-request` |
| Artifact exists but the version is absent | Create or reuse a `library-update-request` |
| Owner cannot be resolved uniquely | Create no issue and retain the routing failure |

The Gradle task records only `reason` and the resolved dependency `coordinate` under ignored `build/` output, then remains failed. Forge adds the routing output and follow-up issue URL to the existing bounded metadata-repair prompt; confirmed foreign-owner failures do not fall through to automatic source `allowed-packages` expansion. This finalization wiring is documented in [§forge/AR-forge-driver-finalization](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/resolve-foreign-metadata-owners/forge/docs/architecture/drivers.md#ar-forge-driver-finalization-finalization-and-metrics).