### PR TITLE
Drop unresolvable log paths from descriptors and PR bodies

### DIFF
--- a/.github/scripts/forge_pr_publisher/publisher.py
+++ b/.github/scripts/forge_pr_publisher/publisher.py
@@ -494,9 +494,13 @@ def _render_local_review(descriptor: dict[str, Any]) -> str:
     action: Any = review.get("action")
     if isinstance(action, str):
         lines.append(f"- Action: `{action}`")
+    lines.append(f"- Model: `{review['model']}`")
+    session_id: Any = review.get("session_id")
+    # Never the log path: `forge/logs/` is gitignored, so the path resolved for
+    # nobody who read the pull request. §forge/AR-publication-descriptor
+    if isinstance(session_id, str) and session_id:
+        lines.append(f"- Review session: `{session_id}`")
     lines.extend([
-        f"- Model: `{review['model']}`",
-        f"- Session log: `{review['session_log_path']}`",
         "",
         review["review_comment"],
     ])

--- a/.github/scripts/forge_pr_publisher/schema.json
+++ b/.github/scripts/forge_pr_publisher/schema.json
@@ -161,7 +161,6 @@
         "finding_body",
         "fix_note",
         "model",
-        "session_log_path",
         "changed_paths"
       ],
       "properties": {
@@ -193,7 +192,14 @@
           "minLength": 1,
           "maxLength": 200
         },
