### PR TITLE
Run Spring AOT smoke tests on the native-image JDK

### DIFF
--- a/.github/workflows/test-affected-spring-aot-main.yml
+++ b/.github/workflows/test-affected-spring-aot-main.yml
@@ -92,7 +92,10 @@ jobs:
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}
-          set-java-home: 'false'
+          # Spring AOT reflects on JDK types to generate hints, so it must run on the
+          # native-image JDK: a split JAVA_HOME records hints for the wrong JDK.
+          # §AR-test-affected-spring-aot.
+          set-java-home: 'true'
           native-image-job-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What this does

The Spring AOT smoke gate (§AR-test-affected-spring-aot) has been running Gradle on JDK 17 while
building the native image on JDK 25. Spring AOT is a build-time generator: it reflects on JDK types
to decide what to register, so generating on one JDK and running on another produces hints for the
wrong JDK. This sets `JAVA_HOME` to the JDK the smoke tests actually run on.

Concretely, `:data:data-mongodb` fails every run with:

```
MissingReflectionRegistrationError: Cannot reflectively access the proxy class inheriting
['java.util.SequencedCollection','...LazyLoadingProxy','java.util.List',
 'org.springframework.aop.SpringProxy','...Advised','...DecoratingProxy']
```

`spring-data-mongodb`'s `LazyLoadingProxyAotProcessor` derives the proxy interfaces from
`targetType.getInterfaces()`. On JDK 17 that yields five interfaces; since JDK 21 `List extends
SequencedCollection`, so the image built and run on 25 asks for six. The registered shape never
matches, and no repository metadata can fix it — the hint is generated into the app's own
`build/generated/…/META-INF/native-image/` on every run.

## Where the JDK 17 pin came from

It was correct once. `97a1f28656` created three lanes from one template, with `ci.json` mapping
`3.5.x → 17`, `4.0.x → 25`, `main → 25`, and each lane hardcoding a harness JDK of `17.0.12`. That
matched on 3.5.x and was a split on the other two. `b06a6677e1` then deleted the 3.5.x and 4.0.x
workflows, leaving only the lane the pin never fit.

Nothing in the job needs 17 today: `setup-native-build-tools` runs before this step and does its own
JDK 17 setup, so an NBT snapshot build is unaffected. `native-image` continues to resolve from
`GRAALVM_HOME`, which is unchanged. The smoke tests declare `sourceCompatibility`/
`targetCompatibility` of 17 but no Gradle toolchain, so the AOT process follows `JAVA_HOME`.

## Why it started failing on 2026-09-01

The mismatch is old; it was masked. `data/data-mongodb/build.gradle` upstream carried
`expectedToFail { becauseOf "https://github.com/oracle/graal/issues/12417" }`, which
`run-spring-aot-triaged-test.sh` pardons. Upstream removed it on 2026-09-01 because the test passes
in their CI, where one JDK 25 serves both AOT and native-image. From the next run onward the failure
was no longer pardoned, and the "passes upstream, fails here" branch reported it as a regression —
against every PR whose coordinate pulls `:data:data-mongodb` into the impact matrix, e.g. #9818.

Setting `set-java-home: 'true'` leaves the metadata source as the only intended difference from
upstream's configuration.
