### PR TITLE
Give every review finding a disposition

### DIFF
--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -14,23 +14,24 @@ Image is normative in the test contract (§FS-test-contract), which makes
 content is normative in §FS-repository-functional-spec.5.1. This contract does
 not restate those rules. It adds only what review needs on top of them: the
 strength of each rule, the contribution-shape limits that can be checked
-algorithmically, the coverage gates, and the enumerated ways a contribution can
-cheat. Review skills and review automation implement this contract and must not
-contradict it.
+algorithmically, the coverage gates, the enumerated ways a contribution can
+cheat, and what a reviewer must do about each of them. Review skills and review
+automation implement this contract and must not contradict it.
 
 ## 1. Rule strength
 
 Every rule is either a **must** or a **should**:
 
 - A **must** holds unconditionally. A concrete must violation blocks the
-  contribution: review requests changes, and the violation is repaired, not
-  argued around. The musts are §FS-test-contract.1 (what a test must have),
+  contribution: the violation is repaired, not argued around, and
+  §FS-contribution-contract.5 decides who repairs it. The musts are
+  §FS-test-contract.1 (what a test must have),
   §FS-test-contract.2 (what it must not do), §FS-test-contract.4 (the Native
   Image execution contract), and sections 2–4 of this contract.
 - A **should** guides generation and repair. The shoulds are
   §FS-test-contract.3 (what a test should do). In review they are advisory: a
-  reviewer may mention a should violation but must not block on it, and
-  automated review must not request changes for one.
+  reviewer may mention a should violation but must not block on it, must not
+  repair on it, and automated review must not request changes for one.
 
 Reviewers block only on a concrete violation of an enumerated must — never on
 self-formed judgments of test quality, test depth, scope taste, or "end-user
@@ -107,8 +108,9 @@ When a scope fails, the reviewer must investigate why before deciding. The
 analysis uses available evidence such as the old and new stats, test diff,
 upstream API or runtime changes, and CI output. The review states the supported
 cause; when the evidence does not establish one, it states that the cause is
-unknown and asks for an explanation. A reviewer must not present speculation as
-the cause of a regression.
+unknown and escalates under §FS-contribution-contract.5.5 rather than deciding
+on a guess. A reviewer must not present speculation as the cause of a
+regression.
 
 PRs with the `chunked-dynamic-access` label are exempt from every percentage
 and repair-comparison gate in this section, including the final chunk. A chunk
@@ -139,9 +141,10 @@ issue-requested metadata gate still apply.
 
 A contribution cheats when its evidence — a green test, a coverage number, a
 metadata entry — does not mean what it claims. Each pattern below is a must
-violation; review states the concrete pattern found and blocks. Where a
-pattern violates a test-contract point, the cited point is the rule; this
-section fixes the review bar for detecting it.
+violation; review states the concrete pattern found, blocks, and takes the
+disposition §FS-contribution-contract.5 assigns it. Where a pattern violates a
+test-contract point, the cited point is the rule; this section fixes the review
+bar for detecting it.
 
 1. **Scaffold-only test** (§FS-test-contract.1.3). The review bar is exact:
    a test is "scaffold" only when its body is still the unmodified placeholder
@@ -191,3 +194,144 @@ the new-library bars for scaffold history or package placement to inherited
 baseline tests — compatibility branches and existing layouts stay acceptable —
 but every pattern above remains blocking wherever it appears in the changed
 code.
