### PR TITLE
Retire exhausted deep coverage targets

### DIFF
--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -348,8 +348,11 @@ Markdown and target-id list contain at most 200 methods globally. Measurement
 itself carries attempt state deterministically in the discovery-report history:
 every target it prompted gets its attempt count incremented at the next
 measurement, ranking prefers less-attempted targets, and covered targets leave
-the uncovered set — so later iterations advance beyond the first 200 without
-any agent-written state.
+the uncovered set. An uncovered target that reaches the configured unsuccessful
+attempt threshold becomes exhausted and leaves later prompts, while remaining
+in `bulkTargets` and the full JSON report for finalization and audit. This lets
+later iterations advance beyond repeatedly unproductive targets without any
+agent-written state.
 The deep phase runs for the same fixed `coverage_iterations` budget and stops
 early when no actionable target remains or when the pass yield collapses
 (§3.3), on the same rule and the same thresholds as the API phase.

--- a/forge/examples/code-coverage-improvement-example/states.yaml
+++ b/forge/examples/code-coverage-improvement-example/states.yaml
@@ -354,9 +354,11 @@ states:
       shutil.copy(report_path, discovery / "discovery-report.json")
 
       # Decide: 0 = phase done, 10 = actionable targets remain and budget left.
+      # Bulk targets retain exhausted entries for audit; prompt IDs alone are actionable.
+      # §AR-code-coverage-improvement.3.2
       report = json.load(open(report_path))
-      actionable = report.get("bulkTargets", [])
-      print(f"[deep-measure] iteration {iteration}: {len(actionable)} actionable deep targets", flush=True)
+      prompt_target_ids = report.get("promptTargetIds", [])
+      print(f"[deep-measure] iteration {iteration}: {len(prompt_target_ids)} actionable deep targets", flush=True)
 
       # Heuristic iteration budget: one cover pass lands at most ~250 methods
       # and roughly half the uncovered targets are reachable in practice, so
@@ -364,7 +366,7 @@ states:
       baseline = json.load(open(discovery / "discovery-report-0.json"))
       budget = min(10, max(1, baseline["summary"]["deepUncovered"] // 500))
       print(f"[deep-measure] iteration budget {budget} from {baseline['summary']['deepUncovered']} baseline uncovered methods", flush=True)
-      if not actionable or iteration >= budget:
+      if not prompt_target_ids or iteration >= budget:
           sys.exit(0)
 
       # Steering: the analyzer already renders the compact Observed /
@@ -375,7 +377,7 @@ states:
       prompts = Path("runtime/code-coverage/prompts")
       prompts.mkdir(parents=True, exist_ok=True)
       (prompts / "deep-cover-prompt.md").write_text(markdown.read_text())
-      print(f"[deep-measure] wrote prompt with {len(actionable)} targets", flush=True)
+      print(f"[deep-measure] wrote prompt with {len(prompt_target_ids)} targets", flush=True)
       sys.exit(10)
       PY
     program_timeout: 120m

--- a/forge/tests/test_code_coverage_finalize.py
+++ b/forge/tests/test_code_coverage_finalize.py
@@ -100,6 +100,7 @@ class FinalizerTests(unittest.TestCase):
             self,
             include_target_state: bool = True,
             include_stop_decisions: bool = True,
+            include_discovery_state: bool = False,
     ) -> dict:
         baseline_api = self._write(
             "api-0.json", _api(["covered", "uncovered", "uncovered", "uncovered"])
@@ -114,13 +115,20 @@ class FinalizerTests(unittest.TestCase):
                 42,
             ),
         )
