### PR TITLE
Measure benchmarks with the runner, not the suite pin

### DIFF
--- a/forge/benchmarks/code_coverage_benchmark.py
+++ b/forge/benchmarks/code_coverage_benchmark.py
@@ -1385,7 +1385,12 @@ def convert_workspace(args: argparse.Namespace) -> None:
             "The fixed benchmark input already contains a coverage suite: "
             f"{coverage_suite}"
         )
-    work_path = source_worktree / "forge"
+    # The pin supplies the input; the runner supplies the measurement. Resolving
+    # helpers from the pinned worktree would freeze ranking, classification, and
+    # prompt rendering at the suite commit and split the final-metrics contract
+    # away from the publisher that has to read it.
+    # §FS-code-coverage-benchmarking.1 §AR-code-coverage-benchmarking.1
+    work_path = runner_forge_path
     conversion = {
         "coordinate": args.coordinate,
         "worktreePath": str(source_worktree),
@@ -1405,8 +1410,8 @@ def convert_workspace(args: argparse.Namespace) -> None:
     (issue_dir / "conversion.md").write_text(
         "# Benchmark conversion\n\n"
         f"- Coordinate: `{args.coordinate}`\n"
-        f"- Worktree: `{source_worktree}`\n"
-        f"- Work path: `{work_path}`\n"
+        f"- Measured input: `{source_worktree}` at `{args.suite_commit}`\n"
+        f"- Measuring helpers: `{work_path}` at `{args.runner_commit}`\n"
         f"- Coverage suite: `{coverage_suite}`\n",
         encoding="utf-8",
     )

--- a/forge/docs/architecture/code-coverage-benchmarking.md
+++ b/forge/docs/architecture/code-coverage-benchmarking.md
@@ -32,6 +32,15 @@ Merged coverage improvements do not move an existing benchmark input. A newer
 runner may still execute the old suite and records both identities.
 §FS-code-coverage-benchmarking.1
 
+The two identities map onto two directories, and the conversion record keeps
+them apart. `worktreePath` is the pinned source worktree — the library state
+under measurement — while `workPath` is the Forge tree the measurement helpers
+are imported and executed from. In the issue-driven flow both live in the same
+worktree, because it branches from `master` and its helpers are already current.
+A benchmark cell is the case where they diverge, so `workPath` is the runner's
+Forge path there and the pin is left holding only its input.
+§FS-code-coverage-benchmarking.1
+
 ## 2. Cell execution sequence
 
 The runner prints the complete selection before creating worktrees. Every cell
@@ -271,6 +280,30 @@ Conversion, preparation, finalization, and publication tokens are excluded from
 the initial metric. Missing partial evidence is `null`, never zero.
 `checkedInAllMethods` keeps the suite snapshot and
 `measuredAllMethodsDifference` exposes a changed measured universe.
+
+### 5.1 Final-metrics contract ownership
+
+The runner owns the final coverage metrics contract, and owns it by
+construction rather than by convention. `utility_scripts/code_coverage_finalize.py`
+writes `schemaVersion`, `schemas/code_coverage_final_metrics_schema.json`
+constrains it, and `code_coverage_benchmark.py` reads the record during
+publication. All three resolve from the runner: the first two through `workPath`,
+the third because publication always ran from the runner.
+
+Resolving the writer and its validator from the pinned worktree is what made a
+schema change landing between the pin and the run fatal. The two pinned ends
+agreed with each other, so finalization validated its own output honestly and
+every in-run gate passed; only the reader was current, and the disagreement
+surfaced at the terminal publication state with the whole execution already paid
+for. Nothing forbade that split, because nothing said which commit owned the
+record.
+
+Comparing the pinned and runner schema versions at launch would not be a
+safeguard against this. The suite commit deliberately does not advance
+(§FS-code-coverage-benchmarking.1), so a pin older than the current schema is
+the normal state, and refusing on that difference would refuse every valid
+campaign. One resolution source, not an equality check, is what keeps the
+contract whole. §FS-code-coverage-benchmarking.1
 
 ## 6. Publication boundary
 

--- a/forge/docs/functional-spec/benchmarking.md
+++ b/forge/docs/functional-spec/benchmarking.md
@@ -132,6 +132,15 @@ records both `benchmarkSuiteCommit` and `runnerCommit`: the first identifies the
 library state being measured and the second is implementation provenance, not a
 second baseline or campaign identifier.
 
+The pinned worktree supplies the input and nothing else: the coordinate's test
+project and its metadata. Measurement is implementation, so every helper that
+analyses, ranks, classifies, renders prompts, or writes and validates metrics
+must resolve from the runner. A run whose helpers come from the pin records a
+`runnerCommit` that did not produce it, and makes a prompt or ranking change
+unmeasurable — the only way to reach the run would be to move the input, which
+changes the measured library state and invalidates comparison with every earlier
+result.
+
 The checked-in totals select and describe the suite; the run's own frozen JaCoCo
 method universe is authoritative in its metrics. A difference between the
 checked-in `All methods` value and the measured universe must be recorded, not

--- a/forge/tests/test_code_coverage_benchmark.py
+++ b/forge/tests/test_code_coverage_benchmark.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 from pathlib import Path
 
@@ -119,6 +120,77 @@ class CodeCoverageBenchmarkMatrixTests(unittest.TestCase):
             "claude-code[high]:anthropic/claude-sonnet-5",
             configuration.target("high"),
         )