+
+## 5. Review disposition
+
+A review is not finished when it has a verdict. Every review ends in exactly
+one disposition, chosen by the first case below that applies. The ladder exists
+because a generated contribution has no author waiting to answer a review: the
+automation that opened the pull request has moved on, so a finding left on it
+stalls the queue instead of resolving it (§forge/FS-automated-pr-review).
+Whoever reviews is the party that acts.
+
+The dispositions are approve, repair, close, and escalate. Approval means every
+must in this contract holds on the tree that will merge — including after a
+repair. Closing is available only where a rule in this contract says a
+contribution must be closed, which today is §FS-contribution-contract.5.4
+alone; absent such a rule, a contribution the reviewer cannot bring inside the
+rules escalates (§FS-contribution-contract.5.5).
+
+### 5.1 A violation inside the contribution is repaired, not reported
+
+When the violation is in the contribution's own files and the reviewer can
+bring it inside the rules, the reviewer makes the change on the pull request's
+head and re-runs the gates that change affects. Recording the finding and
+stopping is not a disposition for generated work: the pre-push review already
+repairs what it finds (§forge/FS-local-branch-review), and the published-PR
+review must not be weaker than the review that preceded it.
+
+Requesting changes is a disposition only when a human author will act on it. On
+a generated contribution it is §FS-contribution-contract.5.5 wearing a review's
+clothes, and it must be recorded as such, so the pull request carries the
+`human-intervention` label a maintainer triages rather than a request nobody
+reads.
+
+A repair is bound by every rule the contribution was bound by. In particular a
+repair must not weaken the evidence to reach a green result: deleting tests,
+disabling test classes, dropping assertions, swallowing the failing exception,
+or reducing a test to triviality is the same violation whether the generator or
+the reviewer commits it (§FS-test-contract.2.9). The review states what it
+changed and why, so the repair is reviewable as a change and not only as an
+outcome.
+
+One removal is not a weakening: dropping a scenario that targets behavior
+Native Image cannot support (§FS-test-contract.4.5) when the refusal cannot be
+verified. Where none of the three proofs of §FS-test-contract.4.3.1 can be
+obtained — the library catches GraalVM's `UnsupportedFeatureError` and leaves
+nothing behind — the scenario can be neither tolerated nor made to pass, so
+keeping it only turns a repairable contribution into an unexplained failure.
+The sanctioned repair is the re-scope of §FS-test-contract.4.3.2: drop that
+scenario and cover the rest of the library's public surface. Three conditions
+bound it, and the review states all three. The unsupported mechanism is named
+concretely, not inferred from a red test. The scenario's failure is genuinely
+unverifiable; a refusal the helper can prove is tolerated with the helper
+instead of deleted. And what remains still exercises the library's public API
+and carries the metadata the contribution ships, with the gates of
+§FS-contribution-contract.3 applied to the re-scoped result and not to the
+tree the reviewer started from. When nothing survives the re-scope, the version
+is unsupportable and the disposition is §FS-contribution-contract.5.4.
+
+### 5.2 A repair stays inside the contribution's file set
+
+The closed file set of §FS-contribution-contract.2 bounds the repair exactly as
+it bounds the contribution. A fix that can only be made by editing build logic,
+the test harness, workflows, the allowed-image scanning machinery — as distinct
+from the single allowed-Docker-image entry §FS-contribution-contract.2 admits
+when the test requires it — or another coordinate is not a repair; it is
+§FS-contribution-contract.5.3.
+
+The recurring form is a test that fails because of a defect in a shared Gradle
+task or harness class. It is repaired by changing the test, or it is not
+repaired here at all. Editing the shared code inside the contribution makes one
+library's pull request carry a repository-wide behavior change through a review
+scoped to one coordinate, and that change reaches master with no reviewer
+having weighed its effect on every other library. The contribution's own
+directories are the only place a reviewer's edit belongs.
+
+### 5.3 A defect in shared infrastructure becomes its own issue
+
+When the cause of a failure is in shared repository infrastructure — build
+logic, the test harness, CI workflows, image scanning, or publication — the
+contribution is not what is wrong, and nothing the reviewer does inside it can
+be the fix. The reviewer, in order:
+
+1. finds the open issue that already tracks the defect, or opens one describing
+   the failure, its cause, and the evidence — one issue per defect, never one
+   per pull request that met it;
+2. comments on the pull request naming that issue and stating that the
+   contribution is blocked on it rather than on its own content;
+3. takes the escalation of §FS-contribution-contract.5.5 for the pull request
+   itself.
+
+An infrastructure defect is met by many contributions. Repairing it inside each
+one hides how often it recurs, splits one change across several unrelated
+diffs, and leaves the repository's shared code changed by whichever pull
+request happened to arrive first. One issue per defect keeps the recurrence
+visible and the fix reviewable on its own terms.
+
+This case is a defect in the repository's own code, which is distinct from a
+transient external failure such as a rate limit, a registry outage, or a
+network error. A transient failure is retried or waited out, and becomes
+neither an issue nor an escalation (§forge/FS-human-intervention-policy).
+
+### 5.4 A library version Native Image cannot support is closed
+
+A library version is unsupportable when the dynamic access it performs is
+reachable only through behavior Native Image does not support
+(§FS-test-contract.4.5): the library guards that access itself, the guard fails
+under Native Image whatever the metadata registers, and the library then falls
+back or degrades. No metadata entry changes the outcome and no test can cover
+the calls, so the coverage gates of §FS-contribution-contract.3 are unreachable
+by construction rather than unmet by this attempt. Reflective access to JDK
+internals that Native Image substitutes and withholds from reflection is the
+recurring shape.
+
+The evidence bar is the mechanism, not the number. The review names the
+concrete unsupported behavior and shows the library's dynamic-access call sites
+standing behind it. Coverage that is merely low, a test that is merely hard to
+write, or a failure not yet diagnosed is §FS-contribution-contract.5.1 or
+§FS-contribution-contract.5.5 — never this.
+
+Where it holds, the contribution is closed rather than repaired or escalated,
+because metadata no test can justify is not shipped (§GOAL-tested-metadata).
+The reviewer closes the pull request with that explanation, labels the linked
+issue `library-unsupported-version`, and closes that issue rather than
+returning it to the work queue: an open request in `Todo` is claimed again and
+spends the same budget on the same wall. Where a library change could remove
+the guard, the incompatibility is reported upstream. This is the library-level
+counterpart of the test-level case in §FS-test-contract.4.3.2.
+
+### 5.5 Everything else is handed to a maintainer
+
+A contribution the reviewer cannot bring inside the rules, and that no rule
+condemns to §FS-contribution-contract.5.4, is labeled `human-intervention` and
+commented on. It is not closed, and it is not approved. The comment states the
+rule at issue, what the reviewer tried, and what it could not decide, so a
+maintainer continues from the review instead of re-deriving it
+(§forge/FS-human-intervention-policy).
+
+Uncertainty is this case. A reviewer that cannot tell whether a must is
+violated escalates instead of resolving the doubt in either direction:
+approving an unclear contribution ships metadata that may be unjustified, and
+closing one throws away work no rule condemns. Escalation is the only
+disposition whose cost is bounded by a maintainer's attention.

