### PR TITLE
Publish code coverage benchmark results through PRs

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -50,7 +50,7 @@ ROUTE_LABELS = {
     "fixes-java-run-fail": ["GenAI", "fixes-java-run-fail"],
     "fixes-native-image-run-fail": ["fixes-native-image-run-fail"],
     "not-for-native-image": ["GenAI", "library-new-request", "not-for-native-image"],
-    "code-coverage-benchmark-result": ["GenAI", "rhei"],
+    "code-coverage-benchmark-result": ["GenAI", "code-coverage-improvement", "rhei"],
     "code-coverage-improvement": ["GenAI", "code-coverage-improvement", "rhei"],
 }
 

--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -37,7 +37,12 @@ SEVERE_METADATA_DROP_RATIO = 0.25
 DYNAMIC_ACCESS_METADATA_ENTRY_NOTE_RATIO = 1.75
 PUBLISHER_LOGIN = "graalvmbot"
 LOCAL_REVIEW_ATTESTATION_OUTPUT = "local_review_attestation"
-PUBLICATION_ID_SUFFIX = re.compile(r"(forge-\d+-\d{14,20}-[0-9a-f]{12})$")
+PUBLICATION_ID_SUFFIX = re.compile(
+    r"(forge-(?:\d+|benchmark)-\d{14,20}-[0-9a-f]{12})$"
+)
+BENCHMARK_RESULT_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3] / "forge/schemas/code_coverage_benchmark_result_schema.json"
+)
 ROUTE_LABELS = {
     "library-new-request": ["GenAI", "library-new-request"],
     "library-update-request": ["GenAI", "library-update-request"],
@@ -45,6 +50,7 @@ ROUTE_LABELS = {
     "fixes-java-run-fail": ["GenAI", "fixes-java-run-fail"],
     "fixes-native-image-run-fail": ["fixes-native-image-run-fail"],
     "not-for-native-image": ["GenAI", "library-new-request", "not-for-native-image"],
+    "code-coverage-benchmark-result": ["GenAI", "rhei"],
     "code-coverage-improvement": ["GenAI", "code-coverage-improvement", "rhei"],
 }
 
@@ -255,24 +261,46 @@ def validate_publication(
     if descriptor["publication_id"] != expected_publication_id:
         raise ValueError("Descriptor publication ID does not match its durable run inputs")
 
+    if descriptor["task_type"] == "code-coverage-benchmark-result":
+        _validate_benchmark_result_publication(
+            descriptor=descriptor,
+            descriptor_path=descriptor_path,
+            head_sha=head_sha,
+            base_commit=base_commit,
+            changed_paths=changed_paths,
+        )
     _validate_render_inputs(descriptor)
     return ValidatedPublication(descriptor, descriptor_path, head_sha)
 
 
 def _build_publication_id(descriptor: dict[str, Any]) -> str:
-    identity = json.dumps(
-        {
+    if descriptor["task_type"] == "code-coverage-benchmark-result":
+        benchmark_run_id = descriptor.get("benchmark_run_id")
+        if not isinstance(benchmark_run_id, str) or not benchmark_run_id:
+            raise ValueError("Benchmark publication requires a run ID")
+        identity_fields: dict[str, Any] = {
+            "benchmark_run_id": benchmark_run_id,
+            "timestamp": descriptor["timestamp"],
+            "coordinates": descriptor["library"]["coordinates"],
+            "task_type": descriptor["task_type"],
+        }
+        prefix = "benchmark"
+    else:
+        identity_fields = {
             "issue_number": descriptor["issue_number"],
             "timestamp": descriptor["timestamp"],
             "coordinates": descriptor["library"]["coordinates"],
             "task_type": descriptor["task_type"],
-        },
+        }
+        prefix = str(descriptor["issue_number"])
+    identity = json.dumps(
+        identity_fields,
         sort_keys=True,
         separators=(",", ":"),
     )
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
     compact_timestamp = re.sub(r"[^0-9]", "", descriptor["timestamp"])[:20]
-    return f"forge-{descriptor['issue_number']}-{compact_timestamp}-{digest}"
+    return f"forge-{prefix}-{compact_timestamp}-{digest}"
 
 
 def _validate_render_inputs(descriptor: dict[str, Any]) -> None:
@@ -294,7 +322,79 @@ def _validate_render_inputs(descriptor: dict[str, Any]) -> None:
             raise ValueError("Not-for-native-image publication requires a reason")
     if template_type == "code-coverage-improvement":
         _validate_code_coverage_render(descriptor["render"])
+    if template_type == "code-coverage-benchmark-result":
+        _validate_benchmark_result(descriptor["render"].get("benchmark_result"))
 
+
+def _validate_benchmark_result(result: Any) -> None:
+    """Validate one compact benchmark result using the trusted schema."""
+    if not BENCHMARK_RESULT_SCHEMA_PATH.is_file():
+        raise ValueError("Trusted benchmark result schema is unavailable")
+    with BENCHMARK_RESULT_SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate([result])
+
+
+def _json_value_at_commit(commit: str, path: str) -> Any:
+    """Read any JSON value from one exact commit."""
+    return json.loads(git("show", f"{commit}:{path}"))
+
+
+def _validate_benchmark_result_publication(
+        *,
+        descriptor: dict[str, Any],
+        descriptor_path: str,
+        head_sha: str,
+        base_commit: str,
+        changed_paths: list[str],
+) -> None:
+    """Accept exactly one schema-valid result appended to its coordinate list.
+
+    §forge/FS-code-coverage-benchmarking.3
+    """
+    library = descriptor["library"]
+    result_path = (
+        f"code-coverage-benchmarks/{library['group']}/{library['artifact']}/"
+        f"{library['version']}.json"
+    )
+    if changed_paths != sorted((descriptor_path, result_path)):
+        raise ValueError(
+            "Benchmark publication must change exactly its result list and descriptor"
+        )
+
+    result = descriptor["render"].get("benchmark_result")
+    _validate_benchmark_result(result)
+    if result["runId"] != descriptor["benchmark_run_id"]:
+        raise ValueError("Benchmark descriptor run IDs do not agree")
+    if result["coordinate"] != library["coordinates"]:
+        raise ValueError("Benchmark descriptor coordinate does not match its result")
+
+    head_entries = _json_value_at_commit(head_sha, result_path)
+    if not isinstance(head_entries, list):
+        raise ValueError("Benchmark result path must contain a JSON list")
+    with BENCHMARK_RESULT_SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        result_schema = json.load(schema_file)
+    Draft202012Validator(
+        result_schema,
+        format_checker=FormatChecker(),
+    ).validate(head_entries)
+
+    base_object = f"{base_commit}:{result_path}"
+    base_entries = (
+        _json_value_at_commit(base_commit, result_path)
+        if _git_object_exists(base_object)
+        else []
+    )
+    if not isinstance(base_entries, list):
+        raise ValueError("Base benchmark result path must contain a JSON list")
+    if any(entry.get("runId") == result["runId"] for entry in base_entries):
+        raise ValueError("Benchmark result already exists in the publication base")
+    expected_entries = [*base_entries, result]
+    expected_entries.sort(key=lambda entry: (entry["timestamp"], entry["runId"]))
+    if head_entries != expected_entries:
+        raise ValueError(
+            "Benchmark result list must be the sorted base list plus the descriptor result"
+        )
 
 def _validate_code_coverage_render(render: dict[str, Any]) -> None:
     """Require the finalized coverage evidence the coverage template reads."""
@@ -965,6 +1065,57 @@ def _render_code_coverage_improvement(
     return title, body
 
 
+def _benchmark_metric(value: Any, suffix: str = "") -> str:
+    """Render a nullable benchmark metric without inventing a zero."""
+    if value is None:
+        return "n/a"
+    return f"{value:,}{suffix}" if isinstance(value, int) else f"{value}{suffix}"
+
+
+def _render_code_coverage_benchmark_result(
+        descriptor: dict[str, Any],
+        _validated: ValidatedPublication | None,
+) -> tuple[str, str]:
+    """Render one schema-validated benchmark result. §forge/FS-code-coverage-benchmarking.3"""
+    result = descriptor["render"]["benchmark_result"]
+    coordinates = result["coordinate"]
+    model = result["configuredModel"]
+    thinking = result["thinking"]
+    title = f"[Benchmark] Record {coordinates} result ({model}, {thinking})"
+    coverage = result["total"]["coverage"]
+    tokens = result["total"]["tokens"]
+    lines = [
+        "## Code coverage benchmark result",
+        "",
+        f"- Run: `{result['runId']}`",
+        f"- Coordinate: `{coordinates}`",
+        f"- Status: `{result['status']}`",
+        f"- Agent: `{result['agent']}`",
+        f"- Configured model: `{model}`",
+        f"- Observed model: `{result['observedModel'] or 'n/a'}`",
+        f"- Thinking level: `{thinking}`",
+        f"- Benchmark suite commit: `{result['benchmarkSuiteCommit']}`",
+        f"- Runner commit: `{result['runnerCommit']}`",
+        "",
+        "## Result",
+        "",
+        f"- Covered methods: {_benchmark_metric(coverage['coveredBefore'])} → "
+        f"{_benchmark_metric(coverage['coveredAfter'])}",
+        f"- Methods gained: {_benchmark_metric(coverage['methodsGained'])}",
+        f"- Coverage gained: {_benchmark_metric(coverage['percentagePointsGained'], 'pp')}",
+        f"- Method universe: {_benchmark_metric(coverage['allMethods'])}",
+        f"- Input tokens: {_benchmark_metric(tokens['input'])}",
+        f"- Cached input tokens: {_benchmark_metric(tokens['cachedInputRead'])}",
+        f"- Output tokens: {_benchmark_metric(tokens['output'])}",
+    ]
+    failure = result.get("failure")
+    if isinstance(failure, dict):
+        lines += [
+            f"- Failure phase: `{failure['phase']}`",
+            f"- Exit code: `{failure['exitCode']}`",
+        ]
+    return title, "\n".join(lines)
+
 _TEMPLATE_BUILDERS = {
     "library-update-request": _render_library_update_request,
     "library-new-request": _render_library_new_request,
@@ -973,6 +1124,7 @@ _TEMPLATE_BUILDERS = {
     "fixes-native-image-run-fail": _render_native_image_run_fix,
     "not-for-native-image": _render_not_for_native_image,
     "code-coverage-improvement": _render_code_coverage_improvement,
+    "code-coverage-benchmark-result": _render_code_coverage_benchmark_result,
 }
 
 

--- a/.github/scripts/forge_pr_publisher/schema.json
+++ b/.github/scripts/forge_pr_publisher/schema.json
@@ -46,8 +46,13 @@
       "$ref": "#/$defs/commit"
     },
     "issue_number": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "minimum": 1
+    },
+    "benchmark_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
     },
     "library": {
       "$ref": "#/$defs/library"
@@ -63,6 +68,7 @@
         "fixes-java-run-fail",
         "fixes-native-image-run-fail",
         "not-for-native-image",
+        "code-coverage-benchmark-result",
         "code-coverage-improvement"
       ]
     },
@@ -74,6 +80,7 @@
         "fixes-java-run-fail",
         "fixes-native-image-run-fail",
         "not-for-native-image",
+        "code-coverage-benchmark-result",
         "code-coverage-improvement"
       ]
     },
