### PR TITLE
Allow forward cross-major library update routing

### DIFF
--- a/forge/docs/architecture/drivers.md
+++ b/forge/docs/architecture/drivers.md
@@ -149,15 +149,18 @@ comparison reaches the PR body without the snapshot reaching the published tree
 **When it does not**, the driver must first find a version-compatible baseline
 suite and probe it. Exact index ownership wins; otherwise it prefers the nearest
 prior version on the same major/minor line, then the nearest following version on
-that line, then candidates within the same major. A test-version alias only
-locates a reusable suite — it does not declare support and cannot contribute a
-candidate. Version lines come from the leading numeric components, including
+that line, then candidates within the same major. If no same-major candidate
+exists, the nearest usable supported version below the requested version is the
+baseline, even when it belongs to an earlier major version. Thus a version newer
+than the repository's latest supported version uses that latest usable suite,
+while a historical backfill never uses a newer-major suite. A test-version alias
+only locates a reusable suite — it does not declare support and cannot contribute
+a candidate. Version lines come from the leading numeric components, including
 conventional `v`- and `r`-prefixed releases; recognized prerelease qualifiers keep
 their explicit ordering, while other valid Maven suffixes keep the numeric line
-and fall back to deterministic ordering rather than becoming ineligible. A
-cross-major baseline is never compatible, even when marked latest, and if no
-baseline can be selected deterministically the route stops with an actionable
-error rather than probing something that cannot work.
+and fall back to deterministic ordering rather than becoming ineligible. If no
+same-major or lower baseline can be selected deterministically, the route stops
+with an actionable error rather than probing a future incompatible suite.
 
 The probe then decides who owns the rest:
 

--- a/forge/tests/test_library_update_router.py
+++ b/forge/tests/test_library_update_router.py
@@ -67,6 +67,49 @@ class LibraryUpdateRouterTests(unittest.TestCase):
             messages = [call.args[1] for call in stage_log.call_args_list]
             self.assertTrue(any("nearest prior same major/minor" in message for message in messages))
 
