### PR TITLE
Normalize Native Image factory paths

### DIFF
--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -427,6 +427,23 @@ in JSON. When a route reaches its target through a closure the enclosing method
 hands to a scheduler or executor, the entry says so: the body then runs on
 another thread, and a test that does not wait for it covers nothing.
 
+Native Image factory stubs owned by
+`com.oracle.svm.core.code.FactoryMethodHolder` render as the constructors they
+stand for when the constructor derived from the factory return type and
+parameters exists in the resolved library bytecode inventory. An unmatched
+factory remains unchanged rather than naming a constructor the library does not
+declare. Route distance and ranking use this translated semantic path: replacing
+one factory with one constructor preserves distance, while an adjacent factory
+and identical constructor collapse to one step. The raw Native Image path remains
+in JSON beside the translated path for auditability.
+
+This normalization is deliberately limited to verified factory stubs. Anonymous
+class owners remain in their bytecode form, and assertion, mocking, container,
+and existing-test frames receive no new display filtering here. Resolving those
+frames requires provenance or ownership judgments that constructor identity does
+not establish, so they are separate design decisions rather than heuristics
+bundled into factory translation.
+
 ### 3.3 Marginal-yield early stop
 
 Both phases stop before their budget when the last passes stop producing

--- a/forge/tests/test_code_coverage_profile_report.py
+++ b/forge/tests/test_code_coverage_profile_report.py
@@ -1085,5 +1085,181 @@ class SyntheticLambdaTest(unittest.TestCase):
         self.assertNotIn("lambda$", markdown)
 
 
