### PR TITLE
Failure-analysis agent invents a repository policy and publishes it as maintainer guidance

### DIFF
--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -508,6 +508,19 @@ additionally carries a continuation marker, so a later run can resume the issue
 from the phase that failed instead of regenerating from scratch
 (§FS-forge-run-continuation).
 
+**The comment states evidence, not policy.** A human-intervention comment is
+published to a maintainer, so every claim in it must be traceable to something
+the run actually observed: the failing stage, the log lines and metrics behind
+that conclusion, what the run already tried, and what a maintainer can do next.
+Its recommendations must not assert a repository policy, convention, or
+prohibition. When the comment does claim that a fix is disallowed here, it
+carries the `grund` citation of the spec point that disallows it, and when no
+such point exists the claim is left out entirely. An uncitable prohibition is
+worse than silence: the comment is read both by the maintainer who picks the
+issue up and by any later run that takes the issue thread as context, so an
+invented rule blocks the precedented fix and then propagates as if it were
+repository guidance.
+
 
 ## FS-automated-pr-review: Automated pull request review
 

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -4160,7 +4160,10 @@ def _build_human_intervention_analysis_prompt(
         claimed_issue: ClaimedIssue,
         candidate: HumanInterventionCandidate,
 ) -> str:
-    """Create the analysis prompt for the follow-up agent run."""
+    """Create the analysis prompt for the follow-up agent run.
+
+    The comment states evidence, not policy. §FS-human-intervention-policy
+    """
     if candidate.coverage is None:
         return _build_failed_generation_analysis_prompt(claimed_issue, candidate, [], None)
 
@@ -4186,6 +4189,9 @@ def _build_human_intervention_analysis_prompt(
         "- Explain briefly why dynamic-access coverage is missing or still very low.\n"
         "- Ground the explanation in concrete project observations.\n"
         "- End with 2 or 3 specific manual next steps.\n"
+        "- Ground every next step in what the logs, metrics, or repository actually show.\n"
+        "- Do not assert repository policy, conventions, or prohibitions. If a fix is disallowed "
+        "here, cite the grund spec point that disallows it; otherwise leave the claim out.\n"
         "- Keep the comment concise and do not use code fences.\n"
         "- Do not mention being an AI."
     )
@@ -4316,7 +4322,10 @@ def _build_failed_generation_analysis_prompt(
         run_metrics: dict | None,
         preservation_result: FailurePreservationResult | None = None,
 ) -> str:
-    """Create a Codex prompt that asks for the exact failure-analysis issue comment."""
+    """Create a Codex prompt that asks for the exact failure-analysis issue comment.
+
+    The comment states evidence, not policy. §FS-human-intervention-policy
+    """
     coverage_details = "- Dynamic-access coverage: unavailable"
     if candidate.coverage is not None:
         coverage_percent = candidate.coverage.coverage_ratio * 100.0
