### PR TITLE
Legacy local_review descriptors fail strict validation and abort the whole PR review queue

### DIFF
--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -49,6 +49,8 @@ from types import SimpleNamespace
 from typing import Any, Optional
 from urllib.parse import quote
 
+from jsonschema import ValidationError
+
 import ai_workflows.core  # noqa: F401 - triggers strategy registration
 from ai_workflows.drivers.add_new_library_support import (
     DEFAULT_MODEL_NAME,
@@ -2450,14 +2452,23 @@ def validate_pull_request_publication(
     if len(producer_parts) != 3 or not producer_parts[1]:
         raise ValueError(f"PR #{pr_number} head branch does not name a producer")
     publisher = _load_trusted_publisher_module(reachability_metadata_path)
-    with contextlib.chdir(reachability_metadata_path):
-        validated = publisher.validate_publication(
-            head_sha=head_sha,
-            branch=head_branch,
-            actor=producer_parts[1],
-            repository=REPO,
-            pull_request_head=True,
-        )
+    try:
+        with contextlib.chdir(reachability_metadata_path):
+            validated = publisher.validate_publication(
+                head_sha=head_sha,
+                branch=head_branch,
+                actor=producer_parts[1],
+                repository=REPO,
+                pull_request_head=True,
+            )
+    except ValidationError as error:
+        # A head whose descriptor was written against an older publication
+        # contract cannot be executed under the current one, so it is ineligible
+        # rather than a run failure (§FS-automated-pr-review).
+        raise ValueError(
+            f"PR #{pr_number} descriptor does not satisfy the current publication "
+            f"schema: {error.message}"
+        ) from error
 
     descriptor = validated.descriptor
     publication_id = descriptor.get("publication_id")

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -15,6 +15,8 @@ import unittest
 from collections.abc import Callable
 from unittest.mock import call, patch
 
+from jsonschema import Draft202012Validator, ValidationError
+
 import forge_metadata
 from types import SimpleNamespace
 from ai_workflows.agents.agent_runtime import AgentRunResult, AgentSelection
@@ -29,6 +31,30 @@ from utility_scripts.continuation_marker import (
 from utility_scripts.fixture_github import FixtureComment, FixtureGitHubState, FixtureIssue
 from utility_scripts.dynamic_access_report import DynamicAccessClass, DynamicAccessCoverageReport
 from utility_scripts.metrics_writer import PENDING_METRICS_FILENAME
+
+
+PUBLICATION_SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    ".github", "scripts", "forge_pr_publisher", "schema.json",
+)
+
+
+def _legacy_local_review() -> dict:
+    """Return the pre-authoritative-review `local_review` object shipped in old descriptors."""
+    return {
+        "decision": "changes_requested",
+        "review_comment": "Repaired the metadata.",
+        "finding_title": "Finding",
+        "finding_body": "Reason.",
+        "fix_note": "Fixed.",
+        "model": "test-model",
+        "session_log_path": "task-logs/review.log",
+        "changed_paths": ["metadata/org.example/demo/1.0/reachability-metadata.json"],
+        "failed_step": None,
+        "published_tree": "0" * 40,
+        "repair_reverted": False,
+        "status": "changes_requested",
+    }
 
 
 def _project_item_status_response(status: str) -> dict:
@@ -3189,6 +3215,56 @@ class PullRequestReviewSelectionTests(unittest.TestCase):
                     state, "/tmp/reachability",
                 )
         fetch.assert_not_called()
+
+    def test_legacy_descriptor_is_skipped_instead_of_failing_the_queue(self) -> None:
+        """A descriptor written against an older contract is ineligible, not a run failure.
+
+        §FS-automated-pr-review
+        """
+        with open(PUBLICATION_SCHEMA_PATH, "r", encoding="utf-8") as schema_file:
+            local_review_schema = json.load(schema_file)["properties"]["local_review"]
+        with self.assertRaises(ValidationError) as unvalidatable:
+            Draft202012Validator(local_review_schema).validate(_legacy_local_review())
+
+        def raise_schema_error(**_kwargs) -> None:
+            raise unvalidatable.exception
+
+        pull_request = _pull_request(9637, [forge_metadata.LABEL_LIBRARY_NEW])
+        state = _pull_request_state(9637, "SUCCESS")
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as reachability_metadata_path:
+            with (
+                    patch.object(
+                        forge_metadata, "get_pull_requests_with_labels", return_value=[],
+                    ),
+                    patch.object(
+                        forge_metadata, "get_pull_requests_with_label",
+                        return_value=[pull_request],
+                    ),
+                    patch.object(
+                        forge_metadata, "attach_pull_request_state",
+                        side_effect=lambda _pull_request, _cache: state,
+                    ),
+                    patch.object(forge_metadata, "run_git_transport"),
+                    patch.object(
+                        forge_metadata, "_load_trusted_publisher_module",
+                        return_value=SimpleNamespace(validate_publication=raise_schema_error),
+                    ),
+                    patch.object(forge_metadata, "approve_pull_request_from_descriptor") as approve,
+                    patch.object(forge_metadata, "reconcile_rejected_publication") as reject,
+                    contextlib.redirect_stdout(output),
+            ):
+                forge_metadata.process_pull_requests_with_label(
+                    forge_metadata.LABEL_LIBRARY_NEW,
+                    2,
+                    reachability_metadata_path,
+                    "automation-user",
+                )
+
+        self.assertIn("Skipping ineligible PR #9637", output.getvalue())
+        self.assertIn("current publication schema", output.getvalue())
+        approve.assert_not_called()
+        reject.assert_not_called()
 
     def test_approved_publication_arms_auto_merge_without_semantic_agent(self) -> None:
         pull_request = _pull_request(9656, [forge_metadata.LABEL_LIBRARY_NEW])


### PR DESCRIPTION
## Summary
Implemented resolution (a)+(c) from issue #9980. forge/forge_metadata.py:validate_pull_request_publication now wraps the trusted publisher's validate_publication call and converts jsonschema ValidationError into ValueError ('PR #N descriptor does not satisfy the current publication schema: ...'), so a descriptor written against the pre-#9964 contract takes the existing ineligible-skip path in process_pull_requests_with_label instead of landing in the generic handler that appends to failures and calls sys.exit(1). This matches §FS-automated-pr-review, which already states that malformed descriptor state makes a PR ineligible for automation, so no spec change was needed. Added a regression test in forge/tests/test_forge_metadata.py that builds the legacy local_review object (decision 'changes_requested' plus failed_step/published_tree/repair_reverted/status), asserts it genuinely fails the current .github/scripts/forge_pr_publisher/schema.json local_review subschema, and then drives process_pull_requests_with_label end to end with a publisher stub raising that error: the queue prints 'Skipping ineligible PR #9637', does not exit non-zero, and neither approves nor rejects. Verified the new test fails on the unpatched tree with the exact reported symptom (SystemExit: 1 at forge_metadata.py sys.exit(1)). Resolution (b) — re-running versus migrating the four stuck PRs (#9969, #9903, #9765, #9637) — was left alone: the issue marks it an explicit maintainer call, and after this fix those PRs are skipped cleanly each cycle rather than breaking the run. Committed as 607b2f5909 on mm/issue-9980.

## Tests
forge: PYTHONPATH=$PWD python3 -m unittest tests.test_forge_metadata -> Ran 184 tests, OK. Targeted class tests.test_forge_metadata.PullRequestReviewSelectionTests -> Ran 19 tests, OK. New test alone against a stashed (unfixed) forge_metadata.py -> FAILED (SystemExit: 1), confirming it pins the reported defect. Full module sweep (all tests/test_*.py, 901 tests) -> FAILED (failures=3, errors=9); the identical 3 failures / 9 errors reproduce on the untouched tree (tests.test_host_requirements, tests.test_publish_not_for_native_image, tests.test_library_update_target, tests.test_native_test_verification, tests.test_publish_new_library_support), so they are pre-existing and unrelated. grund check -> success. python3 -m py_compile on both changed files -> ok; no changed line exceeds the 120-column .pylintrc limit. pylint and pytest are not installed in this environment, so `pylint .` could not be run.

## Triage
Verified in-repo: forge/forge_metadata.py:3796-3812 skips only ValueError as 'ineligible' while publisher.validate_publication (.github/scripts/forge_pr_publisher/publisher.py:213) raises jsonschema ValidationError, which falls into the generic handler, appends to failures and triggers sys.exit(1) at line 3836. The pre-#9964 schema (git show efa1ab1a09^) did carry failed_step/published_tree/repair_reverted and decision 'changes_requested', so legacy descriptors are genuinely unvalidatable under the new strict schema. Suggested fix (a) needs no spec change: §FS-automated-pr-review already states that 'missing, malformed, stale ... descriptor state makes the pull request ineligible for automation' (forge/docs/functional-spec/publication.md:519-520), so the code deviates from the spec today. Scope is well defined: map schema validation failure onto the existing ineligible-skip path plus a regression test alongside forge/tests/test_forge_metadata.py.

Fixes #9980