+        "session_id": {
+          "description": "Identifier of the reviewer session. Never a filesystem path: the operator's log tree is gitignored, so a path resolves for nobody who reads the pull request.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
         "session_log_path": {
+          "description": "Historic. Descriptors already on master carry it; new descriptors must not.",
           "type": "string",
           "minLength": 1,
           "maxLength": 1000
@@ -586,12 +592,6 @@
               },
               "env": {
                 "type": "object"
-              },
-              "log_path": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               },
               "output_excerpt": {
                 "type": "string"

--- a/forge/forge_metadata.py
+++ b/forge/forge_metadata.py
@@ -244,6 +244,7 @@ from utility_scripts.strategy_loader import load_strategy_by_name, require_strat
 from utility_scripts.task_logs import (
     build_task_log_path,
     display_log_path,
+    new_session_id,
     resolve_logs_root,
     sanitize_library_log_segment,
 )
@@ -3270,6 +3271,7 @@ def repair_failed_ci_pull_request(
         f"Failed to create CI-repair worktree for PR #{pr_number}",
     )
     try:
+        session_id = new_session_id()
         evidence_dir = os.path.join(worktree_path, f".forge-ci-repair-{uuid.uuid4().hex[:8]}")
         os.makedirs(evidence_dir)
         evidence_path = os.path.join(evidence_dir, "evidence.json")
@@ -3311,7 +3313,11 @@ def repair_failed_ci_pull_request(
             environment=trusted_environment,
             thinking_level="xhigh",
         )
-        log_path = display_log_path(result.log_path)
+        # The identifier is what the descriptor and the pull request carry; the
+        # path is printed for the operator only. §FS-durable-generation-logs
+        print(
+            f"[CI repair session {session_id}; log: {display_log_path(result.log_path)}]"
+        )
         outcome = _read_ci_repair_outcome(verdict_path) if result.return_code == 0 else None
         shutil.rmtree(evidence_dir, ignore_errors=True)
         changed_paths = _ci_repair_changed_paths(worktree_path)
@@ -3361,7 +3367,10 @@ def repair_failed_ci_pull_request(
             verdict = LocalReviewVerdict(
                 decision="rejected",
                 action="human-intervention",
-                review_comment=f"Forge could not obtain a valid CI-repair verdict. Log: {log_path}",
+                review_comment=(
+                    "Forge could not obtain a valid CI-repair verdict in review session "
+                    f"{session_id}."
+                ),
                 finding_title="CI repair reviewer unavailable",
                 finding_body="The failed-CI repair turn did not return a readable decision.",
                 fix_note="",
@@ -3441,7 +3450,7 @@ def repair_failed_ci_pull_request(
             "finding_body": verdict.finding_body,
             "fix_note": verdict.fix_note,
             "model": selection.model,
-            "session_log_path": log_path,
+            "session_id": session_id,
             "changed_paths": changed_paths[:200],
         }
         if verdict.action is not None:

--- a/forge/git_scripts/local_branch_review.py
+++ b/forge/git_scripts/local_branch_review.py
@@ -35,7 +35,11 @@ from utility_scripts.local_ci_verification import (
 )
 from utility_scripts.metrics_writer import read_pending_metrics, write_pending_metrics
 from utility_scripts.stage_logger import log_stage
-from utility_scripts.task_logs import build_timestamped_task_log_path, display_log_path
+from utility_scripts.task_logs import (
+    build_timestamped_task_log_path,
+    display_log_path,
+    new_session_id,
+)
 
 LOCAL_REVIEW_TIMEOUT_SECONDS: int = 3600
 LOCAL_REVIEW_METRICS_KEY: str = "local_review"
@@ -79,7 +83,7 @@ class ReviewExecution:
     """The observable result of the isolated reviewer process."""
 
     verdict: LocalReviewVerdict | None
-    session_log_path: str
+    session_id: str
     changed_paths: list[str] = field(default_factory=list)
 
 
@@ -88,7 +92,7 @@ class LocalBranchReviewOutcome:
     """Reviewer decision plus the evidence Forge persists."""
 
     model: str
-    session_log_path: str
+    session_id: str
     local_ci_verification: LocalCIVerificationResult
     verdict: LocalReviewVerdict
     changed_paths: list[str] = field(default_factory=list)
@@ -110,9 +114,13 @@ class LocalBranchReviewOutcome:
             "finding_body": self.verdict.finding_body,
             "fix_note": self.verdict.fix_note,
             "model": self.model,
-            "session_log_path": self.session_log_path,
             "changed_paths": list(self.changed_paths[:200]),
         }
+        # A session identifier, not a log path: the operator's `logs/` tree is
+        # gitignored, so a path here resolves for nobody who reads the pull
+        # request. §AR-publication-descriptor
+        if self.session_id:
+            payload["session_id"] = self.session_id
         if self.verdict.action is not None:
             payload["action"] = self.verdict.action
         return payload
@@ -138,7 +146,7 @@ class LocalBranchReviewOutcome:
         )
         return cls(
             model=str(payload["model"]),
-            session_log_path=str(payload["session_log_path"]),
+            session_id=str(payload.get("session_id") or ""),
             local_ci_verification=local_ci_verification,
             verdict=verdict,
             changed_paths=[str(path) for path in payload.get("changed_paths", [])],
@@ -265,7 +273,7 @@ def run_local_branch_review(
     verdict = _resolve_infrastructure_issue(verdict)
     outcome = LocalBranchReviewOutcome(
         model=review_model,
-        session_log_path=execution.session_log_path,
+        session_id=execution.session_id,
         local_ci_verification=local_ci_verification,
         verdict=verdict,
         changed_paths=list(execution.changed_paths),
@@ -403,6 +411,7 @@ def _request_review(
         descriptor_input: Any,
 ) -> ReviewExecution:
     """Run the isolated reviewer, transfer its Git edits, and return its verdict."""
+    session_id: str = new_session_id()
     unavailable_log_path: str = build_timestamped_task_log_path(
         "local-review", coordinates, "local_branch_review"
     )
@@ -411,7 +420,11 @@ def _request_review(
         _write_unavailable_log(
             unavailable_log_path, "Could not create detached review worktree.",
         )
-        return ReviewExecution(None, display_log_path(unavailable_log_path))
+        _log_review(
+            f"review session {session_id}; log: {display_log_path(unavailable_log_path)}",
+            indent_level=1,
+        )
+        return ReviewExecution(None, session_id)
 
     try:
         evidence_dir: str = os.path.join(
@@ -449,9 +462,11 @@ def _request_review(
             model=review_model,
             thinking_level="high",
         )
-        displayed_log_path: str = display_log_path(result.log_path)
+        # The path resolves only on this machine; the identifier is what the
+        # descriptor and the pull request carry. §FS-durable-generation-logs
         _log_review(
-            f"{selection.backend} review log: {displayed_log_path}",
+            f"{selection.backend} review session {session_id}; "
+            f"log: {display_log_path(result.log_path)}",
             indent_level=1,
         )
         if result.return_code != 0:
@@ -465,11 +480,11 @@ def _request_review(
                 f"Review {detail}",
                 indent_level=1,
             )
-            return ReviewExecution(None, displayed_log_path)
+            return ReviewExecution(None, session_id)
 
         verdict: LocalReviewVerdict | None = _read_verdict(verdict_path)
         if verdict is None:
-            return ReviewExecution(None, displayed_log_path)
+            return ReviewExecution(None, session_id)
         finalization_verified: bool = (
             task_type == "not-for-native-image"
             or finalization_receipt_matches(
@@ -490,7 +505,7 @@ def _request_review(
                 "Reviewer edits do not have a stable finalization receipt",
                 indent_level=1,
             )
-            return ReviewExecution(None, displayed_log_path)
+            return ReviewExecution(None, session_id)
         if changed_paths and (
                 not verdict.finding_title.strip() or not verdict.fix_note.strip()
         ):
@@ -498,13 +513,13 @@ def _request_review(
                 "Reviewer edited the tree without a complete finding and fix note",
                 indent_level=1,
             )
-            return ReviewExecution(None, displayed_log_path)
+            return ReviewExecution(None, session_id)
         if verdict.decision == "rejected":
-            return ReviewExecution(verdict, displayed_log_path)
+            return ReviewExecution(verdict, session_id)
         if changed_paths:
             review_commit: str = _git_stdout(worktree_path, ["rev-parse", "HEAD"])
             subprocess.run(["git", "cherry-pick", review_commit], cwd=repo_path, check=True)
-        return ReviewExecution(verdict, displayed_log_path, changed_paths)
+        return ReviewExecution(verdict, session_id, changed_paths)
     finally:
         _remove_review_worktree(repo_path, worktree_path)
 

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -154,7 +154,7 @@ def _validated_publication(
         "finding_body": "" if decision == "approved" else "Reason.",
         "fix_note": "",
         "model": "test-model",
-        "session_log_path": "task-logs/review.log",
+        "session_id": "a1b2c3d4e5f60718",
         "changed_paths": [],
     }
     if action is not None:
@@ -404,16 +404,19 @@ class LibraryUpdateIssueTests(unittest.TestCase):
                 "library": "org.example:lib:1.0.0",
                 "deterministic_setup": [],
                 "failure_reason": "Agent timed out",
-                "session_log_path": "/tmp/preflight-session.log",
             }
             stdout = io.StringIO()
             run_location.enter_phase(PHASE_SETUP)
             with contextlib.redirect_stdout(stdout):
-                preflight_module._write_and_log_preflight(claimed_issue, record)
+                preflight_module._write_and_log_preflight(
+                    claimed_issue, record, "/tmp/preflight-session.log",
+                )
             run_location.reset_run_location()
 
         self.assertIn("Library preflight degraded for org.example:lib:1.0.0: Agent timed out", stdout.getvalue())
+        # The log path reaches the operator's console; the persisted record never carries it.
         self.assertIn("preflight-session.log", stdout.getvalue())
+        self.assertNotIn("session_log_path", record)
 
     def test_library_preflight_dispatches_without_a_strategy(self) -> None:
         claimed_issue = forge_metadata.ClaimedIssue(
@@ -468,9 +471,11 @@ class LibraryUpdateIssueTests(unittest.TestCase):
                 preflight_module, "build_library_preflight_input_bundle",
                 return_value={"library": "org.example:lib:1.0.0"},
         ), patch.object(
-                preflight_module, "_write_text_artifact", return_value="/tmp/a.txt",
+                preflight_module, "_write_text_artifact",
         ), patch.object(
-                preflight_module, "_write_and_log_preflight", side_effect=lambda _i, record: record,
+                preflight_module,
+                "_write_and_log_preflight",
+                side_effect=lambda _i, record, _log=None: record,
         ):
             record = preflight_module.run_library_preparation_preflight(
                 claimed_issue=claimed_issue,
@@ -483,6 +488,10 @@ class LibraryUpdateIssueTests(unittest.TestCase):
         self.assertEqual(record["model"], "cheap-model")
         self.assertEqual(record["input_tokens_used"], 11)
         self.assertEqual(record["output_tokens_used"], 7)
+        # No path field survives into the committed metrics record.
+        self.assertEqual(
+            {"prompt_path", "raw_response_path", "session_log_path"} & set(record), set(),
+        )
 
     def test_issue_lookup_does_not_request_body_for_generic_claiming(self) -> None:
         issue_payload = {

--- a/forge/tests/test_forge_pr_publisher_code_coverage.py
+++ b/forge/tests/test_forge_pr_publisher_code_coverage.py
@@ -119,7 +119,7 @@ def _local_review() -> dict[str, Any]:
         "finding_body": "",
         "fix_note": "",
         "model": "gpt-5.6-terra",
-        "session_log_path": "task-logs/review.log",
+        "session_id": "a1b2c3d4e5f60718",
         "changed_paths": [],
     }
 

--- a/forge/tests/test_forge_pr_publisher_review_actions.py
+++ b/forge/tests/test_forge_pr_publisher_review_actions.py
@@ -40,7 +40,7 @@ def _descriptor(action: str | None = None) -> dict[str, Any]:
         "finding_body": "" if action is None else "Native Image cannot support this version.",
         "fix_note": "",
         "model": "gpt-5.6-terra",
-        "session_log_path": "task-logs/review.log",
+        "session_id": "a1b2c3d4e5f60718",
         "changed_paths": [],
     }
     if action is not None:

--- a/forge/tests/test_local_branch_review.py
+++ b/forge/tests/test_local_branch_review.py
@@ -149,7 +149,7 @@ class LocalBranchReviewTests(unittest.TestCase):
         verdict = _verdict()
         outcome = module.LocalBranchReviewOutcome(
             model="gpt-test",
-            session_log_path="task-logs/review.log",
+            session_id="a1b2c3d4e5f60718",
             local_ci_verification=verification,
             verdict=verdict,
             changed_paths=["source.txt"],
@@ -190,7 +190,7 @@ class LocalBranchReviewTests(unittest.TestCase):
         descriptor_input = SimpleNamespace(timestamp="2026-08-25T10:00:00Z")
         outcome = module.LocalBranchReviewOutcome(
             model="gpt-test",
-            session_log_path="task-logs/review.log",
+            session_id="a1b2c3d4e5f60718",
             local_ci_verification=verification,
             verdict=_verdict(),
         )
@@ -273,9 +273,8 @@ class LocalBranchReviewTests(unittest.TestCase):
             thinking_level="high",
         )
         self.assertEqual(execution.verdict, verdict)
-        self.assertEqual(
-            execution.session_log_path, module.display_log_path(result.log_path),
-        )
+        # A session identifier, never a path into the operator's gitignored logs.
+        self.assertRegex(execution.session_id, r"^[0-9a-f]{16}$")
         remove_worktree.assert_called_once_with("/repo", review_worktree)
 
     def test_review_prompt_finishes_finalization_before_verdict(self) -> None:

--- a/forge/tests/test_publish_not_for_native_image.py
+++ b/forge/tests/test_publish_not_for_native_image.py
@@ -49,7 +49,7 @@ class PublishNotForNativeImageTests(unittest.TestCase):
             return LocalBranchReviewOutcome(
                 status="completed",
                 model="test-model",
-                session_log_path="task-logs/review.log",
+                session_id="a1b2c3d4e5f60718",
                 local_ci_verification=result,
                 verdict=LocalReviewVerdict(
                     decision="approved",

--- a/forge/tests/test_published_path_provenance.py
+++ b/forge/tests/test_published_path_provenance.py
@@ -1,0 +1,159 @@
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+"""Keep operator-only log paths out of what Forge publishes.
+
+Every record here leaves the machine that produced it: the descriptor and the
+pull-request body are read by maintainers, and the metrics record is committed to
+a public repository. A path into `forge/logs/` resolves for none of them, and an
+absolute one carries the operator's home directory along with it.
+§FS-durable-generation-logs, §AR-publication-descriptor
+"""
+
+import glob
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from typing import Any
+
+from git_scripts.local_branch_review import LocalBranchReviewOutcome, LocalReviewVerdict
+from utility_scripts.local_ci_verification import (
+    CommandRecord,
+    FixupRecord,
+    LocalCIVerificationResult,
+)
+from utility_scripts.task_logs import new_session_id
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PUBLISHER_PATH = os.path.join(
+    REPOSITORY_ROOT, ".github", "scripts", "forge_pr_publisher", "publisher.py",
+)
+
+
+def _load_publisher() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "forge_pr_publisher_path_provenance", PUBLISHER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+publisher = _load_publisher()
+
+
+def _string_values(value: Any, path: str = "") -> list[tuple[str, str]]:
+    """Flatten every string a JSON-shaped value carries, with its key path."""
+    if isinstance(value, dict):
+        return [
+            found
+            for key, item in value.items()
+            for found in _string_values(item, f"{path}.{key}")
+        ]
+    if isinstance(value, list):
+        return [found for item in value for found in _string_values(item, f"{path}[]")]
+    return [(path, value)] if isinstance(value, str) else []
+
+
+def _outcome() -> LocalBranchReviewOutcome:
+    verification = LocalCIVerificationResult(
+        status="success",
+        base_commit="base",
+        final_commit="head",
+        commands=[
+            CommandRecord(
+                gate="checkstyle",
+                command=["./gradlew", "checkstyle"],
+                returncode=0,
+                output_excerpt="BUILD SUCCESSFUL",
+            ),
+        ],
+        fixups=[
+            FixupRecord(
+                gate="checkstyle",
+                command=["pi", "gpt-5.6-terra"],
+                commit="fixup",
+                changed_paths=["tests/src/org.example/demo/1.0.0/build.gradle"],
+            ),
+        ],
+    )
+    return LocalBranchReviewOutcome(
+        model="gpt-5.6-terra",
+        session_id=new_session_id(),
+        local_ci_verification=verification,
+        verdict=LocalReviewVerdict(
+            decision="approved",
+            review_comment="Checked every applicable rule.",
+            finding_title="",
+            finding_body="",
+            fix_note="",
+        ),
+        changed_paths=["metadata/org.example/demo/reflect-config.json"],
+    )
+
+
+class PublishedPathProvenanceTests(unittest.TestCase):
+    def test_rendered_pull_request_body_names_no_log_path(self) -> None:
+        outcome = _outcome()
+        body = publisher._render_local_review(
+            {"local_review": outcome.to_descriptor_payload()},
+        )
+
+        self.assertIn(f"- Review session: `{outcome.session_id}`", body)
+        self.assertNotIn("logs/", body)
+        self.assertNotIn(".log", body)
+
+    def test_descriptor_review_evidence_carries_no_filesystem_path(self) -> None:
+        outcome = _outcome()
+        evidence = {
+            "local_review": outcome.to_descriptor_payload(),
+            "local_ci_verification": outcome.local_ci_verification.to_metrics(),
+        }
+
+        for key_path, value in _string_values(evidence):
+            self.assertFalse(key_path.endswith("log_path"), key_path)
+            self.assertNotIn("logs/", value, key_path)
+
+    def test_committed_execution_metrics_carry_no_absolute_path(self) -> None:
+        """The 336 committed home directories of issue #9985 must not come back."""
+        offenders: list[str] = []
+        for metrics_path in glob.glob(
+                os.path.join(REPOSITORY_ROOT, "stats", "*", "*", "*", "execution-metrics.json"),
+        ):
+            with open(metrics_path, encoding="utf-8") as metrics_file:
+                entries = json.load(metrics_file)
+            offenders.extend(
+                f"{os.path.relpath(metrics_path, REPOSITORY_ROOT)}{key_path}: {value}"
+                for key_path, value in _string_values(entries)
+                if value.startswith("/") or value[1:3] == ":\\"
+            )
+
+        self.assertEqual(offenders, [])
+
+    def test_committed_execution_metrics_carry_no_preflight_path_field(self) -> None:
+        offenders: list[str] = []
+        for metrics_path in glob.glob(
+                os.path.join(REPOSITORY_ROOT, "stats", "*", "*", "*", "execution-metrics.json"),
+        ):
+            with open(metrics_path, encoding="utf-8") as metrics_file:
+                entries = json.load(metrics_file)
+            for key, entry in entries.items():
+                preflight = entry.get("library_preparation_preflight")
+                if not isinstance(preflight, dict):
+                    continue
+                offenders.extend(
+                    f"{os.path.relpath(metrics_path, REPOSITORY_ROOT)}[{key}].{field}"
+                    for field in ("prompt_path", "raw_response_path", "session_log_path")
+                    if field in preflight
+                )
+
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -211,9 +211,6 @@ def _degraded_library_preflight_record(
         input_bundle: dict[str, Any],
         failure_reason: str,
         model_name: str | None = None,
-        prompt_path: str | None = None,
-        raw_response_path: str | None = None,
-        session_log_path: str | None = None,
 ) -> dict[str, Any]:
     """Record an unavailable or unusable preflight as no-action advisory output."""
     record = _base_library_preflight_record(claimed_issue, input_bundle)
@@ -221,12 +218,6 @@ def _degraded_library_preflight_record(
     record["failure_reason"] = failure_reason
     if model_name:
         record["model"] = model_name
-    if prompt_path:
-        record["prompt_path"] = prompt_path
-    if raw_response_path:
-        record["raw_response_path"] = raw_response_path
-    if session_log_path:
-        record["session_log_path"] = session_log_path
     return record
 
 
@@ -317,9 +308,6 @@ def _completed_library_preflight_record(
         response_payload: dict[str, Any],
         model_name: str,
         result: Any | None,
-        prompt_path: str | None,
-        raw_response_path: str | None,
-        session_log_path: str | None,
 ) -> dict[str, Any]:
     """Normalize a valid preflight response into the persisted metrics shape."""
     action = str(response_payload.get("action") or "no_action").strip()
@@ -346,12 +334,6 @@ def _completed_library_preflight_record(
     record["model"] = model_name
     record["input_tokens_used"] = int(getattr(result, "input_tokens", 0) or 0)
     record["output_tokens_used"] = int(getattr(result, "output_tokens", 0) or 0)
-    if prompt_path:
-        record["prompt_path"] = prompt_path
-    if raw_response_path:
-        record["raw_response_path"] = raw_response_path
-    if session_log_path:
-        record["session_log_path"] = session_log_path
     return record
 
 
@@ -394,27 +376,11 @@ def _library_preflight_prompt(input_bundle: dict[str, Any]) -> str:
     )
 
 
-def _relative_or_absolute_path(path: str | None, root: str) -> str | None:
-    """Return a stable metrics path, relative when it is under the metrics root."""
-    if not path:
-        return None
-    try:
-        absolute_path = os.path.abspath(path)
-        absolute_root = os.path.abspath(root)
-        if os.path.commonpath([absolute_path, absolute_root]) == absolute_root:
-            return os.path.relpath(absolute_path, absolute_root)
-    except ValueError:
-        pass
-    return path
-
-
-def _write_text_artifact(root: str, file_name: str, content: str) -> str:
-    """Write a preflight text artifact and return its metrics-root-relative path."""
+def _write_text_artifact(root: str, file_name: str, content: str) -> None:
+    """Write a preflight text artifact next to the record it belongs to."""
     os.makedirs(root, exist_ok=True)
-    path = os.path.join(root, file_name)
-    with open(path, "w", encoding="utf-8") as artifact_file:
+    with open(os.path.join(root, file_name), "w", encoding="utf-8") as artifact_file:
         artifact_file.write(content)
-    return os.path.relpath(path, root)
 
 
 def _preflight_artifact_root(claimed_issue: Any) -> str:
@@ -422,8 +388,18 @@ def _preflight_artifact_root(claimed_issue: Any) -> str:
     return getattr(claimed_issue, "preflight_info_path", None) or claimed_issue.scratch_metrics_repo_path
 
 
-def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
-    """Persist the record and log a one-line outcome, covering every decision path."""
+def _write_and_log_preflight(
+        claimed_issue: Any,
+        record: dict[str, Any],
+        session_log_path: str | None = None,
+) -> str:
+    """Persist the record and log a one-line outcome, covering every decision path.
+
+    The session log path is printed, never persisted: the record is committed to
+    `stats/`, where a path into the operator's gitignored `logs/` tree resolves for
+    no reader and an absolute one carries a home directory into a public
+    repository. §FS-durable-generation-logs
+    """
     detail = f"status={record.get('status')} action={record.get('action')}"
     setup_count = len(record.get("deterministic_setup") or [])
     if setup_count:
@@ -446,8 +422,9 @@ def _write_and_log_preflight(claimed_issue: Any, record: dict[str, Any]) -> str:
             f"Library preflight completed for {library}: {outcome}",
         )
     else:
-        log_path = record.get("session_log_path")
-        log_suffix = f" (log: {display_log_path(str(log_path))})" if log_path else ""
+        log_suffix = (
+            f" (log: {display_log_path(session_log_path)})" if session_log_path else ""
+        )
         failure_text = str(failure_reason or "no usable decision")
         log_step_progress(
             PHASE_SETUP,
@@ -489,12 +466,13 @@ def run_library_preparation_preflight(
     )
     prompt = _library_preflight_prompt(input_bundle)
     preflight_artifact_root = _preflight_artifact_root(claimed_issue)
-    prompt_path = _write_text_artifact(
+    # The prompt and the response stay on disk as run evidence; only their paths
+    # are kept out of the committed record.
+    _write_text_artifact(
         preflight_artifact_root,
         "library-preflight-prompt.txt",
         prompt,
     )
-    raw_response_path: str | None = None
     session_log_path: str | None = None
     model_name = selection.model
 
@@ -513,15 +491,12 @@ def run_library_preparation_preflight(
                 + (" (timed out)" if result.timed_out else "")
             )
         response_text = result.response
-        raw_response_path = _write_text_artifact(
+        _write_text_artifact(
             preflight_artifact_root,
             "library-preflight-response.txt",
             response_text,
         )
-        session_log_path = _relative_or_absolute_path(
-            result.session_log_path,
-            preflight_artifact_root,
-        )
+        session_log_path = result.session_log_path
         response_payload = _extract_preflight_json_response(response_text)
         record = _completed_library_preflight_record(
             claimed_issue,
@@ -529,26 +504,17 @@ def run_library_preparation_preflight(
             response_payload,
             model_name,
             result,
-            prompt_path,
-            raw_response_path,
-            session_log_path,
         )
     except Exception as exc:
         if session_log_path is None and result is not None:
-            session_log_path = _relative_or_absolute_path(
-                result.session_log_path,
-                preflight_artifact_root,
-            )
+            session_log_path = result.session_log_path
         record = _degraded_library_preflight_record(
             claimed_issue,
             input_bundle,
             f"{type(exc).__name__}: {exc}",
             model_name=model_name,
-            prompt_path=prompt_path,
-            raw_response_path=raw_response_path,
-            session_log_path=session_log_path,
         )
-    return _write_and_log_preflight(claimed_issue, record)
+    return _write_and_log_preflight(claimed_issue, record, session_log_path)
 
 
 def write_library_preparation_preflight(metrics_repo_root: str, preflight: dict[str, Any]) -> str:

--- a/forge/utility_scripts/local_ci_verification.py
+++ b/forge/utility_scripts/local_ci_verification.py
@@ -53,25 +53,33 @@ DOCKER_IMAGE_LIST_COMMAND = ["docker", "image", "ls", "--format", "{{.Repository
 
 @dataclass
 class CommandRecord:
-    """A single local CI command and its outcome."""
+    """A single local CI command and its outcome.
+
+    The log path is deliberately absent: the record reaches the publication
+    descriptor, where a path into the operator's gitignored `logs/` tree resolves
+    for no reader. The path is printed for the operator instead.
+    §FS-durable-generation-logs
+    """
 
     gate: str
     command: list[str]
     returncode: int
     env: dict[str, str] = field(default_factory=dict)
-    log_path: str | None = None
     output_excerpt: str = ""
 
 
 @dataclass
 class FixupRecord:
-    """A verifier fixup attempt."""
+    """A verifier fixup attempt.
+
+    Like `CommandRecord`, it reaches the publication descriptor and so carries no
+    log path. §FS-durable-generation-logs
+    """
 
     gate: str
     command: list[str]
     commit: str | None
     changed_paths: list[str]
-    log_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -482,7 +490,6 @@ def _run_recorded_command(
             command=command,
             returncode=1,
             env=display_env,
-            log_path=display_log_path(log_path),
             output_excerpt=output,
         )
         result.commands.append(record)
@@ -514,14 +521,17 @@ def _run_recorded_command(
         command=command,
         returncode=returncode,
         env=display_env,
-        log_path=display_log_path(log_path),
         output_excerpt=_tail(output),
     )
     result.commands.append(record)
+    displayed_log_path = display_log_path(log_path)
     if returncode != 0:
-        _log_local_ci(f"Gate {gate} failed with exit code {returncode}; log: {record.log_path}", indent_level=1)
+        _log_local_ci(
+            f"Gate {gate} failed with exit code {returncode}; log: {displayed_log_path}",
+            indent_level=1,
+        )
         return record
-    _log_local_ci(f"Gate {gate} passed; log: {record.log_path}", indent_level=1)
+    _log_local_ci(f"Gate {gate} passed; log: {displayed_log_path}", indent_level=1)
     return None
 
 
@@ -654,12 +664,18 @@ def _run_fixup(repo_path: str, coordinates: str, failed_command: CommandRecord) 
         library=coordinates,
         commit_message="Apply local CI verification fixes",
     )
+    outcome = attempt.failure_reason or f"committed {attempt.commit}"
+    # The record no longer carries the path, so this line is the only place the
+    # operator learns which log holds the fixup turn. §FS-durable-generation-logs
+    _log_local_ci(
+        f"Fixup for gate {failed_command.gate} {outcome}; log: {attempt.log_path}",
+        indent_level=1,
+    )
     return FixupRecord(
         gate=failed_command.gate,
         command=attempt.command,
         commit=attempt.commit,
         changed_paths=attempt.changed_paths,
-        log_path=attempt.log_path,
     )
 
 
@@ -1091,9 +1107,8 @@ def _record_synthetic_failure(
         command=command,
         returncode=1,
         env=dict(env or {}),
-        log_path=display_log_path(log_path),
         output_excerpt=_tail(output),
     )
     result.commands.append(record)
-    _log_local_ci(f"Gate {gate} failed; log: {record.log_path}", indent_level=1)
+    _log_local_ci(f"Gate {gate} failed; log: {display_log_path(log_path)}", indent_level=1)
     return record

--- a/forge/utility_scripts/task_logs.py
+++ b/forge/utility_scripts/task_logs.py
@@ -4,7 +4,18 @@
 # work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import os
+import uuid
 from datetime import datetime, timezone
+
+
+def new_session_id() -> str:
+    """Mint the identifier that names one agent session in durable records.
+
+    A session identifier travels where a log path cannot: it is meaningful to a
+    reader who has no access to the operator's filesystem, and it is the "session
+    or thread identifier" that §FS-durable-generation-logs asks a run to record.
+    """
+    return uuid.uuid4().hex[:16]
 
 
 def sanitize_log_segment(value: str | None) -> str:

--- a/stats/cglib/cglib-nodep/2.2.2/execution-metrics.json
+++ b/stats/cglib/cglib-nodep/2.2.2/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 42788,
-      "output_tokens_used": 4190,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/cglib:cglib-nodep:2.2.2/library-preparation-preflight/pi-generation-2026-08-27T09-26-16-245451Z.log"
+      "output_tokens_used": 4190
     },
     "metrics": {
       "input_tokens_used": 794472,

--- a/stats/classworlds/classworlds/1.1/execution-metrics.json
+++ b/stats/classworlds/classworlds/1.1/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 65541,
-      "output_tokens_used": 3034,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/classworlds:classworlds:1.1/library-preparation-preflight/pi-generation-2026-06-25T00-29-35-792068Z.log"
+      "output_tokens_used": 3034
     },
     "metrics": {
       "input_tokens_used": 405719,

--- a/stats/co.elastic.clients/elasticsearch-java/9.0.3/execution-metrics.json
+++ b/stats/co.elastic.clients/elasticsearch-java/9.0.3/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 53372,
-      "output_tokens_used": 6935,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/co.elastic.clients:elasticsearch-java:9.0.3/library-preparation-preflight/pi-generation-2026-06-28T11-21-14-447213Z.log"
+      "output_tokens_used": 6935
     },
     "metrics": {
       "input_tokens_used": 201901,

--- a/stats/com.amazonaws/aws-lambda-java-events/3.0.0/execution-metrics.json
+++ b/stats/com.amazonaws/aws-lambda-java-events/3.0.0/execution-metrics.json
@@ -60,10 +60,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 30908,
-      "output_tokens_used": 1052,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.amazonaws:aws-lambda-java-events:3.0.0/library-preparation-preflight/pi-generation-2026-08-13T08-16-33-714398Z.log"
+      "output_tokens_used": 1052
     },
     "metrics": {
       "input_tokens_used": 81803,

--- a/stats/com.apollographql.federation/federation-graphql-java-support/6.1.0/execution-metrics.json
+++ b/stats/com.apollographql.federation/federation-graphql-java-support/6.1.0/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 41318,
-      "output_tokens_used": 2768,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/com.apollographql.federation:federation-graphql-java-support:6.1.0/library-preparation-preflight/pi-generation-2026-06-18T14-21-04-843229Z.log"
+      "output_tokens_used": 2768
     },
     "metrics": {
       "input_tokens_used": 55916,

--- a/stats/com.baomidou/mybatis-plus-boot-starter/3.5.3.1/execution-metrics.json
+++ b/stats/com.baomidou/mybatis-plus-boot-starter/3.5.3.1/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 62652,
-      "output_tokens_used": 3710,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/com.baomidou:mybatis-plus-boot-starter:3.5.3.1/library-preparation-preflight/pi-generation-2026-08-25T18-27-14-345172Z.log"
+      "output_tokens_used": 3710
     },
     "metrics": {
       "input_tokens_used": 131703,

--- a/stats/com.couchbase.client/metrics-micrometer/3.11.3/execution-metrics.json
+++ b/stats/com.couchbase.client/metrics-micrometer/3.11.3/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1777611,
-      "output_tokens_used": 8825,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.couchbase.client:metrics-micrometer:3.11.3/library-preparation-preflight/codex-session-h7hi36wa.log"
+      "output_tokens_used": 8825
     },
     "metrics": {
       "input_tokens_used": 203800,

--- a/stats/com.couchbase.client/tracing-micrometer-observation/3.11.3/execution-metrics.json
+++ b/stats/com.couchbase.client/tracing-micrometer-observation/3.11.3/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 6044446,
-      "output_tokens_used": 19411,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.couchbase.client:tracing-micrometer-observation:3.11.3/library-preparation-preflight/codex-session-ha5cwsp6.log"
+      "output_tokens_used": 19411
     },
     "metrics": {
       "input_tokens_used": 274375,

--- a/stats/com.diffplug.durian/durian-io/1.2.0/execution-metrics.json
+++ b/stats/com.diffplug.durian/durian-io/1.2.0/execution-metrics.json
@@ -100,10 +100,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 40107,
-      "output_tokens_used": 6166,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.diffplug.durian:durian-io:1.2.0/library-preparation-preflight/pi-generation-2026-06-28T10-26-49-602049Z.log"
+      "output_tokens_used": 6166
     },
     "metrics": {
       "input_tokens_used": 57215,

--- a/stats/com.esotericsoftware/kryo-shaded/3.0.3/execution-metrics.json
+++ b/stats/com.esotericsoftware/kryo-shaded/3.0.3/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 41398,
-      "output_tokens_used": 6620,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.esotericsoftware:kryo-shaded:3.0.3/library-preparation-preflight/pi-generation-2026-06-24T20-12-29-506164Z.log"
+      "output_tokens_used": 6620
     },
     "metrics": {
       "input_tokens_used": 1331963,

--- a/stats/com.ethlo.time/itu/1.10.3/execution-metrics.json
+++ b/stats/com.ethlo.time/itu/1.10.3/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 21843,
-      "output_tokens_used": 1302,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.ethlo.time:itu:1.10.3/library-preparation-preflight/pi-generation-2026-06-28T01-20-02-607607Z.log"
+      "output_tokens_used": 1302
     },
     "metrics": {
       "input_tokens_used": 49476,

--- a/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.22.1/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.22.1/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 727519,
-      "output_tokens_used": 6160,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22.1/library-preparation-preflight/codex-session-ykzd2a9w.log"
+      "output_tokens_used": 6160
     },
     "metrics": {
       "input_tokens_used": 168101,

--- a/stats/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.22.2/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.22.2/execution-metrics.json
@@ -64,13 +64,10 @@
       "library": "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.22.2",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 2810,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Do not use the Jakarta XML Bind annotations; this artifact supports javax.xml.bind annotations.",
         "If tests exercise DataHandler, DOM, or actual JAXBContext functionality, additional runtime behavior and Native Image metadata may be required."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.22.2/library-preparation-preflight/codex-session-7lqliofs.log",
       "status": "completed",
       "summary": "The module requires explicit registration and JAXB-annotated fixtures for meaningful coverage, but no extra dependency or Docker image."
     },

--- a/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.13.2/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2/library-preparation-preflight/pi-generation-2026-06-09T13-21-56-749153Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 284355,

--- a/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/execution-metrics.json
+++ b/stats/com.fasterxml.jackson.module/jackson-module-scala_3/2.15.0/execution-metrics.json
@@ -113,9 +113,7 @@
       "current_library": "com.fasterxml.jackson.module:jackson-module-scala_3:2.13.2",
       "new_version": "2.15.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.fasterxml.jackson.module:jackson-module-scala_3:2.15.0/library-preparation-preflight/pi-generation-2026-06-09T21-53-35-488337Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 21796,

--- a/stats/com.github.ajalt.mordant/mordant-jvm-jna-jvm/3.0.2/execution-metrics.json
+++ b/stats/com.github.ajalt.mordant/mordant-jvm-jna-jvm/3.0.2/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 39457,
-      "output_tokens_used": 5536,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.github.ajalt.mordant:mordant-jvm-jna-jvm:3.0.2/library-preparation-preflight/pi-generation-2026-06-28T01-04-09-899943Z.log"
+      "output_tokens_used": 5536
     },
     "metrics": {
       "input_tokens_used": 268314,

--- a/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/execution-metrics.json
+++ b/stats/com.github.ghik/silencer-lib_2.13.12/1.7.14/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 47797,
-      "output_tokens_used": 2475,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.github.ghik:silencer-lib_2.13.12:1.7.14/library-preparation-preflight/pi-generation-2026-06-28T06-22-35-884903Z.log"
+      "output_tokens_used": 2475
     },
     "metrics": {
       "input_tokens_used": 135127,

--- a/stats/com.github.seregamorph/spring-test-smart-context/1.0/execution-metrics.json
+++ b/stats/com.github.seregamorph/spring-test-smart-context/1.0/execution-metrics.json
@@ -107,10 +107,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1612020,
-      "output_tokens_used": 12994,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.github.seregamorph:spring-test-smart-context:1.0/library-preparation-preflight/codex-session-haa720gc.log"
+      "output_tokens_used": 12994
     },
     "metrics": {
       "input_tokens_used": 120541,

--- a/stats/com.github.victools/jsonschema-module-jackson/4.38.0/execution-metrics.json
+++ b/stats/com.github.victools/jsonschema-module-jackson/4.38.0/execution-metrics.json
@@ -78,13 +78,10 @@
       "library": "com.github.victools:jsonschema-module-jackson:4.38.0",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 2146,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "If the harness already injects provided-scope dependencies differently, the extra dependency may be redundant, but it matches documented usage and version-alignment guidance.",
         "Coverage can remain superficial if tests only instantiate JacksonModule without generating a schema from annotated model classes."
       ],
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.github.victools:jsonschema-module-jackson:4.38.0/library-preparation-preflight/pi-generation-2026-06-27T03-23-47-527235Z.log",
       "status": "completed",
       "summary": "The Jackson module is an add-on whose POM marks jsonschema-generator and Jackson APIs as provided; meaningful tests need the aligned generator dependency available."
     },

--- a/stats/com.github.waffle/waffle-jna/3.5.0/execution-metrics.json
+++ b/stats/com.github.waffle/waffle-jna/3.5.0/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 80173,
-      "output_tokens_used": 4290,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.github.waffle:waffle-jna:3.5.0/library-preparation-preflight/pi-generation-2026-06-29T01-45-48-734725Z.log"
+      "output_tokens_used": 4290
     },
     "metrics": {
       "input_tokens_used": 107697,

--- a/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
+++ b/stats/com.google.auth/google-auth-library-oauth2-http/1.48.0/execution-metrics.json
@@ -136,9 +136,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.google.auth:google-auth-library-oauth2-http:1.48.0/library-preparation-preflight/pi-generation-2026-06-11T12-00-04-538238Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 260263,

--- a/stats/com.google.cloud/google-cloud-secretmanager/2.64.0/execution-metrics.json
+++ b/stats/com.google.cloud/google-cloud-secretmanager/2.64.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.google.cloud:google-cloud-secretmanager:2.64.0/library-preparation-preflight/pi-generation-2026-06-10T03-09-44-802357Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 288237,

--- a/stats/com.google.code.gson/gson/2.14.0/execution-metrics.json
+++ b/stats/com.google.code.gson/gson/2.14.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.google.code.gson:gson:2.14.0/library-preparation-preflight/pi-generation-2026-06-28T20-40-10-717734Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 434386,

--- a/stats/com.jayway.jsonpath/json-path/2.7.0/execution-metrics.json
+++ b/stats/com.jayway.jsonpath/json-path/2.7.0/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 30292,
-      "output_tokens_used": 1042,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/com.jayway.jsonpath:json-path:2.7.0/library-preparation-preflight/pi-generation-2026-08-26T08-47-17-963568Z.log"
+      "output_tokens_used": 1042
     },
     "metrics": {
       "input_tokens_used": 60273,

--- a/stats/com.knuddels/jtokkit/1.1.0/execution-metrics.json
+++ b/stats/com.knuddels/jtokkit/1.1.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.knuddels:jtokkit:1.1.0/library-preparation-preflight/pi-generation-2026-06-27T01-22-55-380243Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 32253,

--- a/stats/com.lihaoyi/pprint_2.13/0.9.0/execution-metrics.json
+++ b/stats/com.lihaoyi/pprint_2.13/0.9.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.lihaoyi:pprint_2.13:0.9.0/library-preparation-preflight/pi-generation-2026-06-27T18-18-55-230136Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 126314,

--- a/stats/com.mailjet/mailjet-client/6.0.1/execution-metrics.json
+++ b/stats/com.mailjet/mailjet-client/6.0.1/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.mailjet:mailjet-client:6.0.1/library-preparation-preflight/pi-generation-2026-07-06T00-20-42-858182Z.log"
+      "model": "gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 225765,

--- a/stats/com.netflix.graphql.dgs/graphql-dgs-subscription-types/10.5.0/execution-metrics.json
+++ b/stats/com.netflix.graphql.dgs/graphql-dgs-subscription-types/10.5.0/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 3218626,
-      "output_tokens_used": 17405,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.netflix.graphql.dgs:graphql-dgs-subscription-types:10.5.0/library-preparation-preflight/codex-session-fogl3sy2.log"
+      "output_tokens_used": 17405
     },
     "metrics": {
       "input_tokens_used": 215846,

--- a/stats/com.opencsv/opencsv/5.6/execution-metrics.json
+++ b/stats/com.opencsv/opencsv/5.6/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 66690,
-      "output_tokens_used": 3036,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.opencsv:opencsv:5.6/library-preparation-preflight/pi-generation-2026-06-25T18-10-19-958095Z.log"
+      "output_tokens_used": 3036
     },
     "metrics": {
       "input_tokens_used": 974127,

--- a/stats/com.oracle.database.jdbc/ojdbc11/23.26.2.0.0/execution-metrics.json
+++ b/stats/com.oracle.database.jdbc/ojdbc11/23.26.2.0.0/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1929585,
-      "output_tokens_used": 10027,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.oracle.database.jdbc:ojdbc11:23.26.2.0.0/library-preparation-preflight/codex-session-tfscqi1f.log"
+      "output_tokens_used": 10027
     },
     "metrics": {
       "input_tokens_used": 1025337,
@@ -208,10 +205,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1579281,
-      "output_tokens_used": 9207,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.oracle.database.jdbc:ojdbc11:23.26.2.0.0/library-preparation-preflight/codex-session-sb0amqi4.log"
+      "output_tokens_used": 9207
     },
     "metrics": {
       "input_tokens_used": 829301,
@@ -300,10 +294,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-luna",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.oracle.database.jdbc:ojdbc11:23.26.2.0.0/library-preparation-preflight/codex-session-mebm1lfq.log"
+      "model": "gpt-5.6-luna"
     },
     "metrics": {
       "input_tokens_used": 607000,
@@ -458,10 +449,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1019652,
-      "output_tokens_used": 10553,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.oracle.database.jdbc:ojdbc11:23.26.2.0.0/library-preparation-preflight/codex-session-owpkic91.log"
+      "output_tokens_used": 10553
     },
     "metrics": {
       "input_tokens_used": 3635747,
@@ -615,10 +603,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2801026,
-      "output_tokens_used": 17172,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.oracle.database.jdbc:ojdbc11:23.26.2.0.0/library-preparation-preflight/codex-session-lsargks4.log"
+      "output_tokens_used": 17172
     },
     "metrics": {
       "input_tokens_used": 2938503,

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-addons-sasl/3.63.1/execution-metrics.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-addons-sasl/3.63.1/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-luna",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.oracle.oci.sdk:oci-java-sdk-addons-sasl:3.63.1/library-preparation-preflight/codex-session-l8i4f33b.log"
+      "model": "gpt-5.6-luna"
     },
     "metrics": {
       "input_tokens_used": 449439,

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-common-httpclient-jersey3/3.63.1/execution-metrics.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-common-httpclient-jersey3/3.63.1/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3:3.63.1/library-preparation-preflight/pi-generation-2026-06-25T23-29-26-902922Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 58888,

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-common-httpclient/3.63.1/execution-metrics.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-common-httpclient/3.63.1/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.oracle.oci.sdk:oci-java-sdk-common-httpclient:3.63.1/library-preparation-preflight/pi-generation-2026-07-10T12-47-33-829264Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 198301,

--- a/stats/com.oracle.oci.sdk/oci-java-sdk-common/3.63.1/execution-metrics.json
+++ b/stats/com.oracle.oci.sdk/oci-java-sdk-common/3.63.1/execution-metrics.json
@@ -70,10 +70,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.oracle.oci.sdk:oci-java-sdk-common:3.63.1/library-preparation-preflight/pi-generation-2026-07-11T17-28-58-839219Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 127770,

--- a/stats/com.rabbitmq.client/amqp-client/0.8.0/execution-metrics.json
+++ b/stats/com.rabbitmq.client/amqp-client/0.8.0/execution-metrics.json
@@ -90,10 +90,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 67238,
-      "output_tokens_used": 4709,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.rabbitmq.client:amqp-client:0.8.0/library-preparation-preflight/pi-generation-2026-06-29T01-45-48-249709Z.log"
+      "output_tokens_used": 4709
     },
     "metrics": {
       "input_tokens_used": 563570,

--- a/stats/com.sksamuel.hoplite/hoplite-core/2.9.0/execution-metrics.json
+++ b/stats/com.sksamuel.hoplite/hoplite-core/2.9.0/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.sksamuel.hoplite:hoplite-core:2.9.0/library-preparation-preflight/pi-generation-2026-06-11T02-25-43-475917Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 201260,

--- a/stats/com.softwaremill.sttp.client4/json-common_3/4.0.23/execution-metrics.json
+++ b/stats/com.softwaremill.sttp.client4/json-common_3/4.0.23/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 47403,
-      "output_tokens_used": 3739,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.softwaremill.sttp.client4:json-common_3:4.0.23/library-preparation-preflight/pi-generation-2026-06-27T10-14-52-576165Z.log"
+      "output_tokens_used": 3739
     },
     "metrics": {
       "input_tokens_used": 185442,

--- a/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/execution-metrics.json
+++ b/stats/com.softwaremill.sttp.shared/pekko_3/1.5.1/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25674,
-      "output_tokens_used": 2701,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.softwaremill.sttp.shared:pekko_3:1.5.1/library-preparation-preflight/pi-generation-2026-06-27T09-30-01-165014Z.log"
+      "output_tokens_used": 2701
     },
     "metrics": {
       "input_tokens_used": 134693,

--- a/stats/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/execution-metrics.json
+++ b/stats/com.softwaremill.sttp.tapir/tapir-core_3/1.11.25/execution-metrics.json
@@ -53,9 +53,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/com.softwaremill.sttp.tapir:tapir-core_3:1.11.25/library-preparation-preflight/pi-generation-2026-06-10T02-12-13-200651Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 305989,

--- a/stats/com.squareup.okhttp3/okhttp-jvm/5.3.2/execution-metrics.json
+++ b/stats/com.squareup.okhttp3/okhttp-jvm/5.3.2/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 37526,
-      "output_tokens_used": 2400,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.squareup.okhttp3:okhttp-jvm:5.3.2/library-preparation-preflight/pi-generation-2026-06-28T04-25-52-679008Z.log"
+      "output_tokens_used": 2400
     },
     "metrics": {
       "input_tokens_used": 44703,

--- a/stats/com.sun.istack/istack-commons-tools/4.1.2/execution-metrics.json
+++ b/stats/com.sun.istack/istack-commons-tools/4.1.2/execution-metrics.json
@@ -84,10 +84,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 46406,
-      "output_tokens_used": 3120,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.sun.istack:istack-commons-tools:4.1.2/library-preparation-preflight/pi-generation-2026-06-27T20-46-30-790869Z.log"
+      "output_tokens_used": 3120
     },
     "metrics": {
       "input_tokens_used": 57862,

--- a/stats/com.sun.jersey/jersey-core/1.9/execution-metrics.json
+++ b/stats/com.sun.jersey/jersey-core/1.9/execution-metrics.json
@@ -100,10 +100,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 118132,
-      "output_tokens_used": 8366,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.sun.jersey:jersey-core:1.9/library-preparation-preflight/pi-generation-2026-06-29T01-49-31-534969Z.log"
+      "output_tokens_used": 8366
     },
     "metrics": {
       "input_tokens_used": 944927,

--- a/stats/com.sun.xml.ws/jaxws-rt/4.0.5/execution-metrics.json
+++ b/stats/com.sun.xml.ws/jaxws-rt/4.0.5/execution-metrics.json
@@ -56,10 +56,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 432547,
-      "output_tokens_used": 4332,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.sun.xml.ws:jaxws-rt:4.0.5/library-preparation-preflight/codex-session-l2e5q6uj.log"
+      "output_tokens_used": 4332
     },
     "metrics": {
       "input_tokens_used": 393405,

--- a/stats/com.thoughtworks.qdox/qdox/2.0-M5/execution-metrics.json
+++ b/stats/com.thoughtworks.qdox/qdox/2.0-M5/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "2.0-M5",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 50154,
-      "output_tokens_used": 2827,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.thoughtworks.qdox:qdox:2.0-M5/library-preparation-preflight/pi-generation-2026-06-09T13-00-26-423941Z.log"
+      "output_tokens_used": 2827
     },
     "metrics": {
       "input_tokens_used": 149402,

--- a/stats/com.twitter/chill-java/0.10.0/execution-metrics.json
+++ b/stats/com.twitter/chill-java/0.10.0/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 60502,
-      "output_tokens_used": 4302,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/com.twitter:chill-java:0.10.0/library-preparation-preflight/pi-generation-2026-06-28T14-56-22-787564Z.log"
+      "output_tokens_used": 4302
     },
     "metrics": {
       "input_tokens_used": 312872,

--- a/stats/com.typesafe.akka/akka-actor_2.13/2.8.8/execution-metrics.json
+++ b/stats/com.typesafe.akka/akka-actor_2.13/2.8.8/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 36744,
-      "output_tokens_used": 2127,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.typesafe.akka:akka-actor_2.13:2.8.8/library-preparation-preflight/pi-generation-2026-06-27T14-23-36-238928Z.log"
+      "output_tokens_used": 2127
     },
     "metrics": {
       "input_tokens_used": 697495,

--- a/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/execution-metrics.json
+++ b/stats/com.typesafe.akka/akka-slf4j_2.13/2.6.21/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 22414,
-      "output_tokens_used": 2012,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/com.typesafe.akka:akka-slf4j_2.13:2.6.21/library-preparation-preflight/pi-generation-2026-06-27T08-30-50-586016Z.log"
+      "output_tokens_used": 2012
     },
     "metrics": {
       "input_tokens_used": 208768,

--- a/stats/com.typesafe.play/play-streams_2.13/2.9.10/execution-metrics.json
+++ b/stats/com.typesafe.play/play-streams_2.13/2.9.10/execution-metrics.json
@@ -64,10 +64,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25690,
-      "output_tokens_used": 4170,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.typesafe.play:play-streams_2.13:2.9.10/library-preparation-preflight/pi-generation-2026-06-27T17-15-50-279232Z.log"
+      "output_tokens_used": 4170
     },
     "metrics": {
       "input_tokens_used": 176141,

--- a/stats/com.typesafe.play/play-ws-standalone-xml_2.13/2.2.14/execution-metrics.json
+++ b/stats/com.typesafe.play/play-ws-standalone-xml_2.13/2.2.14/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 59694,
-      "output_tokens_used": 3344,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/com.typesafe.play:play-ws-standalone-xml_2.13:2.2.14/library-preparation-preflight/pi-generation-2026-06-28T00-15-00-782097Z.log"
+      "output_tokens_used": 3344
     },
     "metrics": {
       "input_tokens_used": 249096,

--- a/stats/com.veracode.annotation/VeracodeAnnotations/1.2.1/execution-metrics.json
+++ b/stats/com.veracode.annotation/VeracodeAnnotations/1.2.1/execution-metrics.json
@@ -42,10 +42,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1295747,
-      "output_tokens_used": 4945,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/com.veracode.annotation:VeracodeAnnotations:1.2.1/library-preparation-preflight/codex-session-x07yt8cr.log"
+      "output_tokens_used": 4945
     },
     "metrics": {
       "input_tokens_used": 172118,

--- a/stats/commons-el/commons-el/1.0/execution-metrics.json
+++ b/stats/commons-el/commons-el/1.0/execution-metrics.json
@@ -100,10 +100,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 53280,
-      "output_tokens_used": 4564,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/commons-el:commons-el:1.0/library-preparation-preflight/pi-generation-2026-06-28T16-17-27-555584Z.log"
+      "output_tokens_used": 4564
     },
     "metrics": {
       "input_tokens_used": 800617,

--- a/stats/commons-validator/commons-validator/1.6/execution-metrics.json
+++ b/stats/commons-validator/commons-validator/1.6/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/commons-validator:commons-validator:1.6/library-preparation-preflight/pi-generation-2026-06-09T16-02-44-282251Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 222345,

--- a/stats/dev.blaauwendraad/json-masker/1.1.4/execution-metrics.json
+++ b/stats/dev.blaauwendraad/json-masker/1.1.4/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1090011,
-      "output_tokens_used": 8818,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/dev.blaauwendraad:json-masker:1.1.4/library-preparation-preflight/codex-session-h9pqsz4d.log"
+      "output_tokens_used": 8818
     },
     "metrics": {
       "input_tokens_used": 247970,

--- a/stats/dev.langchain4j/langchain4j-embeddings-all-minilm-l6-v2/1.18.0-beta28/execution-metrics.json
+++ b/stats/dev.langchain4j/langchain4j-embeddings-all-minilm-l6-v2/1.18.0-beta28/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-luna",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.18.0-beta28/library-preparation-preflight/codex-session-cduk_znl.log"
+      "model": "gpt-5.6-luna"
     },
     "metrics": {
       "input_tokens_used": 212583,

--- a/stats/dev.optics/monocle-core_3/3.3.0/execution-metrics.json
+++ b/stats/dev.optics/monocle-core_3/3.3.0/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/dev.optics:monocle-core_3:3.3.0/library-preparation-preflight/pi-generation-2026-06-10T21-45-15-124019Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 212495,

--- a/stats/dev.zio/zio-prelude-macros_2.13/1.0.0-RC33/execution-metrics.json
+++ b/stats/dev.zio/zio-prelude-macros_2.13/1.0.0-RC33/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 56496,
-      "output_tokens_used": 6287,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/dev.zio:zio-prelude-macros_2.13:1.0.0-RC33/library-preparation-preflight/pi-generation-2026-06-27T18-03-21-203982Z.log"
+      "output_tokens_used": 6287
     },
     "metrics": {
       "input_tokens_used": 296990,

--- a/stats/dev.zio/zio-prelude_2.13/1.0.0-RC33/execution-metrics.json
+++ b/stats/dev.zio/zio-prelude_2.13/1.0.0-RC33/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 53836,
-      "output_tokens_used": 3362,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/dev.zio:zio-prelude_2.13:1.0.0-RC33/library-preparation-preflight/pi-generation-2026-06-27T18-36-31-666159Z.log"
+      "output_tokens_used": 3362
     },
     "metrics": {
       "input_tokens_used": 317697,

--- a/stats/dev.zio/zio-stacktracer_2.13/2.0.22/execution-metrics.json
+++ b/stats/dev.zio/zio-stacktracer_2.13/2.0.22/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 63971,
-      "output_tokens_used": 3805,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/dev.zio:zio-stacktracer_2.13:2.0.22/library-preparation-preflight/pi-generation-2026-06-27T17-28-32-904378Z.log"
+      "output_tokens_used": 3805
     },
     "metrics": {
       "input_tokens_used": 208899,

--- a/stats/dev.zio/zio-streams_2.13/2.0.22/execution-metrics.json
+++ b/stats/dev.zio/zio-streams_2.13/2.0.22/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25254,
-      "output_tokens_used": 2659,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/dev.zio:zio-streams_2.13:2.0.22/library-preparation-preflight/pi-generation-2026-06-27T18-35-10-145785Z.log"
+      "output_tokens_used": 2659
     },
     "metrics": {
       "input_tokens_used": 26018,

--- a/stats/dev.zio/zio_2.13/2.0.22/execution-metrics.json
+++ b/stats/dev.zio/zio_2.13/2.0.22/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 30578,
-      "output_tokens_used": 2636,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/dev.zio:zio_2.13:2.0.22/library-preparation-preflight/pi-generation-2026-06-27T18-02-23-548914Z.log"
+      "output_tokens_used": 2636
     },
     "metrics": {
       "input_tokens_used": 34284,

--- a/stats/gg.jte/jte-native-resources/3.2.4/execution-metrics.json
+++ b/stats/gg.jte/jte-native-resources/3.2.4/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1258969,
-      "output_tokens_used": 7782,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/gg.jte:jte-native-resources:3.2.4/library-preparation-preflight/codex-session-c456hhlx.log"
+      "output_tokens_used": 7782
     },
     "metrics": {
       "input_tokens_used": 192900,

--- a/stats/gg.jte/jte/3.2.4/execution-metrics.json
+++ b/stats/gg.jte/jte/3.2.4/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 957680,
-      "output_tokens_used": 5465,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/gg.jte:jte:3.2.4/library-preparation-preflight/codex-session-h2ryuksz.log"
+      "output_tokens_used": 5465
     },
     "metrics": {
       "input_tokens_used": 154127,

--- a/stats/io.circe/circe-generic_3/0.14.12/execution-metrics.json
+++ b/stats/io.circe/circe-generic_3/0.14.12/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 38368,
-      "output_tokens_used": 4350,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.circe:circe-generic_3:0.14.12/library-preparation-preflight/pi-generation-2026-06-10T05-20-41-716640Z.log"
+      "output_tokens_used": 4350
     },
     "metrics": {
       "input_tokens_used": 175158,

--- a/stats/io.confluent/kafka-avro-serializer/8.2.1/execution-metrics.json
+++ b/stats/io.confluent/kafka-avro-serializer/8.2.1/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 31980,
-      "output_tokens_used": 3541,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.confluent:kafka-avro-serializer:8.2.1/library-preparation-preflight/pi-generation-2026-07-08T12-43-14-206913Z.log"
+      "output_tokens_used": 3541
     },
     "metrics": {
       "input_tokens_used": 34149,

--- a/stats/io.confluent/kafka-schema-registry-client/8.2.1/execution-metrics.json
+++ b/stats/io.confluent/kafka-schema-registry-client/8.2.1/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 40944,
-      "output_tokens_used": 2101,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.confluent:kafka-schema-registry-client:8.2.1/library-preparation-preflight/pi-generation-2026-06-25T11-53-53-233236Z.log"
+      "output_tokens_used": 2101
     },
     "metrics": {
       "input_tokens_used": 78871,

--- a/stats/io.confluent/kafka-schema-serializer/8.3.0/execution-metrics.json
+++ b/stats/io.confluent/kafka-schema-serializer/8.3.0/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 43950,
-      "output_tokens_used": 4088,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/g/forge/graalvm-reachability-metadata/forge/logs/io.confluent:kafka-schema-serializer:8.3.0/library-preparation-preflight/pi-generation-2026-08-14T20-56-43-086781Z.log"
+      "output_tokens_used": 4088
     },
     "metrics": {
       "input_tokens_used": 236125,

--- a/stats/io.fabric8/kubernetes-client/7.5.2/execution-metrics.json
+++ b/stats/io.fabric8/kubernetes-client/7.5.2/execution-metrics.json
@@ -82,10 +82,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 83037,
-      "output_tokens_used": 2675,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.fabric8:kubernetes-client:7.5.2/library-preparation-preflight/pi-generation-2026-07-30T14-50-32-896619Z.log"
+      "output_tokens_used": 2675
     },
     "metrics": {
       "input_tokens_used": 85701,

--- a/stats/io.fabric8/kubernetes-model-metrics/7.5.2/execution-metrics.json
+++ b/stats/io.fabric8/kubernetes-model-metrics/7.5.2/execution-metrics.json
@@ -60,10 +60,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 32236,
-      "output_tokens_used": 1015,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.fabric8:kubernetes-model-metrics:7.5.2/library-preparation-preflight/pi-generation-2026-07-02T17-00-07-246772Z.log"
+      "output_tokens_used": 1015
     },
     "metrics": {
       "input_tokens_used": 110678,

--- a/stats/io.getquill/quill-sql_2.13/4.8.5/execution-metrics.json
+++ b/stats/io.getquill/quill-sql_2.13/4.8.5/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 36453,
-      "output_tokens_used": 2660,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.getquill:quill-sql_2.13:4.8.5/library-preparation-preflight/pi-generation-2026-06-27T18-54-04-650119Z.log"
+      "output_tokens_used": 2660
     },
     "metrics": {
       "input_tokens_used": 189172,

--- a/stats/io.github.resilience4j/resilience4j-spring-boot4/2.4.0/execution-metrics.json
+++ b/stats/io.github.resilience4j/resilience4j-spring-boot4/2.4.0/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 91789,
-      "output_tokens_used": 6768,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.github.resilience4j:resilience4j-spring-boot4:2.4.0/library-preparation-preflight/pi-generation-2026-06-19T10-50-28-333673Z.log"
+      "output_tokens_used": 6768
     },
     "metrics": {
       "input_tokens_used": 192969,

--- a/stats/io.github.resilience4j/resilience4j-timelimiter/2.3.0/execution-metrics.json
+++ b/stats/io.github.resilience4j/resilience4j-timelimiter/2.3.0/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.github.resilience4j:resilience4j-timelimiter:2.3.0/library-preparation-preflight/pi-generation-2026-06-10T03-44-10-534637Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 156215,

--- a/stats/io.grpc/grpc-auth/1.68.0/execution-metrics.json
+++ b/stats/io.grpc/grpc-auth/1.68.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.grpc:grpc-auth:1.68.0/library-preparation-preflight/pi-generation-2026-06-10T07-15-42-180139Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 77840,

--- a/stats/io.helidon.metadata/helidon-metadata-hson/4.3.4/execution-metrics.json
+++ b/stats/io.helidon.metadata/helidon-metadata-hson/4.3.4/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 30989,
-      "output_tokens_used": 2181,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.helidon.metadata:helidon-metadata-hson:4.3.4/library-preparation-preflight/pi-generation-2026-06-26T10-54-32-106184Z.log"
+      "output_tokens_used": 2181
     },
     "metrics": {
       "input_tokens_used": 363719,

--- a/stats/io.helidon.metadata/helidon-metadata/4.3.4/execution-metrics.json
+++ b/stats/io.helidon.metadata/helidon-metadata/4.3.4/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 107735,
-      "output_tokens_used": 4417,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.helidon.metadata:helidon-metadata:4.3.4/library-preparation-preflight/pi-generation-2026-06-26T11-34-19-408436Z.log"
+      "output_tokens_used": 4417
     },
     "metrics": {
       "input_tokens_used": 69410,

--- a/stats/io.kotest/kotest-assertions-core-jvm/6.1.11/execution-metrics.json
+++ b/stats/io.kotest/kotest-assertions-core-jvm/6.1.11/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 44316,
-      "output_tokens_used": 2738,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.kotest:kotest-assertions-core-jvm:6.1.11/library-preparation-preflight/pi-generation-2026-06-27T23-16-14-573217Z.log"
+      "output_tokens_used": 2738
     },
     "metrics": {
       "input_tokens_used": 59605,

--- a/stats/io.ktor/ktor-client-cio-jvm/3.2.0/execution-metrics.json
+++ b/stats/io.ktor/ktor-client-cio-jvm/3.2.0/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.ktor:ktor-client-cio-jvm:3.2.0/library-preparation-preflight/pi-generation-2026-06-10T00-25-25-970840Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 222701,

--- a/stats/io.ktor/ktor-http-jvm/3.2.0/execution-metrics.json
+++ b/stats/io.ktor/ktor-http-jvm/3.2.0/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25003,
-      "output_tokens_used": 1708,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.ktor:ktor-http-jvm:3.2.0/library-preparation-preflight/pi-generation-2026-06-28T09-19-42-558548Z.log"
+      "output_tokens_used": 1708
     },
     "metrics": {
       "input_tokens_used": 37847,

--- a/stats/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/execution-metrics.json
+++ b/stats/io.ktor/ktor-serialization-kotlinx-cbor-jvm/3.4.3/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.ktor:ktor-serialization-kotlinx-cbor-jvm:3.4.3/library-preparation-preflight/pi-generation-2026-06-10T20-49-19-689145Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 98306,

--- a/stats/io.ktor/ktor-server-call-logging-jvm/3.4.3/execution-metrics.json
+++ b/stats/io.ktor/ktor-server-call-logging-jvm/3.4.3/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 27680,
-      "output_tokens_used": 2432,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.ktor:ktor-server-call-logging-jvm:3.4.3/library-preparation-preflight/pi-generation-2026-06-27T23-37-31-668544Z.log"
+      "output_tokens_used": 2432
     },
     "metrics": {
       "input_tokens_used": 271378,

--- a/stats/io.leangen.geantyref/geantyref/2.0.1/execution-metrics.json
+++ b/stats/io.leangen.geantyref/geantyref/2.0.1/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-sol",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.leangen.geantyref:geantyref:2.0.1/library-preparation-preflight/pi-generation-2026-08-25T13-13-09-621346Z.log"
+      "model": "gpt-5.6-sol"
     },
     "metrics": {
       "input_tokens_used": 113568,

--- a/stats/io.micrometer/micrometer-observation/1.18.0-M1/execution-metrics.json
+++ b/stats/io.micrometer/micrometer-observation/1.18.0-M1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "1.18.0-M1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 573741,
-      "output_tokens_used": 4409,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micrometer:micrometer-observation:1.18.0-M1/library-preparation-preflight/codex-session-6xhbqk_9.log"
+      "output_tokens_used": 4409
     },
     "metrics": {
       "input_tokens_used": 64196,

--- a/stats/io.micrometer/micrometer-tracing-bridge-otel/1.7.0/execution-metrics.json
+++ b/stats/io.micrometer/micrometer-tracing-bridge-otel/1.7.0/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 61618,
-      "output_tokens_used": 3357,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.micrometer:micrometer-tracing-bridge-otel:1.7.0/library-preparation-preflight/pi-generation-2026-06-27T06-33-51-789985Z.log"
+      "output_tokens_used": 3357
     },
     "metrics": {
       "input_tokens_used": 195984,

--- a/stats/io.micrometer/micrometer-tracing/1.7.0/execution-metrics.json
+++ b/stats/io.micrometer/micrometer-tracing/1.7.0/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 61531,
-      "output_tokens_used": 3903,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.micrometer:micrometer-tracing:1.7.0/library-preparation-preflight/pi-generation-2026-06-27T05-57-02-364836Z.log"
+      "output_tokens_used": 3903
     },
     "metrics": {
       "input_tokens_used": 196545,

--- a/stats/io.micronaut.cache/micronaut-cache-caffeine/6.1.1/execution-metrics.json
+++ b/stats/io.micronaut.cache/micronaut-cache-caffeine/6.1.1/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1823077,
-      "output_tokens_used": 11954,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.cache:micronaut-cache-caffeine:6.1.1/library-preparation-preflight/codex-session-2nalt99v.log"
+      "output_tokens_used": 11954
     },
     "metrics": {
       "input_tokens_used": 235739,

--- a/stats/io.micronaut.data/micronaut-data-jdbc/5.1.3/execution-metrics.json
+++ b/stats/io.micronaut.data/micronaut-data-jdbc/5.1.3/execution-metrics.json
@@ -101,10 +101,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 3657398,
-      "output_tokens_used": 15370,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut.data:micronaut-data-jdbc:5.1.3/library-preparation-preflight/codex-session-yfo7dlbg.log"
+      "output_tokens_used": 15370
     },
     "metrics": {
       "input_tokens_used": 313640,

--- a/stats/io.micronaut.serde/micronaut-serde-api/3.1.1/execution-metrics.json
+++ b/stats/io.micronaut.serde/micronaut-serde-api/3.1.1/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1328963,
-      "output_tokens_used": 10948,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.serde:micronaut-serde-api:3.1.1/library-preparation-preflight/codex-session-gam05u4_.log"
+      "output_tokens_used": 10948
     },
     "metrics": {
       "input_tokens_used": 305921,

--- a/stats/io.micronaut.serde/micronaut-serde-jackson/3.1.1/execution-metrics.json
+++ b/stats/io.micronaut.serde/micronaut-serde-jackson/3.1.1/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1595618,
-      "output_tokens_used": 11943,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.serde:micronaut-serde-jackson:3.1.1/library-preparation-preflight/codex-session-j69cylwj.log"
+      "output_tokens_used": 11943
     },
     "metrics": {
       "input_tokens_used": 316901,

--- a/stats/io.micronaut.serde/micronaut-serde-support/3.1.1/execution-metrics.json
+++ b/stats/io.micronaut.serde/micronaut-serde-support/3.1.1/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2438348,
-      "output_tokens_used": 11322,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.serde:micronaut-serde-support:3.1.1/library-preparation-preflight/codex-session-ftowsdk1.log"
+      "output_tokens_used": 11322
     },
     "metrics": {
       "input_tokens_used": 166639,

--- a/stats/io.micronaut.sourcegen/micronaut-sourcegen-annotations/2.1.0/execution-metrics.json
+++ b/stats/io.micronaut.sourcegen/micronaut-sourcegen-annotations/2.1.0/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2208140,
-      "output_tokens_used": 12083,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut.sourcegen:micronaut-sourcegen-annotations:2.1.0/library-preparation-preflight/codex-session-oufsafia.log"
+      "output_tokens_used": 12083
     },
     "metrics": {
       "input_tokens_used": 257020,

--- a/stats/io.micronaut.sql/micronaut-jdbc-hikari/7.1.2/execution-metrics.json
+++ b/stats/io.micronaut.sql/micronaut-jdbc-hikari/7.1.2/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2778940,
-      "output_tokens_used": 8900,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.sql:micronaut-jdbc-hikari:7.1.2/library-preparation-preflight/codex-session-mz26noo2.log"
+      "output_tokens_used": 8900
     },
     "metrics": {
       "input_tokens_used": 309985,

--- a/stats/io.micronaut.validation/micronaut-validation/5.1.0/execution-metrics.json
+++ b/stats/io.micronaut.validation/micronaut-validation/5.1.0/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1910934,
-      "output_tokens_used": 12877,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut.validation:micronaut-validation:5.1.0/library-preparation-preflight/codex-session-0dl6ym2w.log"
+      "output_tokens_used": 12877
     },
     "metrics": {
       "input_tokens_used": 82706,

--- a/stats/io.micronaut.views/micronaut-views-core/6.2.0/execution-metrics.json
+++ b/stats/io.micronaut.views/micronaut-views-core/6.2.0/execution-metrics.json
@@ -76,10 +76,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 718915,
-      "output_tokens_used": 7457,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut.views:micronaut-views-core:6.2.0/library-preparation-preflight/codex-session-hjp9uuq8.log"
+      "output_tokens_used": 7457
     },
     "metrics": {
       "input_tokens_used": 301960,

--- a/stats/io.micronaut.views/micronaut-views-jte/6.2.0/execution-metrics.json
+++ b/stats/io.micronaut.views/micronaut-views-jte/6.2.0/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1900357,
-      "output_tokens_used": 13480,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut.views:micronaut-views-jte:6.2.0/library-preparation-preflight/codex-session-2olfc0ge.log"
+      "output_tokens_used": 13480
     },
     "metrics": {
       "input_tokens_used": 288041,

--- a/stats/io.micronaut/micronaut-buffer-netty/5.1.13/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-buffer-netty/5.1.13/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 844016,
-      "output_tokens_used": 5404,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut:micronaut-buffer-netty:5.1.13/library-preparation-preflight/codex-session-g326uq2s.log"
+      "output_tokens_used": 5404
     },
     "metrics": {
       "input_tokens_used": 256626,

--- a/stats/io.micronaut/micronaut-core/5.0.0/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-core/5.0.0/execution-metrics.json
@@ -56,10 +56,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 862730,
-      "output_tokens_used": 5935,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut:micronaut-core:5.0.0/library-preparation-preflight/codex-session-pmwzyt_y.log"
+      "output_tokens_used": 5935
     },
     "metrics": {
       "input_tokens_used": 357379,

--- a/stats/io.micronaut/micronaut-http-server-netty/5.1.13/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-http-server-netty/5.1.13/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 5761619,
-      "output_tokens_used": 18088,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.micronaut:micronaut-http-server-netty:5.1.13/library-preparation-preflight/codex-session-s76bqg41.log"
+      "output_tokens_used": 18088
     },
     "metrics": {
       "input_tokens_used": 297341,

--- a/stats/io.micronaut/micronaut-http-server/5.1.13/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-http-server/5.1.13/execution-metrics.json
@@ -100,10 +100,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2521790,
-      "output_tokens_used": 18974,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut:micronaut-http-server:5.1.13/library-preparation-preflight/codex-session-j9kjzcbj.log"
+      "output_tokens_used": 18974
     },
     "metrics": {
       "input_tokens_used": 263681,

--- a/stats/io.micronaut/micronaut-jackson-core/5.1.3/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-jackson-core/5.1.3/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 722931,
-      "output_tokens_used": 6060,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut:micronaut-jackson-core:5.1.3/library-preparation-preflight/codex-session-98rnlnio.log"
+      "output_tokens_used": 6060
     },
     "metrics": {
       "input_tokens_used": 299035,

--- a/stats/io.micronaut/micronaut-management/5.1.13/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-management/5.1.13/execution-metrics.json
@@ -102,13 +102,10 @@
       "library": "io.micronaut:micronaut-management:5.1.13",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 9561,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Native-image verification must confirm the embedded server, client, and JSON serialization work together.",
         "Do not add a Docker image: the core management endpoints have no mandatory external service dependency."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut:micronaut-management:5.1.13/library-preparation-preflight/codex-session-jvpsgpot.log",
       "status": "completed",
       "summary": "Meaningful coverage requires exercising management endpoints through an embedded Micronaut HTTP server with JSON responses."
     },

--- a/stats/io.micronaut/micronaut-router/5.1.13/execution-metrics.json
+++ b/stats/io.micronaut/micronaut-router/5.1.13/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1485692,
-      "output_tokens_used": 10786,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.micronaut:micronaut-router:5.1.13/library-preparation-preflight/codex-session-j5lmi9sp.log"
+      "output_tokens_used": 10786
     },
     "metrics": {
       "input_tokens_used": 314142,

--- a/stats/io.mockk/mockk-jvm/1.14.9/execution-metrics.json
+++ b/stats/io.mockk/mockk-jvm/1.14.9/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 78266,
-      "output_tokens_used": 5348,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.mockk:mockk-jvm:1.14.9/library-preparation-preflight/pi-generation-2026-06-25T15-53-04-705580Z.log"
+      "output_tokens_used": 5348
     },
     "metrics": {
       "input_tokens_used": 753524,

--- a/stats/io.netty.contrib/netty-codec-multipart-core/1.0.0.Final/execution-metrics.json
+++ b/stats/io.netty.contrib/netty-codec-multipart-core/1.0.0.Final/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2354331,
-      "output_tokens_used": 8331,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty.contrib:netty-codec-multipart-core:1.0.0.Final/library-preparation-preflight/codex-session-txp5vpt3.log"
+      "output_tokens_used": 8331
     },
     "metrics": {
       "input_tokens_used": 246764,

--- a/stats/io.netty/netty-codec/4.1.105.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec/4.1.105.Final/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "4.1.105.Final",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1375739,
-      "output_tokens_used": 8076,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty:netty-codec:4.1.105.Final/library-preparation-preflight/codex-session-_7v2hl58.log"
+      "output_tokens_used": 8076
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/io.netty/netty-codec/4.1.79.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec/4.1.79.Final/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "4.1.79.Final",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 458657,
-      "output_tokens_used": 2357,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty:netty-codec:4.1.79.Final/library-preparation-preflight/codex-session-e_4rsw0y.log"
+      "output_tokens_used": 2357
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/io.netty/netty-codec/4.2.1.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec/4.2.1.Final/execution-metrics.json
@@ -101,10 +101,7 @@
       "new_version": "4.2.1.Final",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 4627482,
-      "output_tokens_used": 12149,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty:netty-codec:4.2.1.Final/library-preparation-preflight/codex-session-gpyri9k4.log"
+      "output_tokens_used": 12149
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/io.netty/netty-codec/4.2.2.Final/execution-metrics.json
+++ b/stats/io.netty/netty-codec/4.2.2.Final/execution-metrics.json
@@ -101,10 +101,7 @@
       "new_version": "4.2.2.Final",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 397398,
-      "output_tokens_used": 3436,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty:netty-codec:4.2.2.Final/library-preparation-preflight/codex-session-flz5e5h4.log"
+      "output_tokens_used": 3436
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/io.netty/netty-codec/5.0.0.Alpha1/execution-metrics.json
+++ b/stats/io.netty/netty-codec/5.0.0.Alpha1/execution-metrics.json
@@ -107,10 +107,7 @@
       "new_version": "5.0.0.Alpha1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1096574,
-      "output_tokens_used": 8876,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.netty:netty-codec:5.0.0.Alpha1/library-preparation-preflight/codex-session-aaj4jd05.log"
+      "output_tokens_used": 8876
     },
     "metrics": {
       "input_tokens_used": 94624,

--- a/stats/io.netty/netty-common/5.0.0.Alpha1/execution-metrics.json
+++ b/stats/io.netty/netty-common/5.0.0.Alpha1/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "5.0.0.Alpha1",
       "model": "gpt-5.5",
       "input_tokens_used": 33175,
-      "output_tokens_used": 2457,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.netty:netty-common:5.0.0.Alpha1/library-preparation-preflight/pi-generation-2026-08-06T13-54-39-703154Z.log"
+      "output_tokens_used": 2457
     },
     "metrics": {
       "input_tokens_used": 279522,

--- a/stats/io.netty/netty-common/5.0.0.Alpha2/execution-metrics.json
+++ b/stats/io.netty/netty-common/5.0.0.Alpha2/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "5.0.0.Alpha2",
       "model": "gpt-5.6-sol",
       "input_tokens_used": 33260,
-      "output_tokens_used": 3496,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.netty:netty-common:5.0.0.Alpha2/library-preparation-preflight/pi-generation-2026-08-27T20-15-05-957651Z.log"
+      "output_tokens_used": 3496
     },
     "metrics": {
       "input_tokens_used": 789974,

--- a/stats/io.netty/netty-transport/5.0.0.Alpha1/execution-metrics.json
+++ b/stats/io.netty/netty-transport/5.0.0.Alpha1/execution-metrics.json
@@ -120,10 +120,7 @@
       "new_version": "5.0.0.Alpha1",
       "model": "gpt-5.6-terra",
       "input_tokens_used": 33084,
-      "output_tokens_used": 1468,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.netty:netty-transport:5.0.0.Alpha1/library-preparation-preflight/pi-generation-2026-08-13T09-51-53-097809Z.log"
+      "output_tokens_used": 1468
     },
     "metrics": {
       "input_tokens_used": 112210,

--- a/stats/io.netty/netty-transport/5.0.0.Alpha2/execution-metrics.json
+++ b/stats/io.netty/netty-transport/5.0.0.Alpha2/execution-metrics.json
@@ -107,10 +107,7 @@
       "new_version": "5.0.0.Alpha2",
       "model": "gpt-5.6-sol",
       "input_tokens_used": 38506,
-      "output_tokens_used": 1759,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/g/forge/graalvm-reachability-metadata/forge/logs/io.netty:netty-transport:5.0.0.Alpha2/library-preparation-preflight/pi-generation-2026-08-24T14-35-56-511950Z.log"
+      "output_tokens_used": 1759
     },
     "metrics": {
       "input_tokens_used": 46389,

--- a/stats/io.opentelemetry.contrib/opentelemetry-aws-resources/1.57.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.contrib/opentelemetry-aws-resources/1.57.0-alpha/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.contrib:opentelemetry-aws-resources:1.57.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T20-12-26-993614Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 351310,

--- a/stats/io.opentelemetry.contrib/opentelemetry-azure-resources/1.57.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.contrib/opentelemetry-azure-resources/1.57.0-alpha/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 53168,
-      "output_tokens_used": 7230,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.contrib:opentelemetry-azure-resources:1.57.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T19-35-32-732211Z.log"
+      "output_tokens_used": 7230
     },
     "metrics": {
       "input_tokens_used": 233356,

--- a/stats/io.opentelemetry.contrib/opentelemetry-baggage-processor/1.57.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.contrib/opentelemetry-baggage-processor/1.57.0-alpha/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 44923,
-      "output_tokens_used": 2626,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.contrib:opentelemetry-baggage-processor:1.57.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T16-09-34-766130Z.log"
+      "output_tokens_used": 2626
     },
     "metrics": {
       "input_tokens_used": 199803,

--- a/stats/io.opentelemetry.contrib/opentelemetry-cloudfoundry-resources/1.57.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.contrib/opentelemetry-cloudfoundry-resources/1.57.0-alpha/execution-metrics.json
@@ -90,10 +90,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 58727,
-      "output_tokens_used": 7701,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.contrib:opentelemetry-cloudfoundry-resources:1.57.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T19-54-01-041799Z.log"
+      "output_tokens_used": 7701
     },
     "metrics": {
       "input_tokens_used": 214264,

--- a/stats/io.opentelemetry.contrib/opentelemetry-samplers/1.57.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.contrib/opentelemetry-samplers/1.57.0-alpha/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 80013,
-      "output_tokens_used": 5296,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.contrib:opentelemetry-samplers:1.57.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T19-00-00-537911Z.log"
+      "output_tokens_used": 5296
     },
     "metrics": {
       "input_tokens_used": 259117,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-declarative-config-bridge/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-declarative-config-bridge/2.28.1-alpha/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 52337,
-      "output_tokens_used": 5533,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T15-06-51-044996Z.log"
+      "output_tokens_used": 5533
     },
     "metrics": {
       "input_tokens_used": 548033,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations-support/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations-support/2.28.1-alpha/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 46029,
-      "output_tokens_used": 6804,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T19-59-51-672311Z.log"
+      "output_tokens_used": 6804
     },
     "metrics": {
       "input_tokens_used": 50780,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/2.28.1/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/2.28.1/execution-metrics.json
@@ -42,10 +42,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 21109,
-      "output_tokens_used": 2815,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.28.1/library-preparation-preflight/pi-generation-2026-06-26T20-28-17-757880Z.log"
+      "output_tokens_used": 2815
     },
     "metrics": {
       "input_tokens_used": 134639,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-jdbc/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-jdbc/2.28.1-alpha/execution-metrics.json
@@ -78,13 +78,10 @@
       "library": "io.opentelemetry.instrumentation:opentelemetry-jdbc:2.28.1-alpha",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 4015,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "The OpenTelemetry JDBC driver registers globally with DriverManager; tests should avoid deregistering unrelated drivers or leaking global state between test methods.",
         "No-op OpenTelemetry is enough for wrapper/native reachability coverage, but it will not assert emitted spans unless the generated test adds SDK/test exporter infrastructure."
       ],
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-jdbc:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T18-30-16-741779Z.log",
       "status": "completed",
       "summary": "The artifact is only an OpenTelemetry wrapper for JDBC and has no concrete JDBC driver dependency; meaningful coverage requires an underlying JDBC implementation. H2 in-memory is sufficient and matches the library documentation/examples and upstream test setup without requiring Docker."
     },

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-kafka-clients-2.6/2.28.1-alpha/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 65581,
-      "output_tokens_used": 2531,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T15-48-03-249062Z.log"
+      "output_tokens_used": 2531
     },
     "metrics": {
       "input_tokens_used": 59586,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-log4j-context-data-2.17-autoconfigure/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-log4j-context-data-2.17-autoconfigure/2.28.1-alpha/execution-metrics.json
@@ -30,10 +30,7 @@
         }
       ],
       "failure_reason": "ValueError: response did not contain a JSON object",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/root/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.17-autoconfigure:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-22T23-35-54-594797Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 0,
@@ -109,10 +106,7 @@
       "issue_number": 8536,
       "library": "io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.17-autoconfigure:2.28.1-alpha",
       "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [],
-      "session_log_path": "/root/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-log4j-context-data-2.17-autoconfigure:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-22T23-35-54-594797Z.log",
       "status": "degraded",
       "summary": "Library preparation preflight did not produce usable advisory setup."
     },

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-logback-appender-1.0/2.28.1-alpha/execution-metrics.json
@@ -95,10 +95,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 60693,
-      "output_tokens_used": 5273,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T18-26-13-977116Z.log"
+      "output_tokens_used": 5273
     },
     "metrics": {
       "input_tokens_used": 117433,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-logback-mdc-1.0/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-logback-mdc-1.0/2.28.1-alpha/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 63090,
-      "output_tokens_used": 4118,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-logback-mdc-1.0:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T16-49-45-396196Z.log"
+      "output_tokens_used": 4118
     },
     "metrics": {
       "input_tokens_used": 40218,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-micrometer-1.5/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-micrometer-1.5/2.28.1-alpha/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 73010,
-      "output_tokens_used": 4173,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T17-48-21-062005Z.log"
+      "output_tokens_used": 4173
     },
     "metrics": {
       "input_tokens_used": 378404,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-mongo-3.1/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-mongo-3.1/2.28.1-alpha/execution-metrics.json
@@ -96,10 +96,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 43724,
-      "output_tokens_used": 4834,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-mongo-3.1:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T16-22-41-948621Z.log"
+      "output_tokens_used": 4834
     },
     "metrics": {
       "input_tokens_used": 129655,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-resources/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-resources/2.28.1-alpha/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 92398,
-      "output_tokens_used": 6146,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-resources:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T15-49-23-150283Z.log"
+      "output_tokens_used": 6146
     },
     "metrics": {
       "input_tokens_used": 226911,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-spring-kafka-2.7/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-spring-kafka-2.7/2.28.1-alpha/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 77606,
-      "output_tokens_used": 4179,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-spring-kafka-2.7:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T13-11-35-004729Z.log"
+      "output_tokens_used": 4179
     },
     "metrics": {
       "input_tokens_used": 341684,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-spring-web-3.1/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-spring-web-3.1/2.28.1-alpha/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 42245,
-      "output_tokens_used": 4616,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-spring-web-3.1:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T16-44-05-125244Z.log"
+      "output_tokens_used": 4616
     },
     "metrics": {
       "input_tokens_used": 80368,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-spring-webflux-5.3/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-spring-webflux-5.3/2.28.1-alpha/execution-metrics.json
@@ -95,10 +95,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 80568,
-      "output_tokens_used": 8442,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-spring-webflux-5.3:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T14-34-55-917823Z.log"
+      "output_tokens_used": 8442
     },
     "metrics": {
       "input_tokens_used": 176417,

--- a/stats/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-5.3/2.28.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.instrumentation/opentelemetry-spring-webmvc-5.3/2.28.1-alpha/execution-metrics.json
@@ -101,10 +101,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 38206,
-      "output_tokens_used": 4135,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-5.3:2.28.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T13-55-52-693884Z.log"
+      "output_tokens_used": 4135
     },
     "metrics": {
       "input_tokens_used": 276103,

--- a/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.proto/opentelemetry-proto/1.10.0-alpha/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 46140,
-      "output_tokens_used": 2351,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha/library-preparation-preflight/pi-generation-2026-08-11T12-14-12-718213Z.log"
+      "output_tokens_used": 2351
     },
     "metrics": {
       "input_tokens_used": 142724,
@@ -161,10 +158,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 539581,
-      "output_tokens_used": 6184,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha/library-preparation-preflight/codex-session-z1ttzzau.log"
+      "output_tokens_used": 6184
     },
     "metrics": {
       "input_tokens_used": 250716,

--- a/stats/io.opentelemetry.semconv/opentelemetry-semconv-incubating/1.41.1-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry.semconv/opentelemetry-semconv-incubating/1.41.1-alpha/execution-metrics.json
@@ -76,10 +76,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 40733,
-      "output_tokens_used": 4809,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.41.1-alpha/library-preparation-preflight/pi-generation-2026-06-26T20-25-44-641950Z.log"
+      "output_tokens_used": 4809
     },
     "metrics": {
       "input_tokens_used": 241593,

--- a/stats/io.opentelemetry/opentelemetry-extension-trace-propagators/1.62.0/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-extension-trace-propagators/1.62.0/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 33983,
-      "output_tokens_used": 3300,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry:opentelemetry-extension-trace-propagators:1.62.0/library-preparation-preflight/pi-generation-2026-06-27T05-38-36-676025Z.log"
+      "output_tokens_used": 3300
     },
     "metrics": {
       "input_tokens_used": 213205,

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-declarative-config/1.62.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-declarative-config/1.62.0-alpha/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 65764,
-      "output_tokens_used": 4345,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.opentelemetry:opentelemetry-sdk-extension-declarative-config:1.62.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T14-12-04-956958Z.log"
+      "output_tokens_used": 4345
     },
     "metrics": {
       "input_tokens_used": 240319,

--- a/stats/io.opentelemetry/opentelemetry-sdk-extension-incubator/1.62.0-alpha/execution-metrics.json
+++ b/stats/io.opentelemetry/opentelemetry-sdk-extension-incubator/1.62.0-alpha/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 37578,
-      "output_tokens_used": 2538,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.opentelemetry:opentelemetry-sdk-extension-incubator:1.62.0-alpha/library-preparation-preflight/pi-generation-2026-06-26T16-16-44-969184Z.log"
+      "output_tokens_used": 2538
     },
     "metrics": {
       "input_tokens_used": 100091,

--- a/stats/io.prometheus/simpleclient_common/0.16.0/execution-metrics.json
+++ b/stats/io.prometheus/simpleclient_common/0.16.0/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 20796,
-      "output_tokens_used": 1317,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.prometheus:simpleclient_common:0.16.0/library-preparation-preflight/pi-generation-2026-06-26T11-12-17-161152Z.log"
+      "output_tokens_used": 1317
     },
     "metrics": {
       "input_tokens_used": 248610,

--- a/stats/io.quarkus/quarkus-bootstrap-maven4-resolver/3.37.0.CR1/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-bootstrap-maven4-resolver/3.37.0.CR1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "3.37.0.CR1",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 72540,
-      "output_tokens_used": 2493,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.quarkus:quarkus-bootstrap-maven4-resolver:3.37.0.CR1/library-preparation-preflight/pi-generation-2026-06-11T00-15-42-223795Z.log"
+      "output_tokens_used": 2493
     },
     "metrics": {
       "input_tokens_used": 133078,

--- a/stats/io.quarkus/quarkus-classloader-commons/3.37.0/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-classloader-commons/3.37.0/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version" : "3.37.0.CR1",
       "model" : "oca/gpt-5.5",
       "input_tokens_used" : 22624,
-      "output_tokens_used" : 2523,
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.quarkus:quarkus-classloader-commons:3.37.0.CR1/library-preparation-preflight/pi-generation-2026-06-10T22-41-59-608876Z.log"
+      "output_tokens_used" : 2523
     },
     "metrics" : {
       "input_tokens_used" : 30855,

--- a/stats/io.quarkus/quarkus-junit-common/3.37.0/execution-metrics.json
+++ b/stats/io.quarkus/quarkus-junit-common/3.37.0/execution-metrics.json
@@ -103,9 +103,7 @@
       "current_library" : "io.quarkus:quarkus-junit-common:3.33.1",
       "new_version" : "3.37.0.CR1",
       "failure_reason" : "FileNotFoundError: [Errno 2] No such file or directory",
-      "model" : "oca/gpt-5.5",
-      "prompt_path" : "library-preflight-prompt.txt",
-      "session_log_path" : "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/io.quarkus:quarkus-junit-common:3.37.0.CR1/library-preparation-preflight/pi-generation-2026-06-10T23-12-11-723088Z.log"
+      "model" : "oca/gpt-5.5"
     },
     "metrics" : {
       "input_tokens_used" : 0,

--- a/stats/io.smallrye.beanbag/smallrye-beanbag-maven/1.6.1/execution-metrics.json
+++ b/stats/io.smallrye.beanbag/smallrye-beanbag-maven/1.6.1/execution-metrics.json
@@ -70,10 +70,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 52197,
-      "output_tokens_used": 4209,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.smallrye.beanbag:smallrye-beanbag-maven:1.6.1/library-preparation-preflight/pi-generation-2026-06-28T10-49-50-924581Z.log"
+      "output_tokens_used": 4209
     },
     "metrics": {
       "input_tokens_used": 60053,

--- a/stats/io.smallrye.common/smallrye-common-resource/2.19.0/execution-metrics.json
+++ b/stats/io.smallrye.common/smallrye-common-resource/2.19.0/execution-metrics.json
@@ -91,9 +91,7 @@
       "current_library": "io.smallrye.common:smallrye-common-resource:2.14.0",
       "new_version": "2.19.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/io.smallrye.common:smallrye-common-resource:2.19.0/library-preparation-preflight/pi-generation-2026-06-09T21-13-43-463603Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 33158,

--- a/stats/io.smallrye.config/smallrye-config-core/3.16.0/execution-metrics.json
+++ b/stats/io.smallrye.config/smallrye-config-core/3.16.0/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 37613,
-      "output_tokens_used": 3220,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/io.smallrye.config:smallrye-config-core:3.16.0/library-preparation-preflight/pi-generation-2026-06-28T12-31-40-759235Z.log"
+      "output_tokens_used": 3220
     },
     "metrics": {
       "input_tokens_used": 606694,

--- a/stats/io.sundr/sundr-adapter-reflect/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-adapter-reflect/0.230.1/execution-metrics.json
@@ -66,10 +66,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 42483,
-      "output_tokens_used": 2453,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.sundr:sundr-adapter-reflect:0.230.1/library-preparation-preflight/pi-generation-2026-07-09T02-02-34-416901Z.log"
+      "output_tokens_used": 2453
     },
     "metrics": {
       "input_tokens_used": 82450,

--- a/stats/io.sundr/sundr-model-repo/0.230.1/execution-metrics.json
+++ b/stats/io.sundr/sundr-model-repo/0.230.1/execution-metrics.json
@@ -60,10 +60,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 58937,
-      "output_tokens_used": 1845,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.sundr:sundr-model-repo:0.230.1/library-preparation-preflight/pi-generation-2026-07-16T00-44-17-380446Z.log"
+      "output_tokens_used": 1845
     },
     "metrics": {
       "input_tokens_used": 102899,

--- a/stats/io.swagger.core.v3/swagger-core/2.2.53/execution-metrics.json
+++ b/stats/io.swagger.core.v3/swagger-core/2.2.53/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1626471,
-      "output_tokens_used": 8417,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/io.swagger.core.v3:swagger-core:2.2.53/library-preparation-preflight/codex-session-srxmnhbr.log"
+      "output_tokens_used": 8417
     },
     "metrics": {
       "input_tokens_used": 263289,

--- a/stats/io.undertow/undertow-servlet/2.3.18.Final/execution-metrics.json
+++ b/stats/io.undertow/undertow-servlet/2.3.18.Final/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 20676,
-      "output_tokens_used": 2689,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/io.undertow:undertow-servlet:2.3.18.Final/library-preparation-preflight/pi-generation-2026-06-28T00-49-21-416238Z.log"
+      "output_tokens_used": 2689
     },
     "metrics": {
       "input_tokens_used": 200035,

--- a/stats/io.vertx/vertx-auth-common/4.5.24/execution-metrics.json
+++ b/stats/io.vertx/vertx-auth-common/4.5.24/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 77159,
-      "output_tokens_used": 3294,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/io.vertx:vertx-auth-common:4.5.24/library-preparation-preflight/pi-generation-2026-07-03T11-28-15-542373Z.log"
+      "output_tokens_used": 3294
     },
     "metrics": {
       "input_tokens_used": 53436,

--- a/stats/jakarta.mail/jakarta.mail-api/2.1.0/execution-metrics.json
+++ b/stats/jakarta.mail/jakarta.mail-api/2.1.0/execution-metrics.json
@@ -70,10 +70,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/jakarta.mail:jakarta.mail-api:2.1.0/library-preparation-preflight/pi-generation-2026-06-29T00-55-22-760361Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 472554,

--- a/stats/javassist/javassist/3.12.0.GA/execution-metrics.json
+++ b/stats/javassist/javassist/3.12.0.GA/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28704,
-      "output_tokens_used": 4267,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/javassist:javassist:3.12.0.GA/library-preparation-preflight/pi-generation-2026-06-09T02-04-47-738733Z.log"
+      "output_tokens_used": 4267
     },
     "metrics": {
       "input_tokens_used": 1540484,

--- a/stats/javassist/javassist/3.12.0.SP1/execution-metrics.json
+++ b/stats/javassist/javassist/3.12.0.SP1/execution-metrics.json
@@ -118,10 +118,7 @@
       "new_version": "3.12.0.SP1",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 26240,
-      "output_tokens_used": 2084,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/javassist:javassist:3.12.0.SP1/library-preparation-preflight/pi-generation-2026-06-09T08-52-04-063810Z.log"
+      "output_tokens_used": 2084
     },
     "metrics": {
       "input_tokens_used": 120899,

--- a/stats/javax.ws.rs/javax.ws.rs-api/2.0.1/execution-metrics.json
+++ b/stats/javax.ws.rs/javax.ws.rs-api/2.0.1/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 37667,
-      "output_tokens_used": 2822,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/javax.ws.rs:javax.ws.rs-api:2.0.1/library-preparation-preflight/pi-generation-2026-06-28T04-18-58-267141Z.log"
+      "output_tokens_used": 2822
     },
     "metrics": {
       "input_tokens_used": 327384,

--- a/stats/jmock/jmock/1.1.0/execution-metrics.json
+++ b/stats/jmock/jmock/1.1.0/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 24885,
-      "output_tokens_used": 3176,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/jmock:jmock:1.1.0/library-preparation-preflight/pi-generation-2026-06-28T18-32-34-871185Z.log"
+      "output_tokens_used": 3176
     },
     "metrics": {
       "input_tokens_used": 167047,

--- a/stats/junit/junit/3.7/execution-metrics.json
+++ b/stats/junit/junit/3.7/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 57529,
-      "output_tokens_used": 1631,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/junit:junit:3.7/library-preparation-preflight/pi-generation-2026-07-29T10-32-36-493640Z.log"
+      "output_tokens_used": 1631
     },
     "metrics": {
       "input_tokens_used": 195441,
@@ -164,10 +161,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 35024,
-      "output_tokens_used": 3173,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/g/forge/graalvm-reachability-metadata/forge/logs/junit:junit:3.7/library-preparation-preflight/pi-generation-2026-08-15T13-00-56-799987Z.log"
+      "output_tokens_used": 3173
     },
     "metrics": {
       "input_tokens_used": 141381,
@@ -259,10 +253,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 948399,
-      "output_tokens_used": 7932,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/junit:junit:3.7/library-preparation-preflight/codex-session-r4b_ela2.log"
+      "output_tokens_used": 7932
     },
     "metrics": {
       "input_tokens_used": 949138,

--- a/stats/junit/junit/4.13.2/execution-metrics.json
+++ b/stats/junit/junit/4.13.2/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 219224,
-      "output_tokens_used": 3363,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/junit:junit:4.13.2/library-preparation-preflight/codex-session-wrclrsf5.log"
+      "output_tokens_used": 3363
     },
     "metrics": {
       "input_tokens_used": 507947,

--- a/stats/net.java.dev.jna/jna-platform/5.12.1/execution-metrics.json
+++ b/stats/net.java.dev.jna/jna-platform/5.12.1/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 49259,
-      "output_tokens_used": 2964,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/net.java.dev.jna:jna-platform:5.12.1/library-preparation-preflight/pi-generation-2026-06-26T16-56-52-410532Z.log"
+      "output_tokens_used": 2964
     },
     "metrics": {
       "input_tokens_used": 1479375,

--- a/stats/net.logstash.logback/logstash-logback-encoder/9.0/execution-metrics.json
+++ b/stats/net.logstash.logback/logstash-logback-encoder/9.0/execution-metrics.json
@@ -82,10 +82,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 329926,
-      "output_tokens_used": 3926,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/net.logstash.logback:logstash-logback-encoder:9.0/library-preparation-preflight/codex-session-rnv8vozd.log"
+      "output_tokens_used": 3926
     },
     "metrics": {
       "input_tokens_used": 65848,

--- a/stats/net.sf.ehcache/ehcache-core/2.4.4/execution-metrics.json
+++ b/stats/net.sf.ehcache/ehcache-core/2.4.4/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 86249,
-      "output_tokens_used": 5301,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/net.sf.ehcache:ehcache-core:2.4.4/library-preparation-preflight/pi-generation-2026-06-28T01-49-09-084026Z.log"
+      "output_tokens_used": 5301
     },
     "metrics": {
       "input_tokens_used": 710574,

--- a/stats/net.sf.saxon/Saxon-HE/9.9.1-6/execution-metrics.json
+++ b/stats/net.sf.saxon/Saxon-HE/9.9.1-6/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 17240,
-      "output_tokens_used": 1840,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/net.sf.saxon:Saxon-HE:9.9.1-6/library-preparation-preflight/pi-generation-2026-06-09T19-07-59-578626Z.log"
+      "output_tokens_used": 1840
     },
     "metrics": {
       "input_tokens_used": 617916,

--- a/stats/net.thisptr/jackson-jq/1.6.2/execution-metrics.json
+++ b/stats/net.thisptr/jackson-jq/1.6.2/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28255,
-      "output_tokens_used": 3547,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/net.thisptr:jackson-jq:1.6.2/library-preparation-preflight/pi-generation-2026-06-27T06-33-38-961594Z.log"
+      "output_tokens_used": 3547
     },
     "metrics": {
       "input_tokens_used": 67251,

--- a/stats/org.apache.activemq/activemq-broker/6.0.0/execution-metrics.json
+++ b/stats/org.apache.activemq/activemq-broker/6.0.0/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 552833,
-      "output_tokens_used": 6967,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.activemq:activemq-broker:6.0.0/library-preparation-preflight/codex-session-9lkuqxbd.log"
+      "output_tokens_used": 6967
     },
     "metrics": {
       "input_tokens_used": 856832,

--- a/stats/org.apache.activemq/activemq-client-jakarta/5.18.5/execution-metrics.json
+++ b/stats/org.apache.activemq/activemq-client-jakarta/5.18.5/execution-metrics.json
@@ -70,10 +70,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.activemq:activemq-client-jakarta:5.18.5/library-preparation-preflight/pi-generation-2026-06-28T20-32-18-584111Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 654893,
@@ -180,10 +177,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 61422,
-      "output_tokens_used": 7594,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.activemq:activemq-client-jakarta:5.18.5/library-preparation-preflight/pi-generation-2026-06-28T23-49-21-259983Z.log"
+      "output_tokens_used": 7594
     },
     "metrics": {
       "input_tokens_used": 296776,

--- a/stats/org.apache.activemq/artemis-jms-client/2.56.0/execution-metrics.json
+++ b/stats/org.apache.activemq/artemis-jms-client/2.56.0/execution-metrics.json
@@ -131,10 +131,7 @@
       "new_version": "2.56.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1168836,
-      "output_tokens_used": 9218,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.apache.activemq:artemis-jms-client:2.56.0/library-preparation-preflight/codex-session-x8ssfapd.log"
+      "output_tokens_used": 9218
     },
     "metrics": {
       "input_tokens_used": 346388,

--- a/stats/org.apache.ant/ant/1.8.1/execution-metrics.json
+++ b/stats/org.apache.ant/ant/1.8.1/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 45074,
-      "output_tokens_used": 2334,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.ant:ant:1.8.1/library-preparation-preflight/pi-generation-2026-08-26T09-12-20-411533Z.log"
+      "output_tokens_used": 2334
     },
     "metrics": {
       "input_tokens_used": 824742,

--- a/stats/org.apache.avro/avro/1.12.1/execution-metrics.json
+++ b/stats/org.apache.avro/avro/1.12.1/execution-metrics.json
@@ -130,10 +130,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 60020,
-      "output_tokens_used": 3971,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.avro:avro:1.12.1/library-preparation-preflight/pi-generation-2026-06-24T10-13-01-561756Z.log"
+      "output_tokens_used": 3971
     },
     "metrics": {
       "input_tokens_used": 84402,

--- a/stats/org.apache.calcite/calcite-core/1.35.0/execution-metrics.json
+++ b/stats/org.apache.calcite/calcite-core/1.35.0/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 34324,
-      "output_tokens_used": 1494,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.calcite:calcite-core:1.35.0/library-preparation-preflight/pi-generation-2026-08-25T13-49-46-979883Z.log"
+      "output_tokens_used": 1494
     },
     "metrics": {
       "input_tokens_used": 401753,
@@ -169,10 +166,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 829175,
-      "output_tokens_used": 5833,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.apache.calcite:calcite-core:1.35.0/library-preparation-preflight/codex-session-_5ik_6l7.log"
+      "output_tokens_used": 5833
     },
     "metrics": {
       "input_tokens_used": 533959,

--- a/stats/org.apache.camel/camel-core-engine/4.19.0/execution-metrics.json
+++ b/stats/org.apache.camel/camel-core-engine/4.19.0/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.camel:camel-core-engine:4.19.0/library-preparation-preflight/pi-generation-2026-06-10T05-02-28-983598Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 177564,

--- a/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
+++ b/stats/org.apache.camel/camel-jackson/4.20.0/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 34470,
-      "output_tokens_used": 3916,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.camel:camel-jackson:4.20.0/library-preparation-preflight/pi-generation-2026-06-10T09-22-39-029790Z.log"
+      "output_tokens_used": 3916
     },
     "metrics": {
       "input_tokens_used": 311680,

--- a/stats/org.apache.commons/commons-lang3/3.19.0/execution-metrics.json
+++ b/stats/org.apache.commons/commons-lang3/3.19.0/execution-metrics.json
@@ -107,10 +107,7 @@
       "new_version": "3.19.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 22736,
-      "output_tokens_used": 2510,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.commons:commons-lang3:3.19.0/library-preparation-preflight/pi-generation-2026-06-10T00-45-51-924157Z.log"
+      "output_tokens_used": 2510
     },
     "metrics": {
       "input_tokens_used": 56693,

--- a/stats/org.apache.hadoop.thirdparty/hadoop-shaded-guava/1.1.1/execution-metrics.json
+++ b/stats/org.apache.hadoop.thirdparty/hadoop-shaded-guava/1.1.1/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1/library-preparation-preflight/pi-generation-2026-06-09T09-12-01-717381Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 1935392,

--- a/stats/org.apache.httpcomponents.core5/httpcore5-h2/5.4.3/execution-metrics.json
+++ b/stats/org.apache.httpcomponents.core5/httpcore5-h2/5.4.3/execution-metrics.json
@@ -93,10 +93,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 779272,
-      "output_tokens_used": 6492,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.httpcomponents.core5:httpcore5-h2:5.4.3/library-preparation-preflight/codex-session-hn2pydna.log"
+      "output_tokens_used": 6492
     },
     "metrics": {
       "input_tokens_used": 62532,

--- a/stats/org.apache.kafka/kafka-clients/4.2.1/execution-metrics.json
+++ b/stats/org.apache.kafka/kafka-clients/4.2.1/execution-metrics.json
@@ -136,9 +136,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.kafka:kafka-clients:4.2.1/library-preparation-preflight/pi-generation-2026-06-26T10-08-38-207339Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 1162384,
@@ -259,10 +257,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 56708,
-      "output_tokens_used": 7792,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.kafka:kafka-clients:4.2.1/library-preparation-preflight/pi-generation-2026-06-27T12-43-02-037946Z.log"
+      "output_tokens_used": 7792
     },
     "metrics": {
       "input_tokens_used": 739056,

--- a/stats/org.apache.kafka/kafka-streams/4.3.1/execution-metrics.json
+++ b/stats/org.apache.kafka/kafka-streams/4.3.1/execution-metrics.json
@@ -118,10 +118,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1675788,
-      "output_tokens_used": 10817,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.apache.kafka:kafka-streams:4.3.1/library-preparation-preflight/codex-session-axvn4a6v.log"
+      "output_tokens_used": 10817
     },
     "metrics": {
       "input_tokens_used": 162012,

--- a/stats/org.apache.kerby/kerb-server/1.0.1/execution-metrics.json
+++ b/stats/org.apache.kerby/kerb-server/1.0.1/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 75836,
-      "output_tokens_used": 6143,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.kerby:kerb-server:1.0.1/library-preparation-preflight/pi-generation-2026-06-28T13-58-33-090674Z.log"
+      "output_tokens_used": 6143
     },
     "metrics": {
       "input_tokens_used": 278012,

--- a/stats/org.apache.lucene/lucene-core/5.3.0/execution-metrics.json
+++ b/stats/org.apache.lucene/lucene-core/5.3.0/execution-metrics.json
@@ -222,9 +222,7 @@
       "current_library": "org.apache.lucene:lucene-core:5.5.0",
       "new_version": "5.3.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.lucene:lucene-core:5.3.0/library-preparation-preflight/pi-generation-2026-06-10T13-08-19-807105Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.apache.maven.plugin-tools/maven-plugin-annotations/3.1/execution-metrics.json
+++ b/stats/org.apache.maven.plugin-tools/maven-plugin-annotations/3.1/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 35152,
-      "output_tokens_used": 2792,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.apache.maven.plugin-tools:maven-plugin-annotations:3.1/library-preparation-preflight/pi-generation-2026-06-24T23-57-54-131148Z.log"
+      "output_tokens_used": 2792
     },
     "metrics": {
       "input_tokens_used": 320826,

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.10.0/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "3.10.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 29692,
-      "output_tokens_used": 1366,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-compiler-plugin:3.10.0/library-preparation-preflight/pi-generation-2026-06-09T08-49-47-190861Z.log"
+      "output_tokens_used": 1366
     },
     "metrics": {
       "input_tokens_used": 20362,

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.11.0/execution-metrics.json
@@ -155,10 +155,7 @@
       "new_version": "3.11.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 42225,
-      "output_tokens_used": 3992,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-compiler-plugin:3.11.0/library-preparation-preflight/pi-generation-2026-06-09T13-51-37-456596Z.log"
+      "output_tokens_used": 3992
     },
     "metrics": {
       "input_tokens_used": 62863,

--- a/stats/org.apache.maven.plugins/maven-compiler-plugin/3.13.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-compiler-plugin/3.13.0/execution-metrics.json
@@ -108,9 +108,7 @@
       "current_library": "org.apache.maven.plugins:maven-compiler-plugin:3.11.0",
       "new_version": "3.13.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-compiler-plugin:3.13.0/library-preparation-preflight/pi-generation-2026-06-09T20-20-14-375211Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 24661,

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/3.4.0/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "3.4.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25372,
-      "output_tokens_used": 2755,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-jar-plugin:3.4.0/library-preparation-preflight/pi-generation-2026-06-09T07-38-15-865991Z.log"
+      "output_tokens_used": 2755
     },
     "metrics": {
       "input_tokens_used": 10899,

--- a/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/execution-metrics.json
+++ b/stats/org.apache.maven.plugins/maven-jar-plugin/4.0.0-beta-1/execution-metrics.json
@@ -121,10 +121,7 @@
       "new_version": "4.0.0-beta-1",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 19420,
-      "output_tokens_used": 2848,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven.plugins:maven-jar-plugin:4.0.0-beta-1/library-preparation-preflight/pi-generation-2026-06-09T14-25-33-963128Z.log"
+      "output_tokens_used": 2848
     },
     "metrics": {
       "input_tokens_used": 76175,

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.10.0/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "1.10.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25961,
-      "output_tokens_used": 2911,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:1.10.0/library-preparation-preflight/pi-generation-2026-06-09T16-50-34-071918Z.log"
+      "output_tokens_used": 2911
     },
     "metrics": {
       "input_tokens_used": 57270,

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/1.11.1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "1.11.1",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 24355,
-      "output_tokens_used": 4571,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:1.11.1/library-preparation-preflight/pi-generation-2026-06-10T01-56-25-886248Z.log"
+      "output_tokens_used": 4571
     },
     "metrics": {
       "input_tokens_used": 35127,

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.0.0/execution-metrics.json
@@ -96,10 +96,7 @@
       "new_version": "2.0.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 46329,
-      "output_tokens_used": 3694,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:2.0.0/library-preparation-preflight/pi-generation-2026-06-10T14-24-51-835874Z.log"
+      "output_tokens_used": 3694
     },
     "metrics": {
       "input_tokens_used": 26714,

--- a/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/execution-metrics.json
+++ b/stats/org.apache.maven.scm/maven-scm-provider-gitexe/2.1.0/execution-metrics.json
@@ -96,10 +96,7 @@
       "new_version": "2.1.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 80332,
-      "output_tokens_used": 4580,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven.scm:maven-scm-provider-gitexe:2.1.0/library-preparation-preflight/pi-generation-2026-06-10T20-26-35-941854Z.log"
+      "output_tokens_used": 4580
     },
     "metrics": {
       "input_tokens_used": 29297,

--- a/stats/org.apache.maven.surefire/maven-surefire-common/2.22.2/execution-metrics.json
+++ b/stats/org.apache.maven.surefire/maven-surefire-common/2.22.2/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 67005,
-      "output_tokens_used": 3451,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.maven.surefire:maven-surefire-common:2.22.2/library-preparation-preflight/pi-generation-2026-06-28T16-20-22-742284Z.log"
+      "output_tokens_used": 3451
     },
     "metrics": {
       "input_tokens_used": 519650,

--- a/stats/org.apache.maven.surefire/surefire-booter/2.22.2/execution-metrics.json
+++ b/stats/org.apache.maven.surefire/surefire-booter/2.22.2/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 82055,
-      "output_tokens_used": 4489,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.apache.maven.surefire:surefire-booter:2.22.2/library-preparation-preflight/pi-generation-2026-06-28T16-23-45-106450Z.log"
+      "output_tokens_used": 4489
     },
     "metrics": {
       "input_tokens_used": 389417,

--- a/stats/org.apache.maven/maven-api-spi/4.0.0-rc-5/execution-metrics.json
+++ b/stats/org.apache.maven/maven-api-spi/4.0.0-rc-5/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 22951,
-      "output_tokens_used": 2756,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.maven:maven-api-spi:4.0.0-rc-5/library-preparation-preflight/pi-generation-2026-06-28T12-49-00-412527Z.log"
+      "output_tokens_used": 2756
     },
     "metrics": {
       "input_tokens_used": 149471,

--- a/stats/org.apache.maven/maven-core/2.0.6/execution-metrics.json
+++ b/stats/org.apache.maven/maven-core/2.0.6/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 37103,
-      "output_tokens_used": 4362,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.maven:maven-core:2.0.6/library-preparation-preflight/pi-generation-2026-06-27T21-53-02-427678Z.log"
+      "output_tokens_used": 4362
     },
     "metrics": {
       "input_tokens_used": 457876,

--- a/stats/org.apache.maven/maven-model-builder/3.0/execution-metrics.json
+++ b/stats/org.apache.maven/maven-model-builder/3.0/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 50940,
-      "output_tokens_used": 3025,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.apache.maven:maven-model-builder:3.0/library-preparation-preflight/pi-generation-2026-06-28T22-17-05-172815Z.log"
+      "output_tokens_used": 3025
     },
     "metrics": {
       "input_tokens_used": 74591,

--- a/stats/org.apache.maven/maven-settings/2.0.6/execution-metrics.json
+++ b/stats/org.apache.maven/maven-settings/2.0.6/execution-metrics.json
@@ -70,10 +70,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 24328,
-      "output_tokens_used": 4161,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.maven:maven-settings:2.0.6/library-preparation-preflight/pi-generation-2026-06-28T20-26-46-239047Z.log"
+      "output_tokens_used": 4161
     },
     "metrics": {
       "input_tokens_used": 33968,

--- a/stats/org.apache.maven/maven-toolchain/2.2.1/execution-metrics.json
+++ b/stats/org.apache.maven/maven-toolchain/2.2.1/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 55741,
-      "output_tokens_used": 2813,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.apache.maven:maven-toolchain:2.2.1/library-preparation-preflight/pi-generation-2026-08-27T08-53-55-395078Z.log"
+      "output_tokens_used": 2813
     },
     "metrics": {
       "input_tokens_used": 71705,

--- a/stats/org.apache.parquet/parquet-jackson/1.12.2/execution-metrics.json
+++ b/stats/org.apache.parquet/parquet-jackson/1.12.2/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.parquet:parquet-jackson:1.12.2/library-preparation-preflight/pi-generation-2026-06-09T06-30-20-121104Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 1276631,

--- a/stats/org.apache.pekko/pekko-actor_2.13/1.1.5/execution-metrics.json
+++ b/stats/org.apache.pekko/pekko-actor_2.13/1.1.5/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 41526,
-      "output_tokens_used": 3173,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.apache.pekko:pekko-actor_2.13:1.1.5/library-preparation-preflight/pi-generation-2026-06-27T10-26-31-631822Z.log"
+      "output_tokens_used": 3173
     },
     "metrics": {
       "input_tokens_used": 887794,

--- a/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/execution-metrics.json
+++ b/stats/org.apache.pekko/pekko-parsing_2.13/1.3.0/execution-metrics.json
@@ -89,10 +89,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 21252,
-      "output_tokens_used": 3375,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.apache.pekko:pekko-parsing_2.13:1.3.0/library-preparation-preflight/pi-generation-2026-06-28T03-29-09-430004Z.log"
+      "output_tokens_used": 3375
     },
     "metrics": {
       "input_tokens_used": 372306,

--- a/stats/org.apache.pulsar/pulsar-common/4.2.1/execution-metrics.json
+++ b/stats/org.apache.pulsar/pulsar-common/4.2.1/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 53649,
-      "output_tokens_used": 4397,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.apache.pulsar:pulsar-common:4.2.1/library-preparation-preflight/pi-generation-2026-06-28T07-16-40-291977Z.log"
+      "output_tokens_used": 4397
     },
     "metrics": {
       "input_tokens_used": 565994,

--- a/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/execution-metrics.json
+++ b/stats/org.apache.tomcat.embed/tomcat-embed-core/11.0.18/execution-metrics.json
@@ -135,13 +135,10 @@
       "library": "org.apache.tomcat.embed:tomcat-embed-core:11.0.18",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 3640,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Optional Tomcat areas such as JSP/Jasper, WebSocket, APR/native SSL, clustering, or external persistence would need additional artifacts or native libraries, but they are not needed for the reported Connector.getProperty/setProperty coverage path.",
         "Tests should avoid fixed ports and external services; use local embedded Tomcat/Connector APIs and clean lifecycle shutdown, with Gradle/native-image verification remaining authoritative."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.apache.tomcat.embed:tomcat-embed-core:11.0.18/library-preparation-preflight/pi-generation-2026-06-22T12-10-29-258589Z.log",
       "status": "completed",
       "summary": "No extra setup is required: tomcat-embed-core 11.0.18 resolves with only tomcat-annotations-api as a compile dependency, bundles the servlet/security APIs needed for direct embedded-core usage, and the reported Connector/AbstractProtocol introspection path is reachable with the library itself."
     },

--- a/stats/org.bouncycastle/bc-fips/2.1.2/execution-metrics.json
+++ b/stats/org.bouncycastle/bc-fips/2.1.2/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 118793,
-      "output_tokens_used": 7377,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.bouncycastle:bc-fips:2.1.2/library-preparation-preflight/pi-generation-2026-07-24T14-11-56-174389Z.log"
+      "output_tokens_used": 7377
     },
     "metrics": {
       "input_tokens_used": 445722,
@@ -158,10 +155,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 25311,
-      "output_tokens_used": 1298,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.bouncycastle:bc-fips:2.1.2/library-preparation-preflight/pi-generation-2026-08-12T08-03-45-743913Z.log"
+      "output_tokens_used": 1298
     },
     "metrics": {
       "input_tokens_used": 880775,
@@ -243,14 +237,11 @@
       "library": "org.bouncycastle:bc-fips:2.1.2",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 2433,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Without AdditionalSecurityProviders, provider services may be unavailable in the native executable.",
         "Without the java CPU variant, platform-native BC-FIPS loading may make builds or runtime behavior environment-dependent.",
         "The artifact declares no Maven dependencies; bcutil-fips and other FIPS modules are only needed for APIs outside bc-fips itself."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.bouncycastle:bc-fips:2.1.2/library-preparation-preflight/codex-session-0lrsdlhm.log",
       "status": "completed",
       "summary": "BC-FIPS is self-contained, but meaningful Native Image coverage requires provider registration and BC-specific build/runtime properties."
     },

--- a/stats/org.bouncycastle/bcpkix-jdk18on/1.77/execution-metrics.json
+++ b/stats/org.bouncycastle/bcpkix-jdk18on/1.77/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1069725,
-      "output_tokens_used": 11382,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.bouncycastle:bcpkix-jdk18on:1.77/library-preparation-preflight/codex-session-tugk5mtu.log"
+      "output_tokens_used": 11382
     },
     "metrics": {
       "input_tokens_used": 753832,

--- a/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/execution-metrics.json
+++ b/stats/org.codehaus.jackson/jackson-mapper-asl/1.9.0/execution-metrics.json
@@ -103,9 +103,7 @@
       "current_library": "org.codehaus.jackson:jackson-mapper-asl:1.8.3",
       "new_version": "1.9.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.codehaus.jackson:jackson-mapper-asl:1.9.0/library-preparation-preflight/pi-generation-2026-06-11T01-37-35-888621Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 130841,

--- a/stats/org.codehaus.janino/commons-compiler/3.0.16/execution-metrics.json
+++ b/stats/org.codehaus.janino/commons-compiler/3.0.16/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.codehaus.janino:commons-compiler:3.0.16/library-preparation-preflight/pi-generation-2026-06-09T06-43-20-470656Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 271105,

--- a/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-classworlds/2.10.0/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "2.10.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28995,
-      "output_tokens_used": 3267,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.codehaus.plexus:plexus-classworlds:2.10.0/library-preparation-preflight/pi-generation-2026-06-09T05-14-43-192493Z.log"
+      "output_tokens_used": 3267
     },
     "metrics": {
       "input_tokens_used": 40735,

--- a/stats/org.codehaus.plexus/plexus-compiler-manager/2.8.4/execution-metrics.json
+++ b/stats/org.codehaus.plexus/plexus-compiler-manager/2.8.4/execution-metrics.json
@@ -76,10 +76,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 47787,
-      "output_tokens_used": 4930,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.codehaus.plexus:plexus-compiler-manager:2.8.4/library-preparation-preflight/pi-generation-2026-08-26T07-39-58-273228Z.log"
+      "output_tokens_used": 4930
     },
     "metrics": {
       "input_tokens_used": 169481,

--- a/stats/org.conscrypt/conscrypt-openjdk-uber/1.1.4/execution-metrics.json
+++ b/stats/org.conscrypt/conscrypt-openjdk-uber/1.1.4/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 25694,
-      "output_tokens_used": 2958,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.conscrypt:conscrypt-openjdk-uber:1.1.4/library-preparation-preflight/pi-generation-2026-06-28T05-10-50-224197Z.log"
+      "output_tokens_used": 2958
     },
     "metrics": {
       "input_tokens_used": 649766,

--- a/stats/org.easymock/easymock/2.2/execution-metrics.json
+++ b/stats/org.easymock/easymock/2.2/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 33202,
-      "output_tokens_used": 1586,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.easymock:easymock:2.2/library-preparation-preflight/pi-generation-2026-06-28T18-22-05-154183Z.log"
+      "output_tokens_used": 1586
     },
     "metrics": {
       "input_tokens_used": 70304,

--- a/stats/org.eclipse.angus/angus-core/1.0.0/execution-metrics.json
+++ b/stats/org.eclipse.angus/angus-core/1.0.0/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 64796,
-      "output_tokens_used": 3899,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.eclipse.angus:angus-core:1.0.0/library-preparation-preflight/pi-generation-2026-06-29T00-44-38-486914Z.log"
+      "output_tokens_used": 3899
     },
     "metrics": {
       "input_tokens_used": 122752,

--- a/stats/org.eclipse.collections/eclipse-collections/11.1.0/execution-metrics.json
+++ b/stats/org.eclipse.collections/eclipse-collections/11.1.0/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28778,
-      "output_tokens_used": 1933,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.eclipse.collections:eclipse-collections:11.1.0/library-preparation-preflight/pi-generation-2026-06-28T02-24-27-821732Z.log"
+      "output_tokens_used": 1933
     },
     "metrics": {
       "input_tokens_used": 553526,
@@ -159,10 +156,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 69806,
-      "output_tokens_used": 3736,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.eclipse.collections:eclipse-collections:11.1.0/library-preparation-preflight/pi-generation-2026-06-29T10-09-14-135912Z.log"
+      "output_tokens_used": 3736
     },
     "metrics": {
       "input_tokens_used": 395948,

--- a/stats/org.eclipse.jetty/jetty-server/12.1.10/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-server/12.1.10/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.eclipse.jetty:jetty-server:12.1.10/library-preparation-preflight/pi-generation-2026-06-11T01-46-12-795006Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 120330,

--- a/stats/org.eclipse.jetty/jetty-util/12.0.9/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-util/12.0.9/execution-metrics.json
@@ -69,13 +69,10 @@
       "library": "org.eclipse.jetty:jetty-util:12.0.9",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 13179,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "The low coverage is due to the minimal existing test, not missing runtime setup.",
         "Native-image tests involving Jetty's special resource: URL scheme may require in-test URLResourceFactory registration; ordinary file, jar, and jrt coverage does not."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.eclipse.jetty:jetty-util:12.0.9/library-preparation-preflight/codex-session-6l5iyagl.log",
       "status": "completed",
       "summary": "No extra setup is needed. Jetty Util 12.0.9 declares only SLF4J API as a runtime dependency; its other published dependencies are test-only. Its APIs use standard JDK facilities and can be exercised with the existing scaffold. [Maven Central](https://central.sonatype.com/artifact/org.eclipse.jetty/jetty-util/12.0.9) [Jetty API](https://javadoc.jetty.org/jetty-12/org/eclipse/jetty/util/package-summary.html)"
     },

--- a/stats/org.eclipse.jetty/jetty-webapp/9.3.19.v20170502/execution-metrics.json
+++ b/stats/org.eclipse.jetty/jetty-webapp/9.3.19.v20170502/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 42270,
-      "output_tokens_used": 4120,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.eclipse.jetty:jetty-webapp:9.3.19.v20170502/library-preparation-preflight/pi-generation-2026-06-28T13-49-32-406472Z.log"
+      "output_tokens_used": 4120
     },
     "metrics": {
       "input_tokens_used": 112200,

--- a/stats/org.eclipse.jgit/org.eclipse.jgit/7.7.0.202606012155-r/execution-metrics.json
+++ b/stats/org.eclipse.jgit/org.eclipse.jgit/7.7.0.202606012155-r/execution-metrics.json
@@ -70,9 +70,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.eclipse.jgit:org.eclipse.jgit:7.7.0.202606012155-r/library-preparation-preflight/pi-generation-2026-06-11T12-33-51-992712Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 161783,

--- a/stats/org.eclipse.platform/org.eclipse.swt.win32.win32.x86_64/3.133.0/execution-metrics.json
+++ b/stats/org.eclipse.platform/org.eclipse.swt.win32.win32.x86_64/3.133.0/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 47549,
-      "output_tokens_used": 2060,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:3.133.0/library-preparation-preflight/pi-generation-2026-07-08T23-20-38-158425Z.log"
+      "output_tokens_used": 2060
     },
     "metrics": {
       "input_tokens_used": 132816,

--- a/stats/org.flywaydb/flyway-core/13.5.0/execution-metrics.json
+++ b/stats/org.flywaydb/flyway-core/13.5.0/execution-metrics.json
@@ -130,10 +130,7 @@
       "new_version": "13.5.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 875907,
-      "output_tokens_used": 6455,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.flywaydb:flyway-core:13.5.0/library-preparation-preflight/codex-session-zrv13y7s.log"
+      "output_tokens_used": 6455
     },
     "metrics": {
       "input_tokens_used": 198606,

--- a/stats/org.flywaydb/flyway-database-postgresql/10.19.0/execution-metrics.json
+++ b/stats/org.flywaydb/flyway-database-postgresql/10.19.0/execution-metrics.json
@@ -96,10 +96,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 413009,
-      "output_tokens_used": 4205,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.flywaydb:flyway-database-postgresql:10.19.0/library-preparation-preflight/codex-session-spc30tml.log"
+      "output_tokens_used": 4205
     },
     "metrics": {
       "input_tokens_used": 72876,

--- a/stats/org.glassfish.hk2/osgi-resource-locator/1.0.1/execution-metrics.json
+++ b/stats/org.glassfish.hk2/osgi-resource-locator/1.0.1/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 52309,
-      "output_tokens_used": 3618,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.glassfish.hk2:osgi-resource-locator:1.0.1/library-preparation-preflight/pi-generation-2026-06-28T17-54-06-724377Z.log"
+      "output_tokens_used": 3618
     },
     "metrics": {
       "input_tokens_used": 192077,

--- a/stats/org.glassfish.jersey.containers/jersey-container-servlet-core/2.34/execution-metrics.json
+++ b/stats/org.glassfish.jersey.containers/jersey-container-servlet-core/2.34/execution-metrics.json
@@ -100,10 +100,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 67353,
-      "output_tokens_used": 6651,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.glassfish.jersey.containers:jersey-container-servlet-core:2.34/library-preparation-preflight/pi-generation-2026-06-28T13-25-00-127062Z.log"
+      "output_tokens_used": 6651
     },
     "metrics": {
       "input_tokens_used": 79454,

--- a/stats/org.glassfish.jersey.core/jersey-server/3.0.8/execution-metrics.json
+++ b/stats/org.glassfish.jersey.core/jersey-server/3.0.8/execution-metrics.json
@@ -47,10 +47,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 109318,
-      "output_tokens_used": 2377,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.glassfish.jersey.core:jersey-server:3.0.8/library-preparation-preflight/pi-generation-2026-07-13T11-28-08-400047Z.log"
+      "output_tokens_used": 2377
     },
     "metrics": {
       "input_tokens_used": 582800,
@@ -151,12 +148,9 @@
       "library": "org.glassfish.jersey.core:jersey-server:3.0.8",
       "model": "gpt-5.6-terra",
       "output_tokens_used": 2377,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "A real HTTP endpoint would additionally require a Jersey container adapter such as Grizzly, but it is not necessary for meaningful jersey-server coverage."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.glassfish.jersey.core:jersey-server:3.0.8/library-preparation-preflight/pi-generation-2026-07-13T11-28-08-400047Z.log",
       "status": "completed",
       "summary": "jersey-server does not bring an InjectionManager implementation transitively; meaningful server bootstrap via ApplicationHandler requires Jersey's HK2 provider."
     },

