### PR TITLE
Record unsupportable versions as skipped, not only closed

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -544,6 +544,9 @@ def render_publication(
     if builder is None:
         raise ValueError(f"Unsupported template type: {template}")
     title, body = builder(descriptor, validated)
+    skipped = _skip_record_entries(descriptor, validated)
+    if skipped is not None:
+        body = _render_skip_record(descriptor, skipped)
     body += _render_local_review(descriptor)
     body += f"\nForge-Publication-ID: {descriptor['publication_id']}\n"
     return title, _bound_body(body)
@@ -1104,6 +1107,88 @@ def _render_code_coverage_benchmark_result(
             f"- Exit code: `{failure['exitCode']}`",
         ]
     return title, "\n".join(lines)
+
+SKIP_RECORD_TEMPLATES = frozenset({
+    "library-update-request",
+    "fixes-javac-fail",
+    "fixes-java-run-fail",
+    "fixes-native-image-run-fail",
+})
+
+
+def _index_skipped_versions(commit: str, group: str, artifact: str) -> dict[str, str]:
+    """Read one artifact's recorded skip reasons, keyed by version."""
+    path = f"metadata/{group}/{artifact}/index.json"
+    try:
+        payload = json.loads(git("show", f"{commit}:{path}"))
+    except (RuntimeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, list):
+        return {}
+    skipped: dict[str, str] = {}
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        for record in entry.get("skipped-versions") or []:
+            if isinstance(record, dict) and record.get("version"):
+                skipped[str(record["version"])] = str(record.get("reason", ""))
+    return skipped
+
+
+def _tree_has_path(commit: str, path: str) -> bool:
+    return bool(git("ls-tree", "--name-only", commit, "--", path).strip())
+
+
+def _skip_record_entries(
+        descriptor: dict[str, Any],
+        validated: ValidatedPublication | None,
+) -> list[tuple[str, str]] | None:
+    """Detect a contribution the review turned into a skip record (§FS-contribution-contract.5.4).
+
+    Read from the tree rather than the descriptor: the descriptor states what the
+    agent generated, and a review that records versions as skipped deletes exactly
+    those generated files, so only the tree describes what merges (§forge/FS-forge-publication-readiness).
+    """
+    if validated is None or descriptor["template_type"] not in SKIP_RECORD_TEMPLATES:
+        return None
+    group, artifact, version = str(descriptor["library"]["coordinates"]).split(":")
+    if _tree_has_path(validated.head_sha, f"metadata/{group}/{artifact}/{version}"):
+        return None
+    head = _index_skipped_versions(validated.head_sha, group, artifact)
+    base = _index_skipped_versions(str(descriptor["base_commit"]), group, artifact)
+    added = [(v, reason) for v, reason in head.items() if v not in base]
+    if not added:
+        return None
+    return sorted(added)
+
+
+def _render_skip_record(
+        descriptor: dict[str, Any],
+        skipped: list[tuple[str, str]],
+) -> str:
+    """Render the body for a contribution that records versions as skipped.
+
+    The generated statistics, stats diff and test diff of the template body all
+    describe files this tree no longer carries, so they are replaced rather than
+    extended (§forge/FS-forge-publication-readiness).
+    """
+    coordinates = descriptor["library"]["coordinates"]
+    rows = "".join(f"| `{version}` | {reason} |\n" for version, reason in skipped)
+    return (
+        "## What does this PR do?\n\n"
+        f"{_issue_reference(descriptor)}\n\n"
+        f"This pull request records `{coordinates}` as a library version Native Image "
+        "cannot support. It ships no metadata and no test: the generated contribution was "
+        "replaced by `skipped-versions` entries in the artifact's `index.json`, so the "
+        "compatibility automation stops proposing these versions instead of re-testing and "
+        "re-reporting them (§FS-contribution-contract.5.4).\n\n"
+        "### Versions recorded as skipped\n\n"
+        "| Version | Reason |\n| --- | --- |\n"
+        f"{rows}"
+        "\n"
+        f"{_format_forge_revision_section(descriptor)}"
+    )
+
 
 _TEMPLATE_BUILDERS = {
     "library-update-request": _render_library_update_request,

--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -207,9 +207,10 @@ Whoever reviews is the party that acts.
 The dispositions are approve, repair, close, and escalate. Approval means every
 must in this contract holds on the tree that will merge — including after a
 repair. Closing is available only where a rule in this contract says a
-contribution must be closed, which today is §FS-contribution-contract.5.4
-alone; absent such a rule, a contribution the reviewer cannot bring inside the
-rules escalates (§FS-contribution-contract.5.5).
+contribution must be closed, which today is §FS-contribution-contract.5.4 and
+only in the case that rule leaves nothing to record; absent such a rule, a
+contribution the reviewer cannot bring inside the rules escalates
+(§FS-contribution-contract.5.5).
 
 ### 5.1 A violation inside the contribution is repaired, not reported
 
@@ -294,7 +295,7 @@ transient external failure such as a rate limit, a registry outage, or a
 network error. A transient failure is retried or waited out, and becomes
 neither an issue nor an escalation (§forge/FS-human-intervention-policy).
 
-### 5.4 A library version Native Image cannot support is closed
+### 5.4 A library version Native Image cannot support is recorded as skipped
 
 A library version is unsupportable when the dynamic access it performs is
 reachable only through behavior Native Image does not support
@@ -312,14 +313,53 @@ standing behind it. Coverage that is merely low, a test that is merely hard to
 write, or a failure not yet diagnosed is §FS-contribution-contract.5.1 or
 §FS-contribution-contract.5.5 — never this.
 
-Where it holds, the contribution is closed rather than repaired or escalated,
-because metadata no test can justify is not shipped (§GOAL-tested-metadata).
-The reviewer closes the pull request with that explanation, labels the linked
-issue `library-unsupported-version`, and closes that issue rather than
-returning it to the work queue: an open request in `Todo` is claimed again and
-spends the same budget on the same wall. Where a library change could remove
-the guard, the incompatibility is reported upstream. This is the library-level
-counterpart of the test-level case in §FS-test-contract.4.3.2.
+Where it holds, the version is recorded as unsupported rather than repaired or
+escalated, because metadata no test can justify is not shipped
+(§GOAL-tested-metadata). Recording has two halves and both are required.
+
+The first half is the skip record. The reviewer adds a `skipped-versions` entry
+to `metadata/<group>/<artifact>/index.json` for the unsupportable version and
+for every newer version that shares the same unsupported behavior, each with a
+`reason` naming the mechanism the review has already established. Skipping only
+the reported version hands the same wall to the next one, because the
+compatibility walker stops a library at its first failure
+(§FS-library-version-update-automation.2). The skip is what makes the outcome
+stick: a version that is closed but not skipped re-enters the candidate list and
+the automation re-files the same issue on its next run
+(§FS-library-version-update-automation.1).
+
+The second half is the contribution. Where the artifact already has an index
+entry — the `fixes-*` labels and `library-update-request` — the reviewer repairs
+the contribution into that skip record: `metadata/<version>/`,
+`tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and
+`stats/<version>/execution-metrics.json` are dropped, the skip entries are
+written into `index.json`, and the result is approved.
+
+What is dropped is fixed by what the stats gate checks. It validates the whole
+repository rather than the diff, so metadata left without its mirrored stats
+fails it and the two must go together; it also checks execution metrics against
+tested versions, so metrics cannot stay for a version that will never be tested.
+The publication descriptor `stats/<version>/forge-publication.json` is the
+exception and stays: it is exempt from both checks, and it identifies the
+contribution, so deleting it makes the publication unresolvable
+(§forge/FS-forge-publication-readiness).
+
+Where the artifact has no index entry — a new library that turns out to be
+unsupportable — there is nothing to skip and nothing to merge, and the
+contribution is closed.
+
+Either way the linked issue ends labeled `library-unsupported-version` and
+closed rather than returned to the work queue: an open request in `Todo` is
+claimed again and spends the same budget on the same wall. On the closed path
+the reviewer's disposition does both. On the skip path the merge closes the
+issue through the contribution's link, and the label is already present whenever
+the compatibility automation filed the issue
+(§FS-library-version-update-automation.4); where it is absent it is applied
+before the contribution merges.
+
+Where a library change could remove the guard, the incompatibility is reported
+upstream. This is the library-level counterpart of the test-level case in
+§FS-test-contract.4.3.2.
 
 ### 5.5 Everything else is handed to a maintainer
 

--- a/docs/functional-spec/contribution-contract.md
+++ b/docs/functional-spec/contribution-contract.md
@@ -357,6 +357,12 @@ the compatibility automation filed the issue
 (§FS-library-version-update-automation.4); where it is absent it is applied
 before the contribution merges.
 
+The diagnosis may already have happened before generation
+(§forge/FS-unsupportable-version-diagnosis), in which case the contribution
+arrives as the skip record and the reviewer verifies the recorded mechanism
+against the library's source instead of discovering it — the evidence bar
+above is unchanged.
+
 Where a library change could remove the guard, the incompatibility is reported
 upstream. This is the library-level counterpart of the test-level case in
 §FS-test-contract.4.3.2.

--- a/docs/functional-spec/functional-spec.md
+++ b/docs/functional-spec/functional-spec.md
@@ -403,6 +403,17 @@ discarded before Maven Central is queried. Before a candidate enters the run it
 is de-duplicated against open issues: a library whose newest candidate version
 already has an open `[Automation] … fails for <group:artifact:version>` issue is
 skipped, so a known-failing version is not re-tested every day.
+
+That de-duplication is suppression while an issue is open, not a decision. A
+version whose issue has been closed re-enters the run on the next day. The
+permanent exclusion is the artifact's `skipped-versions`, whose entries are
+removed from the candidate list before de-duplication and never re-enter it.
+The distinction matters because §FS-library-version-update-automation.2 stops a
+library at its first failing version: a version that cannot be supported and is
+not skipped both re-files its own issue indefinitely and blocks every later
+version of that library from ever being tested. Skip entries are written by the
+disposition in §FS-contribution-contract.5.4.
+
 `generateNewLibraryVersionCompatibilityMatrix` turns the surviving candidates
 into the CI test matrix, bounded by the per-run library budget and the
 ≤ 30-newer-versions-per-library cap (§FS-repository-functional-spec.5.3). When

--- a/docs/functional-spec/test-contract.md
+++ b/docs/functional-spec/test-contract.md
@@ -514,10 +514,12 @@ signature to close the gap. Instead, in order:
    unsupported scenario and cover the rest of the library's public surface.
    This is the usual outcome and it keeps the shipped metadata justified.
 2. **If no public API works, the version is unsupportable.** Metadata no test
-   justifies is not shipped: close the pull request, label the issue
-   `library-unsupported-version`, and report the incompatibility upstream, as
-   §FS-contribution-contract.5.4 sets out for the same case reached from the
-   library's side.
+   justifies is not shipped: record the version in the artifact's
+   `skipped-versions` so the compatibility automation stops re-testing it, label
+   the issue `library-unsupported-version`, and report the incompatibility
+   upstream. §FS-contribution-contract.5.4 sets out the full disposition for the
+   same case reached from the library's side, including when the contribution
+   becomes the skip record and when it is closed outright.
 
 ### 4.4 No dependence on resource metadata for machine-local paths
 

--- a/forge/ai_workflows/drivers/fix_ni_run.py
+++ b/forge/ai_workflows/drivers/fix_ni_run.py
@@ -41,7 +41,9 @@ from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.issue_requested_metadata import format_issue_requested_metadata_context
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
+    preflight_skip_record_entries,
 )
+from utility_scripts.skip_record import apply_preflight_skip_record
 from utility_scripts.logged_command import LoggedCommandResult, run_logged_command
 from utility_scripts.metadata_index import resolve_metadata_version, resolve_test_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
@@ -412,6 +414,40 @@ def main(argv=None) -> int:
 
     group, artifact, old_version = current_coordinates.split(":")
     library = f"{group}:{artifact}:{new_version}"
+
+    # An unsupportable verdict from the preflight replaces the whole fix run
+    # with a committed skip record. §FS-unsupportable-version-diagnosis
+    skip_entries = preflight_skip_record_entries(library_preparation_preflight, new_version)
+    if skip_entries is not None and not resume_existing_tree:
+        starting_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        ending_commit = apply_preflight_skip_record(
+            reachability_repo_path=reachability_metadata_path,
+            group=group,
+            artifact=artifact,
+            target_version=new_version,
+            entries=skip_entries,
+            continuation_marker_path=args.continuation_marker_path,
+        )
+        if ending_commit is not None:
+            print("[Version recorded as skipped; no fix was attempted.]")
+            run_metrics = metrics_writer.create_java_run_fix_run_metrics_output_json(
+                repo_path=reachability_metadata_path,
+                package=group,
+                artifact=artifact,
+                previous_library_version=old_version,
+                new_library_version=new_version,
+                agent=None,
+                model_name=library_preparation_preflight.get("model"),
+                global_iterations=0,
+                strategy_name=args.strategy_name,
+                status=RUN_STATUS_SUCCESS,
+                starting_commit=starting_commit,
+                ending_commit=ending_commit,
+                library_preparation_preflight=library_preparation_preflight,
+            )
+            metrics_writer.write_workflow_run_metrics(run_metrics, metrics_repo_dir, metrics_repo_root, METRICS_TASK_TYPE)
+            return 0
+
     branch = build_ai_branch_name(
         f"fix-native-image-run-{group}-{artifact}-{new_version}",
         cwd=reachability_metadata_path,

--- a/forge/ai_workflows/drivers/java_fail_workflow.py
+++ b/forge/ai_workflows/drivers/java_fail_workflow.py
@@ -41,8 +41,10 @@ from utility_scripts.gradle_environment import gradle_command_environment
 from utility_scripts.issue_requested_metadata import format_issue_requested_metadata_context
 from utility_scripts.library_preparation_preflight import (
     prepare_library_preparation_preflight,
+    preflight_skip_record_entries,
 )
 from utility_scripts.logged_command import run_logged_command
+from utility_scripts.skip_record import apply_preflight_skip_record
 from utility_scripts.metadata_index import is_newer_than_latest_metadata_version
 from utility_scripts.metrics_writer import create_failure_run_metrics_output
 from utility_scripts.repo_path_resolver import require_complete_reachability_repo
@@ -530,6 +532,39 @@ def run_java_fail_workflow(config: JavaFailWorkflowConfig, argv=None):
     resolve_graalvm_java_home()
     validate_repo_paths(reachability_repo_path, metrics_repo_dir)
     os.chdir(reachability_repo_path)
+
+    # An unsupportable verdict from the preflight replaces the whole fix run
+    # with a committed skip record. §FS-unsupportable-version-diagnosis
+    skip_entries = preflight_skip_record_entries(library_preparation_preflight, updated_library_version)
+    if skip_entries is not None and not resume_existing_tree:
+        starting_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        ending_commit = apply_preflight_skip_record(
+            reachability_repo_path=reachability_repo_path,
+            group=group,
+            artifact=artifact,
+            target_version=updated_library_version,
+            entries=skip_entries,
+            continuation_marker_path=continuation_marker_path,
+        )
+        if ending_commit is not None:
+            print("[Version recorded as skipped; no fix was attempted.]")
+            run_metrics = metrics_writer.create_javac_fix_run_metrics_output_json(
+                repo_path=reachability_repo_path,
+                package=group,
+                artifact=artifact,
+                previous_library_version=old_library_version,
+                new_library_version=updated_library_version,
+                agent=None,
+                model_name=library_preparation_preflight.get("model"),
+                global_iterations=0,
+                strategy_name=strategy_name,
+                status=RUN_STATUS_SUCCESS,
+                starting_commit=starting_commit,
+                ending_commit=ending_commit,
+                library_preparation_preflight=library_preparation_preflight,
+            )
+            write_fix_metrics(config, run_metrics, metrics_repo_dir, metrics_repo_root=metrics_repo_root)
+            return 0
 
     tests_dir = os.path.join(
         reachability_repo_path,

--- a/forge/docs/architecture/orchestration-scripts.md
+++ b/forge/docs/architecture/orchestration-scripts.md
@@ -187,7 +187,7 @@ Failed generation or local finalization still preserves diagnostics
 (§FS-local-ci-equivalent-verification), restores claim state as appropriate, and
 leaves enough context for human follow-up.
 
-### 1.2 Unsupportable-version verdict
+### 1.3 Unsupportable-version verdict
 
 For `fails-*` issues the same preflight decision carries a third possible
 action beyond `no_action` and `advisory_preparation`: an unsupportable-version

--- a/forge/docs/architecture/orchestration-scripts.md
+++ b/forge/docs/architecture/orchestration-scripts.md
@@ -187,6 +187,20 @@ Failed generation or local finalization still preserves diagnostics
 (§FS-local-ci-equivalent-verification), restores claim state as appropriate, and
 leaves enough context for human follow-up.
 
+### 1.2 Unsupportable-version verdict
+
+For `fails-*` issues the same preflight decision carries a third possible
+action beyond `no_action` and `advisory_preparation`: an unsupportable-version
+verdict (§FS-unsupportable-version-diagnosis). The agent returns it with the
+structurally-validated `skipped_versions` entries the verdict prescribes;
+free-text reasons are scanned like the advisory fields because they are
+published verbatim. The record travels to the workflow driver unchanged, and
+the driver — not orchestration — honors it as its first act: it writes the
+entries into the artifact's `index.json`, validates the index, records success
+run metrics with no generation spent, and returns so orchestration hands the
+index-only tree to the ordinary publication finalizer. A verdict the driver
+cannot apply falls through to normal generation.
+
 ## 2. Pull Request Review Queues
 
 `forge_metadata.py` also owns the pull-request review side of Forge, which is a

--- a/forge/docs/functional-spec/README.md
+++ b/forge/docs/functional-spec/README.md
@@ -36,6 +36,7 @@ contract in [strategies.md](strategies.md), the benchmark contract in
 | [§FS-human-intervention-policy](publication.md#fs-human-intervention-policy-human-intervention-policy) | Human intervention policy |
 | [§FS-automated-pr-review](publication.md#fs-automated-pr-review-automated-pull-request-review) | Automated pull request review |
 | [§FS-forge-run-status](functional-spec.md#fs-forge-run-status-run-status-semantics) | Run status semantics |
+| [§FS-unsupportable-version-diagnosis](functional-spec.md#fs-unsupportable-version-diagnosis-pre-generation-unsupportable-version-diagnosis) | Pre-generation unsupportable-version diagnosis |
 | [§FS-forge-run-output-legibility](functional-spec.md#fs-forge-run-output-legibility-legible-run-output) | Legible run output |
 | [§FS-forge-chunked-dynamic-access](functional-spec.md#fs-forge-chunked-dynamic-access-chunked-dynamic-access-semantics) | Chunked dynamic-access semantics |
 | [§FS-forge-workflow-spec-catalog](functional-spec.md#fs-forge-workflow-spec-catalog-workflow-specifications) | Workflow specifications catalog |

--- a/forge/docs/functional-spec/functional-spec.md
+++ b/forge/docs/functional-spec/functional-spec.md
@@ -698,6 +698,47 @@ Every workflow records one of these statuses:
 
 The exit code is `0` for PR-eligible statuses and `1` for failure.
 
+## FS-unsupportable-version-diagnosis: Pre-generation unsupportable-version diagnosis
+
+For issues that report a failing version update (`fails-javac-compile`,
+`fails-java-run`, `fails-native-image-run`), the library preparation preflight
+(§AR-forge-orchestration.1) asks one additional question before any generation
+starts: does covering the library's dynamic-access calls require behavior
+Native Image does not support (§root/FS-test-contract.4.5)? The inputs — the
+automation issue's failure evidence and the library's sources for this and
+newer versions — all exist before the scaffold is prepared, so an
+unsupportable verdict costs one preflight turn and saves the whole fix budget.
+Without it, the disposition of §root/FS-contribution-contract.5.4 is reachable
+only through a branch that got green somehow: a run that fails honestly ends
+`RUN_STATUS_FAILURE`, publishes nothing, and no reviewer ever takes the
+disposition. Issues without failure evidence (`library-new-request`,
+`library-update-request`) are not asked: the first has no index entry to
+record a skip into, and the second carries no failure to diagnose.
+
+The diagnosis applies the evidence bar of §root/FS-contribution-contract.5.4
+in five steps — name the failing operation from the evidence, trace it into
+the library's source, classify it against the unsupported-behavior catalogue,
+prove no public API route avoids it, and bound the version range by verifying
+newer versions' sources. The verdict is structured and strict: anything
+missing, malformed, or uncertain means repairable, because a missed exit costs
+one wasted run while a wrong skip freezes versions that were never attempted.
+The range includes only versions whose sources the diagnosis actually
+verified; an under-skipped range self-heals, since the next version's run
+re-diagnoses before generation.
+
+The verdict travels in the preflight record. On an unsupportable verdict the
+workflow driver, before preparing any scaffold, records the verdict's
+`skipped-versions` entries in the artifact's `index.json`
+(§root/FS-library-version-update-automation.1), validates the index, and ends
+the run `RUN_STATUS_SUCCESS` with no generation spent — the skip record is the
+run's successful outcome. A verdict the driver cannot apply (a rejected index,
+a version already recorded) falls through to normal generation rather than
+failing the run. The publication pipeline is unchanged: the pre-publication
+gate validates the index-only tree, the local pre-push review
+(§FS-local-branch-review) verifies the recorded mechanism instead of
+discovering it, and the trusted publisher renders the pull request from the
+tree's skip record (§FS-forge-publication-readiness).
+
 ## FS-forge-chunked-dynamic-access: Chunked dynamic-access semantics
 
 - `FORGE_DYNAMIC_ACCESS_CHUNK_CLASS_THRESHOLD` configures the class-count threshold

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -348,8 +348,22 @@ satisfies the review rules. A shared infrastructure defect is not repaired on
 the contribution: the reviewer returns structured evidence, Forge opens or
 reuses one issue for that defect, and the descriptor records `rejected` plus
 `human-intervention`. Unsupported library behavior meeting
-§root/FS-contribution-contract.5.4 records `rejected` plus `close`. Every
-other unresolved or uncertain finding records `rejected` plus
+§root/FS-contribution-contract.5.4 records `rejected` plus `close` only where
+that rule finds no index entry to record the skip in. Where the artifact has
+one, the reviewer repairs the contribution into the skip record that rule
+prescribes and the descriptor carries the ordinary `approved` decision.
+
+**A skip record is rendered from the tree.** Descriptor facts state what the
+agent generated, and this repair deletes exactly the generated files, so a body
+rendered from the descriptor would report metadata entries, coverage percentages
+and stats diffs for files that no longer exist. Publication therefore detects the
+repair from the published tree — the artifact's `index.json` gained
+`skipped-versions` entries and the contribution ships no `metadata/<version>/` —
+and replaces the template body with the recorded versions and their reasons, read
+from those same entries. The title is left as the contribution's own template
+rendered it: it carries the run and model provenance, and publication identity is
+the branch and publication ID rather than the title.
+Every other unresolved or uncertain finding records `rejected` plus
 `human-intervention`.
 
 **Findings record.** Every finding is appended to tracked

--- a/forge/git_scripts/local_branch_review.py
+++ b/forge/git_scripts/local_branch_review.py
@@ -821,8 +821,11 @@ def _build_review_prompt(
         "Repair a violation when the complete fix stays inside the contribution's allowed files. "
         "If the repaired tree satisfies every rule, approve it. Never edit shared infrastructure "
         "or another coordinate. Reject with action human-intervention for shared infrastructure, "
-        "uncertainty, or anything else requiring a maintainer. Reject with action close only when "
-        "§root/FS-contribution-contract.5.4 proves the library version is unsupportable.",
+        "uncertainty, or anything else requiring a maintainer. When "
+        "§root/FS-contribution-contract.5.4 proves the library version is unsupportable and "
+        "the artifact has an index entry, repair the contribution into the skip record that "
+        "rule prescribes and approve it. Reject with action close only when that rule leaves "
+        "nothing to record.",
         "For a shared infrastructure defect, include infrastructure_issue with a concise "
         "non-empty title and a body containing the cause and reproducible evidence. Forge "
         "will open or reuse that issue and add its link to the recorded finding.",

--- a/forge/tests/test_forge_pr_publisher_skip_record.py
+++ b/forge/tests/test_forge_pr_publisher_skip_record.py
@@ -1,0 +1,129 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cover the skip-record body a review produces under §root/FS-contribution-contract.5.4."""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUBLISHER_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "publisher.py",
+)
+
+HEAD_SHA = "a" * 40
+BASE_COMMIT = "b" * 40
+COORDINATES = "org.xerial.snappy:snappy-java:1.0.5.3"
+METADATA_PATH = "metadata/org.xerial.snappy/snappy-java"
+REASON = "SnappyLoader defines SnappyNativeLoader at run time through ClassLoader.defineClass."
+
+
+def _load_publisher() -> Any:
+    """Load the trusted publisher the way Actions runs it: straight from the file."""
+    spec = importlib.util.spec_from_file_location("forge_pr_publisher_skip_record", PUBLISHER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+publisher = _load_publisher()
+
+
+def _index(skipped: list[str]) -> str:
+    return json.dumps([{
+        "latest": True,
+        "auto-update": True,
+        "metadata-version": "1.0.4.1",
+        "tested-versions": ["1.0.4.1"],
+        "skipped-versions": [{"version": version, "reason": REASON} for version in skipped],
+    }])
+
+
+def _descriptor(template_type: str = "fixes-java-run-fail") -> dict[str, Any]:
+    return {
+        "template_type": template_type,
+        "base_commit": BASE_COMMIT,
+        "issue_number": 9404,
+        "library": {"coordinates": COORDINATES},
+        "modifiers": {"chunked_dynamic_access": False, "chunk_final": True},
+        "forge": {"monitored_branch": "master", "branch": "forge", "commit": "c" * 40},
+    }
+
+
+def _git(has_metadata_directory: bool, head_skipped: list[str], base_skipped: list[str]):
+    """Stand in for the publisher's git reads of the head and base trees."""
+    def fake_git(*args: str) -> str:
+        if args[0] == "ls-tree":
+            return f"{METADATA_PATH}/1.0.5.3\n" if has_metadata_directory else ""
+        if args[0] == "show":
+            commit = args[1].split(":", 1)[0]
+            return _index(head_skipped if commit == HEAD_SHA else base_skipped)
+        raise AssertionError(f"unexpected git call: {args}")
+    return fake_git
+
+
+class SkipRecordDetectionTests(unittest.TestCase):
+
+    def _entries(self, **kwargs: Any) -> list[tuple[str, str]] | None:
+        validated = publisher.ValidatedPublication({}, "descriptor.json", HEAD_SHA)
+        with patch.object(publisher, "git", side_effect=_git(**kwargs)):
+            return publisher._skip_record_entries(_descriptor(), validated)
+
+    def test_added_skip_entries_without_metadata_are_a_skip_record(self) -> None:
+        entries = self._entries(
+            has_metadata_directory=False, head_skipped=["1.0.5.3", "1.0.5.4"], base_skipped=[],
+        )
+
+        self.assertEqual([("1.0.5.3", REASON), ("1.0.5.4", REASON)], entries)
+
+    def test_a_contribution_that_still_ships_metadata_is_not_a_skip_record(self) -> None:
+        entries = self._entries(
+            has_metadata_directory=True, head_skipped=["1.0.5.3"], base_skipped=[],
+        )
+
+        self.assertIsNone(entries)
+
+    def test_skip_entries_already_on_the_base_are_not_reported_again(self) -> None:
+        entries = self._entries(
+            has_metadata_directory=False, head_skipped=["1.0.5.3"], base_skipped=["1.0.5.3"],
+        )
+
+        self.assertIsNone(entries)
+
+    def test_a_new_library_contribution_is_never_a_skip_record(self) -> None:
+        validated = publisher.ValidatedPublication({}, "descriptor.json", HEAD_SHA)
+        descriptor = _descriptor(template_type="library-new-request")
+
+        with patch.object(publisher, "git", side_effect=_git(
+                has_metadata_directory=False, head_skipped=["1.0.5.3"], base_skipped=[],
+        )):
+            self.assertIsNone(publisher._skip_record_entries(descriptor, validated))
+
+
+class SkipRecordBodyTests(unittest.TestCase):
+
+    def test_body_states_the_skip_and_drops_the_generated_sections(self) -> None:
+        body: str = publisher._render_skip_record(
+            _descriptor(), [("1.0.5.3", REASON), ("1.0.5.4", REASON)],
+        )
+
+        self.assertIn("Fixes: #9404", body)
+        self.assertIn(f"records `{COORDINATES}` as a library version Native Image", body)
+        self.assertIn("### Versions recorded as skipped", body)
+        self.assertIn(f"| `1.0.5.3` | {REASON} |", body)
+        self.assertIn(f"| `1.0.5.4` | {REASON} |", body)
+        self.assertNotIn("Metadata entries:", body)
+        self.assertNotIn("Library coverage percentage:", body)
+        self.assertNotIn("Stats from", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_local_branch_review.py
+++ b/forge/tests/test_local_branch_review.py
@@ -400,6 +400,21 @@ class LocalBranchReviewTests(unittest.TestCase):
             prompt.index("Write exactly one JSON verdict"),
         )
 
+    def test_review_prompt_states_the_skip_record_disposition(self) -> None:
+        prompt = module._build_review_prompt(
+            coordinates="org.example:demo:1.0.0",
+            base_sha="base",
+            verified_sha="head",
+            task_type="fixes-java-run-fail",
+            evidence_path="/tmp/evidence.json",
+            verdict_path="/tmp/verdict.json",
+            finalization_receipt_path="/tmp/finalization-receipt.json",
+        )
+
+        self.assertIn("repair the contribution into the skip record", prompt)
+        self.assertIn("close only when that rule leaves nothing to record", prompt)
+        self.assertNotIn("close only when \u00a7root/FS-contribution-contract.5.4 proves", prompt)
+
     def test_review_model_uses_centralized_analysis_selection(self) -> None:
         selection = SimpleNamespace(model="central-model")
         with patch.object(module, "get_analysis_agent", return_value=selection):

--- a/forge/tests/test_preflight_skip_record.py
+++ b/forge/tests/test_preflight_skip_record.py
@@ -1,0 +1,294 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Cover the preflight skip verdict of §FS-unsupportable-version-diagnosis."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import Any
+
+from utility_scripts import library_preparation_preflight as preflight_module
+from utility_scripts.skip_record import apply_preflight_skip_record, write_skip_record
+
+LIBRARY = "org.xerial.snappy:snappy-java:1.0.5.3"
+REASON = "SnappyLoader defines classes at run time through reflective ClassLoader.defineClass."
+
+
+def _claimed_issue(label: str = "fails-java-run") -> SimpleNamespace:
+    return SimpleNamespace(
+        label=label,
+        issue={"number": 9404, "title": "snappy-java 1.0.5.3 fails java run"},
+        issue_coordinates=LIBRARY,
+        current_coordinates="org.xerial.snappy:snappy-java:1.0.4.1",
+        new_version="1.0.5.3",
+    )
+
+
+def _input_bundle(label: str = "fails-java-run") -> dict[str, Any]:
+    return {
+        "issue": {"number": 9404, "title": "t", "label": label, "body": "", "body_error": ""},
+        "library": LIBRARY,
+        "current_library": "org.xerial.snappy:snappy-java:1.0.4.1",
+        "new_version": "1.0.5.3",
+        "existing_tests": {},
+    }
+
+
+def _skip_response(versions: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "action": "skip_unsupported",
+        "summary": REASON,
+        "skipped_versions": [
+            {"version": version, "reason": REASON}
+            for version in (versions or ["1.0.5.3", "1.0.5.4"])
+        ],
+    }
+
+
+def _completed_record(label: str = "fails-java-run", response: dict[str, Any] | None = None) -> dict[str, Any]:
+    return preflight_module._completed_library_preflight_record(
+        _claimed_issue(label),
+        _input_bundle(label),
+        response if response is not None else _skip_response(),
+        "test-model",
+        None,
+    )
+
+
+def _index_entries(skipped: list[str] | None = None) -> list[dict]:
+    entry: dict = {
+        "latest": True,
+        "auto-update": True,
+        "metadata-version": "1.0.4.1",
+        "tested-versions": ["1.0.4.1"],
+        "allowed-packages": ["org.xerial.snappy"],
+    }
+    if skipped:
+        entry["skipped-versions"] = [
+            {"version": version, "reason": "existing"} for version in skipped
+        ]
+    return [entry]
+
+
+class SkipVerdictPromptTests(unittest.TestCase):
+
+    def test_fail_issues_are_asked_the_diagnosis(self) -> None:
+        prompt = preflight_module._library_preflight_prompt(_input_bundle("fails-java-run"))
+
+        for marker in ("FAILURE:", "TRACE:", "CLASSIFY:", "SOLE PATH:", "RANGE:"):
+            self.assertIn(marker, prompt)
+        self.assertIn("skip_unsupported", prompt)
+        self.assertIn("skipped_versions must include 1.0.5.3", prompt)
+        self.assertIn("Any uncertainty at any step means repairable", prompt)
+
+    def test_issues_without_failure_evidence_are_not_asked(self) -> None:
+        for label in ("library-new-request", "library-update-request"):
+            with self.subTest(label=label):
+                prompt = preflight_module._library_preflight_prompt(_input_bundle(label))
+                self.assertNotIn("skip_unsupported", prompt)
+
+
+class SkipVerdictRecordTests(unittest.TestCase):
+
+    def test_valid_verdict_is_recorded_with_its_entries(self) -> None:
+        record = _completed_record()
+
+        self.assertEqual("completed", record["status"])
+        self.assertEqual("skip_unsupported", record["action"])
+        self.assertEqual(
+            [
+                {"version": "1.0.5.3", "reason": REASON},
+                {"version": "1.0.5.4", "reason": REASON},
+            ],
+            record["skipped_versions"],
+        )
+
+    def test_everything_short_of_proof_degrades_the_verdict(self) -> None:
+        cases: list[dict[str, Any]] = [
+            {"action": "skip_unsupported", "summary": REASON},
+            {"action": "skip_unsupported", "summary": REASON, "skipped_versions": []},
+            _skip_response(versions=["1.0.5.4"]),
+            {"action": "skip_unsupported", "summary": REASON,
+             "skipped_versions": [{"version": "1.0.5.3", "reason": "  "}]},
+            {"action": "skip_unsupported", "summary": REASON,
+             "skipped_versions": [{"version": "1.0.5.3"}]},
+        ]
+        for response in cases:
+            with self.subTest(response=response):
+                with self.assertRaises(ValueError):
+                    _completed_record(response=response)
+
+    def test_labels_without_failure_evidence_cannot_skip(self) -> None:
+        with self.assertRaises(ValueError):
+            _completed_record(label="library-update-request")
+
+    def test_unsafe_reason_text_degrades_the_verdict(self) -> None:
+        response = _skip_response()
+        response["skipped_versions"][0]["reason"] = "run sudo rm -rf to fix it"
+
+        with self.assertRaises(ValueError):
+            _completed_record(response=response)
+
+
+class SkipRecordEntriesReaderTests(unittest.TestCase):
+
+    def test_completed_verdict_returns_its_entries(self) -> None:
+        entries = preflight_module.preflight_skip_record_entries(_completed_record(), "1.0.5.3")
+
+        self.assertEqual(
+            [
+                {"version": "1.0.5.3", "reason": REASON},
+                {"version": "1.0.5.4", "reason": REASON},
+            ],
+            entries,
+        )
+
+    def test_anything_else_means_normal_generation(self) -> None:
+        cases: list[Any] = [
+            None,
+            {"status": "completed", "action": "no_action"},
+            {"status": "degraded", "action": "skip_unsupported",
+             "skipped_versions": [{"version": "1.0.5.3", "reason": REASON}]},
+            {"status": "completed", "action": "skip_unsupported", "skipped_versions": []},
+            {"status": "completed", "action": "skip_unsupported",
+             "skipped_versions": [{"version": "1.0.5.4", "reason": REASON}]},
+        ]
+        for preflight in cases:
+            with self.subTest(preflight=preflight):
+                self.assertIsNone(
+                    preflight_module.preflight_skip_record_entries(preflight, "1.0.5.3"),
+                )
+
+
+class SkipRecordWriterTests(unittest.TestCase):
+
+    def _repo_with_index(self, entries: list[dict]) -> str:
+        repo = tempfile.mkdtemp(prefix="skip-record-")
+        self.addCleanup(lambda: subprocess.run(["rm", "-rf", repo], check=False))
+        index_dir = os.path.join(repo, "metadata", "org.xerial.snappy", "snappy-java")
+        os.makedirs(index_dir)
+        with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+            json.dump(entries, index_file, indent=2)
+        return repo
+
+    def _read_index(self, repo: str) -> list[dict]:
+        path = os.path.join(repo, "metadata", "org.xerial.snappy", "snappy-java", "index.json")
+        with open(path, encoding="utf-8") as index_file:
+            return json.load(index_file)
+
+    def _entries(self) -> list[dict[str, str]]:
+        return [
+            {"version": "1.0.5.3", "reason": REASON},
+            {"version": "1.0.5.4", "reason": REASON},
+        ]
+
+    def test_writes_entries_after_tested_versions_in_index_style(self) -> None:
+        repo = self._repo_with_index(_index_entries())
+
+        written = write_skip_record(repo, "org.xerial.snappy", "snappy-java", self._entries())
+
+        self.assertEqual(["1.0.5.3", "1.0.5.4"], written)
+        entry = self._read_index(repo)[0]
+        keys = list(entry.keys())
+        self.assertEqual(keys.index("tested-versions") + 1, keys.index("skipped-versions"))
+        self.assertEqual(self._entries(), entry["skipped-versions"])
+        path = os.path.join(repo, "metadata", "org.xerial.snappy", "snappy-java", "index.json")
+        with open(path, encoding="utf-8") as index_file:
+            raw = index_file.read()
+        self.assertIn('"latest" : true', raw)
+        self.assertTrue(raw.endswith("\n"))
+
+    def test_versions_already_recorded_keep_their_reason(self) -> None:
+        repo = self._repo_with_index(_index_entries(skipped=["1.0.5.3"]))
+
+        written = write_skip_record(repo, "org.xerial.snappy", "snappy-java", self._entries())
+
+        self.assertEqual(["1.0.5.4"], written)
+        entry = self._read_index(repo)[0]
+        self.assertEqual("existing", entry["skipped-versions"][0]["reason"])
+
+    def test_fully_recorded_verdict_writes_nothing(self) -> None:
+        repo = self._repo_with_index(_index_entries(skipped=["1.0.5.3", "1.0.5.4"]))
+
+        self.assertEqual([], write_skip_record(repo, "org.xerial.snappy", "snappy-java", self._entries()))
+
+
+class ApplySkipRecordTests(unittest.TestCase):
+
+    def _git(self, repo: str, *args: str) -> str:
+        return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+    def _repo(self, skipped: list[str] | None = None) -> str:
+        repo = tempfile.mkdtemp(prefix="skip-apply-")
+        self.addCleanup(lambda: subprocess.run(["rm", "-rf", repo], check=False))
+        self._git(repo, "init", "-q", "-b", "master")
+        self._git(repo, "config", "user.email", "forge@test")
+        self._git(repo, "config", "user.name", "forge")
+        index_dir = os.path.join(repo, "metadata", "org.xerial.snappy", "snappy-java")
+        os.makedirs(index_dir)
+        with open(os.path.join(index_dir, "index.json"), "w", encoding="utf-8") as index_file:
+            json.dump(_index_entries(skipped), index_file, indent=2)
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-q", "-m", "base")
+        return repo
+
+    def _apply(self, repo: str, validate_result: bool = True) -> str | None:
+        return apply_preflight_skip_record(
+            reachability_repo_path=repo,
+            group="org.xerial.snappy",
+            artifact="snappy-java",
+            target_version="1.0.5.3",
+            entries=[
+                {"version": "1.0.5.3", "reason": REASON},
+                {"version": "1.0.5.4", "reason": REASON},
+            ],
+            continuation_marker_path=None,
+            validate_index=lambda _repo, _coordinates: validate_result,
+        )
+
+    def test_valid_verdict_commits_the_index_only_tree(self) -> None:
+        repo = self._repo()
+
+        ending_commit = self._apply(repo)
+
+        self.assertEqual(self._git(repo, "rev-parse", "HEAD"), ending_commit)
+        self.assertEqual(
+            "Record skipped versions for org.xerial.snappy:snappy-java",
+            self._git(repo, "log", "-1", "--format=%s"),
+        )
+        self.assertEqual("", self._git(repo, "status", "--porcelain"))
+        index_path = os.path.join(repo, "metadata", "org.xerial.snappy", "snappy-java", "index.json")
+        with open(index_path, encoding="utf-8") as index_file:
+            entry = json.load(index_file)[0]
+        self.assertEqual(
+            ["1.0.5.3", "1.0.5.4"],
+            [record["version"] for record in entry["skipped-versions"]],
+        )
+
+    def test_rejected_index_falls_through_with_a_clean_tree(self) -> None:
+        repo = self._repo()
+        base_commit = self._git(repo, "rev-parse", "HEAD")
+
+        self.assertIsNone(self._apply(repo, validate_result=False))
+
+        self.assertEqual(base_commit, self._git(repo, "rev-parse", "HEAD"))
+        self.assertEqual("", self._git(repo, "status", "--porcelain"))
+
+    def test_already_recorded_versions_fall_through_with_a_clean_tree(self) -> None:
+        repo = self._repo(skipped=["1.0.5.3", "1.0.5.4"])
+        base_commit = self._git(repo, "rev-parse", "HEAD")
+
+        self.assertIsNone(self._apply(repo))
+
+        self.assertEqual(base_commit, self._git(repo, "rev-parse", "HEAD"))
+        self.assertEqual("", self._git(repo, "status", "--porcelain"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -47,6 +47,14 @@ LIBRARY_PREFLIGHT_UNSAFE_TERMS = (
 # Deterministic setup the driver applies itself, idempotently, as source edits
 # (§AR-forge-orchestration.1.1). Anything else stays advisory guidance.
 LIBRARY_PREFLIGHT_DETERMINISTIC_KINDS = ("dependency", "docker_image")
+# Only issues carrying failure evidence are asked the unsupportable-version
+# question (§FS-unsupportable-version-diagnosis).
+LIBRARY_PREFLIGHT_SKIP_VERDICT_LABELS = (
+    "fails-javac-compile",
+    "fails-java-run",
+    "fails-native-image-run",
+)
+LIBRARY_PREFLIGHT_MAX_SKIPPED_VERSIONS = 12
 LIBRARY_PREFLIGHT_DEPENDENCY_SCOPES = (
     "testImplementation",
     "testRuntimeOnly",
@@ -302,6 +310,39 @@ def _parse_deterministic_setup(value: Any) -> list[dict[str, str]]:
     return parsed
 
 
+def _parse_skipped_versions(value: Any, target_version: str) -> list[dict[str, str]]:
+    """Validate a skip verdict's version records; the burden of proof is on skipping.
+
+    Any malformation raises, degrading the record so the run falls through to
+    normal generation (§FS-unsupportable-version-diagnosis).
+    """
+    if not isinstance(value, list) or not value:
+        raise ValueError("skip_unsupported response did not include skipped_versions")
+    if len(value) > LIBRARY_PREFLIGHT_MAX_SKIPPED_VERSIONS:
+        raise ValueError("skip_unsupported response listed too many skipped versions")
+    parsed: list[dict[str, str]] = []
+    seen_versions: set[str] = set()
+    for record in value:
+        if not isinstance(record, dict):
+            raise ValueError("skipped_versions entries must be objects")
+        version = record.get("version")
+        reason = record.get("reason")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError("skipped_versions entries require a version")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("skipped_versions entries require a reason")
+        if version.strip() in seen_versions:
+            continue
+        seen_versions.add(version.strip())
+        parsed.append({
+            "version": version.strip(),
+            "reason": _truncate_preflight_text(reason, 500),
+        })
+    if target_version not in seen_versions:
+        raise ValueError("skipped_versions must include the reported version")
+    return parsed
+
+
 def _completed_library_preflight_record(
         claimed_issue: Any,
         input_bundle: dict[str, Any],
@@ -311,7 +352,7 @@ def _completed_library_preflight_record(
 ) -> dict[str, Any]:
     """Normalize a valid preflight response into the persisted metrics shape."""
     action = str(response_payload.get("action") or "no_action").strip()
-    if action not in {"no_action", "advisory_preparation"}:
+    if action not in {"no_action", "advisory_preparation", "skip_unsupported"}:
         raise ValueError(f"unsupported preflight action: {action}")
     summary = _truncate_preflight_text(str(response_payload.get("summary") or ""), 1000)
     deterministic_setup = _parse_deterministic_setup(response_payload.get("deterministic_setup"))
@@ -319,10 +360,20 @@ def _completed_library_preflight_record(
     risks = _preflight_string_list(response_payload.get("risks"))
     if action == "advisory_preparation" and not (deterministic_setup or agent_guidance):
         raise ValueError("advisory_preparation response did not include deterministic setup or guidance")
+    skipped_versions: list[dict[str, str]] = []
+    if action == "skip_unsupported":
+        # The verdict is only asked for, and only accepted from, issues that
+        # carry failure evidence (§FS-unsupportable-version-diagnosis).
+        if claimed_issue.label not in LIBRARY_PREFLIGHT_SKIP_VERDICT_LABELS:
+            raise ValueError(f"skip_unsupported verdict is not allowed for label {claimed_issue.label}")
+        target_version = str(input_bundle.get("library") or "").split(":")[-1]
+        skipped_versions = _parse_skipped_versions(response_payload.get("skipped_versions"), target_version)
     # Deterministic entries are validated structurally above; only the free-text
-    # advisory fields can carry prose, so only those are scanned — and only for
-    # requested actions, never subject matter (§AR-forge-orchestration.1.2).
-    unsafe_terms = _unsafe_terms_in(summary, agent_guidance, risks)
+    # fields can carry prose, so only those are scanned — and only for
+    # requested actions, never subject matter (§AR-forge-orchestration.1.2). Skip
+    # reasons are published verbatim in index.json and the pull request.
+    skip_reasons = [entry["reason"] for entry in skipped_versions]
+    unsafe_terms = _unsafe_terms_in(summary, agent_guidance, risks, *skip_reasons)
     if unsafe_terms:
         raise ValueError(
             f"preflight response requested unsafe preparation behavior: {', '.join(unsafe_terms)}"
@@ -335,10 +386,61 @@ def _completed_library_preflight_record(
     record["deterministic_setup"] = deterministic_setup
     record["agent_guidance"] = agent_guidance
     record["risks"] = risks
+    if skipped_versions:
+        record["skipped_versions"] = skipped_versions
     record["model"] = model_name
     record["input_tokens_used"] = int(getattr(result, "input_tokens", 0) or 0)
     record["output_tokens_used"] = int(getattr(result, "output_tokens", 0) or 0)
     return record
+
+
+def _skip_verdict_prompt_section(input_bundle: dict[str, Any]) -> str:
+    """Render the unsupportable-version diagnosis for issues with failure evidence.
+
+    The five-step bar and the strict default come from
+    §FS-unsupportable-version-diagnosis; the disposition it feeds is
+    §root/FS-contribution-contract.5.4.
+    """
+    issue = input_bundle.get("issue") if isinstance(input_bundle.get("issue"), dict) else {}
+    if str(issue.get("label") or "") not in LIBRARY_PREFLIGHT_SKIP_VERDICT_LABELS:
+        return ""
+    library = str(input_bundle.get("library") or "")
+    version = library.split(":")[-1]
+    return (
+        "Separately, decide whether this library version can be supported under GraalVM "
+        "Native Image at all. A version is unsupportable only when covering its "
+        "dynamic-access calls requires behavior Native Image does not support: runtime "
+        "bytecode generation or class definition, runtime lambda definition, Java agent "
+        "self-attach, class redefinition or instrumentation, native-image substitution "
+        "paths, or URL/plugin/OSGi class loader paths that introduce classes not in the "
+        "image.\n\n"
+        "Run these steps in order. An unsupportable verdict requires ALL of them; stay "
+        "with the two actions above the moment one fails:\n"
+        "1. FAILURE: state the failing operation from the issue's failure evidence alone.\n"
+        "2. TRACE: follow the failing symbol into the library's own source and quote the "
+        "code performing the operation.\n"
+        "3. CLASSIFY: show the operation is in the list above. Anything reachability "
+        "metadata can register is repairable.\n"
+        "4. SOLE PATH: prove every public API route the metadata would justify passes "
+        "through this operation, with no configuration, property, or fallback branch "
+        "around it. One viable fallback means repairable.\n"
+        "5. RANGE: list newer released versions whose sources you verified share the "
+        "same mechanism. Include only versions you actually verified; when you cannot "
+        f"verify newer versions, record only {version}.\n\n"
+        "On an unsupportable verdict, return instead:\n"
+        "{\n"
+        '  "action": "skip_unsupported",\n'
+        '  "summary": "one sentence naming the mechanism and why the image cannot perform it",\n'
+        '  "skipped_versions": [{"version": "...", "reason": "mechanism sentence; later '
+        "versions: '; unchanged from <first>'\"}, ...]\n"
+        "}\n"
+        f"skipped_versions must include {version}; reasons are published verbatim in "
+        "index.json and the pull request, so write them for a reader who has not seen "
+        "this analysis. Never base the verdict on a red test, a library's own error "
+        "type, or its error message — only on the mechanism you traced in the library's "
+        "source. Any uncertainty at any step means repairable: attempting the fix is "
+        "the safe default, a wrong skip freezes versions that were never attempted.\n\n"
+    )
 
 
 def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
@@ -375,6 +477,7 @@ def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
         '  "risks": ["risk notes, if any"]\n'
         "}\n\n"
         "Choose no_action unless your research finds concrete evidence that extra setup is needed.\n\n"
+        f"{_skip_verdict_prompt_section(input_bundle)}"
         "Context (starting point):\n"
         f"{json.dumps(input_bundle, indent=2, ensure_ascii=False)}"
     )
@@ -540,6 +643,25 @@ def load_library_preparation_preflight(preflight_path: str | None) -> dict[str, 
     with open(preflight_path, "r", encoding="utf-8") as preflight_file:
         loaded = json.load(preflight_file)
     return loaded if isinstance(loaded, dict) else None
+
+
+def preflight_skip_record_entries(
+        preflight: dict[str, Any] | None,
+        target_version: str,
+) -> list[dict[str, str]] | None:
+    """Return the validated skip-record entries a driver should honor, or None.
+
+    Strict on every field so a malformed record falls through to normal
+    generation (§FS-unsupportable-version-diagnosis).
+    """
+    if not isinstance(preflight, dict):
+        return None
+    if preflight.get("status") != "completed" or preflight.get("action") != "skip_unsupported":
+        return None
+    try:
+        return _parse_skipped_versions(preflight.get("skipped_versions"), target_version)
+    except ValueError:
+        return None
 
 
 def _insert_into_dependencies_block(text: str, new_line: str) -> str | None:

--- a/forge/utility_scripts/skip_record.py
+++ b/forge/utility_scripts/skip_record.py
@@ -1,0 +1,159 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Apply a preflight unsupportable-version verdict as a committed skip record.
+
+A workflow driver honors the verdict before preparing any scaffold: the
+entries land in the artifact's ``index.json``, the index is validated, and the
+index-only tree goes to the unchanged publication pipeline
+(§FS-unsupportable-version-diagnosis). A verdict that cannot be applied falls
+through to normal generation.
+"""
+
+import json
+import os
+import subprocess
+from typing import Callable
+
+from utility_scripts.continuation_marker import (
+    PHASE_FINALIZATION,
+    PHASE_PUBLICATION,
+    save_phase_update,
+)
+from utility_scripts.gradle_environment import gradle_command_environment
+from utility_scripts.logged_command import run_logged_command
+from utility_scripts.stage_logger import log_detail
+
+
+def write_skip_record(
+        repo_path: str,
+        group: str,
+        artifact: str,
+        entries: list[dict[str, str]],
+) -> list[str]:
+    """Merge the verdict's skipped versions into the artifact's index.json.
+
+    Entries land on the unique ``latest: true`` index entry, matching the shape
+    the compatibility automation reads (§root/FS-library-version-update-automation.1).
+    Versions already recorded keep their existing reason. Returns the versions
+    newly written.
+    """
+    index_path = os.path.join(repo_path, "metadata", group, artifact, "index.json")
+    with open(index_path, "r", encoding="utf-8") as index_file:
+        index_entries = json.load(index_file)
+    if not isinstance(index_entries, list) or not index_entries:
+        raise ValueError(f"Unexpected index.json shape at {index_path}")
+
+    target_entry = next(
+        (entry for entry in index_entries if isinstance(entry, dict) and entry.get("latest") is True),
+        index_entries[0],
+    )
+    existing = target_entry.get("skipped-versions") or []
+    existing_versions = {
+        record.get("version") for record in existing if isinstance(record, dict)
+    }
+    written: list[str] = []
+    for skipped in entries:
+        if skipped["version"] in existing_versions:
+            continue
+        existing.append({"version": skipped["version"], "reason": skipped["reason"]})
+        written.append(skipped["version"])
+    if not written:
+        return written
+
+    # Keep skipped-versions in the position validateIndexFiles renders it:
+    # rebuild the entry with the record after tested-versions when present.
+    rebuilt: dict = {}
+    inserted = False
+    for key, value in target_entry.items():
+        if key == "skipped-versions":
+            continue
+        rebuilt[key] = value
+        if key == "tested-versions":
+            rebuilt["skipped-versions"] = existing
+            inserted = True
+    if not inserted:
+        rebuilt["skipped-versions"] = existing
+    index_entries[index_entries.index(target_entry)] = rebuilt
+
+    rendered = json.dumps(index_entries, indent=2, ensure_ascii=False).replace('": ', '" : ')
+    with open(index_path, "w", encoding="utf-8") as index_file:
+        index_file.write(rendered + "\n")
+    return written
+
+
+def _validate_index_with_gradle(repo_path: str, coordinates: str) -> bool:
+    """Run validateIndexFiles for the coordinates; the gate on the skip record."""
+    result = run_logged_command(
+        ["./gradlew", "validateIndexFiles", f"-Pcoordinates={coordinates}"],
+        cwd=repo_path,
+        task_type="preflight-skip-record",
+        subject=coordinates,
+        action="validateIndexFiles",
+        env=gradle_command_environment(repo_path),
+        stage="preflight-skip-record",
+    )
+    return result.returncode == 0
+
+
+def apply_preflight_skip_record(
+        *,
+        reachability_repo_path: str,
+        group: str,
+        artifact: str,
+        target_version: str,
+        entries: list[dict[str, str]],
+        continuation_marker_path: str | None,
+        validate_index: Callable[[str, str], bool] = _validate_index_with_gradle,
+) -> str | None:
+    """Turn a preflight skip verdict into a committed, validated skip record.
+
+    Returns the ending commit when the index-only tree is ready for
+    publication, None when the run should fall through to normal generation
+    (§FS-unsupportable-version-diagnosis).
+    """
+    coordinates = f"{group}:{artifact}:{target_version}"
+    index_path = os.path.join("metadata", group, artifact, "index.json")
+    try:
+        written = write_skip_record(reachability_repo_path, group, artifact, entries)
+    except (OSError, ValueError) as exc:
+        log_detail("preflight-skip-record", f"Could not write skip record for {coordinates}: {exc}")
+        return None
+    if not written:
+        log_detail("preflight-skip-record", f"All skip entries for {coordinates} are already recorded.")
+        _restore_index(reachability_repo_path, index_path)
+        return None
+    if not validate_index(reachability_repo_path, coordinates):
+        log_detail("preflight-skip-record", f"validateIndexFiles rejected the skip record for {coordinates}.")
+        _restore_index(reachability_repo_path, index_path)
+        return None
+    subprocess.run(["git", "add", index_path], cwd=reachability_repo_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"Record skipped versions for {group}:{artifact}"],
+        cwd=reachability_repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    log_detail("preflight-skip-record", f"Recorded skipped versions for {group}:{artifact}: {', '.join(written)}")
+    save_phase_update(
+        continuation_marker_path,
+        lambda marker: (
+            marker.mark_phase_completed(PHASE_FINALIZATION),
+            marker.mark_phase_pending(PHASE_PUBLICATION),
+        ),
+    )
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=reachability_repo_path, text=True,
+    ).strip()
+
+
+def _restore_index(reachability_repo_path: str, index_path: str) -> None:
+    """Drop the uncommitted index edit so normal generation starts clean."""
+    subprocess.run(
+        ["git", "checkout", "--", index_path],
+        cwd=reachability_repo_path,
+        check=True,
+    )

--- a/skills/review-fixes-java-run-fail/SKILL.md
+++ b/skills/review-fixes-java-run-fail/SKILL.md
@@ -117,10 +117,10 @@ Finding a violation is half the review. **Read §FS-contribution-contract.5 and 
 | 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
 | 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
 | 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
-| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Turn the PR into the skip record: drop `metadata/<version>/`, `tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and `execution-metrics.json` — keep `forge-publication.json` — then add `skipped-versions` entries to the artifact's `index.json` for this version and every newer one that shares the behavior, and approve the index-only result; make sure the linked issue carries `library-unsupported-version` — the merge closes it through the PR's link |
 | 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
 
-Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+Never close a PR under any case but 5.4, and under this label 5.4 does not close it either — it records a skip the automation reads, because a closed-but-unskipped version is re-tested and re-reported on the next scheduled run. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
 
 ## Decision Rules
 

--- a/skills/review-fixes-javac-fail/SKILL.md
+++ b/skills/review-fixes-javac-fail/SKILL.md
@@ -114,10 +114,10 @@ Finding a violation is half the review. **Read §FS-contribution-contract.5 and 
 | 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
 | 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
 | 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
-| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Turn the PR into the skip record: drop `metadata/<version>/`, `tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and `execution-metrics.json` — keep `forge-publication.json` — then add `skipped-versions` entries to the artifact's `index.json` for this version and every newer one that shares the behavior, and approve the index-only result; make sure the linked issue carries `library-unsupported-version` — the merge closes it through the PR's link |
 | 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
 
-Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+Never close a PR under any case but 5.4, and under this label 5.4 does not close it either — it records a skip the automation reads, because a closed-but-unskipped version is re-tested and re-reported on the next scheduled run. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
 
 ## Decision Rules
 

--- a/skills/review-fixes-native-image-run-fail/SKILL.md
+++ b/skills/review-fixes-native-image-run-fail/SKILL.md
@@ -113,10 +113,10 @@ Finding a violation is half the review. **Read §FS-contribution-contract.5 and 
 | 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
 | 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
 | 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
-| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Turn the PR into the skip record: drop `metadata/<version>/`, `tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and `execution-metrics.json` — keep `forge-publication.json` — then add `skipped-versions` entries to the artifact's `index.json` for this version and every newer one that shares the behavior, and approve the index-only result; make sure the linked issue carries `library-unsupported-version` — the merge closes it through the PR's link |
 | 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
 
-Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+Never close a PR under any case but 5.4, and under this label 5.4 does not close it either — it records a skip the automation reads, because a closed-but-unskipped version is re-tested and re-reported on the next scheduled run. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
 
 ## Decision Rules
 

--- a/skills/review-library-new-request/SKILL.md
+++ b/skills/review-library-new-request/SKILL.md
@@ -78,7 +78,7 @@ Finding a violation is half the review. **Read §FS-contribution-contract.5 and 
 | 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
 | 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
 | 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
-| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | The artifact has no index entry, so there is nothing to skip and nothing to merge: close the PR, label the linked issue `library-unsupported-version`, and close that issue |
 | 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
 
 Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.

--- a/skills/review-library-update-request/SKILL.md
+++ b/skills/review-library-update-request/SKILL.md
@@ -109,10 +109,10 @@ Finding a violation is half the review. **Read §FS-contribution-contract.5 and 
 | 5.1 | The violation is in the PR's own `metadata/`, `stats/`, and `tests/src/` files | Repair it on the PR head, push, re-run the affected checks, and say what you changed and why |
 | 5.2 | The only possible fix is build logic, harness code, workflows, or another coordinate | Do not repair there; revert such a change if the PR already carries one, then take 5.3 |
 | 5.3 | The cause is a defect in shared repository code | Find or open one issue for the defect, comment that the PR is blocked on it rather than on its own content, then take 5.5 |
-| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Close the PR, label the linked issue `library-unsupported-version`, and close that issue |
+| 5.4 | The library's dynamic access is reachable only through behavior Native Image cannot support | Turn the PR into the skip record: drop `metadata/<version>/`, `tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and `execution-metrics.json` — keep `forge-publication.json` — then add `skipped-versions` entries to the artifact's `index.json` for this version and every newer one that shares the behavior, and approve the index-only result; make sure the linked issue carries `library-unsupported-version` — the merge closes it through the PR's link |
 | 5.5 | Anything else, uncertainty included | Label the PR `human-intervention` and comment with the rule at issue, what you tried, and what you could not decide |
 
-Never close a PR under any case but 5.4. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
+Never close a PR under any case but 5.4, and under this label 5.4 does not close it either — it records a skip the automation reads, because a closed-but-unskipped version is re-tested and re-reported on the next scheduled run. Read §FS-contribution-contract.5.1 before you repair: it bounds what a repair may do, and it carries the one exception that lets you drop a test scenario rather than fix it.
 
 ## Decision Rules
 


### PR DESCRIPTION
Closes #9995 — the review-side disposition, its publication, and detection ahead of generation.

## What this does

[§FS-contribution-contract.5.4](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skipped-versions-disposition/docs/functional-spec/contribution-contract.md#54-a-library-version-native-image-cannot-support-is-recorded-as-skipped) told the reviewer to close the pull request, label the linked issue `library-unsupported-version`, and close it. That leaves no record anywhere the compatibility automation reads, so the version stays in the candidate list and the next scheduled run re-discovers it. `org.xerial.snappy:snappy-java:1.0.5.3` has been filed three times on that path — #8906, #9224, #9404 — each cycle also spending a Forge run on a pull request that was then closed, most recently #9667.

The cost is larger than a repeated issue. `run-consecutive-tests.sh` stops walking a library at its first failing version, so an unsupported version that is never recorded blocks every later version of that artifact indefinitely. `snappy-java` is pinned at tested version 1.0.5.2 and has never reached the 1.1.x line, although 1.1.x removed the `SnappyLoader` root-classloader injection that makes 1.0.x unsupportable in the first place.

This change makes the skip record part of the disposition rather than a separate manual step, turns the contribution itself into that record where one can be merged, and teaches publication to describe it.

## What the reviewer now does

| Case | Disposition |
| --- | --- |
| The artifact already has an index entry — `fixes-*`, `library-update-request` | Drop `metadata/<version>/`, `tests/src/<version>/` and the mirrored `stats/<version>/stats.json` and `execution-metrics.json`, write the `skipped-versions` entries into `index.json`, approve the result |
| The artifact has no index entry — `library-new-request` | Nothing to skip and nothing to merge, so the contribution is closed |

The skip covers the reported version **and every newer version that shares the unsupported behavior**. Skipping one version only hands the same wall to the next, because the walker is head-of-line blocking ([§FS-library-version-update-automation.2](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skipped-versions-disposition/docs/functional-spec/functional-spec.md#2-bulk-compatibility-testing)).

## What survives the deletion, and why

`stats/<version>/forge-publication.json` stays. It is the publication descriptor — `validate_publication` locates the contribution by it, so deleting it makes the publication unresolvable — and `LibraryStatsSchemaValidator` recognises it without checking it against tested versions. Its two neighbours do not have that exemption: `stats.json` is required to exist for every metadata version directory, and `execution-metrics.json` is validated against tested versions, so it cannot stay for a version that will never be tested.

Verified on the reworked #9667: a tree carrying only `forge-publication.json` under `stats/org.xerial.snappy/snappy-java/1.0.5.3/` passes `validateLibraryStats`, and `validateIndexFiles` accepts the skip entries.

## How publication describes a skip record

Descriptor facts state what the agent generated, and this repair deletes exactly the generated files, so a descriptor-rendered body reports metadata entries, coverage percentages and stats diffs for files that no longer exist — visible on #9667 before it was rewritten by hand.

Detection is therefore tree-derived: the artifact's `index.json` gained `skipped-versions` entries relative to the descriptor's `base_commit`, and the contribution ships no `metadata/<version>/`. The body is rendered from those same entries, so the description cannot disagree with what merges. The title is left exactly as the contribution's own template rendered it — it carries the run and model provenance, and publication identity is the branch and publication ID rather than the title.

Rendered from #9667's real descriptor and tree:

```markdown
## What does this PR do?

Fixes: #9404

This pull request records `org.xerial.snappy:snappy-java:1.0.5.3` as a library
version Native Image cannot support. It ships no metadata and no test: the
generated contribution was replaced by `skipped-versions` entries in the
artifact's `index.json`, so the compatibility automation stops proposing these
versions instead of re-testing and re-reporting them (§FS-contribution-contract.5.4).

### Versions recorded as skipped

| Version | Reason |
| --- | --- |
| `1.0.5` | SnappyLoader reaches the JNI library only by injecting … |
| `1.0.5.3` | SnappyLoader reaches the JNI library only by injecting … |
| `1.0.5.4` | SnappyLoader reaches the JNI library only by injecting … |

### Forge
…
```

## Detection before generation

The reviewer path only sees branches that got green somehow — a run that fails honestly ends `RUN_STATUS_FAILURE`, publishes nothing, and never reaches the disposition. And even a masked-green run spends the whole fix budget first. The determination needs nothing from the generated tree, so it now happens before generation, in the library preparation preflight ([§forge/FS-unsupportable-version-diagnosis](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skipped-versions-disposition/forge/docs/functional-spec/functional-spec.md#fs-unsupportable-version-diagnosis-pre-generation-unsupportable-version-diagnosis)):

- **Who is asked.** Only issues that carry failure evidence — `fails-javac-compile`, `fails-java-run`, `fails-native-image-run`. `library-new-request` has no index entry to record into, and `library-update-request` carries no failure to diagnose.
- **The question.** The preflight prompt gains the five-step diagnosis (failure → trace → classify → sole path → range) with the strict default: any uncertainty at any step means repairable, because a missed exit costs one wasted run while a wrong skip freezes versions that were never attempted. An under-skipped range self-heals — the next version's run re-diagnoses.
- **The verdict.** A third preflight action, `skip_unsupported`, carrying structurally-validated `skipped_versions` entries; reasons are published verbatim, so they pass the same unsafe-text scan as advisory guidance. Anything malformed degrades the record and the run proceeds normally.
- **Who honors it.** The fix drivers, as their first act before preparing any scaffold: `write_skip_record` merges the entries into the artifact's `index.json`, `validateIndexFiles` gates the result, the commit lands, run metrics record a success with zero iterations, and the ordinary publication finalizer takes the index-only tree from there — local CI-equivalent verification, local review, descriptor, push, and the tree-derived skip body above. A verdict the driver cannot apply (rejected index, versions already recorded) falls through to normal generation with a clean tree.

Placing the diagnosis in the preflight covers both hooks the issue sketched with one mount point: the run that would have masked its failure and the run that would have failed honestly both answer the question before either outcome can happen.

## Where the ladder changed

- **§FS-contribution-contract.5.4** — the disposition itself, now two required halves: the skip record, and what happens to the contribution.
- **§FS-contribution-contract.5** — the ladder intro said closing is available under 5.4 alone; it now says under 5.4 and only where that rule leaves nothing to record.
- **[§forge/FS-forge-publication-readiness](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skipped-versions-disposition/forge/docs/functional-spec/publication.md)** — the ladder mapped 5.4 to `rejected` plus `close`; that now applies only to the no-index-entry case, and a new paragraph requires the skip body to be rendered from the tree with the title preserved.
- **§FS-test-contract.4.3.2** — item 2 reached the same case from the test side and repeated the close-only wording; it now requires the skip and defers to 5.4.
- **§FS-library-version-update-automation.1** — `skipped-versions` was read by `FetchExistingLibrariesWithNewerVersionsTask` but never described in the spec. The section now states that open-issue de-duplication is suppression while an issue is open, and that `skipped-versions` is the only permanent exclusion.
- **[§forge/FS-unsupportable-version-diagnosis](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/skipped-versions-disposition/forge/docs/functional-spec/functional-spec.md#fs-unsupportable-version-diagnosis-pre-generation-unsupportable-version-diagnosis)** — new: the pre-generation diagnosis, its evidence bar, and the driver's skip-record outcome; `§AR-forge-orchestration.1.2` describes the third preflight action, and §FS-contribution-contract.5.4 cross-references the pre-generation origin so the reviewer verifies the recorded mechanism instead of discovering it.
- **The local review prompt** (`forge/git_scripts/local_branch_review.py`) hardcoded "reject with action close" as the only 5.4 outcome, which would have overridden the updated skill tables and kept reviewers closing. It now states the repair-into-skip-record path and reserves close for the no-index-entry case.

## Open questions

1. **The label on the skip path.** `forge_pr_publisher` applies `library-unsupported-version` only in the `close` action. On the skip path the merge closes the linked issue through the PR's link, and the label is already present whenever the compatibility automation filed the issue, which covers every `fixes-*` case. A `library-update-request` issue raised by hand may not carry it. My recommendation is to add the label on the approved path in a follow-up rather than widen this change further.
2. **`snappy-java` itself.** #9667 now carries the skip entries for 1.0.5.3, 1.0.5.4 and 1.0.5. The 1.1.x line still needs its own metadata version and test project — `SnappyLoader.isNativeLibraryLoaded()` is gone there and the bundled library moved from `native/Linux/amd64` to `native/Linux/x86_64` — which is worth its own issue.



