### PR TITLE
Remeasure coverage after finalization fixes

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -298,6 +298,9 @@ def _validate_render_inputs(descriptor: dict[str, Any]) -> None:
 
 def _validate_code_coverage_render(render: dict[str, Any]) -> None:
     """Require the finalized coverage evidence the coverage template reads."""
+    thinking = render.get("worker_thinking_level")
+    if not isinstance(thinking, str) or not thinking.strip():
+        raise ValueError("Code coverage publication requires a thinking level")
     metrics = render.get("code_coverage")
     if not isinstance(metrics, dict):
         raise ValueError("Code coverage publication requires render.code_coverage")
@@ -940,6 +943,7 @@ def _render_code_coverage_improvement(
         f"- Coordinate: `{coordinates}`",
         f"- Coverage suite path: `{metrics['coverageSuitePath']}`",
         f"- Model: {model}",
+        f"- Thinking level: {render['worker_thinking_level']}",
         f"- Needs human intervention: {'yes' if metrics['needsHumanIntervention'] else 'no'}",
         "",
         "## JaCoCo coverage",

--- a/.github/scripts/forge_pr_publisher/schema.json
+++ b/.github/scripts/forge_pr_publisher/schema.json
@@ -861,6 +861,11 @@
           ],
           "maxLength": 200
         },
