### PR TITLE
Scan preflight prose for actions, not subject matter

### DIFF
--- a/forge/docs/architecture/orchestration-scripts.md
+++ b/forge/docs/architecture/orchestration-scripts.md
@@ -147,9 +147,28 @@ reachability worktree. Durable evidence is the normalized record embedded in
 run metrics (§FS-forge-run-metrics).
 
 If the agent times out during `neural_setup()` or returns invalid, unavailable,
-or unsafe output, the driver must return a setup failure to orchestration. It
+or unusable output, the driver must return a setup failure to orchestration. It
 must keep the collected evidence and failure reason visible in metrics and
 continuation state rather than silently converting the failure to `no_action`.
+
+### 1.2 What the advisory prose scan is for
+
+Advisory guidance reaches the workflow prompt as evidence, never as instructions
+the driver executes, so the only prose the scan must catch is guidance that asks
+an agent to step outside the harness — shelling out, fetching from the network,
+or mutating the machine. The scan therefore matches requested *actions*.
+
+Subject matter is not a safety signal. Terms naming what a library is about —
+credentials, secrets, tokens and the like — describe the domain of database
+drivers, cloud SDKs, mail and SSH clients, and every lexer or parser, and are
+expected vocabulary in correct guidance for exactly those libraries. Scanning
+for them disqualifies sound decisions while stopping nothing, because unsafe
+intent phrased without those words passes untouched. The scan must not reject a
+decision on subject-matter vocabulary.
+
+A match degrades the decision, and the recorded failure reason names the
+matched terms, so a false positive is diagnosable from the metrics alone
+rather than needing a source read and a replay.
 
 Orchestration scripts must not let a failed workflow silently disappear.
 Successful or chunk-ready runs (§AR-chunked-dynamic-access-pr-linking) build one

--- a/forge/tests/test_forge_metadata.py
+++ b/forge/tests/test_forge_metadata.py
@@ -415,6 +415,58 @@ class LibraryUpdateIssueTests(unittest.TestCase):
         self.assertIn("Library preflight degraded for org.example:lib:1.0.0: Agent timed out", stdout.getvalue())
         self.assertIn("preflight-session.log", stdout.getvalue())
 
