### PR TITLE
Compare the publishable tree in the post-repair gate check

### DIFF
--- a/forge/.gitignore
+++ b/forge/.gitignore
@@ -7,6 +7,7 @@ logs/
 fixture-e2e-logs/
 .pending_metrics.json
 .continuation-marker.json
+.library_update_target.json
 
 ##############################
 ## Agent state

--- a/forge/docs/architecture/architecture.md
+++ b/forge/docs/architecture/architecture.md
@@ -818,9 +818,11 @@ and the shared library finalizer with nested agents disabled. The command hashes
 the publishable tree around the run and requires another pass after any mutation,
 so the reviewer writes its verdict only after the complete finalizer succeeds
 without changing that tree. Forge does not run finalization afterward; it reruns
-only `local_ci_check()` without fixups. A repair remains `approved` only when that
-gate passes without changing the reviewed commit; a failure or mutation reaches
-`restore_verified_tree()`. A finding that cannot be resolved results in
+only `local_ci_check()` without fixups. Forge hashes the publishable tree with the
+same function around that gate, so the two checks agree by construction and a
+local scratch file the branch would never publish cannot read as a mutation. A
+repair remains `approved` only when the gate passes without changing that tree;
+a failure or a real mutation reaches `restore_verified_tree()`. A finding that cannot be resolved results in
 `rejected` with action `human-intervention` or `close`. Reviewer failure is the
 fixed rejected human-intervention outcome.
 
@@ -835,7 +837,8 @@ publication adds `human-intervention` only for the explicit rejected action
 **Algorithmic.**
 
 When a review repair cannot pass the no-fixup pre-publication gate without
-changing the reviewed commit, Forge returns to the last commit that gate passed.
+changing the publishable tree, Forge returns to the last commit that gate passed
+and records the paths that actually differed.
 It never reruns finalization or launches another agent after the verdict. This
 preserves an otherwise publishable generated result while ensuring an approval
 never describes edits that were discarded (§FS-local-branch-review).

--- a/forge/docs/functional-spec/publication.md
+++ b/forge/docs/functional-spec/publication.md
@@ -373,12 +373,16 @@ finalization receipt, and owns staging and commits. A changed tree reruns only
 the pre-publication gate (§FS-local-ci-equivalent-verification.2), with fixups
 disabled; an unchanged tree does not. Finalization (§FS-local-ci-equivalent-verification.1) has already
 reached a stable tree inside the review and is not replayed. The gate is
-verification, not another mutation phase: the head and publishable worktree must
-remain byte-for-byte equal to the reviewed commit. If it fails or changes that
-tree, Forge restores the last verified tree, records the failed attempt in the
-finding, and publishes that exact tree as `rejected` with the action selected by
-the disposition ladder. No edit made after the verdict may enter the published
-head, and an approval of a discarded tree must never describe it.
+verification, not another mutation phase: the head and the publishable tree must
+be byte-for-byte identical before and after it runs. The comparison is over the
+publishable tree alone — the same content the finalization receipt hashes — so
+local scratch files that the branch would never publish are not evidence of a
+mutation, and only a difference the gate itself introduced counts. If the gate
+fails or changes that tree, Forge restores the last verified tree, records the
+failed attempt in the finding together with the paths that actually differed,
+and publishes that exact tree as `rejected` with the action selected by the
+disposition ladder. No edit made after the verdict may enter the published head,
+and an approval of a discarded tree must never describe it.
 
 **Durability and rendering.** The review prompt, response, and repair pass are
 durable task logs (§FS-durable-generation-logs). Its in-flight verdict is staged

--- a/forge/git_scripts/local_branch_review.py
+++ b/forge/git_scripts/local_branch_review.py
@@ -25,7 +25,10 @@ from ai_workflows.agents.agent_runtime import (
     get_analysis_agent,
 )
 from git_scripts.common_git import gh, gh_json, parse_coordinate_parts, stage_and_commit
