### PR TITLE
Preserve bulk success in final exploration

### DIFF
--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -337,7 +337,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         len(terminal_classes_this_part),
                     )
                     return True, prompt_iterations
-                if successful_classes > 0:
+                phase_succeeded: bool = self._has_successful_class_coverage(successful_classes)
+                if phase_succeeded:
                     self._mark_continuation_explore_completed(
                         prompt_iterations,
                         exhausted_classes,
@@ -349,7 +350,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         exhausted_classes,
                         len(terminal_classes_this_part),
                     )
-                return successful_classes > 0, prompt_iterations
+                    self._locate_explore_failure()
+                return phase_succeeded, prompt_iterations
 
             class_name = active_class.class_name
             # Snapshot HEAD before this class so we can roll back on failure
@@ -793,6 +795,19 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         """
         record_step_failure(
             location=RunLocation(RUN_PHASE_EXPLORE, STEP_GENERATE_TESTS, class_name or self.library),
+        )
+
+    def _has_successful_class_coverage(self, successful_classes: int) -> bool:
+        """Return whether iterative or preceding bulk work gained class coverage.
+
+        Bulk records its completed classes in the shared exhaust report before
+        iterative exploration finishes the remainder. §FS-forge-chunked-dynamic-access
+        """
+        if successful_classes > 0:
+            return True
+        return (
+            self.dynamic_access_exhaust_report is not None
+            and bool(self.dynamic_access_exhaust_report.completed_classes)
         )
 
     def _mark_continuation_explore_pending(

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -125,6 +125,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         if self._last_phase_status == RUN_STATUS_CHUNK_READY:
             return RUN_STATUS_CHUNK_READY, global_iterations, 1
         if not phase_ok:
+            self._locate_explore_failure()
             recovery_checkpoint = self._latest_class_checkpoint or checkpoint_commit_hash
             subprocess.run(["git", "reset", "--hard", recovery_checkpoint], check=False)
             return RUN_STATUS_FAILURE, global_iterations, 0
@@ -350,7 +351,6 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                         exhausted_classes,
                         len(terminal_classes_this_part),
                     )
-                    self._locate_explore_failure()
                 return phase_succeeded, prompt_iterations
 
             class_name = active_class.class_name

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -13,6 +13,7 @@ from ai_workflows.core.workflow_strategy import (
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
 from utility_scripts.dynamic_access_report import BulkDynamicAccessProgress, DynamicAccessCoverageReport
 from utility_scripts.java_fix_coverage_follow_up import uncovered_dynamic_access_class_count
+from utility_scripts.run_location import RunLocation, STEP_GENERATE_TESTS, record_step_failure
 from utility_scripts.stage_logger import log_detail
 
 
@@ -50,6 +51,15 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
     @staticmethod
     def _print_message(message: str) -> None:
         log_detail("composition-workflow", message)
+
+    def _record_dynamic_access_failure(self) -> None:
+        """Record exploration only after the composite makes it terminal.
+
+        §FS-forge-run-location-reporting.3
+        """
+        record_step_failure(
+            location=RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, self.library),
+        )
 
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None
@@ -158,11 +168,13 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                     "required iterative dynamic-access chunk phase did not succeed"
                 )
                 status = RUN_STATUS_FAILURE
+                self._record_dynamic_access_failure()
             elif self.primary is None and not has_issue_requested_metadata:
                 self._print_message(
                     "dynamic-access coverage phase did not succeed and no reporter-requested metadata phase is available"
                 )
                 status = RUN_STATUS_FAILURE
+                self._record_dynamic_access_failure()
             else:
                 self._print_message(
                     "continuing with existing workflow result because dynamic-access coverage phase did not succeed"

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -458,8 +458,8 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         self.assertEqual(set(saved_report.exhausted_classes), set(remaining_classes))
         self.assertIsNone(failed_run_location())
 
-    def test_terminal_exhaustion_without_completed_classes_locates_failure(self) -> None:
-        """A genuine zero-progress status failure names its explore step.
+    def test_terminal_exhaustion_defers_failure_location_to_caller(self) -> None:
+        """A phase result alone does not record a terminal workflow failure.
 
         §FS-forge-run-location-reporting.3
         """
@@ -480,6 +480,31 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
 
         self.assertFalse(phase_ok)
         self.assertEqual(iterations, 0)
+        self.assertIsNone(failed_run_location())
+
+    def test_standalone_run_locates_terminal_exploration_failure(self) -> None:
+        """The standalone workflow records zero progress when it returns failure.
+
+        §FS-forge-run-location-reporting.3
+        """
+        class_name = "org.example.Exhausted"
+        current_report = self._report_for_class_names([class_name], [])
+        exhaust_report = DynamicAccessExhaustReport.create(
+            coordinate="org.example:lib:1.0.0",
+            issue_number=9776,
+        )
+        exhaust_report.mark_exhausted(class_name)
+        strategy = self._strategy(
+            dynamic_access_exhaust_report=exhaust_report,
+            chunk_class_count=15,
+        )
+
+        with patch.object(strategy, "_generate_dynamic_access_report", return_value=current_report), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch("ai_workflows.core.dynamic_access_iterative_strategy.subprocess.run"):
+            result = strategy.run(agent=object(), checkpoint_commit_hash="checkpoint")
+
+        self.assertEqual(result, (RUN_STATUS_FAILURE, 0, 0))
         self.assertEqual(
             failed_run_location(),
             RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, "org.example:lib:1.0.0"),
@@ -605,6 +630,7 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             self.assertEqual(strategy.run(agent=object()), (RUN_STATUS_SUCCESS, 1))
 
         self.assertEqual(calls, ["dynamic-access", "issue-requested"])