--- a/docs/functional-spec/test-contract.md
+++ b/docs/functional-spec/test-contract.md
@@ -495,7 +495,9 @@ signature to close the gap. Instead, in order:
    This is the usual outcome and it keeps the shipped metadata justified.
 2. **If no public API works, the version is unsupportable.** Metadata no test
    justifies is not shipped: close the pull request, label the issue
-   `library-unsupported-version`, and report the incompatibility upstream.
+   `library-unsupported-version`, and report the incompatibility upstream, as
+   §FS-contribution-contract.5.4 sets out for the same case reached from the
+   library's side.
 
 ### 4.4 No dependence on resource metadata for machine-local paths
 

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -512,6 +512,10 @@ Forge's responsibility boundary, including:
 - The pre-push review found something it could not correct, or its repair did
   not survive finalization and the gate, so the branch publishes with the
   finding still open (§FS-local-branch-review).
+- The published-PR review reached the escalation of the disposition ladder: a
+  rule violation it could not repair inside the contribution's file set, or a
+  defect in shared repository infrastructure that the contribution must not
+  carry and that now has its own issue (§root/FS-contribution-contract.5).
 
 Forge must not use `human-intervention` for failures that are only external or
 transient infrastructure conditions. The issue-side classification is by failure
@@ -595,6 +599,25 @@ Review labels select the review rule set. `library-new-request`,
 own review expectations. The review prompt or skill must apply the rules for
 the PR's label rather than using generic code-review judgment alone.
 