+class FactoryStubTranslationTest(unittest.TestCase):
+    """Native Image factory paths use verified constructors.
+
+    §AR-code-coverage-improvement.3.2.1
+    """
+
+    CALLER = MethodRef("com.example.Api", "start", (), "void")
+    ALPHA_FACTORY = MethodRef(
+        report_module.FACTORY_METHOD_HOLDER,
+        "AlphaEntry_generated",
+        ("java.lang.String",),
+        "com.example.AlphaEntry",
+    )
+    ALPHA_CONSTRUCTOR = MethodRef(
+        "com.example.AlphaEntry", "<init>", ("java.lang.String",), "void",
+    )
+    ALPHA_TARGET = MethodRef("com.example.AlphaEntry", "read", (), "void")
+    ZULU_FACTORY = MethodRef(
+        report_module.FACTORY_METHOD_HOLDER,
+        "ZuluEntry_generated",
+        (),
+        "com.example.ZuluEntry",
+    )
+    ZULU_CONSTRUCTOR = MethodRef("com.example.ZuluEntry", "<init>", (), "void")
+    ZULU_TARGET = MethodRef("com.example.ZuluEntry", "read", (), "void")
+    UNMATCHED_FACTORY = MethodRef(
+        report_module.FACTORY_METHOD_HOLDER,
+        "External_generated",
+        (),
+        "external.Entry",
+    )
+
+    def setUp(self) -> None:
+        methods: dict[int, MethodRef] = {
+            1: self.CALLER,
+            2: self.ALPHA_FACTORY,
+            3: self.ALPHA_CONSTRUCTOR,
+            4: self.ALPHA_TARGET,
+            5: self.ZULU_FACTORY,
+            6: self.ZULU_TARGET,
+            7: self.UNMATCHED_FACTORY,
+        }
+
+        def edge(caller: int, callee: int) -> dict:
+            return {
+                "caller": caller,
+                "callee": callee,
+                "bci": "",
+                "is_direct": "true",
+                "kind": "call",
+            }
+
+        self.graph = report_module.CallGraph(
+            methods=methods,
+            key_to_id={
+                ref.canonical_id: static_id for static_id, ref in methods.items()
+            },
+            adjacency={
+                1: [edge(1, 2), edge(1, 5)],
+                2: [edge(2, 3)],
+                3: [edge(3, 4)],
+                5: [edge(5, 6)],
+            },
+        )
+        library_methods: set[str] = {
+            self.ALPHA_CONSTRUCTOR.canonical_id,
+            self.ZULU_CONSTRUCTOR.canonical_id,
+        }
+        report_module._index_factory_stubs(self.graph, library_methods)
+        jacoco: dict[str, JacocoMethodCoverage] = {
+            ref.canonical_id: _coverage(ref)
+            for ref in (self.ALPHA_TARGET, self.ZULU_TARGET)
+        }
+        self.report, _ = report_module.correlate(
+            report_module.SampledProfile(),
+            self.graph,
+            {"targets": [{"id": self.CALLER.canonical_id, "kind": "method"}]},
+            jacoco,
+        )
+        self.paths: dict[str, dict] = {
+            entry["id"]: entry for entry in self.report["uncoveredPaths"]
+        }
+
+    def test_verified_factories_render_as_constructors(self) -> None:
+        alpha_path: str = report_module._display_path([1, 2, 3, 4], self.graph)
+        zulu_path: str = report_module._display_path([1, 5, 6], self.graph)
+
+        self.assertEqual(alpha_path, "Api.start() → AlphaEntry(...) → read()")
+        self.assertEqual(zulu_path, "Api.start() → ZuluEntry() → read()")
+        self.assertNotIn("FactoryMethodHolder", alpha_path)
+        self.assertNotIn("FactoryMethodHolder", zulu_path)
+
+    def test_semantic_distance_collapses_only_a_duplicate_constructor(self) -> None:
+        alpha: dict = self.paths[self.ALPHA_TARGET.canonical_id]
+        zulu: dict = self.paths[self.ZULU_TARGET.canonical_id]
+
+        self.assertEqual(alpha["stepsRemaining"], 2)
+        self.assertEqual(zulu["stepsRemaining"], 2)
+        self.assertEqual(
+            alpha["reachingPath"],
+            [
+                self.CALLER.canonical_id,
+                self.ALPHA_CONSTRUCTOR.canonical_id,
+                self.ALPHA_TARGET.canonical_id,
+            ],
+        )
+        self.assertIn(self.ALPHA_FACTORY.canonical_id, alpha["reachingPathRaw"])
+        self.assertIn(self.ALPHA_CONSTRUCTOR.canonical_id, alpha["reachingPathRaw"])
+        self.assertEqual(len(alpha["reachingPathRaw"]), 4)
+        self.assertEqual(len(zulu["reachingPathRaw"]), 3)
+
+    def test_semantic_distance_controls_ranking(self) -> None:
+        self.assertEqual(
+            self.report["promptTargetIds"],
+            [self.ALPHA_TARGET.canonical_id, self.ZULU_TARGET.canonical_id],
+        )
+
+    def test_route_selection_uses_semantic_distance(self) -> None:
+        first_factory = MethodRef(
+            report_module.FACTORY_METHOD_HOLDER, "First_generated", (), "com.example.First",
+        )
+        first_constructor = MethodRef("com.example.First", "<init>", (), "void")
+        second_factory = MethodRef(
+            report_module.FACTORY_METHOD_HOLDER, "Second_generated", (), "com.example.Second",
+        )
+        second_constructor = MethodRef("com.example.Second", "<init>", (), "void")
+        raw_steps: list[MethodRef] = [
+            MethodRef("com.example.Raw", name, (), "void")
+            for name in ("one", "two", "three")
+        ]
+        target = MethodRef("com.example.Target", "hit", (), "void")
+        refs: list[MethodRef] = [
+            self.CALLER,
+            first_factory,
+            first_constructor,
+            second_factory,
+            second_constructor,
+            *raw_steps,
+            target,
+        ]
+        graph = report_module.CallGraph(
+            methods={index: ref for index, ref in enumerate(refs, start=1)},
+            key_to_id={ref.canonical_id: index for index, ref in enumerate(refs, start=1)},
+        )
+
+        def add_edge(caller: int, callee: int) -> None:
+            graph.adjacency.setdefault(caller, []).append({
+                "caller": caller,
+                "callee": callee,
+                "kind": "call",
+            })
+
+        semantic_path: list[int] = [1, 2, 3, 4, 5, 9]
+        raw_shorter_path: list[int] = [1, 6, 7, 8, 9]
+        for path in (semantic_path, raw_shorter_path):
+            for caller, callee in zip(path, path[1:]):
+                add_edge(caller, callee)
+        report_module._index_factory_stubs(
+            graph,
+            {first_constructor.canonical_id, second_constructor.canonical_id},
+        )
+
+        routes = report_module._public_entry_routes(graph, [self.CALLER])
+        selected, _ = report_module._route_to(9, routes)
+
+        self.assertEqual(selected, semantic_path)
+        self.assertEqual(routes.distance[9], 3)
+        self.assertEqual(report_module._path_distance(selected, graph), 3)
+
+    def test_unmatched_factory_remains_unchanged(self) -> None:
+        translated: list[MethodRef] = report_module._translated_path([1, 7], self.graph)
+        rendered: str = report_module._display_path([1, 7], self.graph)
+        self.assertEqual(translated[-1], self.UNMATCHED_FACTORY)
+        self.assertIn("FactoryMethodHolder.External_generated()", rendered)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/forge/utility_scripts/code_coverage_profile_report.py
+++ b/forge/utility_scripts/code_coverage_profile_report.py
@@ -87,6 +87,9 @@ TEST_TYPE_SUFFIXES = ("IT", "ITCase", "Test", "TestCase", "Tests")
 #: Marker in the class name the image generator gives a lambda implementation.
 SYNTHETIC_LAMBDA_CLASS_MARKER = "$$Lambda"
 