+
+
+class CodeCoverageBenchmarkConversionTests(unittest.TestCase):
+    """The pin supplies the input; the runner supplies the measurement.
+    §FS-code-coverage-benchmarking.1
+    """
+
+    def _convert(self) -> dict:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        runner = root / "runner"
+        source = root / "run" / "source"
+        workspace = root / "run" / "code-coverage-99000"
+        (runner / "forge").mkdir(parents=True)
+        (runner / "README.md").write_text("seed\n", encoding="utf-8")
+        _git(runner, "init", "-b", "master")
+        _git(runner, "add", "-A")
+        _git(
+            runner,
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "seed",
+        )
+        commit = _git(runner, "rev-parse", "HEAD").stdout.strip()
+        benchmark._create_source_worktree(source, commit, runner)
+        self.addCleanup(benchmark._remove_worktree, source, runner)
+        test_dir = source / "tests" / "src" / "com.example" / "demo" / "1.0.0"
+        test_dir.mkdir(parents=True)
+
+        with patch.object(benchmark, "resolve_test_dir", return_value=str(test_dir)):
+            benchmark.convert_workspace(
+                SimpleNamespace(
+                    workspace=str(workspace),
+                    coordinate="com.example:demo:1.0.0",
+                    run_id="run-1",
+                    started_at="2026-09-09T00:00:00Z",
+                    suite_commit=commit,
+                    runner_commit=commit,
+                    source_worktree=str(source),
+                    runner_forge_path=str(runner / "forge"),
+                    agent="pi",
+                    configured_model="gpt-5.6-sol",
+                    target_model="openai-codex/gpt-5.6-sol",
+                    thinking="high",
+                    checked_in_all_methods=11943,
+                )
+            )
+        conversion = json.loads(
+            (
+                workspace / "runtime" / "code-coverage" / "issues" / "conversion.json"
+            ).read_text(encoding="utf-8")
+        )
+        conversion["_runnerForge"] = str((runner / "forge").resolve())
+        conversion["_source"] = str(source.resolve())
+        return conversion
+
+    def test_measurement_helpers_resolve_from_the_runner(self) -> None:
+        conversion = self._convert()
+
+        self.assertEqual(conversion["_runnerForge"], conversion["workPath"])
+
+    def test_measured_input_stays_the_pinned_worktree(self) -> None:
+        conversion = self._convert()
+
+        self.assertEqual(conversion["_source"], conversion["worktreePath"])
+        self.assertNotIn(conversion["_source"], conversion["workPath"])
 
 
 class CodeCoverageBenchmarkLifecycleTests(unittest.TestCase):


### PR DESCRIPTION
Closes #9972
Closes #9982

## What this does

`benchmarkSuiteCommit` is specified as the fixed benchmark **input** — the coordinate's test project and metadata as they stood at that commit. The implementation pinned the entire source worktree instead, so the measurement *implementation* was frozen there too. Runs ranked targets, classified deep paths, rendered prompts, and wrote their metrics with whatever analysis code existed at the pin, while recording a `runnerCommit` that implies current implementation.