--- a/stats/org.hibernate.orm/hibernate-processor/7.2.6.Final/execution-metrics.json
+++ b/stats/org.hibernate.orm/hibernate-processor/7.2.6.Final/execution-metrics.json
@@ -34,10 +34,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 92780,
-      "output_tokens_used": 4130,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.hibernate.orm:hibernate-processor:7.2.6.Final/library-preparation-preflight/pi-generation-2026-06-19T12-31-33-448093Z.log"
+      "output_tokens_used": 4130
     },
     "metrics": {
       "input_tokens_used": 511995,
@@ -85,13 +82,10 @@
       "library": "org.hibernate.orm:hibernate-processor:7.2.6.Final",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 4130,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Meaningful coverage must actually invoke annotation processing, for example by compiling an in-memory or temporary @Entity source with JavaCompiler/javac and org.hibernate.processor.HibernateProcessor, rather than only instantiating processor classes.",
         "Jakarta Data repository generation is an optional feature; testing that path may require a Jakarta Data API dependency, but the requested issue is about Jakarta Persistence static metamodel generation, which is already covered by transitive dependencies."
       ],
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.hibernate.orm:hibernate-processor:7.2.6.Final/library-preparation-preflight/pi-generation-2026-06-19T12-31-33-448093Z.log",
       "status": "completed",
       "summary": "No extra setup is required: org.hibernate.orm:hibernate-processor:7.2.6.Final is a standard javac annotation processor, and its resolved transitive dependencies already include the Jakarta Persistence API, Hibernate Core, JAXB, Jandex, validation, annotation, ANTLR, Byte Buddy, and JBoss Logging needed for static metamodel generation. It does not require a database, Docker service, environment variable, or system property for the static metamodel use case."
     },