@@ -380,7 +387,7 @@
     {
       "if": {
         "properties": {
-          "task_type": {"const": "code-coverage-improvement"}
+          "task_type": {"enum": ["code-coverage-improvement", "code-coverage-benchmark-result"]}
         },
         "required": ["task_type"]
       },
@@ -389,6 +396,38 @@
       },
       "else": {
         "required": ["local_review"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "task_type": {"const": "code-coverage-benchmark-result"}
+        },
+        "required": ["task_type"]
+      },
+      "then": {
+        "required": ["benchmark_run_id"],
+        "properties": {
+          "issue_number": {"type": "null"},
+          "template_type": {"const": "code-coverage-benchmark-result"},
+          "render": {
+            "properties": {
+              "benchmark_result": {"type": "object"}
+            },
+            "required": ["benchmark_result"]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "issue_number": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "not": {
+          "required": ["benchmark_run_id"]
+        }
       }
     },
     {
@@ -807,6 +846,12 @@
           ]
         },
         "code_coverage": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "benchmark_result": {
           "type": [
             "object",
             "null"

--- a/code-coverage-benchmarks/com.h2database/h2/2.1.210.json
+++ b/code-coverage-benchmarks/com.h2database/h2/2.1.210.json
@@ -1,1 +1,70 @@
-[]
+[
+  {
+    "schemaVersion": "1.0.0",
+    "runId": "20260908T122549Z-l4-pi-gpt-5.6-sol-high-ab3ab09cc9",
+    "timestamp": "2026-09-08T13:03:29Z",
+    "benchmarkSuiteCommit": "92a2a4fa60b2d6532fa533f2d4f8f795dd28a1cb",
+    "runnerCommit": "0a8c545ce70462e6e823df092aef77d5f469cf6e",
+    "coordinate": "com.h2database:h2:2.1.210",
+    "workspaceName": "code-coverage-99000",
+    "agent": "pi",
+    "configuredModel": "gpt-5.6-sol",
+    "observedModel": "openai-codex/gpt-5.6-sol",
+    "thinking": "high",
+    "status": "failure",
+    "failure": {
+      "phase": "api",
+      "exitCode": 1
+    },
+    "checkedInAllMethods": 11943,
+    "measuredAllMethodsDifference": 0,
+    "api": {
+      "coverPasses": 0,
+      "fixInvocations": 0,
+      "tokens": {
+        "input": 215607,
+        "cachedInputRead": 2786432,
+        "output": 28618
+      },
+      "coverage": {
+        "coveredBefore": 2689,
+        "coveredAfter": 2689,
+        "methodsGained": 0,
+        "percentagePointsGained": 0.0,
+        "allMethods": 11943
+      }
+    },
+    "deep": {
+      "coverPasses": null,
+      "fixInvocations": 0,
+      "tokens": {
+        "input": 0,
+        "cachedInputRead": 0,
+        "output": 0
+      },
+      "coverage": {
+        "coveredBefore": null,
+        "coveredAfter": null,
+        "methodsGained": null,
+        "percentagePointsGained": null,
+        "allMethods": 11943
+      }
+    },
+    "total": {
+      "coverPasses": null,
+      "fixInvocations": 0,
+      "tokens": {
+        "input": 215607,
+        "cachedInputRead": 2786432,
+        "output": 28618
+      },
+      "coverage": {
+        "coveredBefore": 2689,
+        "coveredAfter": 2689,
+        "methodsGained": 0,
+        "percentagePointsGained": 0.0,
+        "allMethods": 11943
+      }
+    }
+  }
+]

--- a/docs/functional-spec/functional-spec.md
+++ b/docs/functional-spec/functional-spec.md
@@ -127,6 +127,7 @@ GitHub labels are part of the public triage surface for issues and PRs. Pipeline
 | `docker` | PR | PR updates allowed Docker images used by tests. |
 | `GenAI` | PR | PR was produced by generative-AI automation. Generated PR titles also use a `[GenAI]` prefix when created by the corresponding Forge scripts. |
 | `priority` | Issue | Work-queue priority marker. Forge processes matching issues after `high-priority` issues and before regular issues in the same pipeline batch; issue triage also adds it to eligible native-build-tools-created support requests. |
+| `code-coverage-improvement` | PR | PR carries Rhei code coverage improvement work for a library, or a benchmark result measuring that work. |
 | `rhei` | PR | PR was produced by a Rhei workflow, including compact code coverage benchmark results. |
 | `high-priority` | Issue | Highest work-queue urgency marker. Compatibility automation adds it to failed updates for artifacts whose latest index entry sets `high-priority: true`, and Forge processes it before `priority` and regular issues in the same pipeline batch. |
 | `chunked-dynamic-access` | Issue | Forge split dynamic-access generation for this issue into class-aligned chunks because the uncovered class count exceeded the configured threshold. Normal project status controls whether Forge may claim the next chunk. |

--- a/docs/functional-spec/functional-spec.md
+++ b/docs/functional-spec/functional-spec.md
@@ -100,8 +100,10 @@ The `forge/` toolkit composes LLM agents (Aider, Codex, Pi) with deterministic G
 2. **Fix `javac` failures** raised by a library version bump.
 3. **Fix native-image runtime failures** raised by a library version bump.
 4. **Improve coverage** of already-supported libraries by targeting uncovered dynamic-access call sites.
+5. **Record code coverage benchmarks** — publish compact, reproducible benchmark
+   results through descriptor-backed pull requests without shipping generated tests.
 
-Each Forge run records per-library metrics under `stats/<group>/<artifact>/<version>/execution-metrics.json` and, when invoked through `git_scripts/publish_*.py`, pushes a verified branch that trusted GitHub Actions turn into a PR ready for human review. See [forge/README.md](../../forge/README.md) and [forge/docs/functional-spec/functional-spec.md](../../forge/docs/functional-spec/functional-spec.md).
+Each Forge run records per-library metrics under `stats/<group>/<artifact>/<version>/execution-metrics.json` and, when invoked through a publication script or the benchmark result publisher, pushes a verified branch that trusted GitHub Actions turn into a PR ready for review. See [forge/README.md](../../forge/README.md) and [forge/docs/functional-spec/functional-spec.md](../../forge/docs/functional-spec/functional-spec.md).
 
 #### GitHub label contract
 
@@ -125,6 +127,7 @@ GitHub labels are part of the public triage surface for issues and PRs. Pipeline
 | `docker` | PR | PR updates allowed Docker images used by tests. |
 | `GenAI` | PR | PR was produced by generative-AI automation. Generated PR titles also use a `[GenAI]` prefix when created by the corresponding Forge scripts. |
 | `priority` | Issue | Work-queue priority marker. Forge processes matching issues after `high-priority` issues and before regular issues in the same pipeline batch; issue triage also adds it to eligible native-build-tools-created support requests. |
+| `rhei` | PR | PR was produced by a Rhei workflow, including compact code coverage benchmark results. |
 | `high-priority` | Issue | Highest work-queue urgency marker. Compatibility automation adds it to failed updates for artifacts whose latest index entry sets `high-priority: true`, and Forge processes it before `priority` and regular issues in the same pipeline batch. |
 | `chunked-dynamic-access` | Issue | Forge split dynamic-access generation for this issue into class-aligned chunks because the uncovered class count exceeded the configured threshold. Normal project status controls whether Forge may claim the next chunk. |
 | `human-intervention` | Issue / PR | Automation could not safely complete the work without manual follow-up, or automated PR review requested changes. |

--- a/forge/README.md
+++ b/forge/README.md
@@ -162,9 +162,10 @@ compose and accept multiple values:
 
 Each cell keeps its Rhei workspace below
 `local_repositories/code_coverage_benchmarks/`, immediately appends compact
-metrics to
-`../code-coverage-benchmarks/<group>/<artifact>/<version>.json`, and removes
-only its disposable source worktree after publication succeeds. Retry preserved
+metrics to `../code-coverage-benchmarks/<group>/<artifact>/<version>.json` on a
+descriptor-backed `ai/**` branch, and lets trusted Actions open the result PR.
+It removes only its disposable source worktree after the branch is durable or
+the result is already merged. Retry preserved
 unpublished results without rerunning coverage:
 
 ```console

--- a/forge/benchmarks/code_coverage_benchmark.py
+++ b/forge/benchmarks/code_coverage_benchmark.py
@@ -6,8 +6,8 @@
 """Run and publish fixed-input code coverage improvement benchmarks.
 
 The runner owns deterministic matrix expansion, isolated worktrees, benchmark
-conversion, compact metrics extraction, and immediate same-repository
-publication. Rhei continues to own the coverage phases themselves.
+conversion, compact metrics extraction, and descriptor-backed PR publication.
+Rhei continues to own the coverage phases themselves.
 §FS-code-coverage-benchmarking §AR-code-coverage-benchmarking
 """
 
@@ -41,6 +41,9 @@ RESULT_SCHEMA_PATH = (
 FINAL_METRICS_SCHEMA_PATH = (
     FORGE_ROOT / "schemas" / "code_coverage_final_metrics_schema.json"
 )
+PUBLISHER_SCHEMA_PATH = (
+    REPOSITORY_ROOT / ".github" / "scripts" / "forge_pr_publisher" / "schema.json"
+)
 DEFAULT_WORKSPACE_ROOT = (
     FORGE_ROOT / "local_repositories" / "code_coverage_benchmarks"
 )
@@ -50,13 +53,20 @@ RESULT_RECORD = BENCHMARK_DIR / "result.json"
 PUBLICATION_MARKER = BENCHMARK_DIR / "publication.json"
 RESULT_SCHEMA_VERSION = "1.0.0"
 COMMIT_SUBJECT = "Record code coverage benchmark"
+DESCRIPTOR_COMMIT_SUBJECT = "Add Forge publication descriptor"
+BENCHMARK_TASK_TYPE = "code-coverage-benchmark-result"
 MAX_PUBLISH_ATTEMPTS = 5
 
 sys.path.insert(0, str(FORGE_ROOT))
 
 from git_scripts.common_git import (  # noqa: E402
     GitTransportError,
+    get_authenticated_login,
     run_git_transport,
+)
+from git_scripts.publication_descriptor import (  # noqa: E402
+    build_publication_branch,
+    build_publication_id,
 )
 from utility_scripts.code_coverage_jacoco import (  # noqa: E402
     load_jacoco_method_coverage,
@@ -66,6 +76,15 @@ from utility_scripts.metadata_index import resolve_test_dir  # noqa: E402
 
 class BenchmarkError(RuntimeError):
     """Raised when benchmark evidence or repository state is unsafe."""
+
+@dataclass(frozen=True)
+class BenchmarkPublication:
+    """Durable location of one proposed or already merged result."""
+
+    commit: str
+    branch: str | None
+    publication_id: str
+    already_merged: bool
 
 
 @dataclass(frozen=True)
@@ -1026,12 +1045,184 @@ def _discard_publication_worktree(
         )
 
 
+def _descriptor_relative_path(coordinate: str) -> Path:
+    group, artifact, version = coordinate.split(":")
+    return Path("stats") / group / artifact / version / "forge-publication.json"
+
+
+def _commit_paths(repository: Path, paths: list[Path], subject: str) -> str:
+    subprocess.run(
+        ["git", "add", "--", *(str(path) for path in paths)],
+        cwd=repository,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=metadata-forge",
+            "-c",
+            "user.email=metadata-forge@local",
+            "commit",
+            "-m",
+            subject,
+        ],
+        cwd=repository,
+        check=True,
+    )
+    return _git_output(repository, "rev-parse", "HEAD")
+
+
+def _publication_identity(
+        repository_root: Path,
+        result: dict[str, Any],
+) -> tuple[str, str, str]:
+    producer = get_authenticated_login(cwd=str(repository_root))
+    publication_id = build_publication_id(
+        None,
+        result["timestamp"],
+        result["coordinate"],
+        BENCHMARK_TASK_TYPE,
+        benchmark_run_id=result["runId"],
+    )
+    _, artifact, version = result["coordinate"].split(":")
+    branch_suffix = (
+        f"benchmark-{artifact}-{version}-{result['configuredModel']}-{result['thinking']}"
+    )
+    branch = build_publication_branch(producer, branch_suffix, publication_id)
+    return producer, publication_id, branch
+
+
+def _benchmark_descriptor(
+        *,
+        result: dict[str, Any],
+        producer: str,
+        publication_id: str,
+        branch: str,
+        base_commit: str,
+        result_commit: str,
+        result_path: Path,
+) -> dict[str, Any]:
+    group, artifact, version = result["coordinate"].split(":")
+    return {
+        "schema_version": 1,
+        "publication_id": publication_id,
+        "timestamp": result["timestamp"],
+        "branch": branch,
+        "producer": producer,
+        "base_commit": base_commit,
+        "issue_number": None,
+        "benchmark_run_id": result["runId"],
+        "library": {
+            "group": group,
+            "artifact": artifact,
+            "version": version,
+            "coordinates": result["coordinate"],
+        },
+        "task_type": BENCHMARK_TASK_TYPE,
+        "template_type": BENCHMARK_TASK_TYPE,
+        "metrics": None,
+        "local_ci_verification": {
+            "status": "success",
+            "base_commit": base_commit,
+            "final_commit": result_commit,
+            "commands": [
+                {
+                    "gate": "benchmark-result-schema",
+                    "command": [
+                        "python3",
+                        "forge/utility_scripts/schema_validator.py",
+                        "code_coverage_benchmark_result",
+                        str(result_path),
+                    ],
+                    "returncode": 0,
+                }
+            ],
+            "fixups": [],
+            "repo_fix_paths": [],
+            "human_intervention_required": False,
+        },
+        "forge": {
+            "monitored_branch": "master",
+            "branch": "benchmark-runner",
+            "commit": result["runnerCommit"],
+        },
+        "modifiers": {
+            "chunked_dynamic_access": False,
+            "chunk_final": True,
+            "human_intervention": False,
+        },
+        "follow_ups": [],
+        "render": {"benchmark_result": result},
+    }
+
+
+def _json_at_ref(repository: Path, ref: str, path: Path) -> Any | None:
+    completed = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return json.loads(completed.stdout)
+
+
+def _fetch_existing_publication(
+        repository_root: Path,
+        result: dict[str, Any],
+        branch: str,
+        publication_id: str,
+) -> str | None:
+    remote_ref = f"refs/remotes/origin/{branch}"
+    fetch = subprocess.run(
+        [
+            "git",
+            "fetch",
+            "--quiet",
+            "origin",
+            f"+refs/heads/{branch}:{remote_ref}",
+        ],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        return None
+    descriptor = _json_at_ref(
+        repository_root,
+        remote_ref,
+        _descriptor_relative_path(result["coordinate"]),
+    )
+    entries = _json_at_ref(
+        repository_root,
+        remote_ref,
+        _metrics_relative_path(result["coordinate"]),
+    )
+    if not isinstance(descriptor, dict) or not isinstance(entries, list):
+        raise BenchmarkError(f"Existing publication branch is incomplete: {branch}")
+    if (
+            descriptor.get("publication_id") != publication_id
+            or descriptor.get("branch") != branch
+            or descriptor.get("benchmark_run_id") != result["runId"]
+            or descriptor.get("render", {}).get("benchmark_result") != result
+            or result not in entries
+    ):
+        raise BenchmarkError(f"Existing publication branch conflicts with run {result['runId']}")
+    return _git_output(repository_root, "rev-parse", remote_ref)
+
+
 def _publish_result(
         repository_root: Path,
         workspace: Path,
         result: dict[str, Any],
-) -> str:
+) -> BenchmarkPublication:
     relative_path = _metrics_relative_path(result["coordinate"])
+    descriptor_path = _descriptor_relative_path(result["coordinate"])
+    producer, publication_id, branch = _publication_identity(repository_root, result)
     lock_handle = _publish_lock(repository_root)
     try:
         for attempt in range(1, MAX_PUBLISH_ATTEMPTS + 1):
@@ -1042,6 +1233,16 @@ def _publish_result(
                     ["fetch", "origin", "master"],
                     cwd=str(repository_root),
                 )
+                existing_commit = _fetch_existing_publication(
+                    repository_root,
+                    result,
+                    branch,
+                    publication_id,
+                )
+                if existing_commit is not None:
+                    return BenchmarkPublication(
+                        existing_commit, branch, publication_id, False,
+                    )
                 _create_publication_worktree(
                     repository_root,
                     publisher,
@@ -1049,42 +1250,45 @@ def _publish_result(
                 )
                 created = True
                 changed = _merge_result(publisher / relative_path, result)
-                subprocess.run(
-                    ["git", "add", str(relative_path)],
-                    cwd=publisher,
-                    check=True,
-                )
-                staged = subprocess.run(
-                    ["git", "diff", "--cached", "--quiet"],
-                    cwd=publisher,
-                    check=False,
-                )
-                if staged.returncode == 0:
-                    return _git_output(publisher, "rev-parse", "HEAD")
                 if not changed:
-                    raise BenchmarkError(
-                        "Identical benchmark metrics unexpectedly changed "
-                        "the index."
+                    return BenchmarkPublication(
+                        _git_output(publisher, "rev-parse", "HEAD"),
+                        None,
+                        publication_id,
+                        True,
                     )
-                subprocess.run(
-                    [
-                        "git",
-                        "-c",
-                        "user.name=metadata-forge",
-                        "-c",
-                        "user.email=metadata-forge@local",
-                        "commit",
-                        "-m",
-                        COMMIT_SUBJECT,
-                    ],
-                    cwd=publisher,
-                    check=True,
+                result_commit = _commit_paths(
+                    publisher,
+                    [relative_path],
+                    COMMIT_SUBJECT,
+                )
+                base_commit = _git_output(publisher, "rev-parse", "origin/master")
+                descriptor = _benchmark_descriptor(
+                    result=result,
+                    producer=producer,
+                    publication_id=publication_id,
+                    branch=branch,
+                    base_commit=base_commit,
+                    result_commit=result_commit,
+                    result_path=relative_path,
+                )
+                _validate(descriptor, PUBLISHER_SCHEMA_PATH)
+                _write_json(publisher / descriptor_path, descriptor)
+                descriptor_commit = _commit_paths(
+                    publisher,
+                    [descriptor_path],
+                    DESCRIPTOR_COMMIT_SUBJECT,
                 )
                 run_git_transport(
-                    ["push", "origin", "HEAD:master"],
+                    ["push", "origin", f"HEAD:refs/heads/{branch}"],
                     cwd=str(publisher),
                 )
-                return _git_output(publisher, "rev-parse", "HEAD")
+                return BenchmarkPublication(
+                    descriptor_commit,
+                    branch,
+                    publication_id,
+                    False,
+                )
             except GitTransportError as error:
                 if attempt == MAX_PUBLISH_ATTEMPTS:
                     raise
@@ -1118,7 +1322,7 @@ def publish_workspace(
         candidate = run.get("rheiExitCode")
         known_exit = candidate if type(candidate) is int else None
     result = _collect_result(workspace, status, known_exit)
-    published_commit = _publish_result(repository_root.resolve(), workspace, result)
+    publication = _publish_result(repository_root.resolve(), workspace, result)
     marker = {
         "schemaVersion": "1.0.0",
         "runId": result["runId"],
@@ -1127,18 +1331,27 @@ def publish_workspace(
             .isoformat(timespec="seconds")
             .replace("+00:00", "Z")
         ),
-        "repositoryCommit": published_commit,
+        "repositoryCommit": publication.commit,
+        "publicationBranch": publication.branch,
+        "publicationId": publication.publication_id,
+        "publicationState": (
+            "merged" if publication.already_merged else "branch-pushed"
+        ),
         "resultPath": str(_metrics_relative_path(result["coordinate"])),
     }
     _write_json(_publication_marker_path(workspace), marker)
     print(
-        f"Published benchmark result {result['runId']} at "
-        f"{marker['resultPath']}."
+        f"Published benchmark result {result['runId']} on "
+        + (
+            "origin/master."
+            if publication.already_merged
+            else f"branch {publication.branch}; trusted Actions will open the PR."
+        )
     )
     _write_terminal_result(
         f"Published benchmark result {result['runId']} "
         f"({result['status']}) for {result['coordinate']} at "
-        f"{marker['resultPath']}, repository commit "
+        f"{marker['resultPath']}, publication commit "
         f"{marker['repositoryCommit']}."
     )
     return result

--- a/forge/benchmarks/code_coverage_benchmark.py
+++ b/forge/benchmarks/code_coverage_benchmark.py
@@ -1135,6 +1135,12 @@ def publish_workspace(
         f"Published benchmark result {result['runId']} at "
         f"{marker['resultPath']}."
     )
+    _write_terminal_result(
+        f"Published benchmark result {result['runId']} "
+        f"({result['status']}) for {result['coordinate']} at "
+        f"{marker['resultPath']}, repository commit "
+        f"{marker['repositoryCommit']}."
+    )
     return result
 
 
@@ -1221,6 +1227,28 @@ def convert_workspace(args: argparse.Namespace) -> None:
         "No GitHub issue or Project operation was performed.\n",
         encoding="utf-8",
     )
+    _write_terminal_result(
+        f"Prepared benchmark {args.run_id} for {args.coordinate} at suite "
+        f"commit {args.suite_commit}. Conversion artifacts written; no GitHub "
+        f"issue or Project operation was performed."
+    )
+
+
+def _write_terminal_result(message: str) -> None:
+    """Satisfy Rhei's terminal-result obligation for a program worker.
+
+    Rhei requires a non-empty `runtime/results/<task-id>.md` on every edge into
+    a final state, and hands a program the absolute path in `RHEI_RESULT_PATH`
+    because a program has no prompt to carry it. A program state whose exit-0
+    edge is terminal must write it, or the task stalls instead of advancing.
+    §FS-code-coverage-benchmarking.2
+    """
+    result_path = os.environ.get("RHEI_RESULT_PATH")
+    if not result_path:
+        return
+    path = Path(result_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(message.rstrip("\n") + "\n", encoding="utf-8")
 
 
 def _convert_parser(subparsers: Any) -> None:

--- a/forge/docs/architecture/code-coverage-benchmarking.md
+++ b/forge/docs/architecture/code-coverage-benchmarking.md
@@ -18,7 +18,8 @@ implements §FS-code-coverage-benchmarking while preserving
 | Code coverage Rhei template | Switches conversion and publication behavior through the `benchmark` input. |
 | Source worktree | Disposable checkout of the fixed `benchmarkSuiteCommit`. |
 | Rhei workspace | Permanent local record keyed by `runId` and named `code-coverage-99000`. |
-| Publication worktree | Fresh checkout of `origin/master` used to append and push one result, then removed. |
+| Publication worktree | Fresh checkout of `origin/master` used to append one result and push its descriptor-backed PR branch, then removed. |
+| Trusted Actions publisher | Validates the exact result and descriptor from default-branch code and opens the benchmark-result PR. |
 
 Two commits describe different axes:
 
@@ -54,6 +55,7 @@ sequenceDiagram
     participant W as Preserved workspace
     participant P as Disposable publication worktree
     participant M as origin/master
+    participant A as Trusted publisher
 
     O->>L: run with optional filters
     L->>L: load suite and validate selectors
@@ -95,9 +97,12 @@ sequenceDiagram
         G-->>P: fresh publication checkout
         B->>P: append result.json by runId
         P->>P: validate and commit coordinate JSON
-        P->>M: push HEAD:master
-        M-->>P: push accepted
-        P-->>B: published commit
+        P->>P: write and commit descriptor
+        P->>M: push unique ai/** branch
+        M-->>A: Forge Branch Ready succeeds
+        A->>A: validate exact result and descriptor
+        A->>M: open benchmark-result PR
+        P-->>B: durable publication branch
         B->>G: remove publication worktree
         B->>W: write publication.json
         end
@@ -141,6 +146,7 @@ sequenceDiagram
     participant S as Source worktree
     participant P as Disposable publication worktree
     participant M as origin/master
+    participant A as Trusted publisher
 
     L->>R: execute benchmark cell
     alt workflow stops before terminal publication
@@ -158,10 +164,10 @@ sequenceDiagram
     B->>G: create publisher at origin/master
     G-->>P: fresh publication checkout
     B->>P: append result.json by runId
-    alt push succeeds
-        P->>M: push coordinate metrics
-        M-->>P: accepted
-        P-->>B: published commit
+    alt branch push succeeds
+        P->>M: push result and descriptor branch
+        M-->>A: validate and open PR asynchronously
+        P-->>B: publication branch accepted
         B->>G: remove publication worktree
         B->>W: write publication.json
         L->>S: remove disposable source
@@ -180,7 +186,8 @@ sequenceDiagram
     B->>M: fetch latest origin/master
     B->>G: create fresh publication worktree
     B->>P: append identical result by runId
-    P->>M: push coordinate metrics
+    P->>M: push result and descriptor branch
+    M-->>A: validate and open PR asynchronously
     B->>G: remove publication worktree
     B->>W: write publication.json
     L->>S: remove source
@@ -188,8 +195,9 @@ sequenceDiagram
 ```
 
 `result.json` is written before Git publication and is immutable for its
-`runId`. A retry either finds an identical remote entry or appends the
-same object. Different data with the same `runId` is an integrity error.
+`runId`. A retry either finds an identical merged entry, reuses its exact
+remote publication branch, or proposes the same object. Different data with
+the same `runId` is an integrity error.
 
 ## 4. Data locations
 
@@ -219,13 +227,18 @@ forge/local_repositories/code_coverage_benchmarks/
         logs/
 ```
 
-Only portable result lists enter the repository:
+Only portable result lists and their coordinate-local publication descriptors
+enter the publication branch:
 
 ```text
 code-coverage-benchmarks/
   <group>/
     <artifact>/
       <version>.json
+stats/
+  <group>/
+    <artifact>/
+      <version>/forge-publication.json
 ```
 
 `run.json` may contain machine-specific paths because it drives recovery.
@@ -274,14 +287,19 @@ Under that lock, every attempt:
 4. Sorts by timestamp and `runId`.
 5. Validates the complete coordinate list.
 6. Commits only that coordinate JSON path.
-7. Pushes to `origin/master`.
-8. Removes the publication worktree.
+7. Writes and validates a descriptor containing the exact result and path.
+8. Commits the descriptor as the tip commit.
+9. Pushes the unique `ai/**` publication branch.
+10. Removes the publication worktree.
 
-A push race repeats the sequence with another fresh worktree. An identical entry
-is success; a conflicting entry is rejected. The publication marker is last, so
-its presence means the portable result is durable and source cleanup may begin.
-Publication-worktree cleanup failure is operational state and must not
-reclassify a successful result. §FS-code-coverage-benchmarking.3
+Trusted Actions then validates that the branch is exactly the base list plus the
+descriptor's result and opens the pull request; feature-branch code never gets
+publication credentials. A retry reuses an identical remote branch or accepts
+an identical result already merged into `origin/master`; a conflicting entry is
+rejected. The publication marker is last, so its presence means the portable
+result is durable on a publication branch or already merged and source cleanup
+may begin. Publication-worktree cleanup failure is operational state and must
+not reclassify a successful result. §FS-code-coverage-benchmarking.3
 
 ## 7. Configuration and extension
 

--- a/forge/docs/code-coverage-benchmark-plan.md
+++ b/forge/docs/code-coverage-benchmark-plan.md
@@ -136,8 +136,9 @@ After finalization, render exactly one terminal task:
   `code-coverage-benchmark-publication` in a `benchmark-publication` state.
 
 Benchmark publication collects metrics, updates the coordinate JSON, validates
-it, commits it, and pushes it. It must not push generated source, create a Forge
-publication descriptor, open a pull request, or mutate an issue.
+it, commits it with a Forge publication descriptor, and pushes a unique `ai/**`
+branch that trusted Actions turn into a pull request. It must not push generated
+source, call the pull-request API, or mutate an issue.
 
 If Rhei stops before the terminal task, the outer launcher invokes the same
 idempotent collector so failed or partial executions are recorded.
@@ -158,15 +159,16 @@ idempotent. Keep entries ordered by timestamp.
 
 Publish immediately after each execution, not after the selected matrix
 finishes. For each result, fetch `origin/master`, create a fresh disposable
-worktree at that commit, append and push the result, then remove the worktree.
-A push race retries from a new worktree. Never reset or reuse a publication
+worktree at that commit, append the result, commit its descriptor, push the
+publication branch, then remove the worktree. Never reset or reuse a publication
 checkout; the preserved `result.json` is the retry input. Serialize local
 publishers. Commit subjects must be at most 60 characters.
 
 Write the normalized result into the preserved workspace before Git
-publication. Write a publication marker only after a successful push. Repeating
-publication for the same `runId` validates the identical entry instead of
-appending it again.
+publication. Write a publication marker only after a successful branch push or
+after finding the identical result already merged. Repeating publication for
+the same `runId` reuses the exact branch or validates the merged entry instead
+of appending it again.
 
 ## Initial metrics
 
@@ -201,7 +203,7 @@ Preserve every Rhei workspace locally after success or failure. Print its
 absolute path when the execution ends. Portable metrics retain the run ID and
 stable workspace name, not a machine-specific absolute path.
 
-Remove the disposable source worktree only after its result is pushed. If
+Remove the disposable source worktree only after its result branch is pushed. If
 collection or publication fails, retain both workspace and worktree. Provide a
 command that discovers workspaces without a publication marker and retries
 publication without rerunning coverage.
@@ -235,7 +237,7 @@ Do not commit or push runtime artifacts and logs in the initial implementation.
 - Complete and partial records validate and are idempotent.
 - An existing exact source-worktree path is replaced before creation.
 - A remaining creation failure skips that cell and the matrix continues.
-- Each result is pushed after its execution.
+- Each result is proposed through a descriptor-backed PR after its execution.
 - Workspaces remain; worktrees are removed only after publication.
 
 ## Later decisions

--- a/forge/docs/functional-spec/benchmarking.md
+++ b/forge/docs/functional-spec/benchmarking.md
@@ -190,39 +190,54 @@ name.
 
 A benchmark workspace routes successful finalization to a deterministic
 `code-coverage-benchmark-publication` task instead of the normal publication
-task. It must not push
-the generated source branch, publish a Forge branch descriptor, open a pull
-request, or change the synthetic issue.
+task. It must not push the generated source branch or change the synthetic
+issue. It publishes the compact benchmark result through the trusted Forge
+publication boundary: the local runner pushes a same-repository `ai/**` branch
+carrying the result and a benchmark-result publication descriptor, and trusted
+default-branch Actions validate that exact branch and open its pull request.
+The local runner must never call the pull-request API itself.
 
-Benchmark publication reads the finalized coverage record and Rhei accounting,
-writes the metrics record in §FS-code-coverage-benchmarking.4, and commits and
-pushes only that record to the same reachability-metadata repository. Results
-live in one JSON list per coordinate:
+Benchmark publication reads the finalized coverage record and Rhei accounting
+and writes the metrics record in §FS-code-coverage-benchmarking.4. Results live
+in one JSON list per coordinate:
 
 ```text
 code-coverage-benchmarks/<group>/<artifact>/<version>.json
 ```
 
-Every execution is appended immediately after it finishes, ordered by timestamp.
-Its `runId` is the idempotency key: retrying an identical result validates the
-existing entry instead of appending it again, while conflicting data for one
-run ID is rejected. Publication serializes local writers and creates a fresh
-disposable worktree from the latest `origin/master` for each result. It appends
-the result, commits, and pushes from that worktree, then removes it. A push race
-retries with another fresh worktree; publication never reuses or resets a
-publishing checkout.
+Every execution is proposed immediately after it finishes, ordered by
+timestamp. Its `runId` is the idempotency key: retrying an identical result
+validates either the entry already merged into `origin/master` or the exact
+open publication branch instead of creating another pull request, while
+conflicting data for one run ID is rejected. Publication serializes local
+writers and creates a fresh disposable worktree from the latest
+`origin/master` for each result. It appends the result, validates and commits
+the complete coordinate list, writes a descriptor that repeats the exact result
+and names its repository path, commits the descriptor at the required
+coordinate-local `stats/**/forge-publication.json` path, and pushes the unique
+publication branch. The worktree is then removed.
+
+The trusted publisher accepts a benchmark-result descriptor only when the
+branch changes exactly the coordinate result list and that one descriptor, the
+descriptor's coordinate determines both paths, the embedded result validates
+against the benchmark-result schema, and the list is exactly the base list plus
+that result. It opens one `rhei`-labeled pull request for the run and renders
+the run identity, status, configuration, coverage gain, and token totals from
+the validated descriptor. Repository CI and the normal merge boundary remain
+responsible for accepting it. §FS-forge-publication-readiness
 
 The outer launcher must invoke the same metrics collector when Rhei terminates
 before reaching benchmark publication. Thus a failed or partial workflow remains
 a benchmark result rather than disappearing from the comparison.
 
 The normalized result must be written into the workspace before Git publication,
-and a publication marker may be written only after a successful push. The
-source worktree may be removed only after that marker exists. The Rhei workspace
-must not be removed: it remains on the machine for later inspection of its
-reports, prompts, accounting, fixes, and work notes. If metrics writing or
-pushing fails, both the source worktree and workspace remain so completion can
-be retried without losing evidence.
+and a publication marker may be written only after the publication branch is
+durable or the identical result is already merged. The source worktree may be
+removed only after that marker exists. The Rhei workspace must not be removed:
+it remains on the machine for later inspection of its reports, prompts,
+accounting, fixes, and work notes. If metrics writing, descriptor validation, or
+branch pushing fails, both the source worktree and workspace remain so
+completion can be retried without losing evidence.
 
 The launcher provides a command that discovers workspaces without a publication
 marker and retries their result publication without rerunning coverage.

--- a/forge/docs/functional-spec/benchmarking.md
+++ b/forge/docs/functional-spec/benchmarking.md
@@ -221,7 +221,9 @@ The trusted publisher accepts a benchmark-result descriptor only when the
 branch changes exactly the coordinate result list and that one descriptor, the
 descriptor's coordinate determines both paths, the embedded result validates
 against the benchmark-result schema, and the list is exactly the base list plus
-that result. It opens one `rhei`-labeled pull request for the run and renders
+that result. It opens one pull request for the run, labeled `GenAI`,
+`code-coverage-improvement`, and `rhei` so the run sits in the same triage
+queue as the coverage-improvement PRs it measures, and renders
 the run identity, status, configuration, coverage gain, and token totals from
 the validated descriptor. Repository CI and the normal merge boundary remain
 responsible for accepting it. §FS-forge-publication-readiness

--- a/forge/git_scripts/publication_descriptor.py
+++ b/forge/git_scripts/publication_descriptor.py
@@ -87,19 +87,36 @@ def descriptor_input_from_pending_metrics(
 
 
 def build_publication_id(
-        issue_number: int,
+        issue_number: int | None,
         timestamp: str,
         coordinates: str,
         task_type: str,
+        *,
+        benchmark_run_id: str | None = None,
 ) -> str:
     """Build a stable ID from durable run facts so continuation reuses it."""
-    identity = json.dumps(
-        {
+    if issue_number is None:
+        if not benchmark_run_id:
+            raise ValueError("Issue-less publication requires a benchmark run ID")
+        identity_fields: dict[str, Any] = {
+            "benchmark_run_id": benchmark_run_id,
+            "timestamp": timestamp,
+            "coordinates": coordinates,
+            "task_type": task_type,
+        }
+        prefix = "benchmark"
+    else:
+        if benchmark_run_id is not None:
+            raise ValueError("Issue publication must not carry a benchmark run ID")
+        identity_fields = {
             "issue_number": issue_number,
             "timestamp": timestamp,
             "coordinates": coordinates,
             "task_type": task_type,
-        },
+        }
+        prefix = str(issue_number)
+    identity = json.dumps(
+        identity_fields,
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -107,7 +124,7 @@ def build_publication_id(
     compact_timestamp = re.sub(r"[^0-9]", "", timestamp)[:20]
     if not compact_timestamp:
         raise ValueError("Publication timestamp must contain a date or time")
-    return f"forge-{issue_number}-{compact_timestamp}-{digest}"
+    return f"forge-{prefix}-{compact_timestamp}-{digest}"
 
 
 def build_publication_branch(producer: str, branch_suffix: str, publication_id: str) -> str:

--- a/forge/tests/test_code_coverage_benchmark.py
+++ b/forge/tests/test_code_coverage_benchmark.py
@@ -485,6 +485,47 @@ class CodeCoverageBenchmarkMetricsTests(unittest.TestCase):
         self.assertEqual([], list(workspace.parent.glob("publisher-*")))
 
 
+class CodeCoverageBenchmarkTerminalResultTests(unittest.TestCase):
+    """A program state on a terminal edge owes Rhei a non-empty result."""
+
+    def test_writes_message_to_rhei_result_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "results" / "task.md"
+            with patch.dict("os.environ", {"RHEI_RESULT_PATH": str(path)}):
+                benchmark._write_terminal_result("Prepared benchmark run.")
+            self.assertEqual(
+                "Prepared benchmark run.\n",
+                path.read_text(encoding="utf-8"),
+            )
+
+    def test_is_a_no_op_without_the_environment_variable(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            benchmark._write_terminal_result("ignored")
+
+    def test_publication_records_its_own_terminal_result(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        workspace = root / "run-1" / "code-coverage-99000"
+        workspace.mkdir(parents=True)
+        result = {
+            "runId": "run-1",
+            "coordinate": "com.example:demo:1.0.0",
+            "status": "success",
+        }
+        path = root / "results" / "publication.md"
+
+        with patch.dict("os.environ", {"RHEI_RESULT_PATH": str(path)}), \
+                patch.object(benchmark, "_read_json", return_value={}), \
+                patch.object(benchmark, "_collect_result", return_value=result), \
+                patch.object(benchmark, "_publish_result", return_value="c" * 40):
+            benchmark.publish_workspace(workspace, requested_status="success")
+
+        recorded = path.read_text(encoding="utf-8")
+        self.assertIn("run-1", recorded)
+        self.assertIn("com.example:demo:1.0.0", recorded)
+
+
 class CodeCoverageBenchmarkTemplateTests(unittest.TestCase):
 
     def test_template_has_distinct_conversion_and_terminal_branches(self) -> None:

--- a/forge/tests/test_code_coverage_benchmark.py
+++ b/forge/tests/test_code_coverage_benchmark.py
@@ -424,7 +424,7 @@ class CodeCoverageBenchmarkMetricsTests(unittest.TestCase):
         with self.assertRaisesRegex(benchmark.BenchmarkError, "different metrics"):
             benchmark._merge_result(path, conflicting)
 
-    def test_publication_uses_one_disposable_worktree(self) -> None:
+    def test_publication_pushes_one_descriptor_backed_branch(self) -> None:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
         root = Path(temporary.name)
@@ -453,35 +453,60 @@ class CodeCoverageBenchmarkMetricsTests(unittest.TestCase):
         self._write_run(workspace)
         result = benchmark._collect_result(workspace, "failure", 1)
 
-        first_commit = benchmark._publish_result(repository, workspace, result)
-        second_commit = benchmark._publish_result(repository, workspace, result)
+        with patch.object(
+                benchmark,
+                "get_authenticated_login",
+                return_value="test-bot",
+        ):
+            first = benchmark._publish_result(repository, workspace, result)
+            second = benchmark._publish_result(repository, workspace, result)
 
-        self.assertEqual(first_commit, second_commit)
+        self.assertEqual(first, second)
+        self.assertFalse(first.already_merged)
+        self.assertIsNotNone(first.branch)
         metrics_path = "code-coverage-benchmarks/com.example/demo/1.0.0.json"
         stored = _git(
             repository,
             "show",
-            f"{second_commit}:{metrics_path}",
+            f"{first.commit}:{metrics_path}",
         ).stdout
         self.assertEqual([result], json.loads(stored))
         self.assertEqual(
-            benchmark.COMMIT_SUBJECT,
+            benchmark.DESCRIPTOR_COMMIT_SUBJECT,
             _git(
                 repository,
                 "show",
                 "-s",
                 "--format=%s",
-                second_commit,
+                first.commit,
             ).stdout.strip(),
         )
+        descriptor_path = "stats/com.example/demo/1.0.0/forge-publication.json"
+        descriptor = json.loads(
+            _git(repository, "show", f"{first.commit}:{descriptor_path}").stdout
+        )
+        self.assertEqual(benchmark.BENCHMARK_TASK_TYPE, descriptor["task_type"])
+        self.assertEqual("run-1", descriptor["benchmark_run_id"])
+        self.assertEqual(result, descriptor["render"]["benchmark_result"])
+        master_object = subprocess.run(
+            ["git", "cat-file", "-e", f"origin/master:{metrics_path}"],
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(0, master_object.returncode)
         changed = _git(
             repository,
-            "show",
-            "--pretty=",
+            "diff",
             "--name-only",
-            second_commit,
+            "origin/master",
+            first.commit,
         ).stdout.splitlines()
-        self.assertEqual([metrics_path], [line for line in changed if line])
+        self.assertEqual(
+            sorted((metrics_path, descriptor_path)),
+            sorted(line for line in changed if line),
+        )
         self.assertEqual([], list(workspace.parent.glob("publisher-*")))
 
 
@@ -518,7 +543,13 @@ class CodeCoverageBenchmarkTerminalResultTests(unittest.TestCase):
         with patch.dict("os.environ", {"RHEI_RESULT_PATH": str(path)}), \
                 patch.object(benchmark, "_read_json", return_value={}), \
                 patch.object(benchmark, "_collect_result", return_value=result), \
-                patch.object(benchmark, "_publish_result", return_value="c" * 40):
+                patch.object(
+                    benchmark,
+                    "_publish_result",
+                    return_value=benchmark.BenchmarkPublication(
+                        "c" * 40, "ai/test/benchmark", "forge-benchmark-id", False,
+                    ),
+                ):
             benchmark.publish_workspace(workspace, requested_status="success")
 
         recorded = path.read_text(encoding="utf-8")

--- a/forge/tests/test_forge_pr_publisher_benchmark.py
+++ b/forge/tests/test_forge_pr_publisher_benchmark.py
@@ -139,6 +139,13 @@ class BenchmarkResultPublisherTests(unittest.TestCase):
         self.assertIn("- Failure phase: `api`", body)
         self.assertNotIn("Fixes:", body)
 
+    def test_route_labels_join_the_coverage_queue(self) -> None:
+        """A benchmark result is triaged next to the coverage work it measures."""
+        self.assertEqual(
+            publisher.ROUTE_LABELS["code-coverage-benchmark-result"],
+            ["GenAI", "code-coverage-improvement", "rhei"],
+        )
+
     def test_accepts_exactly_one_result_appended_to_the_base(self) -> None:
         descriptor = _descriptor()
         result_path = "code-coverage-benchmarks/com.example/demo/1.0.0.json"

--- a/forge/tests/test_forge_pr_publisher_benchmark.py
+++ b/forge/tests/test_forge_pr_publisher_benchmark.py
@@ -1,0 +1,175 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cover trusted benchmark-result publication. §FS-code-coverage-benchmarking.3"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUBLISHER_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "publisher.py",
+)
+SCHEMA_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "schema.json",
+)
+
+
+def _load_publisher() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "forge_pr_publisher_benchmark", PUBLISHER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+publisher = _load_publisher()
+
+
+def _phase(before: int, after: int) -> dict[str, Any]:
+    return {
+        "coverPasses": 1,
+        "fixInvocations": 0,
+        "tokens": {"input": 10, "cachedInputRead": 20, "output": 3},
+        "coverage": {
+            "coveredBefore": before,
+            "coveredAfter": after,
+            "methodsGained": after - before,
+            "percentagePointsGained": float(after - before),
+            "allMethods": 100,
+        },
+    }
+
+
+def _result() -> dict[str, Any]:
+    return {
+        "schemaVersion": "1.0.0",
+        "runId": "run-1",
+        "timestamp": "2026-09-08T13:03:29Z",
+        "benchmarkSuiteCommit": "a" * 40,
+        "runnerCommit": "b" * 40,
+        "coordinate": "com.example:demo:1.0.0",
+        "workspaceName": "code-coverage-99000",
+        "agent": "pi",
+        "configuredModel": "gpt-5.6-sol",
+        "observedModel": "openai-codex/gpt-5.6-sol",
+        "thinking": "high",
+        "status": "failure",
+        "failure": {"phase": "api", "exitCode": 1},
+        "checkedInAllMethods": 100,
+        "measuredAllMethodsDifference": 0,
+        "api": _phase(10, 20),
+        "deep": _phase(20, 25),
+        "total": _phase(10, 25),
+    }
+
+
+def _descriptor() -> dict[str, Any]:
+    result = _result()
+    descriptor: dict[str, Any] = {
+        "schema_version": 1,
+        "publication_id": "pending",
+        "timestamp": result["timestamp"],
+        "branch": "pending",
+        "producer": "kimeta",
+        "base_commit": "0" * 40,
+        "issue_number": None,
+        "benchmark_run_id": result["runId"],
+        "library": {
+            "group": "com.example",
+            "artifact": "demo",
+            "version": "1.0.0",
+            "coordinates": result["coordinate"],
+        },
+        "task_type": "code-coverage-benchmark-result",
+        "template_type": "code-coverage-benchmark-result",
+        "metrics": None,
+        "local_ci_verification": {
+            "status": "success",
+            "base_commit": "0" * 40,
+            "final_commit": "1" * 40,
+            "commands": [],
+            "fixups": [],
+            "repo_fix_paths": [],
+            "human_intervention_required": False,
+        },
+        "forge": {"monitored_branch": "master", "branch": "master", "commit": "2" * 40},
+        "modifiers": {
+            "chunked_dynamic_access": False,
+            "chunk_final": True,
+            "human_intervention": False,
+        },
+        "follow_ups": [],
+        "render": {"benchmark_result": result},
+    }
+    publication_id = publisher._build_publication_id(descriptor)
+    descriptor["publication_id"] = publication_id
+    descriptor["branch"] = f"ai/kimeta/benchmark-demo-{publication_id}"
+    return descriptor
+
+
+class BenchmarkResultPublisherTests(unittest.TestCase):
+
+    def test_descriptor_is_schema_valid_and_has_no_issue(self) -> None:
+        descriptor = _descriptor()
+        with open(SCHEMA_PATH, encoding="utf-8") as schema_file:
+            schema = json.load(schema_file)
+
+        Draft202012Validator(schema, format_checker=FormatChecker()).validate(descriptor)
+        self.assertIsNone(descriptor["issue_number"])
+        self.assertTrue(descriptor["publication_id"].startswith("forge-benchmark-"))
+
+    def test_renders_result_without_an_issue_reference(self) -> None:
+        title, body = publisher.render_publication(_descriptor())
+
+        self.assertIn("[Benchmark] Record com.example:demo:1.0.0 result", title)
+        self.assertIn("- Status: `failure`", body)
+        self.assertIn("- Covered methods: 10 → 25", body)
+        self.assertIn("- Failure phase: `api`", body)
+        self.assertNotIn("Fixes:", body)
+
+    def test_accepts_exactly_one_result_appended_to_the_base(self) -> None:
+        descriptor = _descriptor()
+        result_path = "code-coverage-benchmarks/com.example/demo/1.0.0.json"
+        descriptor_path = "stats/com.example/demo/1.0.0/forge-publication.json"
+
+        with patch.object(
+                publisher,
+                "_json_value_at_commit",
+                side_effect=lambda commit, _path: [descriptor["render"]["benchmark_result"]]
+                if commit == "head" else [],
+        ), patch.object(publisher, "_git_object_exists", return_value=True):
+            publisher._validate_benchmark_result_publication(
+                descriptor=descriptor,
+                descriptor_path=descriptor_path,
+                head_sha="head",
+                base_commit="base",
+                changed_paths=sorted((descriptor_path, result_path)),
+            )
+
+    def test_rejects_an_unrelated_changed_path(self) -> None:
+        descriptor = _descriptor()
+
+        with self.assertRaisesRegex(ValueError, "exactly"):
+            publisher._validate_benchmark_result_publication(
+                descriptor=descriptor,
+                descriptor_path="stats/com.example/demo/1.0.0/forge-publication.json",
+                head_sha="head",
+                base_commit="base",
+                changed_paths=["README.md"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why benchmark publication needed a PR boundary

The benchmark runner wrote compact results directly to `master`, while every other Forge publication already uses a branch that trusted Actions validate before `graalvmbot` opens a pull request. Rhei program states also need to write their terminal result artifact or a successful program can stall at its final edge.

This moves benchmark results onto the same trusted boundary defined by §forge/FS-code-coverage-benchmarking.3 and keeps direct pull-request credentials out of the local runner.

## How one result is published

1. The runner appends and schema-validates one result in a fresh `origin/master` worktree.
2. It commits the result and a coordinate-local Forge descriptor.
3. It pushes a unique `ai/**` branch whose publication ID includes the result timestamp and stable run identity.
4. Default-branch publisher code verifies that the diff is exactly the base result list plus that result and descriptor.
5. `graalvmbot` opens the PR with the fixed `GenAI` and `rhei` labels.

Retries reuse the same remote branch, accept an identical result already merged into `master`, and reject conflicting data for the same run ID. The preserved H2 benchmark failure is included so it is not lost while this publication fix lands.

## Terminal program completion

Benchmark conversion and publication now write `RHEI_RESULT_PATH` after their durable work completes, allowing Rhei to advance terminal program states normally.