This resolves the measurement helpers from the runner and leaves the pin holding only its input.

## Why the pin was holding two things at once

The conversion record already has two keys for two different things, and only one of them is the library state:

| Key | Means |
| --- | --- |
| `worktreePath` | The repository under measurement — the pinned suite commit |
| `workPath` | The Forge tree whose helpers are imported and executed |

In the issue-driven flow these are the same directory, and correctly so: the issue worktree branches from `master`, so its helpers are already current. A benchmark cell is the one case where they have to differ, because its worktree is deliberately old. Conversion was handing `workPath` the pinned worktree anyway.

## What it cost

Two things, and the second is [#9982](https://github.com/oracle/graalvm-reachability-metadata/issues/9982).

**Analysis changes could not be benchmarked at all.** They only reach a run when `benchmarkSuiteCommit` moves — and moving it also changes the measured library state, invalidating comparison with every earlier result. [`§forge/FS-code-coverage-benchmarking.1`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/benchmark-runner-measurement/forge/docs/functional-spec/benchmarking.md) requires the suite commit not to advance automatically, so there was no way to hold the input fixed and measure a prompt or ranking change. That is the comparison this benchmark most needs to make.

**The final-metrics contract split across two commits.** Run `20260909T005701Z-l4-pi-gpt-5.6-sol-high` took `com.h2database:h2:2.1.210` from 22.51% to 92.27% method coverage (+8331 methods, `needsHumanIntervention: false`) and then died at the terminal publication state after roughly 22 hours:

```
ERROR: A successful benchmark must have valid final coverage metrics.
  'finalMeasurementArtifacts' is a required property
  ['schemaVersion'] '1.3.0' was expected     (file says 1.2.0)
```

The record has three consumers, and the pin put them on different commits:

| Step | Resolved from | Saw |
| --- | --- | --- |
| `reviewed-execute` **writes** `final-metrics.json` | `workPath` → pinned worktree | 1.2.0 |
| `finalize-verify` **validates** it | same pinned worktree | 1.2.0 |
| `benchmark-publication` **reads** it | the runner, always | 1.3.0 |

`1b8972b852` (#9861) bumped `SCHEMA_VERSION` on 7 September, after the 2 September pin and before the 9 September run. The writer and validator were *both* pinned, so they agreed with each other and `finalize-verify` passed honestly — it answered correctly against the commit it was pinned to. An in-run gate cannot detect a split it is standing on one side of.

## The change is one line

`workPath` is the sole key the coverage template uses to resolve helpers — 19 sites across `sys.path`, `PYTHONPATH`, and script paths, covering `code_coverage_validate.py`, `code_coverage_api_rank.py`, `code_coverage_profile_report.py`, `code_coverage_finalize.py` and `CallGraphExtractor.java`. So moving that one assignment moves the whole measurement implementation:

```python
work_path = runner_forge_path        # was: source_worktree / "forge"
```

Writer, validator, and publication reader now resolve to one commit, which is what makes the split structurally impossible rather than merely unlikely. `runnerCommit` also becomes true: it now names the code that actually produced the result.

The conversion states already invoked `code_coverage_benchmark.py` from `benchmark_runner_forge_path` — that is why publication ran current code at all, since it did not exist at the pin. Only the measurement helpers still pointed at the worktree.

No coverage helper derives the repository under test from its own `__file__`; each takes it as an explicit argument. The one `__file__` use, in `code_coverage_finalize.py`, resolves its schema *next to itself* — precisely the behaviour that keeps writer and schema travelling together.

## Why not a launch-time version check

[#9982](https://github.com/oracle/graalvm-reachability-metadata/issues/9982) proposes refusing a cell when the pinned and runner schema versions differ. I built that first and then removed it: once helpers resolve from the runner, the pinned schema version is never read, and because the suite commit deliberately does not advance, a pin older than the current schema is the **normal** state. Tested against the configured suite, the gate refused it outright.

One resolution source, not an equality check, is what keeps the contract whole. [`§forge/AR-code-coverage-benchmarking.5.1`](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/benchmark-runner-measurement/forge/docs/architecture/code-coverage-benchmarking.md) records that reasoning so the check is not re-proposed.