@@ -181,13 +175,10 @@
       "library": "org.hibernate.orm:hibernate-processor:7.2.6.Final",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 4130,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Meaningful coverage must actually invoke annotation processing, for example by compiling an in-memory or temporary @Entity source with JavaCompiler/javac and org.hibernate.processor.HibernateProcessor, rather than only instantiating processor classes.",
         "Jakarta Data repository generation is an optional feature; testing that path may require a Jakarta Data API dependency, but the requested issue is about Jakarta Persistence static metamodel generation, which is already covered by transitive dependencies."
       ],
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.hibernate.orm:hibernate-processor:7.2.6.Final/library-preparation-preflight/pi-generation-2026-06-19T12-31-33-448093Z.log",
       "status": "completed",
       "summary": "No extra setup is required: org.hibernate.orm:hibernate-processor:7.2.6.Final is a standard javac annotation processor, and its resolved transitive dependencies already include the Jakarta Persistence API, Hibernate Core, JAXB, Jandex, validation, annotation, ANTLR, Byte Buddy, and JBoss Logging needed for static metamodel generation. It does not require a database, Docker service, environment variable, or system property for the static metamodel use case."
     },

--- a/stats/org.hibernate.validator/hibernate-validator/9.1.0.Final/execution-metrics.json
+++ b/stats/org.hibernate.validator/hibernate-validator/9.1.0.Final/execution-metrics.json
@@ -88,10 +88,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 44133,
-      "output_tokens_used": 2679,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.hibernate.validator:hibernate-validator:9.1.0.Final/library-preparation-preflight/pi-generation-2026-06-24T19-13-10-311134Z.log"
+      "output_tokens_used": 2679
     },
     "metrics": {
       "input_tokens_used": 942673,
@@ -198,10 +195,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 65132,
-      "output_tokens_used": 2689,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.hibernate.validator:hibernate-validator:9.1.0.Final/library-preparation-preflight/pi-generation-2026-07-22T21-58-26-780566Z.log"
+      "output_tokens_used": 2689
     },
     "metrics": {
       "input_tokens_used": 104812,

--- a/stats/org.hibernate/hibernate-core/6.1.0.Final/execution-metrics.json
+++ b/stats/org.hibernate/hibernate-core/6.1.0.Final/execution-metrics.json
@@ -130,10 +130,7 @@
       "new_version": "6.1.0.Final",
       "model": "gpt-5.6-terra",
       "input_tokens_used": 29253,
-      "output_tokens_used": 1952,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.hibernate:hibernate-core:6.1.0.Final/library-preparation-preflight/pi-generation-2026-07-27T23-32-50-360574Z.log"
+      "output_tokens_used": 1952
     },
     "metrics": {
       "input_tokens_used": 16356,
@@ -223,13 +220,10 @@
       "library": "org.hibernate:hibernate-core:6.1.0.Final",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 10214,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "H2 compatibility modes do not validate behavior against real vendor databases.",
         "The reported failures are missing Native Image resource/reflection metadata, not missing runtime setup."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.hibernate:hibernate-core:6.1.0.Final/library-preparation-preflight/codex-session-osdadbie.log",
       "status": "completed",
       "summary": "No extra setup is needed: the existing scaffold already provides H2 and the JDBC classes required by the exercised dialect paths. Hibernate core itself does not bundle database drivers ([POM](https://central.sonatype.com/artifact/org.hibernate.orm/hibernate-core/6.1.0.Final))."
     },