+#: Native Image owner for generated allocation methods that replace constructors.
+FACTORY_METHOD_HOLDER = "com.oracle.svm.core.code.FactoryMethodHolder"
+
 #: Method-name prefixes the compiler owns; no test can name one of these
 #: (§AR-code-coverage-improvement.3.2.1).
 SYNTHETIC_METHOD_PREFIXES = ("lambda$", "access$")
@@ -208,6 +211,8 @@ class CallGraph:
     reverse_adjacency: dict[int, list[dict]] = field(default_factory=dict)
     #: Invoke id -> every implementation resolved at that exact call site.
     invoke_fan_out: dict[int, list[int]] = field(default_factory=dict)
+    #: Native Image factory node -> verified source-level constructor.
+    path_aliases: dict[int, MethodRef] = field(default_factory=dict)
     #: Synthetic node -> the method whose source captured that closure.
     creator_of: dict[int, int] = field(default_factory=dict)
     #: Creating method -> the lambda bodies the compiler extracted from it.
@@ -362,6 +367,7 @@ class NearCallRecord:
     static_path_edges: list[dict]
     sample: Sample | None
     sampled_join_path_index: int | None
+    semantic_distance: int | None = None
 
     @property
     def target_ref(self) -> MethodRef:
@@ -375,6 +381,8 @@ class NearCallRecord:
     def distance(self) -> int | None:
         if self.join_kind == "none":
             return None
+        if self.semantic_distance is not None:
+            return self.semantic_distance
         return max(0, len(self.static_path) - 1)
 
     @property
@@ -506,6 +514,27 @@ def _index_synthetic_lambdas(graph: CallGraph) -> None:
         body_ids.sort(key=lambda body_id: graph.methods[body_id].canonical_id)
 
 