+    def _preflight_record(self, response: dict) -> dict:
+        from utility_scripts import library_preparation_preflight as preflight_module
+
+        claimed_issue = SimpleNamespace(
+            issue={"number": 1412},
+            label="library-update-request",
+            current_coordinates=None,
+            new_version=None,
+        )
+        return preflight_module._completed_library_preflight_record(
+            claimed_issue,
+            {"library": "org.example:lib:1.0.0"},
+            response,
+            "gpt-5.6-sol",
+            None,
+            None,
+            None,
+            None,
+        )
+
+    def test_preflight_keeps_a_decision_that_merely_mentions_credentials(self) -> None:
+        record = self._preflight_record({
+            "action": "advisory_preparation",
+            "summary": "The SFTP client needs a live endpoint to cover anything.",
+            "deterministic_setup": [
+                {"kind": "docker_image", "image": "atmoz/sftp:alpine", "slug": "sftp", "reason": "endpoint"},
+            ],
+            "agent_guidance": (
+                "Configure DefaultSftpSessionFactory to connect to localhost on the mapped "
+                "port, authenticate with those credentials, and tokenize the returned "
+                "listing into a secret-free assertion."
+            ),
+            "risks": ["The container ships a throwaway token."],
+        })
+
+        self.assertEqual(record["status"], "completed")
+        self.assertEqual(len(record["deterministic_setup"]), 1)
+        self.assertIn("authenticate with those credentials", record["agent_guidance"])
+        self.assertEqual(record["risks"], ["The container ships a throwaway token."])
+
+    def test_preflight_degrades_on_a_requested_action_and_names_the_term(self) -> None:
+        with self.assertRaises(ValueError) as raised:
+            self._preflight_record({
+                "action": "advisory_preparation",
+                "summary": "Fetch the fixtures first.",
+                "deterministic_setup": [],
+                "agent_guidance": "Run curl -sSL https://example.invalid/fixtures.tar.gz before the tests.",
+                "risks": [],
+            })
+
+        self.assertIn("unsafe preparation behavior: curl", str(raised.exception))
+
     def test_library_preflight_dispatches_without_a_strategy(self) -> None:
         claimed_issue = forge_metadata.ClaimedIssue(
             issue={"number": 1412, "title": "Update org.example:lib:1.0.0"},

--- a/forge/utility_scripts/library_preparation_preflight.py
+++ b/forge/utility_scripts/library_preparation_preflight.py
@@ -31,8 +31,11 @@ LIBRARY_PREFLIGHT_TIMEOUT_SECONDS = 900
 LIBRARY_PREFLIGHT_MAX_ISSUE_BODY_CHARS = 8000
 LIBRARY_PREFLIGHT_MAX_TEST_FILES = 40
 LIBRARY_PREFLIGHT_MAX_DETERMINISTIC_SETUP = 8
-# Only the free-text advisory guidance is scanned for these; the deterministic
-# setup entries are validated structurally and cannot smuggle prose commands.
+# Requested actions that would take an agent outside the harness — shelling out,
+# fetching from the network, mutating the machine. Only the free-text advisory
+# fields are scanned; deterministic setup is validated by shape. Subject-matter
+# vocabulary is deliberately absent: it names what a library is about, not what
+# the guidance asks for (§AR-forge-orchestration.1.2).
 LIBRARY_PREFLIGHT_UNSAFE_TERMS = (
     "sudo",
     "curl ",
@@ -40,9 +43,6 @@ LIBRARY_PREFLIGHT_UNSAFE_TERMS = (
     "git clone",
     "rm -rf",
     "docker run",
-    "credential",
-    "secret",
-    "token",
 )
 # Deterministic setup the driver applies itself, idempotently, as source edits
 # (§AR-forge-orchestration.1.1). Anything else stays advisory guidance.
@@ -267,10 +267,10 @@ def _preflight_string_list(value: Any, limit: int = 8) -> list[str]:
     return normalized
 
 
-def _preflight_contains_unsafe_text(*values: Any) -> bool:
-    """Return True when advisory text asks for unsafe preparation behavior."""
+def _unsafe_terms_in(*values: Any) -> list[str]:
+    """Return the unsafe action terms the advisory text requests, for the error message."""
     combined = "\n".join(str(value).lower() for value in values if value is not None)
-    return any(term in combined for term in LIBRARY_PREFLIGHT_UNSAFE_TERMS)
+    return [term.strip() for term in LIBRARY_PREFLIGHT_UNSAFE_TERMS if term in combined]
 
 
 def _parse_deterministic_setup_entry(entry: Any) -> dict[str, str] | None:
@@ -332,9 +332,13 @@ def _completed_library_preflight_record(
     if action == "advisory_preparation" and not (deterministic_setup or agent_guidance):
         raise ValueError("advisory_preparation response did not include deterministic setup or guidance")
     # Deterministic entries are validated structurally above; only the free-text
-    # advisory fields can carry prose, so only those are scanned for unsafe terms.
-    if _preflight_contains_unsafe_text(summary, agent_guidance, risks):
-        raise ValueError("preflight response requested unsafe preparation behavior")
+    # advisory fields can carry prose, so only those are scanned — and only for
+    # requested actions, never subject matter (§AR-forge-orchestration.1.2).
+    unsafe_terms = _unsafe_terms_in(summary, agent_guidance, risks)
+    if unsafe_terms:
+        raise ValueError(
+            f"preflight response requested unsafe preparation behavior: {', '.join(unsafe_terms)}"
+        )
 
     record = _base_library_preflight_record(claimed_issue, input_bundle)
     record["status"] = "completed"


### PR DESCRIPTION
Closes #9976

## What this does

The library preparation preflight scanned its free-text output against a
substring blocklist that mixed six terms naming an **action** (`sudo`, `curl `,
`wget `, `git clone`, `rm -rf`, `docker run`) with three naming a **subject**
(`credential`, `secret`, `token`). Any hit discarded the whole record.

The subject terms are ordinary vocabulary for exactly the libraries whose
preflight advice is worth the most. 26 recorded runs under `stats/` carry
`ValueError: preflight response requested unsafe preparation behavior` —
`jtokkit`, `google-cloud-secretmanager`, three `awssdk` artifacts, four
`oci-java-sdk` artifacts, `neo4j-java-driver`, `ojdbc11`, `jakarta.mail-api`,
both `spring-security-oauth2` artifacts. Failing soft means this never crashed
a run; it silently paid for the preflight and threw away the answer.

This deletes the three subject terms and makes the raised error name the
matched terms, so a future false positive is diagnosable from the recorded
`failure_reason` alone instead of needing a source read and a replay.

The six action terms stay: `§AR-forge-orchestration.1.1` already establishes
that deterministic setup is "validated by shape rather than scanned as prose"
and that advisory guidance reaches the prompt "as evidence, not trusted
instructions", so the only thing prose can smuggle is a request to step outside
the harness — and that is what the surviving terms describe.
`§AR-forge-orchestration.1.2` records this rationale, landed as its own commit
ahead of the code.