--- a/stats/org.hsqldb/hsqldb/2.7.3/execution-metrics.json
+++ b/stats/org.hsqldb/hsqldb/2.7.3/execution-metrics.json
@@ -67,10 +67,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 44820,
-      "output_tokens_used": 1518,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.hsqldb:hsqldb:2.7.3/library-preparation-preflight/pi-generation-2026-07-07T23-45-47-640105Z.log"
+      "output_tokens_used": 1518
     },
     "metrics": {
       "input_tokens_used": 692360,

--- a/stats/org.jboss.arquillian.container/arquillian-container-test-spi/1.1.10.Final/execution-metrics.json
+++ b/stats/org.jboss.arquillian.container/arquillian-container-test-spi/1.1.10.Final/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 71832,
-      "output_tokens_used": 3883,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jboss.arquillian.container:arquillian-container-test-spi:1.1.10.Final/library-preparation-preflight/pi-generation-2026-06-28T12-31-48-033240Z.log"
+      "output_tokens_used": 3883
     },
     "metrics": {
       "input_tokens_used": 206148,

--- a/stats/org.jboss.resteasy/resteasy-client-api/6.2.15.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-client-api/6.2.15.Final/execution-metrics.json
@@ -82,10 +82,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 26878,
-      "output_tokens_used": 2166,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.jboss.resteasy:resteasy-client-api:6.2.15.Final/library-preparation-preflight/pi-generation-2026-07-30T08-42-54-136968Z.log"
+      "output_tokens_used": 2166
     },
     "metrics": {
       "input_tokens_used": 43438,

--- a/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-client/6.2.16.Final/execution-metrics.json
@@ -113,9 +113,7 @@
       "current_library": "org.jboss.resteasy:resteasy-client:6.2.12.Final",
       "new_version": "6.2.16.Final",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jboss.resteasy:resteasy-client:6.2.16.Final/library-preparation-preflight/pi-generation-2026-06-10T02-25-42-411766Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 121692,

--- a/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/execution-metrics.json
+++ b/stats/org.jboss.resteasy/resteasy-jackson2-provider/6.2.15.Final/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 59419,
-      "output_tokens_used": 4509,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss.resteasy:resteasy-jackson2-provider:6.2.15.Final/library-preparation-preflight/pi-generation-2026-08-07T13-12-15-169604Z.log"
+      "output_tokens_used": 4509
     },
     "metrics": {
       "input_tokens_used": 88521,

--- a/stats/org.jboss/jandex/2.4.5.Final/execution-metrics.json
+++ b/stats/org.jboss/jandex/2.4.5.Final/execution-metrics.json
@@ -113,9 +113,7 @@
       "current_library": "org.jboss:jandex:2.4.2.Final",
       "new_version": "2.4.5.Final",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:2.4.5.Final/library-preparation-preflight/pi-generation-2026-06-10T02-00-23-386888Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.jboss/jandex/3.0.0/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.0.0/execution-metrics.json
@@ -118,10 +118,7 @@
       "new_version": "3.0.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 44992,
-      "output_tokens_used": 3239,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.0.0/library-preparation-preflight/pi-generation-2026-06-10T09-20-39-976129Z.log"
+      "output_tokens_used": 3239
     },
     "metrics": {
       "input_tokens_used": 102324,

--- a/stats/org.jboss/jandex/3.0.7/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.0.7/execution-metrics.json
@@ -113,9 +113,7 @@
       "current_library": "org.jboss:jandex:3.0.0",
       "new_version": "3.0.7",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.0.7/library-preparation-preflight/pi-generation-2026-06-10T20-56-42-295620Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.jboss/jandex/3.1.0/execution-metrics.json
+++ b/stats/org.jboss/jandex/3.1.0/execution-metrics.json
@@ -113,9 +113,7 @@
       "current_library": "org.jboss:jandex:3.0.0",
       "new_version": "3.1.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.jboss:jandex:3.1.0/library-preparation-preflight/pi-generation-2026-06-11T03-20-23-675560Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 59470,

--- a/stats/org.jctools/jctools-core/4.0.3/execution-metrics.json
+++ b/stats/org.jctools/jctools-core/4.0.3/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 56272,
-      "output_tokens_used": 3516,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jctools:jctools-core:4.0.3/library-preparation-preflight/pi-generation-2026-08-19T13-20-31-720896Z.log"
+      "output_tokens_used": 3516
     },
     "metrics": {
       "input_tokens_used": 451912,

--- a/stats/org.jdbi/jdbi3-core/3.49.3/execution-metrics.json
+++ b/stats/org.jdbi/jdbi3-core/3.49.3/execution-metrics.json
@@ -87,10 +87,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2256279,
-      "output_tokens_used": 8897,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.jdbi:jdbi3-core:3.49.3/library-preparation-preflight/codex-session-_4ogiq2t.log"
+      "output_tokens_used": 8897
     },
     "metrics": {
       "input_tokens_used": 343052,

--- a/stats/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/execution-metrics.json
+++ b/stats/org.jetbrains.kotlin/kotlin-stdlib/1.7.10/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1579229,
-      "output_tokens_used": 10780,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.jetbrains.kotlin:kotlin-stdlib:1.7.10/library-preparation-preflight/codex-session-yurgvs7v.log"
+      "output_tokens_used": 10780
     },
     "metrics": {
       "input_tokens_used": 688000,

--- a/stats/org.jetbrains.kotlinx/kotlinx-coroutines-debug/1.10.2/execution-metrics.json
+++ b/stats/org.jetbrains.kotlinx/kotlinx-coroutines-debug/1.10.2/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 35860,
-      "output_tokens_used": 3980,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.10.2/library-preparation-preflight/pi-generation-2026-06-28T04-36-55-380876Z.log"
+      "output_tokens_used": 3980
     },
     "metrics": {
       "input_tokens_used": 277471,

--- a/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/execution-metrics.json
+++ b/stats/org.jetbrains.kotlinx/kotlinx-coroutines-swing/1.10.2/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2/library-preparation-preflight/pi-generation-2026-06-10T14-20-51-173169Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 201507,

--- a/stats/org.jgroups/jgroups/5.2.0.Final/execution-metrics.json
+++ b/stats/org.jgroups/jgroups/5.2.0.Final/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 46272,
-      "output_tokens_used": 4608,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.jgroups:jgroups:5.2.0.Final/library-preparation-preflight/pi-generation-2026-06-29T10-49-16-557187Z.log"
+      "output_tokens_used": 4608
     },
     "metrics": {
       "input_tokens_used": 253483,

--- a/stats/org.jline/jline/3.21.0/execution-metrics.json
+++ b/stats/org.jline/jline/3.21.0/execution-metrics.json
@@ -88,10 +88,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 560817,
-      "output_tokens_used": 6161,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.jline:jline:3.21.0/library-preparation-preflight/codex-session-fqgsfjkt.log"
+      "output_tokens_used": 6161
     },
     "metrics": {
       "input_tokens_used": 312300,

--- a/stats/org.jline/jline/3.24.0/execution-metrics.json
+++ b/stats/org.jline/jline/3.24.0/execution-metrics.json
@@ -88,10 +88,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 294075,
-      "output_tokens_used": 2738,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.jline:jline:3.24.0/library-preparation-preflight/codex-session-2ljrbjvd.log"
+      "output_tokens_used": 2738
     },
     "metrics": {
       "input_tokens_used": 243688,

--- a/stats/org.jruby.jcodings/jcodings/1.0.63/execution-metrics.json
+++ b/stats/org.jruby.jcodings/jcodings/1.0.63/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 40075,
-      "output_tokens_used": 2305,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.jruby.jcodings:jcodings:1.0.63/library-preparation-preflight/pi-generation-2026-06-27T05-03-32-841914Z.log"
+      "output_tokens_used": 2305
     },
     "metrics": {
       "input_tokens_used": 145213,

--- a/stats/org.jruby.joni/joni/2.2.6/execution-metrics.json
+++ b/stats/org.jruby.joni/joni/2.2.6/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 21485,
-      "output_tokens_used": 1805,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.jruby.joni:joni:2.2.6/library-preparation-preflight/pi-generation-2026-06-27T05-15-22-584924Z.log"
+      "output_tokens_used": 1805
     },
     "metrics": {
       "input_tokens_used": 154962,

--- a/stats/org.junit-pioneer/junit-pioneer/2.3.0/execution-metrics.json
+++ b/stats/org.junit-pioneer/junit-pioneer/2.3.0/execution-metrics.json
@@ -88,10 +88,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1705724,
-      "output_tokens_used": 9796,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.junit-pioneer:junit-pioneer:2.3.0/library-preparation-preflight/codex-session-wvogphxz.log"
+      "output_tokens_used": 9796
     },
     "metrics": {
       "input_tokens_used": 90417,

--- a/stats/org.junit.jupiter/junit-jupiter-api/5.11.4/execution-metrics.json
+++ b/stats/org.junit.jupiter/junit-jupiter-api/5.11.4/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "5.11.4",
       "model": "gpt-5.6-sol",
       "input_tokens_used": 48482,
-      "output_tokens_used": 3536,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.junit.jupiter:junit-jupiter-api:5.11.4/library-preparation-preflight/pi-generation-2026-08-27T21-29-45-044976Z.log"
+      "output_tokens_used": 3536
     },
     "metrics": {
       "input_tokens_used": 38836,

--- a/stats/org.junit.jupiter/junit-jupiter-engine/6.1.0/execution-metrics.json
+++ b/stats/org.junit.jupiter/junit-jupiter-engine/6.1.0/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "6.1.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1338181,
-      "output_tokens_used": 8458,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.jupiter:junit-jupiter-engine:6.1.0/library-preparation-preflight/codex-session-j3g08m97.log"
+      "output_tokens_used": 8458
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.junit.jupiter/junit-jupiter-params/5.9.2/execution-metrics.json
+++ b/stats/org.junit.jupiter/junit-jupiter-params/5.9.2/execution-metrics.json
@@ -71,10 +71,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 32128,
-      "output_tokens_used": 1812,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.junit.jupiter:junit-jupiter-params:5.9.2/library-preparation-preflight/pi-generation-2026-08-10T15-12-08-733242Z.log"
+      "output_tokens_used": 1812
     },
     "metrics": {
       "input_tokens_used": 311434,

--- a/stats/org.junit.jupiter/junit-jupiter-params/6.1.0/execution-metrics.json
+++ b/stats/org.junit.jupiter/junit-jupiter-params/6.1.0/execution-metrics.json
@@ -116,10 +116,7 @@
       "new_version": "6.1.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 884541,
-      "output_tokens_used": 9628,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.jupiter:junit-jupiter-params:6.1.0/library-preparation-preflight/codex-session-m8tf5x03.log"
+      "output_tokens_used": 9628
     },
     "metrics": {
       "input_tokens_used": 258877,

--- a/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.11.0/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "1.11.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 241549,
-      "output_tokens_used": 1724,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-commons:1.11.0/library-preparation-preflight/codex-session-u8kezu5r.log"
+      "output_tokens_used": 1724
     },
     "metrics": {
       "input_tokens_used": 243012,

--- a/stats/org.junit.platform/junit-platform-commons/1.12.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-commons/1.12.0/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "1.12.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 998679,
-      "output_tokens_used": 5123,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-commons:1.12.0/library-preparation-preflight/codex-session-d7en8lut.log"
+      "output_tokens_used": 5123
     },
     "metrics": {
       "input_tokens_used": 256130,

--- a/stats/org.junit.platform/junit-platform-engine/1.11.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-engine/1.11.0/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "1.11.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 277091,
-      "output_tokens_used": 2000,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-engine:1.11.0/library-preparation-preflight/codex-session-r280mhnn.log"
+      "output_tokens_used": 2000
     },
     "metrics": {
       "input_tokens_used": 36364,

--- a/stats/org.junit.platform/junit-platform-engine/1.11.1/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-engine/1.11.1/execution-metrics.json
@@ -106,10 +106,7 @@
       "new_version": "1.11.1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 954587,
-      "output_tokens_used": 7045,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-engine:1.11.1/library-preparation-preflight/codex-session-49ay9qjc.log"
+      "output_tokens_used": 7045
     },
     "metrics": {
       "input_tokens_used": 63954,

--- a/stats/org.junit.platform/junit-platform-launcher/6.1.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-launcher/6.1.0/execution-metrics.json
@@ -112,10 +112,7 @@
       "new_version": "6.1.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 750357,
-      "output_tokens_used": 6828,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-launcher:6.1.0/library-preparation-preflight/codex-session-nd2hspvg.log"
+      "output_tokens_used": 6828
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.junit.platform/junit-platform-reporting/6.1.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-reporting/6.1.0/execution-metrics.json
@@ -94,10 +94,7 @@
       "new_version": "6.1.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1202878,
-      "output_tokens_used": 9552,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-reporting:6.1.0/library-preparation-preflight/codex-session-5heas3np.log"
+      "output_tokens_used": 9552
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.junit.platform/junit-platform-suite-api/6.1.0/execution-metrics.json
+++ b/stats/org.junit.platform/junit-platform-suite-api/6.1.0/execution-metrics.json
@@ -54,10 +54,7 @@
       "new_version": "6.1.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 368922,
-      "output_tokens_used": 4046,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.junit.platform:junit-platform-suite-api:6.1.0/library-preparation-preflight/codex-session-rs5pfqui.log"
+      "output_tokens_used": 4046
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.jvnet.jaxb/jaxb-plugins-runtime/4.0.16/execution-metrics.json
+++ b/stats/org.jvnet.jaxb/jaxb-plugins-runtime/4.0.16/execution-metrics.json
@@ -87,10 +87,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2805428,
-      "output_tokens_used": 13713,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.jvnet.jaxb:jaxb-plugins-runtime:4.0.16/library-preparation-preflight/codex-session-5zsiwibr.log"
+      "output_tokens_used": 13713
     },
     "metrics": {
       "input_tokens_used": 149273,

--- a/stats/org.keycloak/keycloak-client-common-synced/26.0.9/execution-metrics.json
+++ b/stats/org.keycloak/keycloak-client-common-synced/26.0.9/execution-metrics.json
@@ -70,10 +70,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.keycloak:keycloak-client-common-synced:26.0.9/library-preparation-preflight/pi-generation-2026-06-28T21-04-44-306269Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 589849,

--- a/stats/org.liquibase/liquibase-core/5.0.3/execution-metrics.json
+++ b/stats/org.liquibase/liquibase-core/5.0.3/execution-metrics.json
@@ -154,10 +154,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 75888,
-      "output_tokens_used": 3116,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.liquibase:liquibase-core:5.0.3/library-preparation-preflight/pi-generation-2026-08-10T16-27-52-139902Z.log"
+      "output_tokens_used": 3116
     },
     "metrics": {
       "input_tokens_used": 129893,

--- a/stats/org.mapstruct/mapstruct/1.6.3/execution-metrics.json
+++ b/stats/org.mapstruct/mapstruct/1.6.3/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28125,
-      "output_tokens_used": 3071,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.mapstruct:mapstruct:1.6.3/library-preparation-preflight/pi-generation-2026-06-26T17-18-19-634855Z.log"
+      "output_tokens_used": 3071
     },
     "metrics": {
       "input_tokens_used": 42301,

--- a/stats/org.mockito/mockito-core/5.0.0/execution-metrics.json
+++ b/stats/org.mockito/mockito-core/5.0.0/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 56500,
-      "output_tokens_used": 5850,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.mockito:mockito-core:5.0.0/library-preparation-preflight/pi-generation-2026-06-12T13-25-57-190775Z.log"
+      "output_tokens_used": 5850
     },
     "metrics": {
       "input_tokens_used": 524961,
@@ -167,13 +164,10 @@
       "library": "org.mockito:mockito-core:5.0.0",
       "model": "oca/gpt-5.5",
       "output_tokens_used": 2874,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "The proxy mock maker only mocks interfaces, so class-based Mockito scenarios will not be covered by this setup.",
         "No extra dependency should be needed: `mockito-core:5.0.0` already declares `byte-buddy`, `byte-buddy-agent`, and `objenesis` in its resolved Maven dependencies."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.mockito:mockito-core:5.0.0/library-preparation-preflight/pi-generation-2026-06-23T12-55-45-202618Z.log",
       "status": "completed",
       "summary": "Mockito 5.0.0 defaults to the inline Byte Buddy mock maker, which depends on runtime instrumentation/agent attachment; meaningful Native Image coverage is reachable by configuring Mockito to use the proxy mock maker for interface-only mocks."
     },

