### PR TITLE
Improve optimistic dynamic-access handoff

### DIFF
--- a/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
@@ -361,13 +361,10 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
         attribute skipped, exhausted, or failed classes
         (§AR-dynamic-access-bulk).
         """
-        processed_classes: set[str] = self._continuation_processed_classes()
-        if self.dynamic_access_exhaust_report is not None:
-            processed_classes.update(self.dynamic_access_exhaust_report.processed_classes())
         progress: BulkDynamicAccessProgress = compute_bulk_dynamic_access_progress(
             initial_report,
             final_report,
-            processed_classes,
+            self.processed_dynamic_access_classes(),
         )
         if self.dynamic_access_exhaust_report is not None:
             for class_name in progress.completed_classes:
@@ -384,6 +381,17 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
                 boundary=self.chunk_class_count,
             )
         )
+
+    def processed_dynamic_access_classes(self) -> set[str]:
+        """Return every class a resumed run must not count as remaining work.
+
+        The exhaust report and the continuation marker record what earlier
+        phases already took (§AR-dynamic-access-exhaust-report).
+        """
+        processed_classes: set[str] = self._continuation_processed_classes()
+        if self.dynamic_access_exhaust_report is not None:
+            processed_classes.update(self.dynamic_access_exhaust_report.processed_classes())
+        return processed_classes
 
     def _continuation_processed_classes(self) -> set[str]:
         """Return classes a resumed bulk run must exclude from its remainder."""

--- a/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
+++ b/forge/ai_workflows/core/bulk_dynamic_access_strategy.py
@@ -89,8 +89,14 @@ class BulkDynamicAccessStrategy(WorkflowStrategy):
             "dynamic-access-coverage.json",
         )
 
-    def run(self, agent: object, **kwargs: object) -> tuple[str, int, int]:
-        initial_report = self._generate_dynamic_access_report()
+    def run(
+            self,
+            agent: object,
+            initial_report: DynamicAccessCoverageReport | None = None,
+            **kwargs: object,
+    ) -> tuple[str, int, int]:
+        if initial_report is None:
+            initial_report = self._generate_dynamic_access_report()
         fallback_prompt_iterations = 0
         fallback_successful_generations = 0
         if not self._report_is_usable(initial_report):

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -84,6 +84,9 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         self.dynamic_access_exhaust_report_path: str | None = self.context.get(
             "dynamic_access_exhaust_report_path",
         )
+        self.preceding_dynamic_access_covered_call_gain: int = int(
+            self.context.get("preceding_dynamic_access_covered_call_gain") or 0
+        )
         self.chunk_class_count = int(self.context.get("chunk_class_count") or 0)
         self._last_phase_status = RUN_STATUS_SUCCESS
         self._latest_class_checkpoint: str | None = None
@@ -720,12 +723,13 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
 
     def _has_successful_class_coverage(self, successful_classes: int) -> bool:
-        """Return whether iterative or preceding bulk work gained class coverage.
+        """Return whether iterative or preceding bulk work gained coverage.
 
-        Bulk records its completed classes in the shared exhaust report before
-        iterative exploration finishes the remainder. §FS-forge-chunked-dynamic-access
+        Bulk passes its covered-call gain directly and records completed classes
+        in the shared exhaust report before iterative exploration finishes the
+        remainder. §FS-forge-chunked-dynamic-access
         """
-        if successful_classes > 0:
+        if successful_classes > 0 or self.preceding_dynamic_access_covered_call_gain > 0:
             return True
         return (
             self.dynamic_access_exhaust_report is not None

--- a/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
+++ b/forge/ai_workflows/core/dynamic_access_iterative_strategy.py
@@ -71,7 +71,9 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
         )
         self.package = self.group
         self.max_class_iterations = self.parameters["max-iterations"]
