### PR TITLE
Clear stale labels after chunk merges

### DIFF
--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -710,6 +710,11 @@ Forge may proceed without a coordinate-local exhaust report and use
 `explore.exhaustedClasses` from the marker as the processed-class set for the
 resumed run (§FS-forge-run-continuation.2).
 
+When a non-final chunk PR merges, Forge releases the linked issue for the next
+chunk by moving it to `Todo`, clearing its assignees, and removing the
+`human-intervention` and `resumable` labels when present. It retains the
+`chunked-dynamic-access` label so the next claim stays in chunked mode.
+
 Chunk PRs use `Refs: #<issue>` until the final chunk. Only the final chunk PR
 may use `Fixes: #<issue>` and move the issue to `Done`. Non-final chunk PRs
 must commit enough exhaust-report state for the next run to skip classes already

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -2645,7 +2645,10 @@ def resolve_non_final_chunked_dynamic_access_issue(pr: dict) -> int | None:
 
 
 def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
-    """Move a merged non-final chunk issue back to Todo for the next chunk."""
+    """Restore a merged non-final chunk issue for a clean next chunk.
+
+    §FS-forge-chunked-dynamic-access
+    """
     issue_number = resolve_non_final_chunked_dynamic_access_issue(pr)
     if issue_number is None:
         return
@@ -2656,6 +2659,10 @@ def apply_chunked_dynamic_access_merge_follow_up(pr: dict) -> None:
             f"Chunked dynamic-access PR #{pr.get('number')} references issue #{issue_number}, "
             f"but the issue is not linked to project {PROJECT_NUMBER}."
         )
+    issue: dict = get_issue_claim_payload(issue_number)
+    for label_name in (LABEL_HUMAN_INTERVENTION, LABEL_RESUMABLE):
+        if issue_has_label(issue, label_name):
+            remove_issue_label(issue_number, label_name)
     set_item_status(item_id, STATUS_TODO)
     clear_issue_assignees(issue_number)
     invalidate_issue_claim_cache_entry(issue_number)

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -4651,14 +4651,59 @@ class PullRequestReviewTests(unittest.TestCase):
         with patch.object(forge_metadata, "get_pull_request_changed_index_files", return_value=[]), \
                 patch.object(forge_metadata, "gh"), \
                 patch.object(forge_metadata, "get_project_item_id", return_value="project-item"), \
+                patch.object(
+                    forge_metadata,
+                    "get_issue_claim_payload",
+                    return_value={
+                        "labels": [
+                            {"name": forge_metadata.LABEL_CHUNKED_DYNAMIC_ACCESS},
+                            {"name": forge_metadata.LABEL_HUMAN_INTERVENTION},
+                            {"name": forge_metadata.LABEL_RESUMABLE},
+                        ],
+                    },
+                ), \
+                patch.object(forge_metadata, "remove_issue_label") as remove_issue_label, \
                 patch.object(forge_metadata, "set_item_status") as set_item_status, \
                 patch.object(forge_metadata, "clear_issue_assignees") as clear_issue_assignees, \
                 patch.object(forge_metadata, "invalidate_issue_claim_cache_entry") as invalidate_cache:
             forge_metadata.merge_pull_request(pr, "/repo")
 
+        self.assertEqual(
+            remove_issue_label.call_args_list,
+            [
+                call(1412, forge_metadata.LABEL_HUMAN_INTERVENTION),
+                call(1412, forge_metadata.LABEL_RESUMABLE),
+            ],
+        )
         set_item_status.assert_called_once_with("project-item", forge_metadata.STATUS_TODO)
         clear_issue_assignees.assert_called_once_with(1412)
         invalidate_cache.assert_called_once_with(1412)
+
+    def test_merge_pull_request_keeps_clean_chunk_issue_labels(self) -> None:
+        pr = {
+            "number": 3513,
+            "url": "https://github.com/oracle/graalvm-reachability-metadata/pull/3513",
+            "headRefOid": "abc123",
+            "body": "Refs: #1412\n\nSummary:\n- Chunked dynamic-access: yes\n",
+        }
+
+        with patch.object(forge_metadata, "get_pull_request_changed_index_files", return_value=[]), \
+                patch.object(forge_metadata, "gh"), \
+                patch.object(forge_metadata, "get_project_item_id", return_value="project-item"), \
+                patch.object(
+                    forge_metadata,
+                    "get_issue_claim_payload",
+                    return_value={
+                        "labels": [{"name": forge_metadata.LABEL_CHUNKED_DYNAMIC_ACCESS}],
+                    },
+                ), \
+                patch.object(forge_metadata, "remove_issue_label") as remove_issue_label, \
+                patch.object(forge_metadata, "set_item_status"), \
+                patch.object(forge_metadata, "clear_issue_assignees"), \
+                patch.object(forge_metadata, "invalidate_issue_claim_cache_entry"):
+            forge_metadata.merge_pull_request(pr, "/repo")
+
+        remove_issue_label.assert_not_called()
 
     def test_merge_pull_request_does_not_release_final_chunked_dynamic_access_issue(self) -> None:
         pr = {


### PR DESCRIPTION
Closes #9620

## Restore a clean next-chunk state

A merged non-final chunk currently moves its linked issue back to `Todo` and clears the assignee, but it can leave `human-intervention` and `resumable` behind. The next Forge cycle then treats already-merged work as resumable and can attempt to continue from a superseded branch.

The chunk contract now defines the complete released state: remove stale intervention and resume labels while retaining `chunked-dynamic-access`, so the next claim starts a new chunk from the merged base. [§FS-forge-chunked-dynamic-access](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/clear-stale-chunk-labels/forge/docs/functional-spec/functional-spec.md#fs-forge-chunked-dynamic-access-chunked-dynamic-access-semantics)

## Merge follow-up

After a successful non-final chunk merge, the reviewer process:

- reads the linked issue current labels;
- removes `human-intervention` and `resumable` only when present;
- retains `chunked-dynamic-access`;
- moves the issue to `Todo`, clears its assignees, and invalidates the claim cache.

Final chunk PRs and ordinary PRs do not enter this follow-up.

## Stacked dependency

This is based on #9674, which makes failed-CI handling uniform and leaves this follow-up exclusively on the successful chunk-merge path. It should be merged after #9674, then retargeted to `master` if GitHub does not update the base automatically.