+def _index_factory_stubs(
+        graph: CallGraph,
+        library_methods: set[str] | None,
+) -> None:
+    """Map verified Native Image allocation stubs to library constructors.
+
+    The return type and parameters identify the constructor represented by a
+    factory stub. Requiring that exact constructor in the bytecode inventory
+    avoids inventing source-level constructors for other generated factories
+    (§AR-code-coverage-improvement.3.2.1).
+    """
+    if library_methods is None:
+        return
+    for static_id, ref in graph.methods.items():
+        if ref.owner != FACTORY_METHOD_HOLDER:
+            continue
+        constructor = MethodRef(ref.return_type, "<init>", ref.params, "void")
+        if constructor.canonical_id in library_methods:
+            graph.path_aliases[static_id] = constructor
+
+
 def _mark_dispatch_edges(
         graph: CallGraph,
         site_edges: dict[int, list[dict]],
@@ -598,6 +627,7 @@ def _load_call_graph(
         reports_dir: str,
         owners: set[str] | None,
         line_numbers: dict[str, tuple[tuple[int, int], ...]],
+        library_methods: set[str] | None,
 ) -> CallGraph:
     """Load the analysis call-tree CSV dump into an id-indexed call graph."""
     methods_path, invokes_path, targets_path = _find_call_tree_files(reports_dir)
@@ -649,6 +679,7 @@ def _load_call_graph(
         graph.reverse_adjacency.setdefault(callee_id, []).append(edge)
 
     _index_synthetic_lambdas(graph)
+    _index_factory_stubs(graph, library_methods)
     _mark_dispatch_edges(graph, site_edges, site_declared, owners)
     _add_creation_edges(graph)
 
@@ -674,10 +705,13 @@ def load_call_graph(
         reports_dir: str,
         owners: set[str] | None = None,
         line_numbers: dict[str, tuple[tuple[int, int], ...]] | None = None,
+        library_methods: set[str] | None = None,
 ) -> CallGraph:
     """Load one coherent call-tree triplet, failing closed on bad input."""
     try:
-        return _load_call_graph(reports_dir, owners, line_numbers or {})
+        return _load_call_graph(
+            reports_dir, owners, line_numbers or {}, library_methods
+        )
     except (OSError, csv.Error, KeyError, TypeError, ValueError) as error:
         raise ProfileFormatError(f"Cannot load call-tree CSVs from '{reports_dir}'.") from error
 
@@ -789,6 +823,15 @@ def _existing_test_frame_index(full_path: list[tuple[MethodRef, int]]) -> int | 
     return None
 
 
+def _translated_ref(static_id: int, graph: CallGraph) -> MethodRef:
+    """Return the source-level identity used to compare path steps.
+
+    §AR-code-coverage-improvement.3.2.1
+    """
+    creator_id: int = graph.creator_of.get(static_id, static_id)
+    return graph.path_aliases.get(creator_id, graph.methods[creator_id])
+
+
 @dataclass
 class RouteMap:
     distance: dict[int, int] = field(default_factory=dict)
@@ -800,7 +843,7 @@ def _multi_source_routes(
         graph: CallGraph,
         seeds: list[tuple[int, tuple, object]],
 ) -> RouteMap:
-    """Compute deterministic shortest paths from ranked source methods."""
+    """Compute deterministic shortest semantic paths from ranked source methods."""
     routes = RouteMap()
     best_keys: dict[int, tuple[int, tuple]] = {}
     queue: list[tuple[int, tuple, str, int]] = []
@@ -818,6 +861,7 @@ def _multi_source_routes(
         distance, seed_rank, _, current = heapq.heappop(queue)
         if best_keys.get(current) != (distance, seed_rank):
             continue
+        current_ref_id: str = _translated_ref(current, graph).canonical_id
         for edge in graph.adjacency.get(current, []):
             # A functional-interface call site names no callee of its own, so
             # routing through it invents a reachability claim
@@ -825,16 +869,21 @@ def _multi_source_routes(
             if edge["kind"] == "dispatch":
                 continue
             callee: int = edge["callee"]
-            candidate_key = (distance + 1, seed_rank)
+            semantic_step: int = int(
+                current_ref_id
+                != _translated_ref(callee, graph).canonical_id
+            )
+            candidate_distance: int = distance + semantic_step
+            candidate_key = (candidate_distance, seed_rank)
             if callee in best_keys and best_keys[callee] <= candidate_key:
                 continue
             best_keys[callee] = candidate_key
-            routes.distance[callee] = distance + 1
+            routes.distance[callee] = candidate_distance
             routes.previous[callee] = (current, edge)
             routes.payload[callee] = routes.payload[current]
             heapq.heappush(
                 queue,
-                (distance + 1, seed_rank, graph.methods[callee].canonical_id, callee),
+                (candidate_distance, seed_rank, graph.methods[callee].canonical_id, callee),
             )
     return routes
 
@@ -922,6 +971,7 @@ def _build_record(
             static_path_edges=edges,
             sample=sample,
             sampled_join_path_index=path_index,
+            semantic_distance=_path_distance(path, graph),
         )
     if target_id in entry_routes.distance:
         path, edges = _route_to(target_id, entry_routes)
@@ -934,6 +984,7 @@ def _build_record(
             static_path_edges=edges,
             sample=None,
             sampled_join_path_index=None,
+            semantic_distance=_path_distance(path, graph),
         )
     return NearCallRecord(
         coverage=coverage,
@@ -1292,14 +1343,19 @@ def _hand_off_note(record: NearCallRecord, graph: CallGraph) -> str | None:
     return None
 
 
-def _translated_path(static_path: list[int], graph: CallGraph) -> list[int]:
-    """Replace synthetic nodes by their creator, collapsing repeats."""
-    translated: list[int] = []
+def _translated_path(static_path: list[int], graph: CallGraph) -> list[MethodRef]:
+    """Replace synthetic nodes by source-level methods, collapsing repeats."""
+    translated: list[MethodRef] = []
     for static_id in static_path:
-        creator_id: int = graph.creator_of.get(static_id, static_id)
-        if not translated or translated[-1] != creator_id:
-            translated.append(creator_id)
+        ref: MethodRef = _translated_ref(static_id, graph)
+        if not translated or translated[-1].canonical_id != ref.canonical_id:
+            translated.append(ref)
     return translated
+
+
+def _path_distance(static_path: list[int], graph: CallGraph) -> int:
+    """Count edges in the source-level path used for prompt ranking."""
+    return max(0, len(_translated_path(static_path, graph)) - 1)
 
 
 def _record_to_json(
@@ -1335,8 +1391,8 @@ def _record_to_json(
         "missClassification": miss_classification,
         "reachingPath": (
             [
-                _format_static_id(static_id, graph)
-                for static_id in _translated_path(record.static_path, graph)
+                ref.canonical_id
+                for ref in _translated_path(record.static_path, graph)
             ]
             if graph_present else None
         ),
@@ -1666,8 +1722,8 @@ def _display_path(static_path: list[int], graph: CallGraph, limit: int = 6) -> s
     # Generated lambda classes and extracted bodies carry compiler-chosen names;
     # the agent can only act on the method that creates them
     # (§AR-code-coverage-improvement.3.2.1).
-    path: list[int] = _translated_path(static_path, graph)
-    selected: list[int | None]
+    path: list[MethodRef] = _translated_path(static_path, graph)
+    selected: list[MethodRef | None]
     if len(path) <= limit:
         selected = list(path)
     else:
@@ -1675,14 +1731,9 @@ def _display_path(static_path: list[int], graph: CallGraph, limit: int = 6) -> s
 
     labels: list[str] = []
     previous_owner: str | None = None
-    for static_id in selected:
-        if static_id is None:
-            labels.append("…")
-            previous_owner = None
-            continue
-        ref = graph.methods.get(static_id)
+    for ref in selected:
         if ref is None:
-            labels.append(f"method-{static_id}")
+            labels.append("…")
             previous_owner = None
             continue
         labels.append(_display_method(ref, ref.owner != previous_owner))
@@ -2005,7 +2056,10 @@ def generate_report(
         if library_methods_path else {}
     )
     graph: CallGraph = load_call_graph(
-        reports_dir, library_owners(library_methods), line_numbers
+        reports_dir,
+        library_owners(library_methods),
+        line_numbers,
+        library_methods,
     )
     profile: SampledProfile = load_sampled_profile(profile_path, graph)
     inventory: dict = _load_json_object(api_inventory_path, "API inventory")


### PR DESCRIPTION
Closes #9906

## Why factory paths need translation

Deep-coverage prompts currently expose Native Image generated `FactoryMethodHolder` names where an agent needs the source-level constructor. Those names are not writable Java operations, and duplicate factory/constructor frames can also distort the distance used to rank targets.

The issue scope was deliberately narrowed after inspecting real run data: normalize constructor surrogates whose identity can be proven from library bytecode, while leaving anonymous-class provenance and framework-frame filtering for separate decisions. That boundary is recorded in [§AR-code-coverage-improvement.3.2.1](https://github.com/oracle/graalvm-reachability-metadata/blob/fix/9906-factory-stub-paths/forge/docs/architecture/code-coverage-improvement.md#321-synthetic-method-attribution-and-route-honesty).

## How constructor identity is established

A `FactoryMethodHolder` row is translated only when this exact identity exists in the resolved library method inventory:

```text
<factory return type>#<init>(<factory parameters>):void
```

That makes translation deterministic. Unmatched factories keep their generated identity rather than inventing a constructor, and `reachingPathRaw` preserves the original Native Image graph path beside the translated path.

## How path distance changes

| Native Image path | Prompt-facing path | Distance |
| --- | --- | --- |
| `caller → factory → target` | `caller → constructor → target` | unchanged |
| `caller → factory → constructor → target` | `caller → constructor → target` | reduced by one |

Ranking and `stepsRemaining` use the same translated semantic path, so display and selection cannot disagree.
