### PR TITLE
Let a new Docker image establish its own scan baseline

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -114,6 +114,20 @@ part of the harness (§AR-test-harness).
 Serves §FS-repository-functional-spec.4.3 — the schedule-driven Docker image
 vulnerability scan.
 
+The PR-scoped scan is a ratchet, not an absolute bar. An image that already
+appears in the allow list at the base commit must carry no more critical or high
+findings than its base-commit version, so a tag bump can only hold or improve the
+count. An image with no counterpart at the base commit has nothing to ratchet
+against: it is accepted, and its counts — printed in the job log so a reviewer
+can weigh them — become the baseline that later changes to that image are
+measured against. The alternative, rejecting every first-time image with findings,
+makes the gate unsatisfiable for any contribution that needs a container the
+repository has not used before, because no realistic tag of a service image is
+free of high findings.
+
+The baseline is read from the base commit the task is given rather than from a
+fixed branch, so a pull request is measured against the commit it branched from.
+
 ### AR-sync-docker-images: Sync Docker images
 
 On PRs touching `allowed-docker-images/**` (Dependabot updates), synchronizes

--- a/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
+++ b/tests/tck-build-logic/src/main/java/org/graalvm/internal/tck/GrypeTask.java
@@ -14,16 +14,13 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
 
 import javax.inject.Inject;
 import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -52,6 +49,8 @@ public abstract class GrypeTask extends DefaultTask {
 
     private static final String JQ_MATCHER = " | jq -c '.matches | .[] | .vulnerability | select(.severity | (contains(\"High\") or contains(\"Critical\")))'";
     private static final String DOCKERFILE_DIRECTORY = "allowed-docker-images";
+    private static final String DOCKERFILE_PATH = "tests/tck-build-logic/src/main/resources/" + DOCKERFILE_DIRECTORY;
+    private static final String FROM_DIRECTIVE = "FROM";
 
     private static final String HIGH_VULNERABILITY = "HIGH";
     private static final String CRITICAL_VULNERABILITY = "CRITICAL";
@@ -101,39 +100,48 @@ public abstract class GrypeTask extends DefaultTask {
 
     /**
      * Scans images that have been changed between org.graalvm.internal.tck.GrypeTask#baseCommit and org.graalvm.internal.tck.GrypeTask#newCommit.
-     * If changed images are not more vulnerable than previously allowed images, they won't be reported as vulnerable
+     * An image that is already allowed at the base commit must not be more vulnerable than its base-commit version;
+     * an image that is not allowed yet has nothing to compare against, so it establishes its own baseline
+     * (§AR-scan-docker-images).
      */
     private void scanChangedImages() throws IOException, URISyntaxException {
         Set<DockerImage> imagesToCheck = getChangedImages().stream().map(this::makeDockerImage).collect(Collectors.toSet());
         List<DockerImage> vulnerableImages = imagesToCheck.stream().filter(DockerImage::isVulnerableImage).toList();
+        if (vulnerableImages.isEmpty()) {
+            return;
+        }
 
-        if (!vulnerableImages.isEmpty()) {
-            int acceptedImages = 0;
-            Set<String> currentlyAllowedImages = getAllowedImagesFromMaster();
+        Set<String> currentlyAllowedImages = getAllowedImagesFromBaseCommit();
+        int acceptedImages = 0;
 
-            for (DockerImage image : vulnerableImages) {
-                image.printVulnerabilityStatus();
+        for (DockerImage image : vulnerableImages) {
+            image.printVulnerabilityStatus();
 
-                // get allowed image with the same name, if it exists
-                Optional<String> existingAllowedImage = currentlyAllowedImages.stream()
-                        .filter(allowedImage -> DockerUtils.getImageName(allowedImage).equalsIgnoreCase(image.getImageName()))
-                        .findFirst();
+            // get allowed image with the same name, if it exists
+            Optional<String> existingAllowedImage = currentlyAllowedImages.stream()
+                    .filter(allowedImage -> DockerUtils.getImageName(allowedImage).equalsIgnoreCase(image.getImageName()))
+                    .findFirst();
 
-                // check if a new image is not more vulnerable than the existing one
-                if (existingAllowedImage.isPresent()) {
-                    DockerImage imageToCompare = makeDockerImage(existingAllowedImage.get());
-                    imageToCompare.printVulnerabilityStatus();
-
-                    if (image.isNotMoreVulnerable(imageToCompare)) {
-                        System.out.println("Accepting: " + image.image() + " because it does not have more vulnerabilities than existing: " + imageToCompare.image());
-                        acceptedImages++;
-                    }
-                }
+            if (existingAllowedImage.isEmpty()) {
+                // the image is allowed for the first time: its counts printed above become the baseline
+                System.out.println("Accepting: " + image.image() + " because it is not allowed yet. "
+                        + "The vulnerabilities reported above become the baseline that later changes to this image must not exceed");
+                acceptedImages++;
+                continue;
             }
 
-            if (acceptedImages < vulnerableImages.size()) {
-                throw new IllegalStateException("Highly vulnerable images found. Please check the list of vulnerable images provided above.");
+            // check if a new image is not more vulnerable than the existing one
+            DockerImage imageToCompare = makeDockerImage(existingAllowedImage.get());
+            imageToCompare.printVulnerabilityStatus();
+
+            if (image.isNotMoreVulnerable(imageToCompare)) {
+                System.out.println("Accepting: " + image.image() + " because it does not have more vulnerabilities than existing: " + imageToCompare.image());
+                acceptedImages++;
             }
+        }
+
+        if (acceptedImages < vulnerableImages.size()) {
+            throw new IllegalStateException("Highly vulnerable images found. Please check the list of vulnerable images provided above.");
         }
     }
 
@@ -213,35 +221,27 @@ public abstract class GrypeTask extends DefaultTask {
     }
 
     /**
-     * Return all allowed docker images from master branch
+     * Returns all docker images that are allowed at org.graalvm.internal.tck.GrypeTask#baseCommit, which is the
+     * baseline a changed image is compared against (§AR-scan-docker-images). Reading the base commit rather than a
+     * fixed branch keeps a pull request measured against the commit it branched from.
      */
-    private Set<String> getAllowedImagesFromMaster() throws URISyntaxException, IOException {
-        URL url = GrypeTask.class.getResource(DockerUtils.ALLOWED_DOCKER_IMAGES);
-        if (url == null) {
-            throw new RuntimeException("Cannot find allowed-docker-images directory");
+    private Set<String> getAllowedImagesFromBaseCommit() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ExecResult result = getExecOperations().exec(spec -> {
+            spec.setStandardOutput(outputStream);
+            spec.setIgnoreExitValue(true);
+            spec.commandLine("git", "grep", "-h", "^" + FROM_DIRECTIVE + " ", baseCommit, "--", DOCKERFILE_PATH);
+        });
+
+        // git grep exits with 1 when nothing matches, which is the legitimate "no image is allowed yet" case
+        if (result.getExitValue() > 1) {
+            result.assertNormalExitValue();
         }
 
-        Set<String> allowedImages = new HashSet<>();
-        try (FileSystem fs = FileSystems.newFileSystem(url.toURI(), Collections.emptyMap())) {
-            List<String> files = Files.walk(fs.getPath(DockerUtils.ALLOWED_DOCKER_IMAGES))
-                    .filter(Files::isRegularFile)
-                    .map(Path::toString)
-                    .map(path -> path.substring(path.lastIndexOf("/") + 1))
-                    .map(DockerUtils::getDockerFile)
-                    .map(DockerUtils::fileNameFromJar)
-                    .toList();
-
-            for (String file : files) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                getExecOperations().exec(spec -> {
-                    spec.setStandardOutput(baos);
-                    spec.commandLine("git", "show", "origin/master:tests/tck-build-logic/src/main/resources" + file);
-                });
-
-                allowedImages.add(baos.toString());
-            }
-        }
-
-        return allowedImages.stream().map(line -> line.substring("FROM".length()).trim()).collect(Collectors.toSet());
+        return Arrays.stream(outputStream.toString(StandardCharsets.UTF_8).split("\\r?\\n"))
+                .map(String::trim)
+                .filter(line -> line.startsWith(FROM_DIRECTIVE))
+                .map(line -> line.substring(FROM_DIRECTIVE.length()).trim())
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
Closes #9956

## What this does

`checkAllowedDockerImages` is a ratchet: a changed image must carry no more critical or high grype findings than the version allowed at the base commit. The rule has no base case. An image being allow-listed for the first time has no base-commit counterpart, so the accept branch is never reached and the task throws — and no tag can satisfy it, because no realistic tag of a service image is free of high findings.

#9765 is stuck on exactly this. Its test needs `quay.io/microcks/microcks-uber:1.14.0` (18 critical, 85 high), dropping the container would reduce the test to a scaffold, and the only way past the gate was to carry an unrelated `GrypeTask` rewrite inside a metadata PR.

A first-time image now establishes its own baseline: it is accepted, and its counts are printed so a reviewer sees what was admitted. Every later change to that image is measured against those numbers, so the ratchet is untouched for every image that already has a history. [§AR-scan-docker-images](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/issue-9956-docker-baseline/docs/architecture/ci.md#ar-scan-docker-images-scan-docker-images) states the rule and why the alternative is unsatisfiable.

## The second failure, in the same path

`getAllowedImagesFromMaster()` listed Dockerfiles from the packaged build resources — which already contain the newly added one — and then ran `git show origin/master:<path>` once per file. For the PR that adds the file, that lookup fails outright:

```
fatal: path 'tests/.../allowed-docker-images/Dockerfile-debian' exists on disk, but not in 'origin/master'
> Process 'command 'git'' finished with non-zero exit value 128
```

The job therefore died before it ever reached the missing-baseline problem. It also read `origin/master` rather than the `--baseCommit` it was handed, which is the wrong baseline whenever a PR is not branched from the tip. The replacement reads the base commit it was given, with a single `git grep -h "^FROM " <baseCommit> -- <dir>` in place of one subprocess per Dockerfile.

## Measured against a live grype 0.104.0 run

| Change under test | Base-commit baseline | Before | After |
| --- | --- | --- | --- |
| New `Dockerfile-debian`, `debian:bullseye-slim` — 9 critical, 23 high | none | `git` exit 128 | accepted, counts recorded as the baseline |
| `eclipse-mosquitto:2.0.22` → `1.6.15` — 4 critical, 36 high | 4 critical, 17 high | rejected | rejected |
| `eclipse-mosquitto:2.0.22` → `2.0.18` — 1 critical, 6 high | 4 critical, 17 high | accepted | accepted |

## What this does not fix

The weekly all-image scan is a separate, absolute rule — any high or critical finding in any allowed image fails it — and it has failed on every scheduled run in the archive. This change neither repairs nor worsens it.