+**The review disposition ladder decides the outcome.** Finding a violation is
+half of a review; §root/FS-contribution-contract.5 fixes what follows, and
+review automation is bound by it. The reviewer repairs the contribution on the
+pull request's head when the fix lies inside the contribution's file set, opens
+or links an infrastructure issue and escalates when the cause is shared
+repository code, closes an unsupportable library version, and otherwise labels
+the pull request `human-intervention` with a comment stating what it could not
+decide. A generated pull request has no author to answer a requested-changes
+review, so submitting one is the escalation of §root/FS-contribution-contract.5.5
+and must carry that label rather than stand alone.
+
+A repair is pushed to the pull request's head, which restarts its checks exactly
+as a conflict-refresh push does. Review and merge therefore belong to a later
+pass: Forge must re-read the checks and the review decision after a repair push
+rather than carrying pre-repair state forward, and the approval is earned against
+the repaired head. A reviewer that cannot push to the head — a fork, or a
+permission failure — takes the escalation path instead, because a repair the
+pull request never receives is not a disposition.
+
 Review automation must skip PRs already labeled `human-intervention`. That
 label means maintainer judgment is required before normal automated review may
 continue, per §FS-human-intervention-policy. A PR labeled
@@ -615,19 +638,21 @@ analysis agent, model, and provider. Neither check may invoke a model. The
 review agent is trusted automation acting on Forge's behalf: it must run in an
 execution environment that can use the authenticated `gh` session without an
 interactive approval boundary, inspect the live pull request and its checked-out
-diff, and submit the approval or requested-changes review itself. Forge does not
-parse an agent verdict and resubmit it through a second GitHub client. An
+diff, commit and push a repair to a same-repository head, and submit the
+approval or requested-changes review itself. Forge does not parse an agent
+verdict and resubmit it through a second GitHub client. An
 authentication failure, timeout, or unsuccessful agent turn must stop processing
 that review rather than being treated as an approval. This agent contract is
 unchanged for every pull request without a reusable attestation.
 
-Automated review may add or request the `human-intervention` PR label only when
-the applicable label-specific review rules say the result cannot be handled by
-a normal approval or requested-changes review. Review uncertainty, transient CI
-noise, GitHub status/API failures, Maven download failures, or other external
-infrastructure errors must not be converted into `human-intervention` unless
-the review rules identify a semantic generated-result, repository-automation,
-metadata, or library-execution problem that requires maintainer judgment
+Automated review adds the `human-intervention` PR label exactly where
+§root/FS-contribution-contract.5.5 assigns the escalation: a rule violation the
+reviewer could not repair inside the contribution's file set, a defect in shared
+repository infrastructure once its issue exists, or a judgment the reviewer could
+not make. Transient CI noise, GitHub status/API failures, Maven download
+failures, and other external infrastructure errors are none of those and must not
+be converted into `human-intervention`; they are retried or waited out, and the
+review runs again once the transient condition clears
 (§FS-human-intervention-policy).
 
 **A conflict that needs no judgment is resolved, not escalated.** A pull request

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -107,7 +107,23 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
    - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
 
+## Disposition
+
+Finding a violation is half the review. **Read §FS-contribution-contract.5 and take the disposition it assigns** — `grund FS-contribution-contract.5 --full`, or section 5 of `docs/functional-spec/contribution-contract.md` in the checkout. That section is authoritative and this table is only a dispatch: it tells you which case you are in, not what the case permits. You are the party that acts, because the PR was generated and no author is waiting to answer a review comment.
+
+| Case | When | What you do |
+|---|---|---|
+| 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
+| 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
+| 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
+
+Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+
 ## Decision Rules
+
+These decide the verdict. **Disposition** above decides what you then do with it: a violation you can correct inside the PR's own files is repaired and pushed, not requested from an author who is not there.
 
 Approve when all of these are true:
 
