### PR TITLE
Prevent coverage tests from bypassing package visibility

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -551,6 +551,12 @@ states:
       Rules:
       - Attempt every listed uncovered path through its shown public entry;
         never invoke an internal target directly.
+      - Never bypass Java visibility by declaring a test in a package that
+        exists in the tested library. Use a distinct test-only package. A
+        `public` member on a package-private class is not public user-callable
+        API. If no public user-callable API reaches an internal target, leave
+        that target uncovered rather than call it directly.
+        §AR-code-coverage-improvement.3.2
       - `Observed:` lines are sampled guidance only; every `Uncovered paths`
         target is uncovered according to exact JaCoCo evidence.
       - Add or edit test classes only under the tracked extension suite

--- a/forge/examples/code-coverage-improvement-example/states.yaml
+++ b/forge/examples/code-coverage-improvement-example/states.yaml
@@ -398,6 +398,12 @@ states:
       Rules:
       - Attempt every listed uncovered path through its shown public entry;
         never invoke an internal target directly.
+      - Never bypass Java visibility by declaring a test in a package that
+        exists in the tested library. Use a distinct test-only package. A
+        `public` member on a package-private class is not public user-callable
+        API. If no public user-callable API reaches an internal target, leave
+        that target uncovered rather than call it directly.
+        §AR-code-coverage-improvement.3.2
       - `Observed:` lines are sampled guidance only; every `Uncovered paths`
         target is uncovered according to exact JaCoCo evidence.
       - Edit generated tests only under the tracked extension suite

--- a/forge/tests/test_code_coverage_rhei_template.py
+++ b/forge/tests/test_code_coverage_rhei_template.py
@@ -36,6 +36,54 @@ def _render_numeric_placeholders(source: str) -> str:
 
 class CodeCoverageRheiTemplateTests(unittest.TestCase):
 
+    def test_deep_cover_preserves_java_package_visibility(self) -> None:
+        """Deep-cover prompts must reach internals through public behavior.
+
+        §AR-code-coverage-improvement.3.2
+        """
+        forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        states_paths: tuple[str, ...] = (
+            os.path.join(
+                forge_root,
+                ".agents",
+                "rhei",
+                "templates",
+                "code-coverage-improvement",
+                "states.yaml",
+            ),
+            os.path.join(
+                forge_root,
+                "examples",
+                "code-coverage-improvement-example",
+                "states.yaml",
+            ),
+        )
+
+        for states_path in states_paths:
+            with open(states_path, encoding="utf-8") as states_file:
+                source: str = states_file.read()
+            machine: dict = yaml.safe_load(_render_numeric_placeholders(source))
+            instructions: str = machine["states"]["deep-cover"]["instructions"]
+            normalized_instructions: str = " ".join(instructions.split())
+
+            with self.subTest(path=states_path):
+                self.assertIn(
+                    "Never bypass Java visibility by declaring a test in a package "
+                    "that exists in the tested library.",
+                    normalized_instructions,
+                )
+                self.assertIn("Use a distinct test-only package.", normalized_instructions)
+                self.assertIn(
+                    "A `public` member on a package-private class is not public "
+                    "user-callable API.",
+                    normalized_instructions,
+                )
+                self.assertIn(
+                    "If no public user-callable API reaches an internal target, "
+                    "leave that target uncovered rather than call it directly.",
+                    normalized_instructions,
+                )
+
     def test_measurement_repairs_reuse_the_logical_cover_pass(self) -> None:
         """Both loops must keep retries out of the pass-yield history."""
         forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Closes #9774

## Keep deep coverage consumer-reachable

Deep-cover agents could satisfy JaCoCo targets by placing generated tests in a library-owned Java package, gaining package-private access that an external consumer does not have. That produces real execution but violates the requirement to reach internal methods through public behavior. §forge/AR-code-coverage-improvement.3.2

The deep-cover prompt now requires a distinct test-only package, clarifies that a public member on a package-private class is not public user-callable API, and leaves targets uncovered when no consumer-facing route exists. A regression test parses both the reusable template and runnable example and checks every part of that rule.