+    def test_missing_kafka_major_version_probes_prior_major_baseline(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            group = "org.apache.kafka"
+            artifact = "kafka-streams"
+            index_dir = os.path.join(repo, "metadata", group, artifact)
+            os.makedirs(index_dir, exist_ok=True)
+            baseline_entry = {
+                "latest": True,
+                "metadata-version": "3.6.0",
+                "tested-versions": ["3.6.0", "3.6.1", "3.6.2"],
+            }
+            with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+                json.dump([baseline_entry], index_file)
+            _write_file(os.path.join(repo, "metadata", group, artifact, "3.6.0", "metadata.json"))
+            _write_file(os.path.join(repo, "tests", "src", group, artifact, "3.6.0", "build.gradle"))
+            compile_failure = library_update_router._ProbeCommandResult(
+                exit_code=1,
+                log_path="compile.log",
+            )
+
+            with patch.object(
+                    library_update_router,
+                    "_probe_baseline_suite",
+                    return_value=(compile_failure, None, None),
+            ) as probe, patch.object(
+                    library_update_router,
+                    "write_library_update_route",
+            ), patch.object(library_update_router, "log_stage") as stage_log:
+                route = library_update_router.select_library_update_route(
+                    repo,
+                    os.path.join(repo, "metrics"),
+                    "org.apache.kafka:kafka-streams:4.3.1",
+                )
+
+            self.assertEqual(route.selected_driver, library_update_router.ROUTE_FIX_JAVAC)
+            self.assertEqual(route.baseline_coordinates, "org.apache.kafka:kafka-streams:3.6.0")
+            self.assertEqual(
+                probe.call_args.kwargs["baseline_entry"]["metadata-version"],
+                "3.6.0",
+            )
+            messages = [call.args[1] for call in stage_log.call_args_list]
+            self.assertTrue(any("nearest prior earlier-major" in message for message in messages))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/forge/tests/test_library_update_target.py
+++ b/forge/tests/test_library_update_target.py
@@ -157,7 +157,80 @@ class LibraryUpdateTargetTests(unittest.TestCase):
                 self.assertEqual(baseline.match_type, expected_match_type)
                 self.assertIn("nearest prior", baseline.reason)
 
-    def test_backfill_fails_when_only_cross_major_suite_is_usable(self) -> None:
+    def test_forward_update_uses_nearest_prior_major_suite(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            _write_index(repo, [
+                {
+                    "metadata-version": "3.5.1",
+                    "tested-versions": ["3.5.1", "3.5.2"],
+                },
+                {
+                    "latest": True,
+                    "metadata-version": "3.6.0",
+                    "tested-versions": ["3.6.0", "3.6.1", "3.6.2"],
+                },
+            ], group="org.apache.kafka", artifact="kafka-streams")
+            for version in ["3.5.1", "3.6.0"]:
+                _write_file(os.path.join(
+                    repo,
+                    "metadata",
+                    "org.apache.kafka",
+                    "kafka-streams",
+                    version,
+                    "reachability-metadata.json",
+                ))
+                _write_file(os.path.join(
+                    repo,
+                    "tests",
+                    "src",
+                    "org.apache.kafka",
+                    "kafka-streams",
+                    version,
+                    "build.gradle",
+                ))
+
+            baseline = require_version_backfill_baseline(
+                repo,
+                "org.apache.kafka",
+                "kafka-streams",
+                "4.3.1",
+            )
+
+            self.assertEqual(baseline.metadata_version, "3.6.0")
+            self.assertEqual(baseline.test_version, "3.6.0")
+            self.assertEqual(baseline.supported_version, "3.6.2")
+            self.assertEqual(baseline.match_type, "prior-major")
+            self.assertIn("nearest prior earlier-major", baseline.reason)
+
+    def test_same_major_following_suite_wins_over_prior_major(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            _write_index(repo, [
+                {
+                    "metadata-version": "3.9.0",
+                    "tested-versions": ["3.9.0"],
+                },
+                {
+                    "latest": True,
+                    "metadata-version": "4.1.0",
+                    "tested-versions": ["4.1.0"],
+                },
+            ])
+            for version in ["3.9.0", "4.1.0"]:
+                _write_file(os.path.join(repo, "metadata", "org.example", "demo", version, "metadata.json"))
+                _write_file(os.path.join(repo, "tests", "src", "org.example", "demo", version, "build.gradle"))
+
+            baseline = require_version_backfill_baseline(
+                repo,
+                "org.example",
+                "demo",
+                "4.0.0",
+            )
+
+            self.assertEqual(baseline.supported_version, "4.1.0")
+            self.assertEqual(baseline.match_type, "same-major")
+            self.assertIn("nearest following same-major", baseline.reason)
+
+    def test_backfill_rejects_only_newer_major_suite(self) -> None:
         with tempfile.TemporaryDirectory() as repo:
             _write_index(repo, [{
                 "latest": True,
@@ -170,7 +243,7 @@ class LibraryUpdateTargetTests(unittest.TestCase):
             baseline = resolve_version_backfill_baseline(repo, "org.example", "demo", "1.9.9")
 
             self.assertIsNone(baseline)
-            with self.assertRaisesRegex(RuntimeError, "cross-major `latest` entry"):
+            with self.assertRaisesRegex(RuntimeError, "newer-major suite"):
                 require_version_backfill_baseline(repo, "org.example", "demo", "1.9.9")
 
     def test_exact_tested_version_owner_wins_over_nearer_entry(self) -> None:

--- a/forge/utility_scripts/metadata_index.py
+++ b/forge/utility_scripts/metadata_index.py
@@ -226,10 +226,11 @@ def resolve_version_backfill_baseline(
         artifact: str,
         requested_version: str,
 ) -> VersionBackfillBaseline | None:
-    """Resolve one usable same-major baseline for deterministic version backfill.
+    """Resolve one usable baseline for deterministic version backfill.
 
-    Exact index ownership takes precedence over version ordering. Non-exact
-    selection never crosses a major-version boundary. §AR-forge-driver-queues
+    Exact index ownership takes precedence over version ordering. A non-exact
+    selection prefers the requested major, then the nearest prior version from
+    an earlier major. §AR-forge-driver-queues.2
     """
     target = resolve_library_update_target(repo_path, group, artifact, requested_version)
     if target.match_type != MATCH_NEW_VERSION and target.matched_entry is not None:
@@ -293,6 +294,19 @@ def resolve_version_backfill_baseline(
             "same-major",
             f"{ordering} same-major supported version {selected.supported_version}",
         )
+
+    prior_major = [
+        candidate for candidate in candidates
+        if _is_prior_version(candidate.supported_version, requested_version)
+    ]
+    selected = _select_ordered_baseline_candidate(prior_major, requested_version)
+    if selected is not None:
+        return _version_backfill_baseline(
+            selected.entry,
+            selected.supported_version,
+            "prior-major",
+            f"nearest prior earlier-major supported version {selected.supported_version}",
+        )
     return None
 
 
@@ -317,10 +331,10 @@ def require_version_backfill_baseline(
     raise RuntimeError(
         "ERROR: Cannot resolve a compatible version-backfill baseline for "
         f"{coordinate} from {index_display}. Expected a usable exact owner or "
-        "a supported test suite in the same major version; each baseline must "
-        "have both metadata and test directories. A cross-major `latest` entry "
-        "is not a compatible baseline. Restore a compatible test suite or "
-        "route the issue for human intervention."
+        "a supported test suite from the same major or an earlier version; each "
+        "baseline must have both metadata and test directories. A newer-major "
+        "suite is not a compatible baseline for a historical backfill. Restore "
+        "a compatible test suite or route the issue for human intervention."
     )
 
 
@@ -413,6 +427,11 @@ def _baseline_ordering_reason(supported_version: str, requested_version: str) ->
     if comparison is not None and comparison <= 0:
         return "nearest prior"
     return "nearest following"
+
+
+def _is_prior_version(candidate_version: str, requested_version: str) -> bool:
+    comparison = _compare_parseable_metadata_versions(candidate_version, requested_version)
+    return comparison is not None and comparison < 0
 
 
 def latest_metadata_version(repo_path: str, group: str, artifact: str) -> str | None:


### PR DESCRIPTION
Closes #9769

## What this does

Library-update routing currently rejects every cross-major baseline. That blocks forward upgrades even when the nearest prior suite is the correct input for the existing compile, JVM, and native compatibility probe. The routing rule now keeps same-major selection first and permits only the nearest usable earlier version across a major boundary, as specified by [§AR-forge-driver-queues.2](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/library-update-cross-major-routing/forge/docs/architecture/drivers.md#2-library-update).

## How baseline selection changes

| Requested-version state | Selected baseline |
| --- | --- |
| Exact index ownership | The owning suite |
| Same-major support exists | The nearest same-major suite, unchanged |
| No same-major support exists | The nearest usable earlier supported version |
| Only a newer-major suite exists | No baseline; stop with an actionable error |

The chosen suite continues through the existing compile, JVM-test, and native-test probe, so the first failing stage selects the established repair driver before coverage improvement.