-        self.max_class_test_iterations = self.parameters["max-class-test-iterations"]
+        # The established configuration key budgets complete repair rounds.
+        # §FS-predefined-strategy-parameter-families
+        self.max_class_test_repairs = self.parameters["max-class-test-iterations"]
         self.native_test_verification_batch_size = self._parameter_int(
             "native-test-verification-batch-size",
             DEFAULT_NATIVE_TEST_VERIFICATION_BATCH_SIZE,
@@ -353,17 +355,18 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                 reached_native_test = False
                 last_test_output = ""
                 last_failed_task = None
-                for test_iteration in range(self.max_class_test_iterations):
+                test_attempts: int = self.max_class_test_repairs + 1
+                for test_iteration in range(test_attempts):
                     log_step_progress(
                         RUN_PHASE_EXPLORE,
                         STEP_GENERATE_TESTS,
-                        f"Running test {test_iteration + 1}/{self.max_class_test_iterations}",
+                        f"Running test {test_iteration + 1}/{test_attempts}",
                         indent_level=1,
                     )
                     self._print_dynamic_access_detail(
                         "test {current}/{maximum}: running ./gradlew test -Pcoordinates={library}".format(
                             current=test_iteration + 1,
-                            maximum=self.max_class_test_iterations,
+                            maximum=test_attempts,
                             library=self.library,
                         ),
                         indent_level=2,
@@ -381,7 +384,7 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     log_step_progress(
                         RUN_PHASE_EXPLORE,
                         STEP_GENERATE_TESTS,
-                        f"Test {test_iteration + 1}/{self.max_class_test_iterations} {test_outcome}",
+                        f"Test {test_iteration + 1}/{test_attempts} {test_outcome}",
                         indent_level=1,
                     )
                     self._print_dynamic_access_detail(
@@ -392,6 +395,8 @@ class DynamicAccessIterativeStrategy(WorkflowStrategy):
                     )
                     if failed_task in {"nativeTest", None}:
                         reached_native_test = True
+                        break
+                    if test_iteration == test_attempts - 1:
                         break
                     log_step_progress(
                         RUN_PHASE_EXPLORE,

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -11,7 +11,11 @@ from ai_workflows.core.workflow_strategy import (
     WorkflowStrategy,
 )
 from utility_scripts.continuation_marker import PHASE_EXPLORE, PHASE_FIX, save_phase_update
-from utility_scripts.dynamic_access_report import BulkDynamicAccessProgress, DynamicAccessCoverageReport
+from utility_scripts.dynamic_access_report import (
+    BulkDynamicAccessProgress,
+    DynamicAccessCoverageReport,
+    remaining_uncovered_classes,
+)
 from utility_scripts.java_fix_coverage_follow_up import uncovered_dynamic_access_class_count
 from utility_scripts.run_location import RunLocation, STEP_GENERATE_TESTS, record_step_failure
 from utility_scripts.stage_logger import log_detail
@@ -69,7 +73,13 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
     def _precheck_optimistic_bulk(
             self,
     ) -> tuple[DynamicAccessCoverageReport | None, int | None]:
-        """Return the reusable report and a small-report iterative budget."""
+        """Return the reusable report and a small-report iterative budget.
+
+        The budget is the remainder iterative exploration can still take, on
+        the same basis as the post-bulk boundary: a class an earlier phase
+        already processed is not work either phase can repeat
+        (§AR-dynamic-access-composite).
+        """
         if (
                 self.primary_workflow_name != "bulk_dynamic_access"
                 or self.bulk_min_uncovered_classes <= 0
@@ -81,17 +91,36 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
             return report, None
 
         uncovered_class_count: int = uncovered_dynamic_access_class_count(report)
+        if uncovered_class_count == 0:
+            self._print_message("skipping bulk dynamic-access primary: no uncovered classes remain")
+            return report, 0
         if uncovered_class_count >= self.bulk_min_uncovered_classes:
+            return report, None
+
+        remaining_class_count: int = len(remaining_uncovered_classes(
+            report,
+            self.primary.processed_dynamic_access_classes(),
+        ))
+        if remaining_class_count == 0:
+            # Bulk is the only phase that still prompts on a class iterative
+            # exploration exhausted, so a fully processed remainder stays with it.
+            self._print_message(
+                "keeping bulk dynamic-access primary: "
+                "uncovered_classes={uncovered} are already processed".format(
+                    uncovered=uncovered_class_count,
+                )
+            )
             return report, None
 
         self._print_message(
             "skipping bulk dynamic-access primary: "
-            "uncovered_classes={uncovered} minimum={minimum}".format(
+            "uncovered_classes={uncovered} remaining={remaining} minimum={minimum}".format(
                 uncovered=uncovered_class_count,
+                remaining=remaining_class_count,
                 minimum=self.bulk_min_uncovered_classes,
             )
         )
-        return report, uncovered_class_count
+        return report, remaining_class_count
 
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None
@@ -112,6 +141,13 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
             status = RUN_STATUS_SUCCESS
             iterations = 0
         elif small_report_iterative_count is not None:
+            # The skipped primary still owns its phase transition, so the
+            # composite releases the fix phase bulk would have released
+            # (§FS-forge-run-continuation.1).
+            save_phase_update(
+                self.continuation_marker_path,
+                lambda marker: marker.mark_phase_skipped_if_pending(PHASE_FIX),
+            )
             result: tuple[str, int, int] = (RUN_STATUS_SUCCESS, 0, 1)
             status = RUN_STATUS_SUCCESS
             iterations = 0

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -31,6 +31,11 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
         super().__init__(strategy_obj, **context)
         self.primary_workflow_name: str | None = strategy_obj.get("primary-workflow")
         self.chunk_class_count: int = int(self.context.get("chunk_class_count") or 0)
+        self.bulk_min_uncovered_classes: int = int(
+            self.parameters.get("bulk-min-uncovered-classes") or 0
+        )
+        if self.bulk_min_uncovered_classes < 0:
+            raise ValueError("bulk-min-uncovered-classes must be non-negative")
         self.reachability_repo_path = self.context["reachability_repo_path"]
         self.library = self.context.get("library") or self.context.get("updated_library")
         self.group, self.artifact, self.version = self.library.split(":")
@@ -61,12 +66,42 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
             location=RunLocation(PHASE_EXPLORE, STEP_GENERATE_TESTS, self.library),
         )
 
+    def _precheck_optimistic_bulk(
+            self,
+    ) -> tuple[DynamicAccessCoverageReport | None, int | None]:
+        """Return the reusable report and a small-report iterative budget."""
+        if (
+                self.primary_workflow_name != "bulk_dynamic_access"
+                or self.bulk_min_uncovered_classes <= 0
+        ):
+            return None, None
+
+        report = self.primary._generate_dynamic_access_report()
+        if report is None or not report.has_dynamic_access or report.total_calls == 0:
+            return report, None
+
+        uncovered_class_count: int = uncovered_dynamic_access_class_count(report)
+        if uncovered_class_count >= self.bulk_min_uncovered_classes:
+            return report, None
+
+        self._print_message(
+            "skipping bulk dynamic-access primary: "
+            "uncovered_classes={uncovered} minimum={minimum}".format(
+                uncovered=uncovered_class_count,
+                minimum=self.bulk_min_uncovered_classes,
+            )
+        )
+        return report, uncovered_class_count
+
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None
         iterative_chunk_count: int | None = None
         preceding_covered_call_gain: int = 0
         required_iterative_chunk_phase: bool = False
         skip_dynamic_access_phase: bool = False
+        small_report_iterative_count: int | None = None
+        if self.primary is not None:
+            current_report, small_report_iterative_count = self._precheck_optimistic_bulk()
 
         if self.primary is None:
             self._print_message("no primary workflow configured, skipping to dynamic-access coverage phase")
@@ -76,15 +111,28 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
             )
             status = RUN_STATUS_SUCCESS
             iterations = 0
+        elif small_report_iterative_count is not None:
+            result: tuple[str, int, int] = (RUN_STATUS_SUCCESS, 0, 1)
+            status = RUN_STATUS_SUCCESS
+            iterations = 0
+            iterative_chunk_count = small_report_iterative_count
+            skip_dynamic_access_phase = small_report_iterative_count == 0
+            required_iterative_chunk_phase = small_report_iterative_count > 0
+            agent.clear_context()
         else:
             self._print_message("starting primary workflow")
-            result = self.primary.run(agent, **kwargs)
+            primary_kwargs: dict[str, object] = dict(kwargs)
+            if current_report is not None:
+                primary_kwargs["initial_report"] = current_report
+            result = self.primary.run(agent, **primary_kwargs)
             status = result[0]
             iterations = result[1]
             self._print_message(f"primary workflow completed with status: {status}")
 
             if status != RUN_STATUS_SUCCESS:
-                self._print_message("skipping dynamic-access coverage phase because primary workflow did not succeed")
+                self._print_message(
+                    "skipping dynamic-access coverage phase because primary workflow did not succeed"
+                )
                 self.post_generation_intervention = self.primary.post_generation_intervention
                 return result
 
@@ -155,7 +203,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
                 lambda marker: marker.mark_phase_completed(PHASE_EXPLORE),
             )
             phase_ok, da_iterations = True, 0
-            self._print_message("all dynamic-access classes are covered after bulk")
+            self._print_message("all dynamic-access classes are covered")
         else:
             self._print_message("starting dynamic-access coverage phase")
             if current_report is None:

--- a/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
+++ b/forge/ai_workflows/core/increase_dynamic_access_coverage_strategy.py
@@ -64,6 +64,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
     def run(self, agent, **kwargs):
         current_report: DynamicAccessCoverageReport | None = None
         iterative_chunk_count: int | None = None
+        preceding_covered_call_gain: int = 0
         required_iterative_chunk_phase: bool = False
         skip_dynamic_access_phase: bool = False
 
@@ -90,6 +91,13 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
             agent.clear_context()
             if self.primary_workflow_name == "bulk_dynamic_access":
                 current_report, iterative_chunk_count, chunk_ready = self._route_after_bulk()
+                bulk_progress: BulkDynamicAccessProgress | None = getattr(
+                    self.primary,
+                    "bulk_chunk_progress",
+                    None,
+                )
+                if bulk_progress is not None:
+                    preceding_covered_call_gain = bulk_progress.covered_call_gain
                 if chunk_ready:
                     save_phase_update(
                         self.continuation_marker_path,
@@ -113,6 +121,7 @@ class IncreaseDynamicAccessCoverageStrategy(WorkflowStrategy):
         library = self.context.get("library") or self.context.get("updated_library")
         da_context = dict(self.context)
         da_context["library"] = library
+        da_context["preceding_dynamic_access_covered_call_gain"] = preceding_covered_call_gain
         if iterative_chunk_count is not None:
             da_context["chunk_class_count"] = iterative_chunk_count
 

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -283,6 +283,14 @@ therefore gives iterative the whole boundary. When no more than the boundary
 remain, iterative exploration receives the entire remainder and finishes the
 final chunk even if bulk already met the boundary.
 
+An optimistic composite first generates the report that would steer bulk. When
+the report is usable but names fewer uncovered classes than the configured
+`bulk-min-uncovered-classes`, it skips the bulk primary and starts iterative
+exploration with that same report. A report at or above the minimum is handed to
+bulk without another refresh. An unavailable or empty report still enters bulk
+so its basic-iterative bootstrap remains available. This routing belongs to the
+composite only; a pure-bulk strategy always runs its configured bulk workflow.
+
 The bulk primary and iterative refinement are one `explore` phase. The bulk
 primary leaves that phase running when the composite owns the next
 transition. The composite completes it only when the bulk result is already a

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -236,8 +236,10 @@ chunked run it retains the initial report and, after the full iteration budget,
 compares it with the report refreshed immediately before the last passing gate.
 Every class that changed from uncovered to covered is recorded as completed;
 bulk never records a class as skipped, exhausted, or failed because it cannot
-attribute those outcomes to one class. This comparison runs once after the
-bulk loop and does not regenerate the report.
+attribute those outcomes to one class. The same comparison records the total
+covered-call gain so a partial improvement inside one class remains visible to
+the composite. This comparison runs once after the bulk loop and does not
+regenerate the report.
 
 In a pure-bulk workflow, a productive pass with more than the configured
 threshold still remaining returns chunk-ready. A zero-yield pass is final, as
@@ -286,6 +288,11 @@ primary leaves that phase running when the composite owns the next
 transition. The composite completes it only when the bulk result is already a
 chunk boundary or covers the whole report; otherwise the iterative workflow
 completes or leaves pending the same phase (§FS-forge-run-continuation.1).
+At the natural end of iterative refinement, any positive covered-call gain from
+the gated bulk phase counts as acceptable progress even when bulk did not fully
+complete a class and iterative work added no further coverage. That accumulated
+gain does not mask an iterative report, test, or native-gate failure, which ends
+the phase before the natural completion decision.
 
 Parameters: the primary workflow's parameters plus the iterative exploration
 parameters, from one bundle. Families: composite coverage strategies, Java-fix

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -286,10 +286,19 @@ final chunk even if bulk already met the boundary.
 An optimistic composite first generates the report that would steer bulk. When
 the report is usable but names fewer uncovered classes than the configured
 `bulk-min-uncovered-classes`, it skips the bulk primary and starts iterative
-exploration with that same report. A report at or above the minimum is handed to
-bulk without another refresh. An unavailable or empty report still enters bulk
-so its basic-iterative bootstrap remains available. This routing belongs to the
-composite only; a pure-bulk strategy always runs its configured bulk workflow.
+exploration with that same report. The budget it hands over is the remainder
+iterative exploration can still take, measured against the exhaust report and
+continuation marker like the post-bulk boundary is. A small report whose
+remainder is entirely processed therefore stays with bulk, which is the only
+phase that prompts again on a class per-class exploration exhausted. A report
+at or above the minimum is handed to bulk without another refresh. A report
+with nothing uncovered left skips both phases and completes exploration. An
+unavailable or empty report still enters bulk so its basic-iterative bootstrap
+remains available. Whenever the composite skips the primary it releases the
+same pending fix phase the primary would have released, so a skipped primary
+never holds back the continuation phase order (§FS-forge-run-continuation.1).
+This routing belongs to the composite only; a pure-bulk strategy always runs
+its configured bulk workflow.
 
 The bulk primary and iterative refinement are one `explore` phase. The bulk
 primary leaves that phase running when the composite owns the next

--- a/forge/docs/architecture/workflows.md
+++ b/forge/docs/architecture/workflows.md
@@ -194,7 +194,8 @@ class-scoped, reviewable progress on the coverage-improvement queue
 (§FS-forge-scope). It generates the initial report, selects one
 uncovered class, and gives that class a bounded number of prompt attempts; each
 attempt gets a bounded number of test-repair rounds before the class is rolled
-back to its checkpoint.
+back to its checkpoint. The initial test precedes those rounds, and every repair
+is followed by another test before Forge decides that the budget is exhausted.
 
 Per class, the correlated report decides the outcome. All call sites covered
 resolves the class and commits it. Some call sites newly covered commits partial
@@ -207,7 +208,7 @@ Committing per class is what makes chunking and resume possible: each terminal
 class transition advances the checkpoint past its own commit, so a whole-phase
 reset preserves the classes already recorded rather than resurrecting them.
 
-Parameters: prompt-attempt budget per class, test-iteration budget per class,
+Parameters: prompt-attempt budget per class, test-repair budget per class,
 source-context types, native-test verification budget. Families:
 `dynamic_access_*`, library-update coverage strategies.
 

--- a/forge/strategies/predefined_strategies.json
+++ b/forge/strategies/predefined_strategies.json
@@ -448,6 +448,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-iterations": 2,
       "max-bulk-iterations": 3,
       "max-test-iterations": 5,
@@ -649,6 +650,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-iterations": 2,
       "max-test-iterations": 5,
       "max-class-test-iterations": 2,
@@ -673,6 +675,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-iterations": 2,
       "max-test-iterations": 5,
       "max-class-test-iterations": 2,
@@ -697,6 +700,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-iterations": 2,
       "max-test-iterations": 5,
       "max-class-test-iterations": 2,
@@ -721,6 +725,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-iterations": 2,
       "max-test-iterations": 5,
       "max-class-test-iterations": 2,
@@ -952,6 +957,7 @@
       "issue-requested-metadata": "prompt_templates/issue_requested_metadata/issue-requested-metadata.md"
     },
     "parameters": {
+      "bulk-min-uncovered-classes": 5,
       "max-bulk-iterations": 3,
       "max-test-iterations": 5,
       "max-iterations": 3,

--- a/forge/tests/test_bulk_dynamic_access_strategy.py
+++ b/forge/tests/test_bulk_dynamic_access_strategy.py
@@ -5,6 +5,7 @@
 
 import io
 import os
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -14,6 +15,13 @@ from ai_workflows.core.increase_dynamic_access_coverage_strategy import (
 )
 from ai_workflows.core.bulk_dynamic_access_strategy import BulkDynamicAccessStrategy
 from ai_workflows.core.workflow_strategy import RUN_STATUS_FAILURE, RUN_STATUS_SUCCESS
+from utility_scripts.continuation_marker import (
+    PHASE_EXPLORE,
+    PHASE_FIX,
+    STATUS_COMPLETED,
+    STATUS_SKIPPED,
+    ContinuationMarker,
+)
 from utility_scripts.dynamic_access_exhaust_report import DynamicAccessExhaustReport
 from utility_scripts.dynamic_access_report import (
     BulkDynamicAccessProgress,
@@ -177,6 +185,113 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         self.assertEqual(captured_context["chunk_class_count"], 4)
         self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
 
+    def test_composite_budget_excludes_already_processed_classes(self) -> None:
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
+        primary = self._FakePrimary(
+            self._progress(0, 4),
+            processed_classes={"remaining-0", "remaining-1"},
+        )
+        strategy.primary = primary
+        captured_context: dict[str, object] = {}
+
+        result = self._run_with_fake_iterative(strategy, captured_context)
+
+        self.assertEqual(result, (RUN_STATUS_SUCCESS, 2, 1))
+        self.assertEqual(primary.run_calls, 0)
+        self.assertEqual(captured_context["chunk_class_count"], 2)
+
+    def test_composite_keeps_bulk_when_the_small_remainder_is_processed(self) -> None:
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
+        primary = self._FakePrimary(
+            self._progress(0, 4),
+            processed_classes={f"remaining-{index}" for index in range(4)},
+        )
+        strategy.primary = primary
+        captured_context: dict[str, object] = {}
+
+        result = self._run_with_fake_iterative(strategy, captured_context)
+
+        self.assertEqual(result, (RUN_STATUS_SUCCESS, 5, 1))
+        self.assertEqual(primary.run_calls, 1)
+
+    def test_composite_skips_both_phases_when_nothing_is_uncovered(self) -> None:
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
+        primary = self._FakePrimary(self._progress(3, 0))
+        strategy.primary = primary
+        captured_context: dict[str, object] = {}
+
+        with tempfile.TemporaryDirectory() as marker_dir:
+            marker_path = self._pending_fix_marker(marker_dir)
+            strategy.continuation_marker_path = marker_path
+            result = self._run_with_fake_iterative(strategy, captured_context)
+            marker = ContinuationMarker.load(marker_path)
+
+        self.assertEqual(result, (RUN_STATUS_SUCCESS, 0, 1))
+        self.assertEqual(primary.run_calls, 0)
+        # A skipped primary must still release the fix phase, or the marker
+        # resumes at `fix` and never reaches publication.
+        self.assertEqual(marker.phases[PHASE_FIX]["status"], STATUS_SKIPPED)
+        self.assertEqual(marker.phases[PHASE_EXPLORE]["status"], STATUS_COMPLETED)
+
+    def test_composite_releases_the_fix_phase_when_it_skips_bulk(self) -> None:
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
+        primary = self._FakePrimary(self._progress(0, 4))
+        strategy.primary = primary
+        captured_context: dict[str, object] = {}
+
+        with tempfile.TemporaryDirectory() as marker_dir:
+            marker_path = self._pending_fix_marker(marker_dir)
+            strategy.continuation_marker_path = marker_path
+            self._run_with_fake_iterative(strategy, captured_context)
+            marker = ContinuationMarker.load(marker_path)
+
+        self.assertEqual(primary.run_calls, 0)
+        self.assertEqual(marker.phases[PHASE_FIX]["status"], STATUS_SKIPPED)
+
+    @staticmethod
+    def _pending_fix_marker(marker_dir: str) -> str:
+        marker = ContinuationMarker.create(
+            strategy_name="optimistic",
+            issue_number=9864,
+            label="library-update-request",
+            coordinate="org.example:lib:1.0.0",
+            new_version=None,
+        )
+        marker.mark_setup_done()
+        marker_path = os.path.join(marker_dir, "continuation.json")
+        marker.save(marker_path)
+        return marker_path
+
+    @staticmethod
+    def _run_with_fake_iterative(
+            strategy: IncreaseDynamicAccessCoverageStrategy,
+            captured_context: dict[str, object],
+    ) -> tuple[str, int, int]:
+        class FakeDynamicAccess:
+            def __init__(self, strategy_obj: dict, **context: object) -> None:
+                captured_context.update(context)
+                self._last_phase_status = RUN_STATUS_SUCCESS
+
+            def _run_dynamic_access_phase(
+                    self,
+                    agent: object,
+                    report: DynamicAccessCoverageReport | None = None,
+            ) -> tuple[bool, int]:
+                return True, 2
+
+            def has_issue_requested_metadata_context(self) -> bool:
+                return False
+
+        class FakeAgent:
+            def clear_context(self) -> None:
+                pass
+
+        with patch(
+                "ai_workflows.core.increase_dynamic_access_coverage_strategy.DynamicAccessIterativeStrategy",
+                FakeDynamicAccess,
+        ):
+            return strategy.run(FakeAgent())
+
     def test_composite_fails_when_required_iterative_shortfall_fails(self) -> None:
         for has_reporter_context in (False, True):
             with self.subTest(has_reporter_context=has_reporter_context):
@@ -314,15 +429,23 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         )
 
     class _FakePrimary:
-        def __init__(self, progress: BulkDynamicAccessProgress) -> None:
+        def __init__(
+                self,
+                progress: BulkDynamicAccessProgress,
+                processed_classes: set[str] | None = None,
+        ) -> None:
             self.bulk_chunk_progress = progress
             self.saved = False
             self.post_generation_intervention = None
             self.run_calls = 0
             self.initial_report: DynamicAccessCoverageReport | None = None
+            self.processed_classes = processed_classes or set()
 
         def _generate_dynamic_access_report(self) -> DynamicAccessCoverageReport:
             return self.bulk_chunk_progress.final_report
+
+        def processed_dynamic_access_classes(self) -> set[str]:
+            return set(self.processed_classes)
 
         def run(
                 self,

--- a/forge/tests/test_bulk_dynamic_access_strategy.py
+++ b/forge/tests/test_bulk_dynamic_access_strategy.py
@@ -102,7 +102,7 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
                 self.assertEqual(primary.saved, expected_chunk_ready)
 
     def test_composite_passes_shortfall_and_gated_report_to_iterative(self) -> None:
-        strategy = self._composite_strategy()
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
         primary = self._FakePrimary(self._progress(10, 90, covered_call_gain=4))
         strategy.primary = primary
         strategy.primary_workflow_name = "bulk_dynamic_access"
@@ -135,6 +135,46 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         self.assertEqual(result, (RUN_STATUS_SUCCESS, 5, 1))
         self.assertEqual(captured_context["chunk_class_count"], 5)
         self.assertEqual(captured_context["preceding_dynamic_access_covered_call_gain"], 4)
+        self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
+        self.assertEqual(primary.run_calls, 1)
+        self.assertIs(primary.initial_report, primary.bulk_chunk_progress.final_report)
+
+    def test_composite_skips_bulk_below_minimum_class_count(self) -> None:
+        strategy = self._composite_strategy(bulk_min_uncovered_classes=5)
+        primary = self._FakePrimary(self._progress(0, 4))
+        strategy.primary = primary
+        captured_context: dict[str, object] = {}
+        captured_reports: list[DynamicAccessCoverageReport] = []
+
+        class FakeDynamicAccess:
+            def __init__(self, strategy_obj: dict, **context: object) -> None:
+                captured_context.update(context)
+                self._last_phase_status = RUN_STATUS_SUCCESS
+
+            def _run_dynamic_access_phase(
+                    self,
+                    agent: object,
+                    report: DynamicAccessCoverageReport,
+            ) -> tuple[bool, int]:
+                captured_reports.append(report)
+                return True, 2
+
+            def has_issue_requested_metadata_context(self) -> bool:
+                return False
+
+        class FakeAgent:
+            def clear_context(self) -> None:
+                pass
+
+        with patch(
+                "ai_workflows.core.increase_dynamic_access_coverage_strategy.DynamicAccessIterativeStrategy",
+                FakeDynamicAccess,
+        ):
+            result = strategy.run(FakeAgent())
+
+        self.assertEqual(result, (RUN_STATUS_SUCCESS, 2, 1))
+        self.assertEqual(primary.run_calls, 0)
+        self.assertEqual(captured_context["chunk_class_count"], 4)
         self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
 
     def test_composite_fails_when_required_iterative_shortfall_fails(self) -> None:
@@ -193,11 +233,15 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         )
 
     @staticmethod
-    def _composite_strategy() -> IncreaseDynamicAccessCoverageStrategy:
+    def _composite_strategy(
+            bulk_min_uncovered_classes: int = 0,
+    ) -> IncreaseDynamicAccessCoverageStrategy:
         strategy = IncreaseDynamicAccessCoverageStrategy(
             {
                 "model": "test-model",
-                "parameters": {},
+                "parameters": {
+                    "bulk-min-uncovered-classes": bulk_min_uncovered_classes,
+                },
                 "prompts": {},
             },
             reachability_repo_path="/tmp/reachability",
@@ -274,8 +318,20 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
             self.bulk_chunk_progress = progress
             self.saved = False
             self.post_generation_intervention = None
+            self.run_calls = 0
+            self.initial_report: DynamicAccessCoverageReport | None = None
 
-        def run(self, agent: object, **kwargs: object) -> tuple[str, int, int]:
+        def _generate_dynamic_access_report(self) -> DynamicAccessCoverageReport:
+            return self.bulk_chunk_progress.final_report
+
+        def run(
+                self,
+                agent: object,
+                initial_report: DynamicAccessCoverageReport | None = None,
+                **kwargs: object,
+        ) -> tuple[str, int, int]:
+            self.run_calls += 1
+            self.initial_report = initial_report
             return RUN_STATUS_SUCCESS, 3, 1
 
         def save_bulk_chunk_state(self) -> None:
@@ -318,6 +374,20 @@ class BulkDynamicAccessRunTests(unittest.TestCase):
         self.assertIn("[explore]   Test 1/2 passed (1/3)", printed)
         self.assertNotIn("[bulk-da]", printed)
         self.assertNotIn("./gradlew", printed)
+
+    def test_prechecked_report_avoids_duplicate_initial_refresh(self) -> None:
+        strategy, agent = self._runnable_strategy(reports=[self._usable_report()])
+        refresh_report = strategy._generate_dynamic_access_report
+
+        with patch.object(
+                strategy,
+                "_generate_dynamic_access_report",
+                wraps=refresh_report,
+        ) as refresh:
+            status, _, _ = strategy.run(agent, initial_report=self._usable_report())
+
+        self.assertEqual(status, RUN_STATUS_SUCCESS)
+        self.assertEqual(refresh.call_count, 1)
 
     def test_empty_report_bootstraps_through_the_fallback_then_runs_bulk(self) -> None:
         # A report only becomes usable once tests exist; the fallback creates

--- a/forge/tests/test_bulk_dynamic_access_strategy.py
+++ b/forge/tests/test_bulk_dynamic_access_strategy.py
@@ -38,6 +38,25 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         self.assertIs(progress.final_report, final_report)
         self.assertEqual(progress.completed_classes, ("A", "B"))
         self.assertEqual(progress.remaining_classes, ("C",))
+        self.assertEqual(progress.covered_call_gain, 2)
+
+    def test_bulk_progress_counts_partial_call_gain(self) -> None:
+        initial_report = self._partial_report(0)
+        final_report = self._partial_report(1)
+
+        progress = compute_bulk_dynamic_access_progress(initial_report, final_report, set())
+
+        self.assertEqual(progress.completed_classes, ())
+        self.assertEqual(progress.remaining_classes, ("A",))
+        self.assertEqual(progress.covered_call_gain, 1)
+
+    def test_bulk_progress_ignores_unchanged_partial_coverage(self) -> None:
+        initial_report = self._partial_report(1)
+        final_report = self._partial_report(1)
+
+        progress = compute_bulk_dynamic_access_progress(initial_report, final_report, set())
+
+        self.assertEqual(progress.covered_call_gain, 0)
 
     def test_bulk_progress_is_recorded_in_shared_exhaust_state(self) -> None:
         exhaust_report = DynamicAccessExhaustReport.create(
@@ -84,7 +103,7 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
 
     def test_composite_passes_shortfall_and_gated_report_to_iterative(self) -> None:
         strategy = self._composite_strategy()
-        primary = self._FakePrimary(self._progress(10, 90))
+        primary = self._FakePrimary(self._progress(10, 90, covered_call_gain=4))
         strategy.primary = primary
         strategy.primary_workflow_name = "bulk_dynamic_access"
         captured_context: dict[str, object] = {}
@@ -115,6 +134,7 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
 
         self.assertEqual(result, (RUN_STATUS_SUCCESS, 5, 1))
         self.assertEqual(captured_context["chunk_class_count"], 5)
+        self.assertEqual(captured_context["preceding_dynamic_access_covered_call_gain"], 4)
         self.assertEqual(captured_reports, [primary.bulk_chunk_progress.final_report])
 
     def test_composite_fails_when_required_iterative_shortfall_fails(self) -> None:
@@ -188,7 +208,12 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
         return strategy
 
     @classmethod
-    def _progress(cls, completed: int, remaining: int) -> BulkDynamicAccessProgress:
+    def _progress(
+            cls,
+            completed: int,
+            remaining: int,
+            covered_call_gain: int = 0,
+    ) -> BulkDynamicAccessProgress:
         final_report = cls._report(
             [f"completed-{index}" for index in range(completed)]
             + [f"remaining-{index}" for index in range(remaining)],
@@ -198,6 +223,7 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
             final_report=final_report,
             completed_classes=tuple(f"completed-{index}" for index in range(completed)),
             remaining_classes=tuple(f"remaining-{index}" for index in range(remaining)),
+            covered_call_gain=covered_call_gain,
         )
 
     @staticmethod
@@ -221,6 +247,25 @@ class BulkDynamicAccessChunkTests(unittest.TestCase):
                     call_sites=[],
                 )
                 for class_name in class_names
+            ],
+        )
+
+    @staticmethod
+    def _partial_report(covered_calls: int) -> DynamicAccessCoverageReport:
+        return DynamicAccessCoverageReport(
+            coordinate="org.example:lib:1.0.0",
+            has_dynamic_access=True,
+            total_calls=2,
+            covered_calls=covered_calls,
+            classes=[
+                DynamicAccessClass(
+                    class_name="A",
+                    source_file=None,
+                    resolved_source_file=None,
+                    total_calls=2,
+                    covered_calls=covered_calls,
+                    call_sites=[],
+                )
             ],
         )
 

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -423,6 +423,86 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
         self.assertEqual(set(saved_report.exhausted_classes), set(remaining_classes))
         self.assertIsNone(failed_run_location())
 
+    def test_final_remainder_succeeds_after_partial_bulk_call_gain(self) -> None:
+        """A partial bulk gain remains successful after iterative exhaustion.
+
+        §FS-forge-chunked-dynamic-access
+        """
+        phase_ok, iterations, exhaust_report = self._run_exhausted_partial_remainder(1)
+
+        self.assertTrue(phase_ok)
+        self.assertEqual(iterations, 1)
+        self.assertEqual(exhaust_report.exhausted_classes, ["org.example.Partial"])
+
+    def test_final_remainder_fails_without_partial_bulk_call_gain(self) -> None:
+        """An unchanged bulk report does not excuse iterative exhaustion.
+
+        §FS-forge-chunked-dynamic-access
+        """
+        phase_ok, iterations, _ = self._run_exhausted_partial_remainder(0)
+
+        self.assertFalse(phase_ok)
+        self.assertEqual(iterations, 1)
+
+    def test_partial_bulk_call_gain_does_not_mask_report_failure(self) -> None:
+        """Accumulated progress applies only at natural phase completion.
+
+        §FS-forge-chunked-dynamic-access
+        """
+        phase_ok, iterations, _ = self._run_exhausted_partial_remainder(
+            1,
+            report_refresh_succeeds=False,
+        )
+
+        self.assertFalse(phase_ok)
+        self.assertEqual(iterations, 1)
+
+    def _run_exhausted_partial_remainder(
+            self,
+            preceding_covered_call_gain: int,
+            report_refresh_succeeds: bool = True,
+    ) -> tuple[bool, int, DynamicAccessExhaustReport]:
+        class FakeAgent:
+            def send_prompt(self, prompt: str) -> None:
+                pass
+
+            def run_test_command(self, command: str) -> str:
+                return "BUILD SUCCESSFUL"
+
+            def clear_context(self) -> None:
+                pass
+
+        class_name = "org.example.Partial"
+        current_report = DynamicAccessCoverageReport(
+            coordinate="org.example:lib:1.0.0",
+            has_dynamic_access=True,
+            total_calls=2,
+            covered_calls=1,
+            classes=[self._class_coverage(class_name, 2, 1)],
+        )
+        exhaust_report = DynamicAccessExhaustReport.create(
+            coordinate="org.example:lib:1.0.0",
+            issue_number=9864,
+        )
+        strategy = self._strategy(
+            dynamic_access_exhaust_report=exhaust_report,
+            chunk_class_count=15,
+            preceding_dynamic_access_covered_call_gain=preceding_covered_call_gain,
+        )
+        refreshed_report = current_report if report_refresh_succeeds else None
+
+        with patch.object(strategy, "_render_prompt", return_value="prompt"), \
+                patch.object(strategy, "_generate_dynamic_access_report", return_value=refreshed_report), \
+                patch.object(strategy, "_print_failure_analysis"), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="checkpoint\n",
+                ):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(FakeAgent(), current_report)
+
+        return phase_ok, iterations, exhaust_report
+
     def test_terminal_exhaustion_defers_failure_location_to_caller(self) -> None:
         """A phase result alone does not record a terminal workflow failure.
 

--- a/forge/tests/test_dynamic_access_iterative_strategy.py
+++ b/forge/tests/test_dynamic_access_iterative_strategy.py
@@ -175,6 +175,95 @@ class DynamicAccessProgressLoggingTests(unittest.TestCase):
             strategy.dynamic_access_report_path,
         )
 
+    def test_final_class_feedback_fix_is_verified(self) -> None:
+        class FakeAgent:
+            def __init__(self) -> None:
+                self.prompts: list[str] = []
+                self.test_commands: list[str] = []
+                self.test_outputs: list[str] = [
+                    "> Task :compileTestJava FAILED",
+                    "> Task :test FAILED",
+                    "> Task :nativeTest FAILED",
+                ]
+
+            def send_prompt(self, prompt: str) -> None:
+                self.prompts.append(prompt)
+
+            def run_test_command(self, command: str) -> str:
+                self.test_commands.append(command)
+                return self.test_outputs.pop(0)
+
+            def clear_context(self) -> None:
+                pass
+
+        class_name = "org.example.Exhausted"
+        current_report = self._report_for_class_names([class_name], [])
+        covered_report = self._report_for_class_names([class_name], [class_name])
+        strategy = self._strategy(parameters={"max-class-test-iterations": 2})
+        agent = FakeAgent()
+
+        with patch.object(strategy, "_render_prompt", return_value="initial prompt"), \
+                patch.object(strategy, "_generate_dynamic_access_report", return_value=covered_report), \
+                patch.object(strategy, "_commit_test_sources"), \
+                patch.object(strategy, "_run_native_test_verification_gate", return_value=True), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="checkpoint\n",
+                ):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(agent, current_report)
+
+        self.assertTrue(phase_ok)
+        self.assertEqual(iterations, 3)
+        self.assertEqual(len(agent.test_commands), 3)
+        self.assertEqual(len(agent.prompts), 3)
+        self.assertIn("compileTestJava FAILED", agent.prompts[1])
+        self.assertIn("test FAILED", agent.prompts[2])
+
+    def test_exhausted_class_does_not_request_unverified_fix(self) -> None:
+        class FakeAgent:
+            def __init__(self) -> None:
+                self.prompts: list[str] = []
+                self.test_commands: list[str] = []
+                self.test_outputs: list[str] = [
+                    "> Task :compileTestJava FAILED",
+                    "> Task :test FAILED",
+                    "> Task :test FAILED",
+                ]
+
+            def send_prompt(self, prompt: str) -> None:
+                self.prompts.append(prompt)
+
+            def run_test_command(self, command: str) -> str:
+                self.test_commands.append(command)
+                return self.test_outputs.pop(0)
+
+            def clear_context(self) -> None:
+                pass
+
+        class_name = "org.example.Exhausted"
+        current_report = self._report_for_class_names([class_name], [])
+        strategy = self._strategy(parameters={"max-class-test-iterations": 2})
+        agent = FakeAgent()
+
+        with patch.object(strategy, "_render_prompt", return_value="initial prompt"), \
+                patch.object(strategy, "_print_failure_analysis"), \
+                patch.object(strategy, "_library_test_change_signature", return_value="clean"), \
+                patch(
+                    "ai_workflows.core.dynamic_access_iterative_strategy.subprocess.check_output",
+                    return_value="checkpoint\n",
+                ), \
+                patch("ai_workflows.core.dynamic_access_iterative_strategy.subprocess.run"):
+            phase_ok, iterations = strategy._run_dynamic_access_phase(agent, current_report)
+
+        self.assertFalse(phase_ok)
+        self.assertEqual(iterations, 3)
+        self.assertEqual(len(agent.test_commands), 3)
+        self.assertEqual(len(agent.prompts), 3)
+        self.assertFalse(agent.test_outputs)
+        self.assertIn("compileTestJava FAILED", agent.prompts[1])
+        self.assertIn("test FAILED", agent.prompts[2])
+
     def test_native_test_gate_flushes_leftover_classes_at_end(self) -> None:
         class FakeAgent:
             def send_prompt(self, prompt: str) -> None:

--- a/forge/utility_scripts/dynamic_access_report.py
+++ b/forge/utility_scripts/dynamic_access_report.py
@@ -87,13 +87,14 @@ class BulkDynamicAccessProgress:
     """Post-gate class progress from one bulk phase.
 
     The workflow compares its baseline with the last successfully gated report
-    and carries that exact report into the composite boundary
+    and carries that exact report and covered-call gain into the composite boundary
     (§AR-dynamic-access-bulk).
     """
 
     final_report: DynamicAccessCoverageReport
     completed_classes: tuple[str, ...]
     remaining_classes: tuple[str, ...]
+    covered_call_gain: int
 
 
 def compute_bulk_dynamic_access_progress(
@@ -123,7 +124,13 @@ def compute_bulk_dynamic_access_progress(
             and class_coverage.class_name not in processed_classes
         )
     )
-    return BulkDynamicAccessProgress(final_report, completed_classes, remaining_classes)
+    covered_call_gain: int = max(final_report.covered_calls - initial_report.covered_calls, 0)
+    return BulkDynamicAccessProgress(
+        final_report,
+        completed_classes,
+        remaining_classes,
+        covered_call_gain,
+    )
 
 
 @dataclass(frozen=True)

--- a/forge/utility_scripts/dynamic_access_report.py
+++ b/forge/utility_scripts/dynamic_access_report.py
@@ -97,6 +97,26 @@ class BulkDynamicAccessProgress:
     covered_call_gain: int
 
 
+def remaining_uncovered_classes(
+        report: DynamicAccessCoverageReport,
+        processed_classes: set[str],
+) -> tuple[str, ...]:
+    """Return uncovered classes no phase has processed yet.
+
+    The remainder a phase can still take is the report's uncovered classes
+    minus the exhaust report and continuation marker's processed set
+    (§AR-dynamic-access-composite).
+    """
+    return tuple(
+        class_coverage.class_name
+        for class_coverage in report.classes
+        if (
+            class_coverage.uncovered_calls > 0
+            and class_coverage.class_name not in processed_classes
+        )
+    )
+
+
 def compute_bulk_dynamic_access_progress(
         initial_report: DynamicAccessCoverageReport,
         final_report: DynamicAccessCoverageReport,
@@ -116,14 +136,7 @@ def compute_bulk_dynamic_access_progress(
             and final_class.uncovered_calls == 0
         )
     ))
-    remaining_classes: tuple[str, ...] = tuple(
-        class_coverage.class_name
-        for class_coverage in final_report.classes
-        if (
-            class_coverage.uncovered_calls > 0
-            and class_coverage.class_name not in processed_classes
-        )
-    )
+    remaining_classes: tuple[str, ...] = remaining_uncovered_classes(final_report, processed_classes)
     covered_call_gain: int = max(final_report.covered_calls - initial_report.covered_calls, 0)
     return BulkDynamicAccessProgress(
         final_report,


### PR DESCRIPTION
Closes #9864

## What this does

The optimistic dynamic-access composite previously had two avoidable failure and cost cases around its bulk-to-iterative handoff. It lost a call-site gain when the affected class remained partial, and it still spent three broad bulk attempts on reports small enough for targeted iterative work.

The handoff now preserves partial bulk progress and routes small reports directly to iterative generation. This aligns the composite with [§forge/FS-forge-chunked-dynamic-access](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/functional-spec/functional-spec.md#fs-forge-chunked-dynamic-access) and [§forge/AR-dynamic-access-composite](https://github.com/oracle/graalvm-reachability-metadata/blob/master/forge/docs/architecture/workflows.md#ar-dynamic-access-composite-composite-fix-then-explore).

## How progress crosses the handoff

Bulk records the covered-call delta between its baseline and last gated report. Iterative refinement consults that delta only at natural phase completion, so `0/2 → 1/2` remains successful while `1/2 → 1/2` and hard report, test, or native-gate failures still fail.

## How small reports are routed

The six optimistic strategy configurations set `bulk-min-uncovered-classes` to `5`. Their composite prechecks the dynamic-access report and:

- sends `0–4` uncovered classes directly to iterative refinement;
- runs bulk first for `5+` classes;
- reuses the prechecked report as the bulk baseline, avoiding a duplicate refresh;
- retains the existing bulk fallback for unavailable or empty reports.

Pure-bulk strategies are unchanged.