-from git_scripts.review_finalization import finalization_receipt_matches
+from git_scripts.review_finalization import (
+    finalization_receipt_matches,
+    publishable_tree_digest,
+)
 from utility_scripts.local_ci_verification import (
     FINDINGS_RELATIVE_PATH,
     LocalCIVerificationError,
@@ -303,11 +306,35 @@ def run_local_branch_review(
     return outcome
 
 
-def _tree_matches_commit(repo_path: str, expected_sha: str) -> bool:
-    """Keep the post-verdict gate read-only. §FS-local-branch-review"""
-    current_sha: str = _git_stdout(repo_path, ["rev-parse", "HEAD"])
-    status: str = _git_stdout(repo_path, ["status", "--porcelain"])
-    return current_sha == expected_sha and not status
+@dataclass(frozen=True)
+class PublishableTree:
+    """The publishable content of the review worktree at one moment."""
+
+    head: str
+    digest: str
+    status: tuple[str, ...]
+
+
+def _capture_publishable_tree(repo_path: str) -> PublishableTree:
+    """Snapshot only the content the branch would publish. §FS-local-branch-review"""
+    return PublishableTree(
+        head=_git_stdout(repo_path, ["rev-parse", "HEAD"]),
+        digest=publishable_tree_digest(repo_path),
+        status=tuple(_git_stdout(repo_path, ["status", "--porcelain"]).splitlines()),
+    )
+
+
+def _describe_tree_change(before: PublishableTree, after: PublishableTree) -> str:
+    """Name what the gate changed so the finding diagnoses itself. §FS-local-branch-review"""
+    details: list[str] = []
+    if before.head != after.head:
+        details.append(f"HEAD moved from {before.head[:12]} to {after.head[:12]}")
+    details.extend(f"appeared: {line}" for line in after.status if line not in before.status)
+    details.extend(f"disappeared: {line}" for line in before.status if line not in after.status)
+    if not details:
+        details.append("publishable content changed without a new `git status` entry")
+        details.extend(f"still present: {line}" for line in after.status)
+    return "; ".join(details)
 
 
 def _verify_reviewer_edits(
@@ -321,7 +348,7 @@ def _verify_reviewer_edits(
         outcome: LocalBranchReviewOutcome,
 ) -> None:
     """Replay the cross-cutting gate without accepting a post-verdict mutation."""
-    reviewed_sha: str = _git_stdout(repo_path, ["rev-parse", "HEAD"])
+    reviewed_tree: PublishableTree = _capture_publishable_tree(repo_path)
     try:
         outcome.local_ci_verification = run_local_ci_verification(
             repo_path=repo_path,
@@ -340,25 +367,34 @@ def _verify_reviewer_edits(
         )
         return
 
-    if not _tree_matches_commit(repo_path, reviewed_sha):
-        _reset_reviewer_edits(
-            repo_path, verified_sha, metrics_repo_path, original_verification,
-        )
-        outcome.local_ci_verification = original_verification
-        _reject_failed_repair(
-            outcome, "pre-publication-gate-mutated-reviewed-tree",
-        )
+    gate_tree: PublishableTree = _capture_publishable_tree(repo_path)
+    if gate_tree.digest == reviewed_tree.digest:
+        return
+    change_detail: str = _describe_tree_change(reviewed_tree, gate_tree)
+    _log_review(
+        f"Pre-publication gate changed the publishable tree: {change_detail}",
+        indent_level=1,
+    )
+    _reset_reviewer_edits(
+        repo_path, verified_sha, metrics_repo_path, original_verification,
+    )
+    outcome.local_ci_verification = original_verification
+    _reject_failed_repair(
+        outcome, "pre-publication-gate-mutated-reviewed-tree", change_detail,
+    )
 
 
 def _reject_failed_repair(
         outcome: LocalBranchReviewOutcome,
         failed_step: str,
+        change_detail: str = "",
 ) -> None:
     """Ensure the descriptor decision describes the restored verified tree."""
     verdict: LocalReviewVerdict = outcome.verdict
+    observed: str = f" ({change_detail})" if change_detail else ""
     detail: str = (
-        f"The attempted review repair did not pass {failed_step}; Forge restored "
-        "the last verified tree, where this finding remains unresolved."
+        f"The attempted review repair did not pass {failed_step}{observed}; Forge "
+        "restored the last verified tree, where this finding remains unresolved."
     )
     finding_title: str = verdict.finding_title or "Pre-push review repair did not verify"
     finding_body: str = verdict.finding_body

--- a/forge/tests/test_local_branch_review.py
+++ b/forge/tests/test_local_branch_review.py
@@ -20,6 +20,30 @@ def _git(repo_path: str, *args: str) -> str:
     return subprocess.check_output(["git", *args], cwd=repo_path, text=True).strip()
 
 
+def _write(repo_path: str, relative_path: str, contents: str) -> None:
+    absolute_path = os.path.join(repo_path, relative_path)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+    with open(absolute_path, "w", encoding="utf-8") as target_file:
+        target_file.write(contents)
+
+
+def _init_repo(repo_path: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Forge Test"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "forge-test@example.invalid"],
+        cwd=repo_path,
+        check=True,
+    )
+    _write(repo_path, "source.txt", "before\n")
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "Initial"], cwd=repo_path, check=True)
+
+
+def _tree(digest: str = "stable") -> module.PublishableTree:
+    return module.PublishableTree(head="reviewed", digest=digest, status=())
+
+
 def _verdict() -> module.LocalReviewVerdict:
     return module.LocalReviewVerdict(
         decision="approved",
@@ -115,11 +139,11 @@ class LocalBranchReviewTests(unittest.TestCase):
         execution = module.ReviewExecution(_verdict(), "task-logs/review.log", ["source.txt"])
 
         with patch.object(module, "_load_persisted_outcome", return_value=None), \
-                patch.object(module, "_git_stdout", side_effect=["base", "head", "reviewed"]), \
+                patch.object(module, "_git_stdout", side_effect=["base", "head"]), \
                 patch.object(module, "_request_review", return_value=execution), \
                 patch.object(module, "_record_outcome_finding"), \
                 patch.object(module, "_persist_outcome"), \
-                patch.object(module, "_tree_matches_commit", return_value=True), \
+                patch.object(module, "_capture_publishable_tree", return_value=_tree()), \
                 patch.object(module, "run_local_ci_verification", return_value=reverified) as local_ci:
             outcome = module.run_local_branch_review(
                 repo_path="/repo",
@@ -161,7 +185,7 @@ class LocalBranchReviewTests(unittest.TestCase):
                 side_effect=module.LocalCIVerificationError(failed),
             ) as local_ci, patch.object(
                 module, "_git_stdout", return_value="reviewed",
-            ), patch.object(module, "_tree_matches_commit", return_value=True), \
+            ), patch.object(module, "_capture_publishable_tree", return_value=_tree()), \
                 patch.object(module, "_reset_reviewer_edits") as reset:
             module._verify_reviewer_edits(
                 repo_path="/repo",
@@ -184,6 +208,86 @@ class LocalBranchReviewTests(unittest.TestCase):
             metrics_repo_path="/metrics",
             max_fixup_attempts=0,
         )
+
+    def test_scratch_file_does_not_revert_a_reviewer_repair(self) -> None:
+        """An unignored non-contribution file is not a gate mutation. §FS-local-branch-review"""
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        reverified = LocalCIVerificationResult(status="success", base_commit="base")
+        verdict = _verdict()
+        outcome = module.LocalBranchReviewOutcome(
+            model="gpt-test",
+            session_log_path="task-logs/review.log",
+            local_ci_verification=verification,
+            verdict=verdict,
+            changed_paths=["source.txt"],
+        )
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            _init_repo(repo_path)
+            base_commit = _git(repo_path, "rev-parse", "HEAD")
+            _write(repo_path, "source.txt", "reviewer repair\n")
+            subprocess.run(["git", "commit", "-aqm", "Repair"], cwd=repo_path, check=True)
+            _write(repo_path, "forge/.library_update_target.json", "{}\n")
+
+            with patch.object(
+                    module, "run_local_ci_verification", return_value=reverified,
+            ), patch.object(module, "_reset_reviewer_edits") as reset:
+                module._verify_reviewer_edits(
+                    repo_path=repo_path,
+                    coordinates="org.example:demo:1.0.0",
+                    base_commit=base_commit,
+                    verified_sha=base_commit,
+                    metrics_repo_path=None,
+                    original_verification=verification,
+                    outcome=outcome,
+                )
+
+        reset.assert_not_called()
+        self.assertIs(outcome.verdict, verdict)
+        self.assertEqual(outcome.verdict.decision, "approved")
+        self.assertIs(outcome.local_ci_verification, reverified)
+
+    def test_gate_changing_a_contribution_path_reverts_and_names_it(self) -> None:
+        """Only a publishable difference produces the mutation label. §FS-local-branch-review"""
+        verification = LocalCIVerificationResult(status="success", base_commit="base")
+        reverified = LocalCIVerificationResult(status="success", base_commit="base")
+        outcome = module.LocalBranchReviewOutcome(
+            model="gpt-test",
+            session_log_path="task-logs/review.log",
+            local_ci_verification=verification,
+            verdict=_verdict(),
+            changed_paths=["source.txt"],
+        )
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            _init_repo(repo_path)
+            base_commit = _git(repo_path, "rev-parse", "HEAD")
+            _write(repo_path, "forge/.library_update_target.json", "{}\n")
+
+            def mutating_gate(**_: object) -> LocalCIVerificationResult:
+                _write(repo_path, "source.txt", "gate rewrote this\n")
+                return reverified
+
+            with patch.object(
+                    module, "run_local_ci_verification", side_effect=mutating_gate,
+            ), patch.object(module, "_reset_reviewer_edits") as reset:
+                module._verify_reviewer_edits(
+                    repo_path=repo_path,
+                    coordinates="org.example:demo:1.0.0",
+                    base_commit=base_commit,
+                    verified_sha=base_commit,
+                    metrics_repo_path=None,
+                    original_verification=verification,
+                    outcome=outcome,
+                )
+
+        reset.assert_called_once_with(repo_path, base_commit, None, verification)
+        self.assertEqual(outcome.verdict.decision, "rejected")
+        self.assertEqual(outcome.verdict.action, "human-intervention")
+        self.assertIn("pre-publication-gate-mutated-reviewed-tree", outcome.verdict.finding_body)
+        self.assertIn("source.txt", outcome.verdict.finding_body)
+        self.assertNotIn(".library_update_target.json", outcome.verdict.finding_body)
+        self.assertIs(outcome.local_ci_verification, verification)
 
     def test_persisted_verdict_is_scoped_to_publication_timestamp(self) -> None:
         verification = LocalCIVerificationResult(status="success", base_commit="base")


### PR DESCRIPTION
Closes #9993

## What this does

A verified reviewer repair was thrown away and published as `rejected` +
`human-intervention` because the post-repair check asked the wrong question. After the
no-fixup pre-publication gate runs, Forge confirmed the tree was untouched with

```python
current_sha == expected_sha and not _git_stdout(repo_path, ["status", "--porcelain"])
```

`git status --porcelain` lists untracked files, so **any** unignored scratch file in the
worktree failed the check — including files the gate never touched. In the observed run
the gate recorded `commands: []` and `status: success`, so it provably mutated nothing,
yet a repair that took `org.bouncycastle:bcpkix-jdk15on:1.70` from 0/6 to 4/6
dynamic-access coverage was reverted and labelled `pre-publication-gate-mutated-reviewed-tree`.

The invariant §FS-local-branch-review actually wants is that the *publishable* tree is
identical before and after the gate. `review_finalization.publishable_tree_digest()`
already computes exactly that — it is what the reviewer's own finalization receipt
hashes. Forge now uses the same function on both sides, so the receipt check and the
post-repair check agree by construction and cannot disagree about what "clean" means.

## How the check works now

`_verify_reviewer_edits` snapshots the publishable tree before the gate and compares it
after:

```python
reviewed_tree = _capture_publishable_tree(repo_path)
...run the gate...
gate_tree = _capture_publishable_tree(repo_path)
if gate_tree.digest == reviewed_tree.digest:
    return
```

Because a pre-existing scratch file is in *both* snapshots, it is neutral. Only a
difference the gate itself introduced can fail the check.

When it does fail, `_describe_tree_change` names what moved, and that text lands in both
the run log and the published finding instead of a bare label:

```
[local-review]   Pre-publication gate changed the publishable tree: appeared:  M source.txt
```

## The scratch file that triggered it

`forge/.library_update_target.json` is written into the worktree by
`write_library_update_target_sidecar()`. `branch_publication.py` already classifies it as a
`LOCAL_PUBLICATION_INPUT_PATH` — a local-only PR input that is deliberately never
published — but unlike its two siblings written to the same directory it was missing from
`forge/.gitignore`:

| Sidecar | Local-only input | Was ignored |
| --- | --- | --- |
| `.pending_metrics.json` | yes | yes |
| `.continuation-marker.json` | yes | yes |
| `.library_update_target.json` | yes | **no** |

It is ignored now. That removes the known instance; the digest comparison is what keeps
the next one from costing a 40-minute review.

## Spec and docs

`§FS-local-branch-review` said the head and publishable worktree must "remain byte-for-byte
equal to the reviewed commit", which is what invited the commit comparison. It now states
the comparison is over the publishable tree alone, that local scratch files are not
evidence of a mutation, and that a failure records the paths that actually differed.
`§AR-forge-workflow-pipeline` is aligned with it. The spec change is committed ahead of the
code.

`forge/tests/test_local_branch_review.py` gains two regression tests over a real temporary
repository: a repair with an untracked `forge/.library_update_target.json` present still
publishes as `approved`, and a gate that genuinely rewrites a contribution path still
reverts — with `source.txt` named in the finding and the scratch file absent from it.