-        final_deep = self._write(
-            "deep-5.json",
-            _deep(
-                ["covered", "covered", "uncovered", "uncovered", "uncovered"],
-                84,
-            ),
+        final_deep_report = _deep(
+            ["covered", "covered", "uncovered", "uncovered", "uncovered"],
+            84,
         )
+        if include_discovery_state:
+            final_deep_report["targetStates"] = [{
+                "id": "example.Internal#m2():void",
+                "status": "exhausted",
+                "terminal": True,
+                "attemptCount": 3,
+                "lastAttemptedIteration": None,
+                "reason": "3 attempts without coverage change",
+            }]
+        final_deep = self._write("deep-5.json", final_deep_report)
         state = self._write(
             "targets.json",
             {
@@ -274,6 +282,21 @@ class FinalizerTests(unittest.TestCase):
         self.assertEqual(metrics["targets"]["exhausted"], [])
         self.assertEqual(metrics["targets"]["failed"], [])
         self.assertFalse(metrics["needsHumanIntervention"])
+
+    def test_final_discovery_report_supplies_exhausted_outcomes(self) -> None:
+        metrics = self._run(
+            include_target_state=False,
+            include_discovery_state=True,
+        )
+
+        self.assertEqual(metrics["targets"]["exhausted"], [{
+            "id": "example.Internal#m2():void",
+            "phase": "deep",
+            "status": "exhausted",
+            "attemptCount": 3,
+            "lastAttemptedIteration": None,
+            "reason": "3 attempts without coverage change",
+        }])
 
     def test_coverage_reports_determine_completion(self) -> None:
         metrics = self._run()

--- a/forge/tests/test_code_coverage_profile_report.py
+++ b/forge/tests/test_code_coverage_profile_report.py
@@ -582,18 +582,55 @@ class ReportArtifactsTest(unittest.TestCase):
         report = self._generate(iteration=0, target_state_paths=[state_path])
 
         by_id = {entry["id"]: entry for entry in report["uncoveredPaths"]}
-        self.assertEqual(report["promptTargetIds"], [RESOLVE_ID, RELOAD_ID])
-        self.assertEqual(report["summary"]["terminalUncovered"], 2)
-        for method_id in (PARSE_ID, LOAD_ID):
+        self.assertEqual(report["promptTargetIds"], [RESOLVE_ID])
+        self.assertEqual(report["summary"]["terminalUncovered"], 3)
+        for method_id in (PARSE_ID, LOAD_ID, RELOAD_ID):
             self.assertTrue(by_id[method_id]["terminal"])
             self.assertNotIn(method_id, report["promptTargetIds"])
-        self.assertEqual(by_id[RELOAD_ID]["targetStatus"], "attempted")
+        self.assertEqual(by_id[RELOAD_ID]["targetStatus"], "exhausted")
         self.assertEqual(by_id[RELOAD_ID]["attemptCount"], 3)
-        self.assertFalse(by_id[RELOAD_ID]["terminal"])
+        self.assertEqual(
+            by_id[RELOAD_ID]["stateReason"],
+            "3 attempts without coverage change",
+        )
+        bulk = {entry["id"]: entry for entry in report["bulkTargets"]}
+        self.assertEqual(bulk[RELOAD_ID]["targetStatus"], "exhausted")
         persisted = {entry["id"]: entry for entry in report["targetStates"]}
         self.assertEqual(persisted[RESOLVE_INTEGER_ID]["status"], "completed")
         self.assertEqual(persisted[PARSE_ID]["status"], "skipped")
         self.assertEqual(persisted[LOAD_ID]["status"], "exhausted")
+        self.assertEqual(persisted[RELOAD_ID]["status"], "exhausted")
+
+    def test_uncovered_targets_are_exhausted_after_attempt_threshold(self) -> None:
+        reports: list[dict] = [
+            self._generate(iteration=iteration)
+            for iteration in range(report_module.MAX_UNCOVERED_ATTEMPTS + 1)
+        ]
+
+        report: dict = reports[-1]
+        bulk = {entry["id"]: entry for entry in report["bulkTargets"]}
+        target = bulk[RESOLVE_ID]
+        self.assertNotIn(RESOLVE_ID, report["promptTargetIds"])
+        self.assertIn(RESOLVE_ID, {entry["id"] for entry in report["uncoveredPaths"]})
+        self.assertEqual(target["attemptCount"], report_module.MAX_UNCOVERED_ATTEMPTS)
+        self.assertEqual(target["targetStatus"], "exhausted")
+        self.assertEqual(target["stateReason"], "3 attempts without coverage change")
+
+    def test_covered_target_is_not_exhausted_before_threshold(self) -> None:
+        state_path = self._write_json("deep-cover-0.json", {
+            "coordinate": "com.example:demo:1.0.0",
+            "targets": [{
+                "id": RESOLVE_INTEGER_ID,
+                "status": "attempted",
+                "attemptCount": report_module.MAX_UNCOVERED_ATTEMPTS - 1,
+            }],
+        })
+
+        report = self._generate(iteration=0, target_state_paths=[state_path])
+
+        persisted = {entry["id"]: entry for entry in report["targetStates"]}
+        self.assertEqual(persisted[RESOLVE_INTEGER_ID]["status"], "attempted")
+        self.assertIsNone(persisted[RESOLVE_INTEGER_ID]["reason"])
 
     def test_target_state_rejects_unknown_status(self) -> None:
         state_path = self._write_json("bad-state.json", {

--- a/forge/utility_scripts/code_coverage_finalize.py
+++ b/forge/utility_scripts/code_coverage_finalize.py
@@ -478,6 +478,51 @@ def _validate_target_state_document(
         )
 
 
+def _target_states_from_entries(
+        value: Any, label: str
+) -> dict[str, dict[str, Any]]:
+    states: dict[str, dict[str, Any]] = {}
+    entries: list[Any] = _array(value, label)
+    for index, item in enumerate(entries):
+        entry_label: str = f"{label}[{index}]"
+        target: dict[str, Any] = _object(item, entry_label)
+        target_id: str = _method_id(target.get("id"), f"{entry_label}.id")
+        if target_id in states:
+            raise FinalizationError(f"{label} repeats target '{target_id}'.")
+        status: str = _string(target.get("status"), f"{entry_label}.status")
+        if status not in TARGET_STATE_STATUSES:
+            raise FinalizationError(
+                f"Target-state target '{target_id}' has unknown status '{status}'."
+            )
+        reason: str | None = target.get("reason")
+        if reason is not None:
+            _string(reason, f"{entry_label}.reason")
+        if status in TERMINAL_NEGATIVE_STATUSES and reason is None:
+            raise FinalizationError(
+                f"Target '{target_id}' with status '{status}' requires a reason."
+            )
+        last_iteration_value: Any = target.get("lastAttemptedIteration")
+        last_iteration: int | None = None
+        if last_iteration_value is not None:
+            last_iteration = _integer(
+                last_iteration_value, f"{entry_label}.lastAttemptedIteration"
+            )
+            if last_iteration == 0:
+                raise FinalizationError(
+                    f"{entry_label}.lastAttemptedIteration must be positive."
+                )
+        states[target_id] = {
+            "id": target_id,
+            "status": status,
+            "attemptCount": _integer(
+                target.get("attemptCount"), f"{entry_label}.attemptCount"
+            ),
+            "lastAttemptedIteration": last_iteration,
+            "reason": reason,
+        }
+    return states
+
+
 def _load_latest_target_states(
         paths: list[str], coordinate: str
 ) -> dict[str, dict[str, Any]]:
@@ -487,46 +532,9 @@ def _load_latest_target_states(
         document: dict[str, Any] = _read_object(path, "Target-state file")
         _validate_target_state_document(document, path)
         _check_coordinate(document, coordinate, "Target-state file")
-        seen: set[str] = set()
-        targets: list[Any] = _array(
-            document.get("targets"), "Target-state file.targets"
-        )
-        for index, item in enumerate(targets):
-            target: dict[str, Any] = _object(
-                item, f"Target-state file.targets[{index}]"
-            )
-            target_id: str = _method_id(
-                target.get("id"), f"Target-state file.targets[{index}].id"
-            )
-            if target_id in seen:
-                raise FinalizationError(
-                    f"Target-state file '{path}' repeats target '{target_id}'."
-                )
-            seen.add(target_id)
-            status: str = _string(
-                target.get("status"), f"Target-state file.targets[{index}].status"
-            )
-            if status not in TARGET_STATE_STATUSES:
-                raise FinalizationError(
-                    f"Target-state target '{target_id}' has unknown status '{status}'."
-                )
-            reason: str | None = target.get("reason")
-            if reason is not None:
-                _string(reason, f"Target-state file.targets[{index}].reason")
-            if status in TERMINAL_NEGATIVE_STATUSES and reason is None:
-                raise FinalizationError(
-                    f"Target '{target_id}' with status '{status}' requires a reason."
-                )
-            latest[target_id] = {
-                "id": target_id,
-                "status": status,
-                "attemptCount": _integer(
-                    target.get("attemptCount"),
-                    f"Target-state file.targets[{index}].attemptCount",
-                ),
-                "lastAttemptedIteration": target.get("lastAttemptedIteration"),
-                "reason": reason,
-            }
+        latest.update(_target_states_from_entries(
+            document.get("targets"), f"Target-state file '{path}'.targets"
+        ))
     return latest
 
 
@@ -561,9 +569,12 @@ def _target_outcomes(
         deep_baseline_report: dict[str, Any],
         deep_final_report: dict[str, Any],
 ) -> dict[str, list[dict[str, Any]]]:
-    states: dict[str, dict[str, Any]] = _load_latest_target_states(
-        paths, coordinate
+    # Measurement owns automatic attempt and exhaustion state; explicit files
+    # remain later overrides for compatibility (§AR-code-coverage-improvement.3.2).
+    states: dict[str, dict[str, Any]] = _target_states_from_entries(
+        deep_final_report.get("targetStates", []), "Deep final.targetStates"
     )
+    states.update(_load_latest_target_states(paths, coordinate))
     api_baseline: dict[str, str] = _coverage_statuses(
         api_baseline_report,
         "targets",

--- a/forge/utility_scripts/code_coverage_profile_report.py
+++ b/forge/utility_scripts/code_coverage_profile_report.py
@@ -56,6 +56,9 @@ from utility_scripts.code_coverage_model import (
 )
 
 MAX_LISTED_METHODS = 200
+#: Uncovered targets leave the prompt after this many unsuccessful attempts
+#: (§AR-code-coverage-improvement.3.2).
+MAX_UNCOVERED_ATTEMPTS = 3
 TARGET_STATE_STATUSES: frozenset[str] = frozenset({
     "pending", "selected", "attempted", "completed", "skipped", "exhausted", "failed",
 })
@@ -1022,11 +1025,24 @@ def _effective_target_state(
         method_id: str,
         target_states: dict[str, TargetState],
         attempt_counts: dict[str, int],
+        jacoco_uncovered: bool = False,
 ) -> TargetState:
     state = target_states.get(method_id, TargetState())
+    attempt_count: int = max(state.attempt_count, attempt_counts.get(method_id, 0))
+    if (
+            jacoco_uncovered
+            and not state.terminal
+            and attempt_count >= MAX_UNCOVERED_ATTEMPTS
+    ):
+        return TargetState(
+            status="exhausted",
+            attempt_count=attempt_count,
+            last_attempted_iteration=state.last_attempted_iteration,
+            reason=f"{MAX_UNCOVERED_ATTEMPTS} attempts without coverage change",
+        )
     return TargetState(
         status=state.status,
-        attempt_count=max(state.attempt_count, attempt_counts.get(method_id, 0)),
+        attempt_count=attempt_count,
         last_attempted_iteration=state.last_attempted_iteration,
         reason=state.reason,
     )
@@ -1089,6 +1105,9 @@ def correlate(
     deep_uncovered: list[JacocoMethodCoverage] = [
         coverage for coverage in deep_coverage if not coverage.covered
     ]
+    deep_uncovered_ids: set[str] = {
+        coverage.method_ref.canonical_id for coverage in deep_uncovered
+    }
 
     sampled_routes: RouteMap = _sample_routes(graph, profile)
     entry_routes: RouteMap = _public_entry_routes(graph, [ref for ref, _ in inventory_refs])
@@ -1102,6 +1121,7 @@ def correlate(
                 coverage.method_ref.canonical_id,
                 states,
                 attempts,
+                jacoco_uncovered=True,
             ),
         )
         for coverage in deep_uncovered
@@ -1117,12 +1137,14 @@ def correlate(
     # agent can write a test naming one, and for nearly all of them the
     # enclosing method is an offered target already
     # (§AR-code-coverage-improvement.3.2.1).
-    actionable_records: list[NearCallRecord] = [
+    bulk_records: list[NearCallRecord] = [
         record
         for record in uncovered_records
         if record.join_kind != "none"
-        and not record.target_state.terminal
         and not _is_synthetic_method(record.target_ref)
+    ]
+    actionable_records: list[NearCallRecord] = [
+        record for record in bulk_records if not record.target_state.terminal
     ]
     synthetic_excluded: int = sum(
         1
@@ -1140,11 +1162,11 @@ def correlate(
         )
         for record in uncovered_records
     ]
-    prompt_json: list[dict] = [
+    bulk_json: list[dict] = [
         _record_to_json(
             record, graph, mathematical_ranks[record.target_ref.canonical_id], jacoco_methods
         )
-        for record in prompt_records
+        for record in bulk_records
     ]
 
     report: dict = {
@@ -1183,7 +1205,15 @@ def correlate(
         },
         "inventory": inventory_report,
         "targetStates": [
-            _target_state_to_json(method_id, _effective_target_state(method_id, states, attempts))
+            _target_state_to_json(
+                method_id,
+                _effective_target_state(
+                    method_id,
+                    states,
+                    attempts,
+                    jacoco_uncovered=method_id in deep_uncovered_ids,
+                ),
+            )
             for method_id in sorted(set(states) | set(attempts))
         ],
         "deepMethods": [
@@ -1214,7 +1244,7 @@ def correlate(
         "observedMethods": _observed_methods(profile, graph, jacoco_methods),
         "uncoveredPaths": uncovered_json,
         "promptTargetIds": [record.target_ref.canonical_id for record in prompt_records],
-        "bulkTargets": prompt_json,
+        "bulkTargets": bulk_json,
         "caveats": [
             "JaCoCo is the only coverage authority; sampled PGO evidence is guidance only.",
             "Absence of a sample never proves non-execution.",


### PR DESCRIPTION
Closes #9908

## Stop repeating targets that do not move

Deep-coverage measurement already carried attempt counts forward, but used them only for sorting. When a run had fewer than 200 candidates, every target remained in the prompt indefinitely even after several attempts produced no coverage change.

After `MAX_UNCOVERED_ATTEMPTS` unsuccessful prompts, correlation now marks a still-uncovered, non-terminal target as:

```json
{
  "status": "exhausted",
  "reason": "3 attempts without coverage change"
}
```

The target leaves `promptTargetIds`, while its complete record remains in `bulkTargets`, `uncoveredPaths`, and persisted target state for finalization and audit. Targets that become covered before the threshold are unaffected. This is the deterministic retirement described by [§AR-code-coverage-improvement.3.2](https://github.com/oracle/graalvm-reachability-metadata/blob/fix/9908-retire-deep-coverage-targets/forge/docs/architecture/code-coverage-improvement.md#32-deep-implementation-coverage).

## Separate prompt actionability from report history

The Rhei measurement state now decides whether another deep-coverage pass is useful from `promptTargetIds`, not from the retained bulk records. Exhausted entries can therefore remain visible without falsely keeping the phase actionable, while the named threshold remains independently tunable.