+        "worker_thinking_level": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
         "reason": {
           "type": [
             "string",

--- a/forge/.agents/rhei/templates/code-coverage-improvement/README.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/README.md
@@ -60,7 +60,8 @@ unreviewed; finalization executes as a deterministic step program (JVM tests
 only at this stage — no Native Image validation) whose nonzero exit code names
 the failed step, and completes only when the deterministic `finalize-verify`
 program accepts its artifacts. Fixable failures are repaired by `finalize-fix`
-for at most `fix_passes` pass(es) before the steps re-run. Failed targets or an
+for at most `fix_passes` pass(es) before final evidence is remeasured and the
+steps re-run. Failed targets or an
 explicit `needsHumanIntervention` flag route to `human-intervention`. Pipeline
 tasks also route there when a required helper or artifact fails instead of
 completing with partial evidence. Finalization writes schema-validated,

--- a/forge/.agents/rhei/templates/code-coverage-improvement/index.rhei.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/index.rhei.md
@@ -55,7 +55,7 @@ finalization task runs as a deterministic program of numbered steps (read the
 conversion record, run checkstyle, run the JVM tests with the coverage
 suite, finalize
 metrics); a nonzero exit code is the number of the failed step and routes to
-`finalize-fix`, after which the steps re-run from the start. `finalize-verify`
+`finalize-fix`, after which final evidence is remeasured and the steps re-run. `finalize-verify`
 then accepts the artifacts only on presence, schema validation of
 `final-metrics.json`, and metrics outcomes — never on an agent's own claim.
 Fixable failures are bounded by `{{fix_passes}}` pass(es); failed targets or an

--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -25,7 +25,8 @@
 #
 # Final verified task (finalization only):
 #   reviewed-prepared -> reviewed-execute -- 0 -> finalize-verify -- 0 -> completed
-#     (exit N names the failed step -> finalize-fix -> re-run; 75/80 as before)
+#     (failure -> finalize-fix -> finalize-remeasure -> reviewed-execute;
+#      final remeasurement failures require human intervention)
 #
 # Measurement is a deterministic program that always writes the current
 # report to one fixed path and, when the loop continues, derives the cover
@@ -803,6 +804,14 @@ states:
       jacoco_after_api, jacoco_final = report_bounds(
           "runtime/code-coverage/discovery", "jacoco-deep", ".xml"
       )
+      final_measurement = Path("runtime/code-coverage/final-measurement")
+      final_deep = final_measurement / "discovery-report.json"
+      final_jacoco = final_measurement / "jacoco.xml"
+      if final_deep.exists() != final_jacoco.exists():
+          fail(7, "final measurement is incomplete")
+      if final_deep.is_file():
+          deep_final = final_deep
+          jacoco_final = final_jacoco
       finalize_command = [
           sys.executable,
           f"{work_path}/utility_scripts/code_coverage_finalize.py",
@@ -941,6 +950,129 @@ states:
       - name: fix
         path: runtime/code-coverage/fixes/{task_id}-{visit_count}.md
         description: Fixes applied after a failed finalization step or verification.
+
+  finalize-remeasure:
+    description: Regenerate final coverage evidence after a finalization repair.
+    concurrent: true
+    visits: {{fix_passes * 2 + 2}}
+    program: |
+      python3 - "$RHEI_INPUT_CONVERSION_PATH" <<'PY'
+      import json
+      import os
+      import shutil
+      import subprocess
+      import sys
+      from pathlib import Path
+
+      def fail(step: int, message: str) -> None:
+          print(f"step {step}: {message}", file=sys.stderr)
+          sys.exit(step)
+
+      def run(
+              step: int,
+              command: list,
+              cwd: str | None = None,
+              env: dict | None = None,
+      ) -> None:
+          command = [str(part) for part in command]
+          try:
+              if subprocess.run(command, cwd=cwd, env=env).returncode != 0:
+                  fail(step, f"command failed: {' '.join(command[:2])}")
+          except OSError as error:
+              fail(step, f"command could not run: {error}")
+
+      try:
+          conversion = json.load(open(sys.argv[1]))
+          coordinate = conversion["coordinate"]
+          worktree = conversion["worktreePath"]
+          work_path = conversion["workPath"]
+          group, artifact, version = coordinate.split(":")
+          sys.path.insert(0, work_path)
+          from utility_scripts.metadata_index import resolve_test_dir
+          subproject = Path(resolve_test_dir(
+              worktree, group, artifact, version
+          ))
+      except Exception as error:
+          fail(1, f"conversion or test project is invalid: {error}")
+
+      output = Path("runtime/code-coverage/final-measurement")
+      if output.exists():
+          shutil.rmtree(output)
+      output.mkdir(parents=True)
+      gradle = [f"{worktree}/gradlew", f"-Pcoordinates={coordinate}"]
+      include_suite = "-PincludeCodeCoverageSuite=true"
+
+      run(2, gradle + ["jacocoCodeCoverageReport"], cwd=worktree)
+      jacoco_source = (
+          subproject
+          / "build/reports/jacoco/jacocoCodeCoverageReport"
+          / "jacocoCodeCoverageReport.xml"
+      )
+      if not jacoco_source.is_file():
+          fail(2, f"missing JaCoCo XML at {jacoco_source}")
+      jacoco = output / "jacoco.xml"
+      shutil.copy(jacoco_source, jacoco)
+
+      run(3, gradle + ["nativeTestPGOSampling", include_suite], cwd=worktree)
+      profile = (output / "pgo-profile.iprof").resolve()
+      run(
+          4,
+          gradle + [
+              "runNativeTestPGO",
+              include_suite,
+              f"-PpgoProfilePath={profile}",
+          ],
+          cwd=worktree,
+      )
+      if not profile.is_file():
+          fail(4, "sampling run wrote no .iprof")
+
+      reports_dir = subproject / "build/native/nativeTestCompile/reports"
+      triplets: dict = {}
+      for csv_path in reports_dir.glob("call_tree_*.csv"):
+          rest = csv_path.stem.partition("call_tree_")[2]
+          csv_kind, _, suffix = rest.partition("_")
+          triplets.setdefault(suffix, {})[csv_kind] = csv_path
+      complete = {
+          suffix: files
+          for suffix, files in triplets.items()
+          if {"methods", "invokes", "targets"} <= set(files)
+      }
+      if not complete:
+          fail(5, f"no coherent call-tree CSV triplet under {reports_dir}")
+      triplet = output / "call-tree"
+      triplet.mkdir()
+      for csv_path in complete[sorted(complete)[-1]].values():
+          shutil.copy(csv_path, triplet / csv_path.name)
+
+      analyzer = [
+          sys.executable,
+          f"{work_path}/utility_scripts/code_coverage_profile_report.py",
+          "--profile", profile,
+          "--reports-dir", triplet,
+          "--api-inventory",
+          "runtime/code-coverage/api-inventory/api-inventory.json",
+          "--jacoco-xml", jacoco,
+          "--library-methods", "runtime/code-coverage/graph/methods.csv",
+          "--coordinate", coordinate,
+          "--iteration", "0",
+          "--output-dir", output,
+      ]
+      run(6, analyzer, env=dict(os.environ, PYTHONPATH=work_path))
+      discovery = output / "discovery-report-0.json"
+      if not discovery.is_file():
+          fail(6, f"analyzer wrote no report at {discovery}")
+      discovery.rename(output / "discovery-report.json")
+      PY
+    program_timeout: 120m
+    inputs:
+      - name: conversion
+        path: runtime/code-coverage/issues/conversion.json
+    outputs:
+      - name: final-jacoco
+        path: runtime/code-coverage/final-measurement/jacoco.xml
+      - name: final-discovery
+        path: runtime/code-coverage/final-measurement/discovery-report.json
 
   human-intervention:
     description: Human decision or manual repair is required.
@@ -1280,9 +1412,44 @@ transitions:
     exit_code: 80
     description: Final metrics demand human action (failed targets or explicit flag).
 
-  - from: finalize-fix
+  - from: finalize-remeasure
     to: reviewed-execute
-    description: Repairs applied; the finalization steps re-run from the start.
+    exit_code: 0
+    description: Final evidence is fresh; rerun finalization.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 1
+    description: Final measurement setup failed after a repair.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 2
+    description: Final JaCoCo measurement failed after a repair.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 3
+    description: Final PGO image build failed after a repair.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 4
+    description: Final PGO sampling run failed after a repair.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 5
+    description: Final call-tree capture failed after a repair.
+
+  - from: finalize-remeasure
+    to: human-intervention
+    exit_code: 6
+    description: Final discovery analysis failed after a repair.
+
+  - from: finalize-fix
+    to: finalize-remeasure
+    description: Repairs applied; refresh final evidence before rerunning finalization.
 
   - from: human-intervention
     to: execute

--- a/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/tasks/code-coverage-improvement.md
@@ -189,14 +189,14 @@
 **Prior:** Task code-coverage-deep-coverage
 
 - Final API report: highest-iteration `runtime/code-coverage/validation/api-cover-report-<n>.json`
-- Final deep report: highest-iteration `runtime/code-coverage/discovery/discovery-report-<n>.json`
+- Final deep report: highest-iteration deep report, or `runtime/code-coverage/final-measurement/discovery-report.json` after `finalize-fix`
 - Helper script: `forge/utility_scripts/code_coverage_finalize.py`
 - Purpose: gate publication on deterministic post-loop validation, update the
   committed library coverage stats, and summarize JaCoCo and sampled-path
   guidance.
 - Execution: this task is a deterministic program (the `reviewed-execute`
   state), not an agent checklist. A nonzero exit code is the number of the
-  failed step and routes to `finalize-fix`. Finalization runs no Native Image
+  failed step and routes to `finalize-fix`, then deterministic final remeasurement. Finalization runs no Native Image
   validation of the coverage tests; the stats step (5) does build a native image,
   because the dynamic-access half of `stats.json` is only observable from one.
 - Program steps:
@@ -228,8 +228,7 @@
   6. Invoke `forge/utility_scripts/code_coverage_finalize.py` with the resolved
      `--coordinate`, repository-relative `--coverage-suite-path`, the API
      baseline/final reports (`api-cover-report-0.json` and the highest-iteration report),
-     the deep baseline/final reports (`discovery-report-0.json` and the
-     highest-iteration report), any externally provided
+     the deep baseline and selected final reports, any externally provided
      `runtime/code-coverage/targets/*.json` as repeated `--target-state`
      arguments (the workflow itself no longer produces them), the exact
      checkstyle, JVM test, and stats commands as repeated

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -549,8 +549,8 @@ The Rhei template should decompose the workflow into these phases:
 
    The descriptor carries the render inputs and only those: coordinate, coverage
    suite path, the whole-run coverage checkpoints and phase gains, the per-phase
-   JaCoCo records, the human-intervention flag, the generating model, and
-   per-phase token usage read from the Rhei accounting directory. The body links
+   JaCoCo records, the human-intervention flag, the generating model and thinking
+   level, and per-phase token usage read from the Rhei accounting directory. The body links
    its issue with `Fixes:`, never conditionally: one run publishes one pull
    request, so merging it closes
    the issue that claimed the coordinate (§AR-issue-linking). Per-target
@@ -799,8 +799,9 @@ engine:
   model written as `<model>:<thinking>` is parsed as a provider/model pair and
   silently resolves to a different model. The template therefore bundles a `pi`
   agent profile in its `settings.json` whose `high` and `xhigh` modes add
-  `--thinking`, and publication reads the model back out of the same target to
-  name the head branch (§AR-code-coverage-improvement.4). That profile replaces
+  `--thinking`, and publication reads the model and thinking level back out of
+  the same target, using the model to name the head branch and rendering both in the pull
+  request body (§AR-code-coverage-improvement.4). That profile replaces
   Rhei's built-in one outright rather than extending it, so it restates the
   `session` block as well: without it Rhei passes no `--session-dir`, cannot
   read back the agent's native transcript, and silently captures no per-state

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -511,8 +511,9 @@ The Rhei template should decompose the workflow into these phases:
    (including the tracked coverage suite); run the regular JVM tests (`javaTest`)
    and the tracked extension suite (`codeCoverageTest`); regenerate the
    coordinate's committed library stats from the combined main-JAR-only JaCoCo
-   report; and persist final metrics from the baseline and highest-iteration
-   JaCoCo and deep reports, including each phase's recorded stop decision
+   report; and persist final metrics from the baseline and final JaCoCo and deep reports. After a finalization
+   repair, the final reports come from one agent-free deterministic
+   remeasurement, including each phase's recorded stop decision
    (§3.3). The stats update makes the repository coverage
    dashboard reflect the tests this workflow adds without counting classified
    artifacts such as an upstream test JAR in the denominator
@@ -620,7 +621,9 @@ nonzero exit code names the failed step, and its completion is decided by a
 deterministic verification program, not by an agent's own claim: it checks the
 finalization artifacts exist, schema-validates the final metrics, and inspects
 their outcomes. Fixable step or verification failures return to a bounded fix
-state, after which the steps re-run; failed targets or an explicit
+state, after which one agent-free final remeasurement refreshes JaCoCo,
+sampled PGO, call-tree, and discovery evidence before the steps re-run. A failed
+final remeasurement routes directly to human intervention; failed targets or an explicit
 human-intervention flag in the metrics, and failures that survive the fix
 budget, route to human intervention.
 

--- a/forge/git_scripts/publish_code_coverage_improvement.py
+++ b/forge/git_scripts/publish_code_coverage_improvement.py
@@ -122,6 +122,26 @@ def model_slug(worker_agent: str) -> str:
     return slug
 
 
+def thinking_level(worker_agent: str) -> str:
+    """Return the thinking mode selected by a Rhei worker target.
+
+    The bracketed mode is the workflow's reasoning level
+    (§AR-code-coverage-improvement.4).
+    """
+    agent_target: str = worker_agent.split(":", 1)[0]
+    match: re.Match[str] | None = re.fullmatch(
+        r"[A-Za-z0-9._-]+(?:\[([A-Za-z0-9._-]+)\])?",
+        agent_target,
+    )
+    if match is None:
+        print(
+            f"ERROR: worker agent '{worker_agent}' has an invalid agent mode.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return match.group(1) or "default"
+
+
 def load_finalization_metrics(finalization_dir: str) -> dict[str, Any]:
     metrics_path: str = os.path.join(finalization_dir, "final-metrics.json")
     if not os.path.isfile(metrics_path):
@@ -187,6 +207,7 @@ def build_descriptor_input(
         issue_number: int,
         metrics: dict[str, Any],
         model: str,
+        thinking: str,
         token_usage: list[dict[str, Any]],
 ) -> PublicationDescriptorInput:
     """Carry the finalized coverage evidence to the trusted renderer as data.
@@ -207,6 +228,7 @@ def build_descriptor_input(
             },
             "token_usage": token_usage,
             "worker_model": model,
+            "worker_thinking_level": thinking,
         },
     )
 
@@ -250,6 +272,7 @@ def publish(
     # pipeline appends separates repeated runs of one model
     # (§AR-code-coverage-improvement.4).
     model: str = model_slug(worker_agent)
+    thinking: str = thinking_level(worker_agent)
     suffix: str = f"-{branch_suffix}" if branch_suffix else ""
     # Rhei writes accounting beside the workflow runtime, two levels above the
     # finalization directory it hands this helper.
@@ -260,6 +283,7 @@ def publish(
         issue_number,
         metrics,
         model,
+        thinking,
         load_token_usage(resolved_accounting),
     )
 

--- a/forge/schemas/code_coverage_final_metrics_schema.json
+++ b/forge/schemas/code_coverage_final_metrics_schema.json
@@ -8,6 +8,7 @@
     "generatedAt",
     "coordinate",
     "coverageSuitePath",
+    "finalMeasurementArtifacts",
     "runCoverage",
     "apiJacoco",
     "deepJacoco",
@@ -18,7 +19,7 @@
     "needsHumanIntervention"
   ],
   "properties": {
-    "schemaVersion": {"const": "1.2.0"},
+    "schemaVersion": {"const": "1.3.0"},
     "generatedAt": {
       "type": "string",
       "format": "date-time"
@@ -28,6 +29,15 @@
       "pattern": "^[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+:[A-Za-z0-9_.+-]+$"
     },
     "coverageSuitePath": {"type": "string", "minLength": 1},
+    "finalMeasurementArtifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["jacoco", "discoveryReport"],
+      "properties": {
+        "jacoco": {"type": "string", "minLength": 1},
+        "discoveryReport": {"type": "string", "minLength": 1}
+      }
+    },
     "runCoverage": {"$ref": "#/$defs/runCoverage"},
     "apiJacoco": {"$ref": "#/$defs/apiEvidence"},
     "deepJacoco": {"$ref": "#/$defs/deepEvidence"},

--- a/forge/tests/fixtures/code_coverage/final_metrics.json
+++ b/forge/tests/fixtures/code_coverage/final_metrics.json
@@ -1,8 +1,9 @@
 {
-  "schemaVersion": "1.2.0",
+  "schemaVersion": "1.3.0",
   "generatedAt": "2026-08-20T10:15:30Z",
   "coordinate": "com.example:demo:1.0.0",
   "coverageSuitePath": "tests/src/com.example/demo/1.0.0/code-coverage-improvement",
+  "finalMeasurementArtifacts": {"jacoco": "jacoco-final.xml", "discoveryReport": "deep-final.json"},
   "runCoverage": {
     "universe": 30,
     "apiUniverse": 10,

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -328,7 +328,9 @@ class FinalizerTests(unittest.TestCase):
         loaded = module.load_validated_final_metrics(
             os.path.join(output, "final-metrics.json")
         )
-        self.assertEqual(loaded["schemaVersion"], "1.2.0")
+        self.assertEqual(loaded["schemaVersion"], "1.3.0")
+        self.assertTrue(loaded["finalMeasurementArtifacts"]["jacoco"].endswith("jacoco-final.xml"))
+        self.assertTrue(loaded["finalMeasurementArtifacts"]["discoveryReport"].endswith("deep-5.json"))
         with open(
                 os.path.join(output, "final-summary.md"),
                 encoding="utf-8",

--- a/forge/tests/test_code_coverage_rhei_template.py
+++ b/forge/tests/test_code_coverage_rhei_template.py
@@ -94,5 +94,58 @@ class CodeCoverageRheiTemplateTests(unittest.TestCase):
                         self.assertIn("{visit_count}", output["path"])
 
 
+    def test_finalization_fix_requires_one_agent_free_remeasurement(self) -> None:
+        """A finalization repair cannot complete with its pre-repair evidence."""
+        forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        states_path: str = os.path.join(
+            forge_root,
+            ".agents",
+            "rhei",
+            "templates",
+            "code-coverage-improvement",
+            "states.yaml",
+        )
+        with open(states_path, encoding="utf-8") as states_file:
+            machine: dict = yaml.safe_load(
+                _render_numeric_placeholders(states_file.read())
+            )
+
+        transitions: list[dict] = machine["transitions"]
+        self.assertEqual(
+            {
+                transition["to"]
+                for transition in transitions
+                if transition["from"] == "finalize-fix"
+            },
+            {"finalize-remeasure"},
+        )
+        self.assertEqual(
+            {
+                (transition["exit_code"], transition["to"])
+                for transition in transitions
+                if transition["from"] == "finalize-remeasure"
+            },
+            {
+                (0, "reviewed-execute"),
+                *((code, "human-intervention") for code in range(1, 7)),
+            },
+        )
+        program: str = machine["states"]["finalize-remeasure"]["program"]
+        python_source: str = program.split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+        compile(python_source, "finalize-remeasure", "exec")
+        for command in (
+                "jacocoCodeCoverageReport",
+                "nativeTestPGOSampling",
+                "runNativeTestPGO",
+                "code_coverage_profile_report.py",
+        ):
+            self.assertIn(command, program)
+        self.assertNotIn("begin_measurement", program)
+        self.assertNotIn("deep-cover", program)
+        finalization: str = machine["states"]["reviewed-execute"]["program"]
+        self.assertIn("runtime/code-coverage/final-measurement", finalization)
+        self.assertIn("jacoco.xml", finalization)
+        self.assertIn("discovery-report.json", finalization)
+
 if __name__ == "__main__":
     unittest.main()

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -67,6 +67,7 @@ def _descriptor(**render_overrides: Any) -> dict[str, Any]:
         "code_coverage": _coverage_evidence(),
         "token_usage": [],
         "worker_model": "gpt-5.6-luna",
+        "worker_thinking_level": "high",
     }
     render.update(render_overrides)
     return {
@@ -180,6 +181,18 @@ class CoveragePublisherTemplateTests(unittest.TestCase):
         self.assertEqual(
             title, "[GenAI] Improve code coverage for com.example:demo:1.0.0 using gpt-5.6-luna"
         )
+
+    def test_body_reports_the_worker_thinking_level(self) -> None:
+        _, body = publisher.render_publication(_descriptor())
+
+        self.assertIn("- Thinking level: high", body)
+
+    def test_render_validation_rejects_a_missing_thinking_level(self) -> None:
+        descriptor = _descriptor()
+        descriptor["render"].pop("worker_thinking_level")
+
+        with self.assertRaisesRegex(ValueError, "thinking level"):
+            publisher._validate_render_inputs(descriptor)
 
     def test_body_reports_every_checkpoint_on_one_denominator(self) -> None:
         """One universe of 30: 10 reportable API entries plus 20 deep methods."""

--- a/forge/tests/test_publish_code_coverage_improvement.py
+++ b/forge/tests/test_publish_code_coverage_improvement.py
@@ -260,6 +260,7 @@ class CoveragePublicationTests(unittest.TestCase):
         self.assertEqual(descriptor_input.issue_number, 8380)
         self.assertEqual(descriptor_input.status, "success")
         self.assertEqual(descriptor_input.render["worker_model"], "gpt-5.6-luna")
+        self.assertEqual(descriptor_input.render["worker_thinking_level"], "high")
         self.assertEqual(descriptor_input.render["token_usage"], usage)
         self.assertEqual(
             descriptor_input.render["code_coverage"]["coordinate"],
@@ -290,6 +291,20 @@ class CoveragePublicationTests(unittest.TestCase):
             module.model_slug("codex[xhigh]:openai:gpt-5.5"), "gpt-5.5"
         )
         self.assertEqual(module.model_slug("gpt-5.6-sol"), "gpt-5.6-sol")
+
+    def test_thinking_level_reads_the_mode_out_of_a_rhei_target(self) -> None:
+        self.assertEqual(
+            module.thinking_level("pi[high]:openai-codex/gpt-5.6-luna"),
+            "high",
+        )
+        self.assertEqual(
+            module.thinking_level("codex[xhigh]:openai:gpt-5.5"),
+            "xhigh",
+        )
+        self.assertEqual(
+            module.thinking_level("pi:openai-codex/gpt-5.6-sol"),
+            "default",
+        )
 
     def test_model_slug_rejects_a_target_without_a_model(self) -> None:
         with self.assertRaises(SystemExit):

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -24,7 +24,7 @@ from jsonschema import Draft202012Validator
 from utility_scripts.code_coverage_model import parse_inventory_id
 from utility_scripts.code_coverage_jacoco import load_jacoco_method_coverage
 
-SCHEMA_VERSION = "1.2.0"
+SCHEMA_VERSION = "1.3.0"
 
 #: Run checkpoints, in run order. Each is one JaCoCo report, and each phase
 #: begins at the checkpoint the previous phase ended on
@@ -800,6 +800,10 @@ def finalize_coverage(
         "generatedAt": _generated_at(),
         "coordinate": coordinate,
         "coverageSuitePath": _suite_path(coverage_suite_path),
+        "finalMeasurementArtifacts": {
+            "jacoco": jacoco_paths[2],
+            "discoveryReport": deep_final_path,
+        },
         "runCoverage": _run_coverage(
             api_baseline_report, deep_baseline_report, jacoco_paths
         ),


### PR DESCRIPTION
Closes #9775

## What this does

A finalization repair can change coverage tests, resources, dependencies, build
configuration, or metadata after the deep loop records its last JaCoCo and
sampled-PGO evidence. Finalization previously reused that pre-repair evidence,
so published metrics did not necessarily describe the verified work product.

Every successful `finalize-fix` now routes through one agent-free
`finalize-remeasure` state before finalization runs again. This implements the
verified-evidence requirement in
[§forge/AR-code-coverage-improvement.4](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/issue-9775-final-remeasurement/forge/docs/architecture/code-coverage-improvement.md#4-workflow).

## How remeasurement works

The state reruns the deterministic measurement sequence:

1. Generate the combined JaCoCo XML.
2. Build and run the PGO-sampling native image.
3. Copy one coherent analysis call-tree triplet.
4. Regenerate the discovery report.

It writes the final JaCoCo and discovery reports under
`runtime/code-coverage/final-measurement/`. Finalization prefers those fixed
reports when present and records their paths in `final-metrics.json`.

Remeasurement does not invoke `deep-cover`, append discovery history, count as
a coverage iteration, or change either phase stop decision. A measurement
failure routes directly to human intervention instead of starting another
unbudgeted repair loop.

## What generated coverage PRs report

The publication handoff now parses the thinking level from the existing Rhei
worker target—for example, `high` from
`pi[high]:openai-codex/gpt-5.6-luna`—and carries it through the trusted
descriptor. Code-coverage PR bodies render it beside the generating model as
`Thinking level: high`.