+        self.assertIsNone(failed_run_location())
 
     def test_increase_coverage_strategy_fails_when_no_primary_dynamic_access_or_issue_work_succeeds(self) -> None:
         class NoProgressDynamicAccess:
@@ -632,6 +658,10 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
                 NoProgressDynamicAccess,
         ):
             self.assertEqual(strategy.run(agent=object()), (RUN_STATUS_FAILURE, 0))
+        self.assertEqual(
+            failed_run_location(),
+            RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, "org.example:lib:1.0.0"),
+        )
 
     @staticmethod
     def _class_coverage(class_name: str, total_calls: int, covered_calls: int) -> DynamicAccessClass:

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -17,7 +17,13 @@ from ai_workflows.core.workflow_strategy import RUN_STATUS_CHUNK_READY, RUN_STAT
 from utility_scripts.dynamic_access_report import DynamicAccessClass, DynamicAccessCoverageReport
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.continuation_marker import PHASE_EXPLORE
-from utility_scripts.run_location import enter_phase, reset_run_location
+from utility_scripts.run_location import (
+    RunLocation,
+    STEP_GENERATE_TESTS,
+    enter_phase,
+    failed_run_location,
+    reset_run_location,
+)
 
 
 class DynamicAccessProgressLoggingTests(unittest.TestCase):
@@ -392,6 +398,92 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         self.assertEqual(strategy._last_phase_status, RUN_STATUS_CHUNK_READY)
         self.assertEqual(set(saved_report.completed_classes), {"org.example.A", "org.example.B"})
         self.assertNotIn("org.example.C", saved_report.completed_classes)
+
+    def test_final_remainder_succeeds_after_bulk_completed_classes(self) -> None:
+        """A terminal iterative remainder keeps productive bulk work successful.
+
+        §FS-forge-chunked-dynamic-access
+        """
+        class FakeAgent:
+            def send_prompt(self, prompt: str) -> None:
+                pass
+
+            def run_test_command(self, command: str) -> str:
+                return "BUILD SUCCESSFUL"
+
+            def clear_context(self) -> None:
+                pass
+
+        completed_classes = [f"org.example.Completed{index}" for index in range(27)]
+        remaining_classes = [f"org.example.Remaining{index}" for index in range(6)]
+        current_report = self._report_for_class_names(
+            completed_classes + remaining_classes,
+            completed_classes,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exhaust_report_path = os.path.join(tmpdir, "dynamic-access-exhaust-report.json")
+            exhaust_report = DynamicAccessExhaustReport.create(
+                coordinate="org.example:lib:1.0.0",
+                issue_number=9776,
+            )
+            for class_name in completed_classes:
+                exhaust_report.mark_completed(class_name)
+            strategy = self._strategy(
+                dynamic_access_exhaust_report=exhaust_report,
+                dynamic_access_exhaust_report_path=exhaust_report_path,
+                chunk_class_count=15,
+            )
+
+            with patch.object(strategy, "_render_prompt", return_value="prompt"), \
+                    patch.object(strategy, "_generate_dynamic_access_report", return_value=current_report), \
+                    patch.object(strategy, "_print_failure_analysis"), \
+                    patch.object(
+                        strategy,
+                        "_commit_dynamic_access_exhaust_report",
+                        side_effect=lambda message: strategy._save_dynamic_access_exhaust_report(),
+                    ), \
+                    patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                    patch(
+                        "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
+                        return_value="checkpoint\n",
+                    ):
+                phase_ok, iterations = strategy._run_dynamic_access_phase(FakeAgent(), current_report)
+
+            saved_report = DynamicAccessExhaustReport.load(exhaust_report_path)
+
+        self.assertTrue(phase_ok)
+        self.assertEqual(iterations, 6)
+        self.assertEqual(len(saved_report.completed_classes), 27)
+        self.assertEqual(set(saved_report.exhausted_classes), set(remaining_classes))
+        self.assertIsNone(failed_run_location())
+
+    def test_terminal_exhaustion_without_completed_classes_locates_failure(self) -> None:
+        """A genuine zero-progress status failure names its explore step.
+
+        §FS-forge-run-location-reporting.3
+        """
+        class_name = "org.example.Exhausted"
+        current_report = self._report_for_class_names([class_name], [])
+        exhaust_report = DynamicAccessExhaustReport.create(
+            coordinate="org.example:lib:1.0.0",
+            issue_number=9776,
+        )
+        exhaust_report.mark_exhausted(class_name)
+        strategy = self._strategy(
+            dynamic_access_exhaust_report=exhaust_report,
+            chunk_class_count=15,
+        )
+
+        with patch.object(strategy, "_library_test_change_signature", return_value="clean"):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(object(), current_report)
+
+        self.assertFalse(phase_ok)
+        self.assertEqual(iterations, 0)
+        self.assertEqual(
+            failed_run_location(),
+            RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, "org.example:lib:1.0.0"),
+        )
 
     def test_should_stop_for_chunked_dynamic_access_returns_false_without_report(self) -> None:
         strategy = self._strategy()


### PR DESCRIPTION
Closes #9776

## Preserve final chunk progress

The optimistic composite discarded productive bulk work when the final iterative remainder only exhausted classes. This counts completions already persisted in the shared exhaust report, allowing an all-terminal final remainder to proceed to finalization as required by [§FS-forge-chunked-dynamic-access](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/functional-spec/functional-spec.md#fs-forge-chunked-dynamic-access).

A run with no completed classes still fails and now records `explore/generate_tests()` as required by [§FS-forge-run-location-reporting.3](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/functional-spec/functional-spec.md#3-failure-output).