@@ -4361,6 +4370,9 @@ def _build_failed_generation_analysis_prompt(
         "- Explain the most likely failing stage and the concrete evidence from logs or metrics.\n"
         "- Mention specific log paths that a maintainer should inspect.\n"
         "- End with 2 or 3 specific manual next steps.\n"
+        "- Ground every next step in what the logs, metrics, or repository actually show.\n"
+        "- Do not assert repository policy, conventions, or prohibitions. If a fix is disallowed "
+        "here, cite the grund spec point that disallows it; otherwise leave the claim out.\n"
         "- Keep the comment concise but detailed enough to act on.\n"
         "- Do not use code fences.\n"
         "- Do not mention being an AI."

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -4410,6 +4410,76 @@ class FailedRunFollowUpTests(unittest.TestCase):
 
         post_follow_up.assert_not_called()
 
+    def test_failed_generation_prompt_forbids_uncitable_policy_claims(self) -> None:
+        """The published comment states evidence, not invented repository policy."""
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name=None,
+            workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+            reason="test_generation_failed",
+        )
+
+        prompt = forge_metadata._build_failed_generation_analysis_prompt(
+            _claimed_issue(),
+            candidate,
+            ["/tmp/logs/run.log"],
+            None,
+        )
+
+        self.assertIn("Ground every next step in what the logs, metrics, or repository actually show.", prompt)
+        self.assertIn("Do not assert repository policy, conventions, or prohibitions.", prompt)
+        self.assertIn("cite the grund spec point that disallows it; otherwise leave the claim out.", prompt)
+
+    def test_low_coverage_prompt_forbids_uncitable_policy_claims(self) -> None:
+        """The low-coverage variant is published the same way, so it carries the same constraint."""
+        candidate = forge_metadata.HumanInterventionCandidate(
+            strategy_name="strategy",
+            workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+            coverage=forge_metadata.DynamicAccessCoverageSnapshot(
+                covered_calls=0,
+                total_calls=12,
+                coverage_ratio=0.0,
+                source="dynamic-access-coverage.json",
+            ),
+        )
+
+        prompt = forge_metadata._build_human_intervention_analysis_prompt(_claimed_issue(), candidate)
+
+        self.assertIn("Ground every next step in what the logs, metrics, or repository actually show.", prompt)
+        self.assertIn("Do not assert repository policy, conventions, or prohibitions.", prompt)
+        self.assertIn("cite the grund spec point that disallows it; otherwise leave the claim out.", prompt)
+
+    def test_fallback_comments_assert_no_repository_policy(self) -> None:
+        """The deterministic fallbacks must stay policy-free too."""
+        claimed_issue = _claimed_issue()
+        failed_generation = forge_metadata._build_failed_generation_fallback_comment(
+            claimed_issue,
+            forge_metadata.HumanInterventionCandidate(
+                strategy_name=None,
+                workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+                reason="test_generation_failed",
+            ),
+            [],
+        )
+        low_coverage = forge_metadata._build_human_intervention_fallback_comment(
+            claimed_issue,
+            forge_metadata.HumanInterventionCandidate(
+                strategy_name="strategy",
+                workflow_status=forge_metadata.RUN_STATUS_FAILURE,
+                coverage=forge_metadata.DynamicAccessCoverageSnapshot(
+                    covered_calls=0,
+                    total_calls=12,
+                    coverage_ratio=0.0,
+                    source="dynamic-access-coverage.json",
+                ),
+            ),
+        )
+
+        for comment in (failed_generation, low_coverage):
+            lowered = comment.lower()
+            self.assertNotIn("repository policy", lowered)
+            self.assertNotIn("forbid", lowered)
+            self.assertNotIn("not allowed", lowered)
+
 
 class InterruptHandlingTests(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
Spec first: added the 'comment states evidence, not policy' paragraph to §forge/FS-human-intervention-policy (forge/docs/functional-spec/publication.md), requiring every human-intervention comment claim to be traceable to observed evidence and forbidding uncitable repository-policy/prohibition assertions. Cited that point from both published-comment prompt builders in forge/forge_metadata.py (_build_failed_generation_analysis_prompt and _build_human_intervention_analysis_prompt) and added two constraint lines to each prompt: ground every next step in what logs/metrics/repository actually show, and do not assert repository policy/conventions/prohibitions unless the grund spec point that disallows the fix is cited. Both prompts were fixed because they share the same 'manual next steps' instruction and both are published to the issue. Deterministic fallback comments were left as-is (they assert no policy) but are now regression-guarded. Issue parts (b) spec decision on build-time initialization and (c) the corrective comment on #9952 are out of scope for the worktree and were not attempted.

## Tests
cd forge && python3 -m unittest tests.test_forge_metadata -> Ran 186 tests, OK (3 new tests in FailedRunFollowUpTests: failed-generation prompt constraint, low-coverage prompt constraint, fallback comments policy-free). grund check (repo root) -> success. python3 -m py_compile on both changed Python files -> clean. pylint/pytest are not installed in this environment, so those runners were not used.

## Triage
Verified in-tree: no build-time-initialization prohibition exists in docs/, forge/docs/, skills/, CONTRIBUTING.md, AGENTS.md, or forge/prompt_templates/; two accepted counterexamples exist (tests/src/com.opencsv/opencsv/5.6/build.gradle:34, tests/src/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/build.gradle:82) and skills/review-fixes-native-image-run-fail/SKILL.md:24 lists 'initialization' among expected adjustments. The defect has a single well-defined site: _build_failed_generation_analysis_prompt (forge/forge_metadata.py:4312-4367) tells the analysis agent to 'End with 2 or 3 specific manual next steps' with no constraint tying those steps to observed evidence or to citable spec points, and the fallback comment path shares the same section. Fix is scoped: add the grounding constraint to §forge/FS-human-intervention-policy (forge/docs/functional-spec/publication.md:444) first, cite it from the prompt builder, and extend the existing prompt coverage in forge/tests/test_forge_metadata.py. Part (b) is explicitly a maintainer decision and part (c) is a GitHub comment, so neither blocks (a).

Fixes #9974