@@ -126,7 +142,7 @@ Request changes when any of these are true:
 Ask for follow-up instead of rejecting when:
 
 - Stats needed for the old/new version comparison are missing or stale.
-- CI failed in a way that looks like infrastructure noise.
+- CI failed in a way that looks like infrastructure noise. A transient external failure is waited out; a reproducible defect in the repository's own code is case 5.3 of **Disposition** (§FS-contribution-contract.5.3).
 - A failing repair-coverage scope may reflect a plausible upstream API or runtime change, but the PR does not explain it.
 
 ## Output Style

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -104,7 +104,23 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
    - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
 
+## Disposition
+
+Finding a violation is half the review. **Read §FS-contribution-contract.5 and take the disposition it assigns** — `grund FS-contribution-contract.5 --full`, or section 5 of `docs/functional-spec/contribution-contract.md` in the checkout. That section is authoritative and this table is only a dispatch: it tells you which case you are in, not what the case permits. You are the party that acts, because the PR was generated and no author is waiting to answer a review comment.
+
+| Case | When | What you do |
+|---|---|---|
+| 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
+| 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
+| 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
+
+Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+
 ## Decision Rules
+
+These decide the verdict. **Disposition** above decides what you then do with it: a violation you can correct inside the PR's own files is repaired and pushed, not requested from an author who is not there.
 
 Approve when all of these are true:
 
@@ -123,7 +139,7 @@ Request changes when any of these are true:
 Ask for follow-up instead of rejecting when:
 
 - Stats needed for the old/new version comparison are missing or stale.
-- CI failed in a way that looks like infrastructure noise.
+- CI failed in a way that looks like infrastructure noise. A transient external failure is waited out; a reproducible defect in the repository's own code is case 5.3 of **Disposition** (§FS-contribution-contract.5.3).
 - A failing repair-coverage scope may reflect a plausible upstream API or runtime change, but the PR does not explain it.
 
 ## Output Style

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -103,7 +103,23 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly targets only one failing lane and the other failure is unrelated infrastructure noise.
    - If CI is flaky but the diff and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
 
+## Disposition
+
+Finding a violation is half the review. **Read §FS-contribution-contract.5 and take the disposition it assigns** — `grund FS-contribution-contract.5 --full`, or section 5 of `docs/functional-spec/contribution-contract.md` in the checkout. That section is authoritative and this table is only a dispatch: it tells you which case you are in, not what the case permits. You are the party that acts, because the PR was generated and no author is waiting to answer a review comment.
+
+| Case | When | What you do |
+|---|---|---|
+| 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
+| 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
+| 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
+
+Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+
 ## Decision Rules
+
+These decide the verdict. **Disposition** above decides what you then do with it: a violation you can correct inside the PR's own files is repaired and pushed, not requested from an author who is not there.
 
 Approve when all of these are true:
 
@@ -122,7 +138,7 @@ Request changes when any of these are true:
 Ask for follow-up instead of rejecting when:
 
 - Stats needed for the old/new version comparison are missing or stale.