--- a/stats/org.modelmapper/modelmapper/3.2.0/execution-metrics.json
+++ b/stats/org.modelmapper/modelmapper/3.2.0/execution-metrics.json
@@ -73,10 +73,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 81714,
-      "output_tokens_used": 3757,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.modelmapper:modelmapper:3.2.0/library-preparation-preflight/pi-generation-2026-08-25T19-12-03-716005Z.log"
+      "output_tokens_used": 3757
     },
     "metrics": {
       "input_tokens_used": 301339,

--- a/stats/org.neo4j.bolt/neo4j-bolt-connection-netty/4.0.0/execution-metrics.json
+++ b/stats/org.neo4j.bolt/neo4j-bolt-connection-netty/4.0.0/execution-metrics.json
@@ -96,10 +96,7 @@
       "new_version": "4.0.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1773999,
-      "output_tokens_used": 11298,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.neo4j.bolt:neo4j-bolt-connection-netty:4.0.0/library-preparation-preflight/codex-session-lrwa9mje.log"
+      "output_tokens_used": 11298
     },
     "metrics": {
       "input_tokens_used": 90381,

--- a/stats/org.neo4j.bolt/neo4j-bolt-connection-pooled/4.0.0/execution-metrics.json
+++ b/stats/org.neo4j.bolt/neo4j-bolt-connection-pooled/4.0.0/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "4.0.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1136653,
-      "output_tokens_used": 9232,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.neo4j.bolt:neo4j-bolt-connection-pooled:4.0.0/library-preparation-preflight/codex-session-i0uwxyb6.log"
+      "output_tokens_used": 9232
     },
     "metrics": {
       "input_tokens_used": 96147,

--- a/stats/org.neo4j.bolt/neo4j-bolt-connection-routed/3.0.0/execution-metrics.json
+++ b/stats/org.neo4j.bolt/neo4j-bolt-connection-routed/3.0.0/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "3.0.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 901511,
-      "output_tokens_used": 7630,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.neo4j.bolt:neo4j-bolt-connection-routed:3.0.0/library-preparation-preflight/codex-session-c8jsdt6j.log"
+      "output_tokens_used": 7630
     },
     "metrics": {
       "input_tokens_used": 60956,

--- a/stats/org.neo4j.driver/neo4j-java-driver/5.28.5/execution-metrics.json
+++ b/stats/org.neo4j.driver/neo4j-java-driver/5.28.5/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.neo4j.driver:neo4j-java-driver:5.28.5/library-preparation-preflight/pi-generation-2026-06-28T09-42-26-185903Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 315327,

--- a/stats/org.orbisgis/h2gis/2.2.5/execution-metrics.json
+++ b/stats/org.orbisgis/h2gis/2.2.5/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1351654,
-      "output_tokens_used": 6317,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.orbisgis:h2gis:2.2.5/library-preparation-preflight/codex-session-20tkusxa.log"
+      "output_tokens_used": 6317
     },
     "metrics": {
       "input_tokens_used": 218293,

--- a/stats/org.osgi/org.osgi.service.log/1.3.0/execution-metrics.json
+++ b/stats/org.osgi/org.osgi.service.log/1.3.0/execution-metrics.json
@@ -39,9 +39,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.osgi:org.osgi.service.log:1.3.0/library-preparation-preflight/pi-generation-2026-06-10T13-29-13-088436Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 163048,

--- a/stats/org.osgi/org.osgi.service.log/1.4.0/execution-metrics.json
+++ b/stats/org.osgi/org.osgi.service.log/1.4.0/execution-metrics.json
@@ -101,10 +101,7 @@
       "new_version": "1.4.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 38279,
-      "output_tokens_used": 5494,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.osgi:org.osgi.service.log:1.4.0/library-preparation-preflight/pi-generation-2026-06-11T03-01-52-965519Z.log"
+      "output_tokens_used": 5494
     },
     "metrics": {
       "input_tokens_used": 62916,

--- a/stats/org.projectlombok/lombok/1.18.20/execution-metrics.json
+++ b/stats/org.projectlombok/lombok/1.18.20/execution-metrics.json
@@ -75,10 +75,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 46120,
-      "output_tokens_used": 4639,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.projectlombok:lombok:1.18.20/library-preparation-preflight/pi-generation-2026-06-28T05-01-27-545066Z.log"
+      "output_tokens_used": 4639
     },
     "metrics": {
       "input_tokens_used": 497821,

--- a/stats/org.projectlombok/lombok/1.18.38/execution-metrics.json
+++ b/stats/org.projectlombok/lombok/1.18.38/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 23631,
-      "output_tokens_used": 2151,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.projectlombok:lombok:1.18.38/library-preparation-preflight/pi-generation-2026-07-08T20-01-50-327040Z.log"
+      "output_tokens_used": 2151
     },
     "metrics": {
       "input_tokens_used": 229986,

--- a/stats/org.scala-lang/scala-library/2.11.8/execution-metrics.json
+++ b/stats/org.scala-lang/scala-library/2.11.8/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 36481,
-      "output_tokens_used": 2267,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.scala-lang:scala-library:2.11.8/library-preparation-preflight/pi-generation-2026-08-23T23-19-12-321353Z.log"
+      "output_tokens_used": 2267
     },
     "metrics": {
       "input_tokens_used": 654572,
@@ -169,10 +166,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 261927,
-      "output_tokens_used": 3805,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.scala-lang:scala-library:2.11.8/library-preparation-preflight/codex-session-k9t3c_ag.log"
+      "output_tokens_used": 3805
     },
     "metrics": {
       "input_tokens_used": 237599,

--- a/stats/org.scala-lang/scala3-library_3/3.0.0/execution-metrics.json
+++ b/stats/org.scala-lang/scala3-library_3/3.0.0/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 34903,
-      "output_tokens_used": 3609,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/g/forge/graalvm-reachability-metadata/forge/logs/org.scala-lang:scala3-library_3:3.0.0/library-preparation-preflight/pi-generation-2026-08-15T11-10-31-233220Z.log"
+      "output_tokens_used": 3609
     },
     "metrics": {
       "input_tokens_used": 207207,

--- a/stats/org.scala-lang/tasty-core_3/3.2.2/execution-metrics.json
+++ b/stats/org.scala-lang/tasty-core_3/3.2.2/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 32477,
-      "output_tokens_used": 3312,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.scala-lang:tasty-core_3:3.2.2/library-preparation-preflight/pi-generation-2026-06-27T23-53-37-503181Z.log"
+      "output_tokens_used": 3312
     },
     "metrics": {
       "input_tokens_used": 363881,

--- a/stats/org.scalatest/scalatest-propspec_3/3.2.19/execution-metrics.json
+++ b/stats/org.scalatest/scalatest-propspec_3/3.2.19/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 67923,
-      "output_tokens_used": 3288,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.scalatest:scalatest-propspec_3:3.2.19/library-preparation-preflight/pi-generation-2026-06-28T21-45-04-531911Z.log"
+      "output_tokens_used": 3288
     },
     "metrics": {
       "input_tokens_used": 227468,

--- a/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/execution-metrics.json
+++ b/stats/org.scalatestplus/mockito-5-12_3/3.2.19.0/execution-metrics.json
@@ -64,10 +64,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 60532,
-      "output_tokens_used": 3787,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.scalatestplus:mockito-5-12_3:3.2.19.0/library-preparation-preflight/pi-generation-2026-06-26T13-16-08-142111Z.log"
+      "output_tokens_used": 3787
     },
     "metrics": {
       "input_tokens_used": 190021,

--- a/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
+++ b/stats/org.scodec/scodec-core_3/2.2.0/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.scodec:scodec-core_3:2.2.0/library-preparation-preflight/pi-generation-2026-06-10T15-19-33-036766Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 260049,

--- a/stats/org.slf4j/slf4j-log4j12/1.6.1/execution-metrics.json
+++ b/stats/org.slf4j/slf4j-log4j12/1.6.1/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 74397,
-      "output_tokens_used": 2925,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.slf4j:slf4j-log4j12:1.6.1/library-preparation-preflight/pi-generation-2026-07-28T23-47-13-059933Z.log"
+      "output_tokens_used": 2925
     },
     "metrics": {
       "input_tokens_used": 59740,

--- a/stats/org.sonatype.plexus/plexus-sec-dispatcher/1.3/execution-metrics.json
+++ b/stats/org.sonatype.plexus/plexus-sec-dispatcher/1.3/execution-metrics.json
@@ -83,10 +83,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 29225,
-      "output_tokens_used": 2851,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.sonatype.plexus:plexus-sec-dispatcher:1.3/library-preparation-preflight/pi-generation-2026-08-26T08-08-55-829814Z.log"
+      "output_tokens_used": 2851
     },
     "metrics": {
       "input_tokens_used": 208991,

--- a/stats/org.sonatype.sisu.inject/cglib/2.2.1-v20090111/execution-metrics.json
+++ b/stats/org.sonatype.sisu.inject/cglib/2.2.1-v20090111/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 59959,
-      "output_tokens_used": 4068,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.sonatype.sisu.inject:cglib:2.2.1-v20090111/library-preparation-preflight/pi-generation-2026-08-27T07-19-51-738208Z.log"
+      "output_tokens_used": 4068
     },
     "metrics": {
       "input_tokens_used": 493239,

--- a/stats/org.sonatype.sisu/sisu-guice/2.1.7/execution-metrics.json
+++ b/stats/org.sonatype.sisu/sisu-guice/2.1.7/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 75546,
-      "output_tokens_used": 7599,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.sonatype.sisu:sisu-guice:2.1.7/library-preparation-preflight/pi-generation-2026-06-28T22-49-45-959719Z.log"
+      "output_tokens_used": 7599
     },
     "metrics": {
       "input_tokens_used": 432069,
@@ -171,10 +168,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 39560,
-      "output_tokens_used": 4085,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.sonatype.sisu:sisu-guice:2.1.7/library-preparation-preflight/pi-generation-2026-06-29T00-36-05-970898Z.log"
+      "output_tokens_used": 4085
     },
     "metrics": {
       "input_tokens_used": 394103,

--- a/stats/org.springdoc/springdoc-openapi-starter-webmvc-ui/3.0.3/execution-metrics.json
+++ b/stats/org.springdoc/springdoc-openapi-starter-webmvc-ui/3.0.3/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 235150,
-      "output_tokens_used": 2210,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3/library-preparation-preflight/codex-session-9dxggqoj.log"
+      "output_tokens_used": 2210
     },
     "metrics": {
       "input_tokens_used": 278550,

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-chat-client/2.0.0-RC2/execution-metrics.json
@@ -114,10 +114,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 45937,
-      "output_tokens_used": 5476,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-chat-client:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T04-19-47-259888Z.log"
+      "output_tokens_used": 5476
     },
     "metrics": {
       "input_tokens_used": 246917,

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-embedding-observation/2.0.0/execution-metrics.json
@@ -102,10 +102,7 @@
       ],
       "model" : "oca/gpt-5.5",
       "input_tokens_used" : 71250,
-      "output_tokens_used" : 8786,
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-embedding-observation:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T02-46-38-432052Z.log"
+      "output_tokens_used" : 8786
     },
     "metrics" : {
       "input_tokens_used" : 110160,

--- a/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-autoconfigure-model-openai/2.0.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason" : "ValueError: preflight response requested unsafe preparation behavior",
-      "model" : "oca/gpt-5.5",
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-autoconfigure-model-openai:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T01-29-40-322796Z.log"
+      "model" : "oca/gpt-5.5"
     },
     "metrics" : {
       "input_tokens_used" : 303319,

--- a/stats/org.springframework.ai/spring-ai-client-chat/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-client-chat/2.0.0/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model" : "oca/gpt-5.5",
       "input_tokens_used" : 61582,
-      "output_tokens_used" : 4264,
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-client-chat:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T00-07-27-599363Z.log"
+      "output_tokens_used" : 4264
     },
     "metrics" : {
       "input_tokens_used" : 413281,

--- a/stats/org.springframework.ai/spring-ai-commons/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-commons/2.0.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason" : "ValueError: preflight response requested unsafe preparation behavior",
-      "model" : "oca/gpt-5.5",
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-commons:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-27T00-38-55-503835Z.log"
+      "model" : "oca/gpt-5.5"
     },
     "metrics" : {
       "input_tokens_used" : 21811,

--- a/stats/org.springframework.ai/spring-ai-model/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-model/2.0.0/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model" : "oca/gpt-5.5",
       "input_tokens_used" : 28654,
-      "output_tokens_used" : 2522,
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-model:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-26T22-41-53-418148Z.log"
+      "output_tokens_used" : 2522
     },
     "metrics" : {
       "input_tokens_used" : 273759,

--- a/stats/org.springframework.ai/spring-ai-template-st/2.0.0/execution-metrics.json
+++ b/stats/org.springframework.ai/spring-ai-template-st/2.0.0/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model" : "oca/gpt-5.5",
       "input_tokens_used" : 48609,
-      "output_tokens_used" : 2544,
-      "prompt_path" : "library-preflight-prompt.txt",
-      "raw_response_path" : "library-preflight-response.txt",
-      "session_log_path" : "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.ai:spring-ai-template-st:2.0.0-RC2/library-preparation-preflight/pi-generation-2026-06-26T22-49-30-461323Z.log"
+      "output_tokens_used" : 2544
     },
     "metrics" : {
       "input_tokens_used" : 203151,

--- a/stats/org.springframework.amqp/spring-rabbitmq-client/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.amqp/spring-rabbitmq-client/4.1.0/execution-metrics.json
@@ -94,10 +94,7 @@
       "new_version": "4.1.0",
       "model": "oca/gpt-5.5",
       "input_tokens_used": 50557,
-      "output_tokens_used": 4958,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.amqp:spring-rabbitmq-client:4.1.0/library-preparation-preflight/pi-generation-2026-06-09T21-14-07-350093Z.log"
+      "output_tokens_used": 4958
     },
     "metrics": {
       "input_tokens_used": 51635,

--- a/stats/org.springframework.amqp/spring-rabbitmq-client/4.2.0-M1/execution-metrics.json
+++ b/stats/org.springframework.amqp/spring-rabbitmq-client/4.2.0-M1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "4.2.0-M1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 552639,
-      "output_tokens_used": 8090,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.amqp:spring-rabbitmq-client:4.2.0-M1/library-preparation-preflight/codex-session-dru3h4pk.log"
+      "output_tokens_used": 8090
     },
     "metrics": {
       "input_tokens_used": 61661,

--- a/stats/org.springframework.boot/spring-boot-actuator-autoconfigure/3.2.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-actuator-autoconfigure/3.2.0/execution-metrics.json
@@ -100,10 +100,7 @@
       "new_version": "3.2.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 524904,
-      "output_tokens_used": 4732,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.boot:spring-boot-actuator-autoconfigure:3.2.0/library-preparation-preflight/codex-session-h910u0xe.log"
+      "output_tokens_used": 4732
     },
     "metrics": {
       "input_tokens_used": 49408,

--- a/stats/org.springframework.boot/spring-boot-actuator/2.6.3/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-actuator/2.6.3/execution-metrics.json
@@ -63,10 +63,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 41231,
-      "output_tokens_used": 4964,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-actuator:2.6.3/library-preparation-preflight/pi-generation-2026-06-28T17-35-40-925438Z.log"
+      "output_tokens_used": 4964
     },
     "metrics": {
       "input_tokens_used": 270790,

--- a/stats/org.springframework.boot/spring-boot-amqp/4.2.0-M1/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-amqp/4.2.0-M1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "4.2.0-M1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 3059433,
-      "output_tokens_used": 18249,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.boot:spring-boot-amqp:4.2.0-M1/library-preparation-preflight/codex-session-ykxcvbqa.log"
+      "output_tokens_used": 18249
     },
     "metrics": {
       "input_tokens_used": 53599,

--- a/stats/org.springframework.boot/spring-boot-devtools/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-devtools/4.1.0/execution-metrics.json
@@ -70,10 +70,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-devtools:4.1.0/library-preparation-preflight/pi-generation-2026-07-31T00-36-31-609145Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 209338,

--- a/stats/org.springframework.boot/spring-boot-h2console/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-h2console/4.1.0/execution-metrics.json
@@ -101,10 +101,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 61162,
-      "output_tokens_used": 6801,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-h2console:4.1.0/library-preparation-preflight/pi-generation-2026-06-26T23-46-19-840996Z.log"
+      "output_tokens_used": 6801
     },
     "metrics": {
       "input_tokens_used": 231730,

--- a/stats/org.springframework.boot/spring-boot-jackson2/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-jackson2/4.1.0/execution-metrics.json
@@ -95,10 +95,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 41455,
-      "output_tokens_used": 4119,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-jackson2:4.1.0/library-preparation-preflight/pi-generation-2026-08-07T09-27-41-641636Z.log"
+      "output_tokens_used": 4119
     },
     "metrics": {
       "input_tokens_used": 172869,

--- a/stats/org.springframework.boot/spring-boot-kafka/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-kafka/4.1.0/execution-metrics.json
@@ -91,9 +91,7 @@
       "current_library": "org.springframework.boot:spring-boot-kafka:4.0.2",
       "new_version": "4.1.0",
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-kafka:4.1.0/library-preparation-preflight/pi-generation-2026-06-11T03-49-19-573569Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 0,

--- a/stats/org.springframework.boot/spring-boot-reactor-netty/4.2.0-M1/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-reactor-netty/4.2.0-M1/execution-metrics.json
@@ -95,10 +95,7 @@
       "new_version": "4.2.0-M1",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1253419,
-      "output_tokens_used": 8130,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.boot:spring-boot-reactor-netty:4.2.0-M1/library-preparation-preflight/codex-session-zcz8mbcz.log"
+      "output_tokens_used": 8130
     },
     "metrics": {
       "input_tokens_used": 73320,

--- a/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-security-oauth2-resource-server/4.1.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: response did not contain a JSON object",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.boot:spring-boot-security-oauth2-resource-server:4.1.0/library-preparation-preflight/pi-generation-2026-08-12T07-22-06-369309Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 76898,

--- a/stats/org.springframework.boot/spring-boot-testcontainers/4.1.1/execution-metrics.json
+++ b/stats/org.springframework.boot/spring-boot-testcontainers/4.1.1/execution-metrics.json
@@ -114,10 +114,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2127109,
-      "output_tokens_used": 13551,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.boot:spring-boot-testcontainers:4.1.1/library-preparation-preflight/codex-session-omd2_0hu.log"
+      "output_tokens_used": 13551
     },
     "metrics": {
       "input_tokens_used": 364900,

--- a/stats/org.springframework.cloud/spring-cloud-context/5.0.2/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-context/5.0.2/execution-metrics.json
@@ -109,10 +109,7 @@
       "new_version": "5.0.2",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1170890,
-      "output_tokens_used": 11414,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-context:5.0.2/library-preparation-preflight/codex-session-zo4ho6mz.log"
+      "output_tokens_used": 11414
     },
     "metrics": {
       "input_tokens_used": 85749,

--- a/stats/org.springframework.cloud/spring-cloud-function-context/5.0.4/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-function-context/5.0.4/execution-metrics.json
@@ -116,10 +116,7 @@
       "new_version": "5.0.4",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 259397,
-      "output_tokens_used": 2109,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-function-context:5.0.4/library-preparation-preflight/codex-session-773bh7wb.log"
+      "output_tokens_used": 2109
     },
     "metrics": {
       "input_tokens_used": 176671,

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka-streams/5.0.3/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka-streams/5.0.3/execution-metrics.json
@@ -94,10 +94,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 3952290,
-      "output_tokens_used": 16350,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.cloud:spring-cloud-stream-binder-kafka-streams:5.0.3/library-preparation-preflight/codex-session-nevhqz6p.log"
+      "output_tokens_used": 16350
     },
     "metrics": {
       "input_tokens_used": 391766,

--- a/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-stream-binder-kafka/5.0.1/execution-metrics.json
@@ -62,10 +62,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 51032,
-      "output_tokens_used": 5000,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-stream-binder-kafka:5.0.1/library-preparation-preflight/pi-generation-2026-08-07T12-15-35-898624Z.log"
+      "output_tokens_used": 5000
     },
     "metrics": {
       "input_tokens_used": 198081,

--- a/stats/org.springframework.cloud/spring-cloud-vault-config/5.0.2/execution-metrics.json
+++ b/stats/org.springframework.cloud/spring-cloud-vault-config/5.0.2/execution-metrics.json
@@ -85,10 +85,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1449490,
-      "output_tokens_used": 9673,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-vault-config:5.0.2/library-preparation-preflight/codex-session-_04gmoje.log"
+      "output_tokens_used": 9673
     },
     "metrics": {
       "input_tokens_used": 472239,
@@ -221,13 +218,10 @@
       "library": "org.springframework.cloud:spring-cloud-vault-config:5.0.2",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 9673,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Dynamic container ports must be configured before Spring ConfigData resolution.",
         "Native Image verification may require additional generated reachability metadata for Spring Boot and Testcontainers."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework.cloud:spring-cloud-vault-config:5.0.2/library-preparation-preflight/codex-session-_04gmoje.log",
       "status": "completed",
       "summary": "Meaningful coverage requires a Spring Boot context backed by a running Vault service."
     },