-- CI failed in a way that looks like infrastructure noise.
+- CI failed in a way that looks like infrastructure noise. A transient external failure is waited out; a reproducible defect in the repository's own code is case 5.3 of **Disposition** (§FS-contribution-contract.5.3).
 - A failing repair-coverage scope may reflect a plausible upstream API or runtime change, but the PR does not explain it.
 
 ## Output Style

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -65,12 +65,26 @@ Work through the steps in order. Each step cites the Review Signals (by number, 
 
 6. Check validation status.
    - Expected minimum: metadata validation and library test jobs for the target coordinates are green.
-   - If the PR is small and the review concerns correctness rather than infra noise, prefer asking for code changes over rerunning CI.
+   - If the PR is small and the review concerns correctness rather than infra noise, repair the PR under **Disposition** rather than rerunning CI.
    - If CI is flaky but the content is otherwise solid, ask for a rerun after the review issues are resolved.
+
+## Disposition
+
+Finding a violation is half the review. **Read §FS-contribution-contract.5 and take the disposition it assigns** — `grund FS-contribution-contract.5 --full`, or section 5 of `docs/functional-spec/contribution-contract.md` in the checkout. That section is authoritative and this table is only a dispatch: it tells you which case you are in, not what the case permits. You are the party that acts, because the PR was generated and no author is waiting to answer a review comment.
+
+| Case | When | What you do |
+|---|---|---|
+| 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
+| 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
+| 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
+
+Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
 
 ## Output Style
 
-Match the concise review style already used in this repository:
+Match the concise review style already used in this repository. Each line below is what you say about the violation; **Disposition** above decides whether you say it in a repair note, in a blocked-on-infrastructure comment, in a close, or in a `human-intervention` comment.
 
 - For scaffold-only tests: say that tests must differ from the scaffold and should not be accepted as-is.
 - For native skips that does not depend on the open-ended dynamic class loading: say that the PR avoids the failing native path instead of fixing it, so it does not demonstrate native-image runtime coverage.

--- a/skills/review-library-update-request/SKILL.md
+++ b/skills/review-library-update-request/SKILL.md
@@ -99,7 +99,23 @@ The PR number or URL can be passed as an optional argument (for example, `1234`,
    - If current-defaults and future-defaults lanes both run, both should pass unless the PR clearly explains an unrelated infrastructure issue.
    - If CI is flaky but the diff, issue-requested metadata, and coverage comparison are sound, ask for a rerun instead of blocking on speculation.
 
+## Disposition
+
+Finding a violation is half the review. **Read §FS-contribution-contract.5 and take the disposition it assigns** — `grund FS-contribution-contract.5 --full`, or section 5 of `docs/functional-spec/contribution-contract.md` in the checkout. That section is authoritative and this table is only a dispatch: it tells you which case you are in, not what the case permits. You are the party that acts, because the PR was generated and no author is waiting to answer a review comment.
+
+| Case | When | What you do |
+|---|---|---|
+| 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
+| 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
+| 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
+
+Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+
 ## Decision Rules
+
+These decide the verdict. **Disposition** above decides what you then do with it: a violation you can correct inside the PR's own files is repaired and pushed, not requested from an author who is not there.
 
 Approve when all of these are true:
 
@@ -124,7 +140,7 @@ Ask for follow-up instead of rejecting when:
 
 - Previous/new stats needed for the percentage comparison are missing or stale.
 - The linked issue request is ambiguous and the PR needs a short explanation tying metadata and tests to the reporter's failure.
-- CI failed in a way that looks like infrastructure noise.
+- CI failed in a way that looks like infrastructure noise. A transient external failure is waited out; a reproducible defect in the repository's own code is case 5.3 of **Disposition** (§FS-contribution-contract.5.3).
 
 ## Output Style
 


### PR DESCRIPTION
Stacked on #9934 — its five commits ride along here; the new work is the last commit, `Spec: reviewers repair generated PRs, not report them`.

## What this does

The contribution contract says what a reviewer may block on and nothing about what happens next. Every rule ends in "block", and blocking a generated pull request is a dead end: Forge opened it and moved on, so a requested-changes review sits in the queue with nobody to answer it. Three open PRs show the three ways that gap gets filled by improvisation — #9903 sits on `human-intervention` for a coverage gate the library can never meet, #9765 "fixed" a contribution by editing `GrypeTask.java` so one library's PR now carries a repository-wide change, and a reviewer that is merely unsure has no defined move at all.

This adds §FS-contribution-contract.5: a five-case ladder that assigns exactly one disposition to every finding, so the reviewer is the party that acts.

## The ladder

First matching case wins.

| | Case | Disposition |
|---|---|---|
| 5.1 | Violation is in the contribution's own files | **Repair** on the PR head, push, re-run the affected gates |
| 5.2 | The only fix is build logic, harness, workflows, another coordinate | **Not a repair** — revert such a change if the PR carries one, then 5.3 |
| 5.3 | Cause is a defect in shared repository code | **One issue per defect**, comment that the PR is blocked on it, then 5.5 |
| 5.4 | Library's dynamic access is reachable only through unsupported Native Image behavior | **Close** the PR, label the linked issue `library-unsupported-version`, close it too |
| 5.5 | Anything else, uncertainty included | **`human-intervention`** plus a comment saying what was tried |

Closing is available only where a rule says so — today 5.4 alone. Anything the reviewer cannot bring inside the rules escalates rather than disappearing.

## Why the cases are drawn where they are

**Repairing is not a new power.** The pre-push review already repairs what it finds — §FS-local-branch-review: "on a finding the reviewer must both record it and, when it can, correct it in the worktree in the same pass". The published-PR review was the weaker of the two for no reason. §FS-contribution-contract.5.1 also closes the loophole that opens with it: a repair is bound by every rule the contribution was bound by, so fix-by-weakening is the same violation whether the generator or the reviewer commits it (§FS-test-contract.2.9).

One removal is exempt, and it is the one #9934 just wrote for the generator: dropping a scenario that targets behavior Native Image cannot support **when the refusal cannot be proved**. Where none of the three proofs of §FS-test-contract.4.3.1 can be obtained, the scenario can be neither tolerated nor made to pass, and re-scoping the test to API that works is §FS-test-contract.4.3.2's own answer. Three conditions bound it: the mechanism is named concretely rather than inferred from a red test, the failure is genuinely unverifiable, and §FS-contribution-contract.3's gates are re-checked against the re-scoped result — shrinking the test shrinks the evidence, and the shrunken evidence is what must clear the gate.

**An infrastructure defect gets one issue, not one repair per PR.** #9765 is the shape: a scan failure in `GrypeTask` was repaired inside a microcks contribution, so a repository-wide behavior change reaches master through a review scoped to one coordinate, and the recurrence is invisible because it was never written down anywhere. §FS-contribution-contract.5.3 splits it — find or open one issue for the defect, comment on the PR that it is blocked on that issue rather than on its own content, escalate the PR — and keeps it distinct from a transient external failure, which is retried or waited out rather than filed.

**Some library versions cannot be supported at all.** #9903's six dynamic-access calls all sit inside `PrivateLoomSupport`, which reflects on `VirtualThread.DEFAULT_SCHEDULER` — a field Native Image substitutes and withholds from reflection. The guard fails whatever the metadata registers, so the 20% gate is unreachable by construction rather than unmet by that attempt. §FS-contribution-contract.5.4 makes that a close, with the evidence bar on the mechanism rather than the number: coverage that is merely low, or a failure not yet diagnosed, is 5.1 or 5.5. It is the library-side counterpart of the test-side case #9934 added at §FS-test-contract.4.3.2, and it closes the linked issue too — an open request in `Todo` is claimed again and spends the same budget on the same wall.

## What review automation has to do differently

§FS-automated-pr-review is bound to the ladder, plus the two things it needs to obey it:

- the review agent's environment contract now includes committing and pushing a repair to a same-repository head; a reviewer that cannot push — a fork, a permission failure — escalates instead, because a repair the pull request never receives is not a disposition;
- a repair push restarts the checks exactly as a conflict-refresh push already does, so review and merge belong to a later pass and the approval is earned against the repaired head, not the pre-repair one.

`human-intervention` is now defined as exactly the 5.5 escalation rather than by a list of things it is not, and §FS-human-intervention-policy gains the published-PR-review case beside the pre-push one.

The five label-scoped review skills gain a `## Disposition` section that dispatches to the ladder and cites it rather than restating it: it names the five cases so a reviewer cannot skip the step, and sends them to the spec for what each case permits, so the bounds on a repair, the carve-out's conditions, and the evidence bar for a close keep one home (§PRCPL-prefer-algorithmic). The lines that contradicted the ladder are fixed too — "prefer asking for code changes", and a CI-noise bullet that did not separate a transient outage from a reproducible repository defect. `review-library-bulk-update` is untouched: a bulk index bump is not a contribution under this contract's opening definition and has its own close rules.