--- a/stats/org.springframework.integration/spring-integration-file/7.1.1/execution-metrics.json
+++ b/stats/org.springframework.integration/spring-integration-file/7.1.1/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 332008,
-      "output_tokens_used": 2497,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.integration:spring-integration-file:7.1.1/library-preparation-preflight/codex-session-vql2lkiy.log"
+      "output_tokens_used": 2497
     },
     "metrics": {
       "input_tokens_used": 151544,

--- a/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/execution-metrics.json
+++ b/stats/org.springframework.security/spring-security-oauth2-jose/7.1.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.security:spring-security-oauth2-jose:7.1.0/library-preparation-preflight/pi-generation-2026-08-11T12-43-20-333203Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 143647,

--- a/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/execution-metrics.json
+++ b/stats/org.springframework.security/spring-security-oauth2-resource-server/7.1.0/execution-metrics.json
@@ -59,10 +59,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "gpt-5.6-terra",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.security:spring-security-oauth2-resource-server:7.1.0/library-preparation-preflight/pi-generation-2026-08-11T13-50-08-884074Z.log"
+      "model": "gpt-5.6-terra"
     },
     "metrics": {
       "input_tokens_used": 154973,

--- a/stats/org.springframework.shell/spring-shell-core/4.0.2/execution-metrics.json
+++ b/stats/org.springframework.shell/spring-shell-core/4.0.2/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 42299,
-      "output_tokens_used": 1709,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework.shell:spring-shell-core:4.0.2/library-preparation-preflight/pi-generation-2026-08-13T07-10-16-673605Z.log"
+      "output_tokens_used": 1709
     },
     "metrics": {
       "input_tokens_used": 32757,

--- a/stats/org.springframework/spring-beans/5.3.15/execution-metrics.json
+++ b/stats/org.springframework/spring-beans/5.3.15/execution-metrics.json
@@ -69,12 +69,9 @@
       "library": "org.springframework:spring-beans:5.3.15",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 7375,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "ApplicationContext and component scanning belong to spring-context and are outside this artifact; Native Image verification remains authoritative for reflective bean paths."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework:spring-beans:5.3.15/library-preparation-preflight/codex-session-ejrdede6.log",
       "status": "completed",
       "summary": "spring-beans:5.3.15 has only spring-core:5.3.15 as a published dependency, and its BeanFactory and BeanWrapper APIs are usable in-process with the normal scaffold. https://repo1.maven.org/maven2/org/springframework/spring-beans/5.3.15/spring-beans-5.3.15.pom https://docs.spring.io/spring-framework/docs/5.3.15/reference/html/core.html"
     },

--- a/stats/org.springframework/spring-context/6.0.2/execution-metrics.json
+++ b/stats/org.springframework/spring-context/6.0.2/execution-metrics.json
@@ -117,10 +117,7 @@
       "new_version": "6.0.2",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 957480,
-      "output_tokens_used": 10474,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework:spring-context:6.0.2/library-preparation-preflight/codex-session-yjrisd80.log"
+      "output_tokens_used": 10474
     },
     "metrics": {
       "input_tokens_used": 358497,

--- a/stats/org.springframework/spring-core/5.3.15/execution-metrics.json
+++ b/stats/org.springframework/spring-core/5.3.15/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-sol",
       "input_tokens_used": 14891,
-      "output_tokens_used": 1674,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework:spring-core:5.3.15/library-preparation-preflight/pi-generation-2026-08-24T00-43-13-141853Z.log"
+      "output_tokens_used": 1674
     },
     "metrics": {
       "input_tokens_used": 1101935,
@@ -183,10 +180,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 647697,
-      "output_tokens_used": 4064,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework:spring-core:5.3.15/library-preparation-preflight/codex-session-o69n70rw.log"
+      "output_tokens_used": 4064
     },
     "metrics": {
       "input_tokens_used": 596923,
@@ -304,10 +298,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1372476,
-      "output_tokens_used": 11630,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework:spring-core:5.3.15/library-preparation-preflight/codex-session-d7j5ukfm.log"
+      "output_tokens_used": 11630
     },
     "metrics": {
       "input_tokens_used": 489322,
@@ -425,10 +416,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1969083,
-      "output_tokens_used": 10505,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework:spring-core:5.3.15/library-preparation-preflight/codex-session-wtw6lez0.log"
+      "output_tokens_used": 10505
     },
     "metrics": {
       "input_tokens_used": 397369,

--- a/stats/org.springframework/spring-web/5.3.32/execution-metrics.json
+++ b/stats/org.springframework/spring-web/5.3.32/execution-metrics.json
@@ -108,10 +108,7 @@
       "new_version": "5.3.32",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 10239511,
-      "output_tokens_used": 28595,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework:spring-web:5.3.32/library-preparation-preflight/codex-session-mjehuyj6.log"
+      "output_tokens_used": 28595
     },
     "metrics": {
       "input_tokens_used": 316808,

--- a/stats/org.springframework/spring-webflux/6.0.0/execution-metrics.json
+++ b/stats/org.springframework/spring-webflux/6.0.0/execution-metrics.json
@@ -133,10 +133,7 @@
       "new_version": "6.0.0",
       "model": "gpt-5.6-luna",
       "input_tokens_used": 3009634,
-      "output_tokens_used": 14930,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/org.springframework:spring-webflux:6.0.0/library-preparation-preflight/codex-session-a0olmwas.log"
+      "output_tokens_used": 14930
     },
     "metrics": {
       "input_tokens_used": 68559,

--- a/stats/org.springframework/spring-websocket/6.2.10/execution-metrics.json
+++ b/stats/org.springframework/spring-websocket/6.2.10/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 2991579,
-      "output_tokens_used": 12531,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.springframework:spring-websocket:6.2.10/library-preparation-preflight/codex-session-s510q3g8.log"
+      "output_tokens_used": 12531
     },
     "metrics": {
       "input_tokens_used": 246520,

--- a/stats/org.testcontainers/testcontainers-junit-jupiter/2.0.5/execution-metrics.json
+++ b/stats/org.testcontainers/testcontainers-junit-jupiter/2.0.5/execution-metrics.json
@@ -68,10 +68,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1317675,
-      "output_tokens_used": 8144,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.testcontainers:testcontainers-junit-jupiter:2.0.5/library-preparation-preflight/codex-session-4c10t0f0.log"
+      "output_tokens_used": 8144
     },
     "metrics": {
       "input_tokens_used": 43775,

--- a/stats/org.tpolecat/doobie-hikari_3/0.13.4/execution-metrics.json
+++ b/stats/org.tpolecat/doobie-hikari_3/0.13.4/execution-metrics.json
@@ -65,9 +65,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge2/graalvm-reachability-metadata/forge/logs/org.tpolecat:doobie-hikari_3:0.13.4/library-preparation-preflight/pi-generation-2026-06-11T03-35-58-391733Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 49916,

--- a/stats/org.tpolecat/doobie-postgres_3/0.13.4/execution-metrics.json
+++ b/stats/org.tpolecat/doobie-postgres_3/0.13.4/execution-metrics.json
@@ -59,9 +59,7 @@
         }
       ],
       "failure_reason": "FileNotFoundError: [Errno 2] No such file or directory",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.tpolecat:doobie-postgres_3:0.13.4/library-preparation-preflight/pi-generation-2026-06-11T03-57-24-428883Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 309468,

--- a/stats/org.typelevel/cats-effect-std_3/3.5.2/execution-metrics.json
+++ b/stats/org.typelevel/cats-effect-std_3/3.5.2/execution-metrics.json
@@ -77,10 +77,7 @@
       ],
       "model": "oca/gpt-5.5",
       "input_tokens_used": 28673,
-      "output_tokens_used": 2656,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/org.typelevel:cats-effect-std_3:3.5.2/library-preparation-preflight/pi-generation-2026-06-09T01-58-58-353741Z.log"
+      "output_tokens_used": 2656
     },
     "metrics": {
       "input_tokens_used": 92031,

--- a/stats/org.wildfly.common/wildfly-common/1.5.0.Final/execution-metrics.json
+++ b/stats/org.wildfly.common/wildfly-common/1.5.0.Final/execution-metrics.json
@@ -128,10 +128,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 37936,
-      "output_tokens_used": 2724,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/org.wildfly.common:wildfly-common:1.5.0.Final/library-preparation-preflight/pi-generation-2026-07-03T12-23-22-421360Z.log"
+      "output_tokens_used": 2724
     },
     "metrics": {
       "input_tokens_used": 212117,

--- a/stats/schemas/run-metrics-output-schema-v1.0.1.json
+++ b/stats/schemas/run-metrics-output-schema-v1.0.1.json
@@ -346,14 +346,17 @@
           "minimum": 0
         },
         "prompt_path": {
+          "description": "Historic. Records already on master carry it; new records must not, because the path resolves only on the machine that produced it.",
           "type": "string",
           "minLength": 1
         },
         "raw_response_path": {
+          "description": "Historic. Records already on master carry it; new records must not, because the path resolves only on the machine that produced it.",
           "type": "string",
           "minLength": 1
         },
         "session_log_path": {
+          "description": "Historic. Records already on master carry it; new records must not, because the path resolves only on the machine that produced it.",
           "type": "string",
           "minLength": 1
         }

--- a/stats/software.amazon.awssdk/iotdataplane/2.44.11/execution-metrics.json
+++ b/stats/software.amazon.awssdk/iotdataplane/2.44.11/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/software.amazon.awssdk:iotdataplane:2.44.11/library-preparation-preflight/pi-generation-2026-06-26T00-15-19-973948Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 83537,

--- a/stats/software.amazon.awssdk/sqs/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/sqs/2.34.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge1/graalvm-reachability-metadata/forge/logs/software.amazon.awssdk:sqs:2.34.0/library-preparation-preflight/pi-generation-2026-06-09T23-40-09-667413Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 51632,

--- a/stats/software.amazon.awssdk/sts/2.34.0/execution-metrics.json
+++ b/stats/software.amazon.awssdk/sts/2.34.0/execution-metrics.json
@@ -65,10 +65,7 @@
         }
       ],
       "failure_reason": "ValueError: preflight response requested unsafe preparation behavior",
-      "model": "oca/gpt-5.5",
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/vjovanov/c/forge/forge4/graalvm-reachability-metadata/forge/logs/software.amazon.awssdk:sts:2.34.0/library-preparation-preflight/pi-generation-2026-06-28T09-52-03-847723Z.log"
+      "model": "oca/gpt-5.5"
     },
     "metrics": {
       "input_tokens_used": 90910,

--- a/stats/tools.jackson.dataformat/jackson-dataformat-avro/3.1.5/execution-metrics.json
+++ b/stats/tools.jackson.dataformat/jackson-dataformat-avro/3.1.5/execution-metrics.json
@@ -69,10 +69,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 1675775,
-      "output_tokens_used": 9933,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/tools.jackson.dataformat:jackson-dataformat-avro:3.1.5/library-preparation-preflight/codex-session-4eeq5ys2.log"
+      "output_tokens_used": 9933
     },
     "metrics": {
       "input_tokens_used": 93544,

--- a/stats/tools.jackson.module/jackson-module-blackbird/3.1.5/execution-metrics.json
+++ b/stats/tools.jackson.module/jackson-module-blackbird/3.1.5/execution-metrics.json
@@ -64,13 +64,10 @@
       "library": "tools.jackson.module:jackson-module-blackbird:3.1.5",
       "model": "gpt-5.6-luna",
       "output_tokens_used": 7810,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
       "risks": [
         "Blackbird dynamically creates accessors on the JVM; modulepath or unusual class-loader scenarios may require custom lookup handling.",
         "Each BlackbirdModule/ObjectMapper instance can retain generated lambda classes for its class loader."
       ],
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/tools.jackson.module:jackson-module-blackbird:3.1.5/library-preparation-preflight/codex-session-opg8mekb.log",
       "status": "completed",
       "summary": "No extra dependency or Docker image is needed; meaningful coverage requires registering BlackbirdModule with a Jackson mapper."
     },

--- a/stats/wsdl4j/wsdl4j/1.6.3/execution-metrics.json
+++ b/stats/wsdl4j/wsdl4j/1.6.3/execution-metrics.json
@@ -74,10 +74,7 @@
       ],
       "model": "gpt-5.6-luna",
       "input_tokens_used": 454057,
-      "output_tokens_used": 3523,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata-copy/forge/logs/wsdl4j:wsdl4j:1.6.3/library-preparation-preflight/codex-session-zx5z496e.log"
+      "output_tokens_used": 3523
     },
     "metrics": {
       "input_tokens_used": 223208,

--- a/stats/xerces/xercesImpl/2.3.0/execution-metrics.json
+++ b/stats/xerces/xercesImpl/2.3.0/execution-metrics.json
@@ -67,10 +67,7 @@
       ],
       "model": "gpt-5.6-terra",
       "input_tokens_used": 20748,
-      "output_tokens_used": 1345,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/mihailo/git/graalvm-reachability-metadata/forge/logs/xerces:xercesImpl:2.3.0/library-preparation-preflight/pi-generation-2026-07-30T14-37-32-727399Z.log"
+      "output_tokens_used": 1345
     },
     "metrics": {
       "input_tokens_used": 784750,
@@ -156,10 +153,7 @@
       ],
       "model": "gpt-5.5",
       "input_tokens_used": 45884,
-      "output_tokens_used": 3990,
-      "prompt_path": "library-preflight-prompt.txt",
-      "raw_response_path": "library-preflight-response.txt",
-      "session_log_path": "/home/jovan/Work/graalvm-reachability-metadata/forge/logs/xerces:xercesImpl:2.3.0/library-preparation-preflight/pi-generation-2026-08-07T11-43-34-119594Z.log"
+      "output_tokens_used": 3990
     },
     "metrics": {
       "input_tokens_used": 31283,


### PR DESCRIPTION
Closes #9985

## What this does

Every log path Forge recorded into a publication descriptor or a committed metrics
record pointed into `forge/logs/`, which is gitignored. One of them was rendered
into the body of every generated pull request, where it resolved for nobody, and
350 of the committed values were absolute and carried operator home directories
(`/home/mihailo`, `/home/vjovanov`, `/home/jovan`) into a public repository.

The two spec points pull in different directions.
§forge/FS-durable-generation-logs asks that the workflow "print **or** record" the
log path — printing alone satisfies it, on the machine where the path resolves.
§forge/AR-publication-descriptor asks the review object to carry "model and
**session** provenance", so deleting the field outright would drop provenance the
descriptor is required to have. The resolution stays inside both: the descriptor
carries a **session identifier**, which FS-durable-generation-logs already names
among what a run must record, and which means something to a reader who cannot see
the operator's filesystem. No spec change was needed.

## What each field became

| Field | Was | Is |
|---|---|---|
| `local_review.session_log_path` | `logs/<coord>/local-branch-review/pi.log`, rendered in the PR body | `local_review.session_id`, a 16-hex token |
| `local_ci_verification.commands[].log_path` | written, never read | gone; the gate result line prints the path |
| `local_ci_verification.fixups[].log_path` | written, never read | gone; a new line prints the fixup outcome and path |
| `library_preparation_preflight.{prompt_path,raw_response_path,session_log_path}` | committed to `stats/` | gone; the prompt and response files are still written as run evidence |

The operator loses nothing. `[local-review]   pi review session 3f2a…; log: logs/…`
still names both, and the CI-repair turn now prints the same pair instead of
splicing the path into a `review_comment` that ends up in the PR body.

## Why the schemas keep the old keys

Both schemas use `additionalProperties: false`, so deleting a property rejects every
document that still has it — the #9980 failure mode in reverse. `session_log_path`
therefore leaves `required` but stays in `properties`, marked historic. The three
preflight properties stay in `stats/schemas/run-metrics-output-schema-v1.0.1.json`
for the same reason: 28 open PRs carry `execution-metrics.json` records written by
the old code, and `validateLibraryStats` walks the whole `stats/` tree on every PR.
For the symmetric reason `session_id` is added to `properties` but not to
`required` — every new run sets it, and no descriptor already pushed is invalidated.

## The scrub

The second commit strips the three fields from 323 committed records. It is a
line-level edit, not a `json.dump` round-trip, because roughly fifty of those files
were written by the Gson-based Java writer with `" : "` spacing; re-serializing
would have reformatted them into a thousand lines of noise. Each rewrite is checked
against a programmatic removal before it is written:

```python
assert json.loads(scrubbed) == scrub_object(json.loads(original)), path
```

After it, `stats/*/*/*/execution-metrics.json` holds zero absolute filesystem paths,
down from 350.

## The guard

`forge/tests/test_published_path_provenance.py` asserts four invariants: the
rendered review block names a session and no `logs/` path; the descriptor's review
and local-CI evidence carry no `*_log_path` key and no `logs/` substring; and no
committed metrics record carries an absolute path or a preflight path field. On
master the last two fail with 350 and 1018 offenders respectively.
