### PR TITLE
Open maintainer branch PRs as graalvmbot

### DIFF
--- a/.github/maintainer-pr-template.md
+++ b/.github/maintainer-pr-template.md
@@ -1,0 +1,30 @@
+<!--
+  Title and body template for pull requests opened automatically from a push to
+  an `mm/**` branch (.github/workflows/maintainer-open-pr.yml).
+
+  The first line below that is neither blank nor an HTML comment becomes the PR
+  title; everything after it becomes the PR body.
+
+  Placeholders:
+    {{SUBJECT}}  subject of the first commit the branch adds to the base branch
+    {{BRANCH}}   pushed branch name
+    {{AUTHOR}}   login of the account that pushed
+    {{COMMITS}}  bullet list of every commit subject on the branch
+-->
+{{SUBJECT}}
+
+## What this does
+
+<!--
+  Motivation first: the problem or the "before" state, then what this change
+  does about it. Replace this comment — `gh pr edit --body-file -` works, and
+  editing the body does not change the PR author.
+-->
+
+## Commits
+
+{{COMMITS}}
+
+---
+
+Authored by @{{AUTHOR}} on `{{BRANCH}}`, opened by `graalvmbot` so the author can review it.

--- a/.github/maintainer-pr-template.md
+++ b/.github/maintainer-pr-template.md
@@ -7,12 +7,13 @@
   title; everything after it becomes the PR body.
 
   Placeholders:
-    {{SUBJECT}}  subject of the first commit the branch adds to the base branch
-    {{BRANCH}}   pushed branch name
-    {{AUTHOR}}   login of the account that pushed
-    {{COMMITS}}  bullet list of every commit subject on the branch
+    {{BRANCH_NAME}}  branch with the maintainer's own prefix removed
+    {{SUBJECT}}      subject of the first commit the branch adds to the base branch
+    {{BRANCH}}       pushed branch name
+    {{AUTHOR}}       login of the account that pushed
+    {{COMMITS}}      bullet list of every commit subject on the branch
 -->
-{{SUBJECT}}
+Auto PR: {{BRANCH_NAME}}
 
 ## What this does
 

--- a/.github/maintainer-pr-template.md
+++ b/.github/maintainer-pr-template.md
@@ -1,6 +1,7 @@
 <!--
-  Title and body template for pull requests opened automatically from a push to
-  an `mm/**` branch (.github/workflows/maintainer-open-pr.yml).
+  Title and body template for pull requests opened automatically from a push to a
+  branch listed in the `MAINTAINER_PR_BRANCHES` variable
+  (.github/workflows/maintainer-open-pr.yml).
 
   The first line below that is neither blank nor an HTML comment becomes the PR
   title; everything after it becomes the PR body.

--- a/.github/workflows/maintainer-open-pr.yml
+++ b/.github/workflows/maintainer-open-pr.yml
@@ -1,12 +1,16 @@
-# Opens the pull request for an `mm/**` branch as the graalvmbot machine account, so the
-# pushing maintainer is not the PR author and stays eligible to review it. Title and body
-# come from .github/maintainer-pr-template.md.
+# Opens the pull request for a maintainer branch as the graalvmbot machine account, so the
+# pushing maintainer is not the PR author and stays eligible to review it. Which branches
+# qualify is the `MAINTAINER_PR_BRANCHES` variable; title and body come from
+# .github/maintainer-pr-template.md.
 name: Maintainer Open PR
 
 on:
   push:
+    # A branch filter cannot read a variable, so this matches every namespaced branch and
+    # the allowlist does the real selection below. `*` does not match `/`, so the default
+    # branch and other unnamespaced branches never start a run.
     branches:
-      - "mm/**"
+      - "*/**"
 
 permissions:
   contents: read
@@ -19,11 +23,12 @@ concurrency:
 jobs:
   open-pr:
     name: Open pull request as graalvmbot
-    # Commas on both sides match whole logins, so `kim` cannot match `kimeta`. An unlisted
-    # pusher skips the job rather than failing it, and an empty variable disables the
-    # workflow entirely.
+    # Cheap prefilter so an unlisted pusher never starts a runner: `MAINTAINER_PR_BRANCHES`
+    # holds `login:pattern` entries, and a leading comma plus the trailing colon anchor the
+    # login as a whole word, so `kim` cannot match an entry for `kimeta`. The branch pattern
+    # itself is matched in the gate step; an empty variable disables the workflow entirely.
     if: >-
-      ${{ contains(format(',{0},', vars.MAINTAINER_PR_ACTORS), format(',{0},', github.actor)) }}
+      ${{ contains(format(',{0}', vars.MAINTAINER_PR_BRANCHES), format(',{0}:', github.actor)) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the pushed branch
@@ -33,8 +38,24 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Gate the branch against the allowlist
+        id: gate
+        env:
+          ALLOWLIST: ${{ vars.MAINTAINER_PR_BRANCHES }}
+          HEAD_BRANCH: ${{ github.ref_name }}
+          HEAD_ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          python3 .github/workflows/scripts/match-maintainer-branch.py \
+            --allowlist "$ALLOWLIST" \
+            --actor "$HEAD_ACTOR" \
+            --branch "$HEAD_BRANCH" > "$RUNNER_TEMP/gate.txt"
+          cat "$RUNNER_TEMP/gate.txt" >> "$GITHUB_STEP_SUMMARY"
+          tail -n 1 "$RUNNER_TEMP/gate.txt" >> "$GITHUB_OUTPUT"
+
       - name: Render the template
         id: render
+        if: ${{ steps.gate.outputs.allowed == 'true' }}
         env:
           HEAD_SHA: ${{ github.sha }}
           HEAD_BRANCH: ${{ github.ref_name }}
@@ -43,8 +64,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin "$BASE_BRANCH"
-          # Only commit subjects are read from the branch; no branch-supplied script,
-          # action, or build file is executed.
+          # Only commit subjects are read from the branch; no branch-supplied action or
+          # build file is executed.
           git log --reverse --format=%s "origin/$BASE_BRANCH..$HEAD_SHA" > "$RUNNER_TEMP/subjects.txt"
           if [ ! -s "$RUNNER_TEMP/subjects.txt" ]; then
             echo "Branch adds no commits over $BASE_BRANCH; nothing to open." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/maintainer-open-pr.yml
+++ b/.github/workflows/maintainer-open-pr.yml
@@ -38,6 +38,23 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The pushed branch supplies commit subjects and nothing else: every script and the
+      # template are read from the base branch, so a branch cannot run its own code in the
+      # job that later holds GRAALBOT_PR_TOKEN.
+      - name: Take the scripts and template from the base branch
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_BRANCH"
+          for path in \
+            .github/workflows/scripts/match-maintainer-branch.py \
+            .github/workflows/scripts/render-maintainer-pr.py \
+            .github/maintainer-pr-template.md
+          do
+            git show "origin/$BASE_BRANCH:$path" > "$RUNNER_TEMP/$(basename "$path")"
+          done
+
       - name: Gate the branch against the allowlist
         id: gate
         env:
@@ -46,12 +63,13 @@ jobs:
           HEAD_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          python3 .github/workflows/scripts/match-maintainer-branch.py \
+          python3 "$RUNNER_TEMP/match-maintainer-branch.py" \
             --allowlist "$ALLOWLIST" \
             --actor "$HEAD_ACTOR" \
-            --branch "$HEAD_BRANCH" > "$RUNNER_TEMP/gate.txt"
-          cat "$RUNNER_TEMP/gate.txt" >> "$GITHUB_STEP_SUMMARY"
-          tail -n 1 "$RUNNER_TEMP/gate.txt" >> "$GITHUB_OUTPUT"
+            --branch "$HEAD_BRANCH" \
+            > "$RUNNER_TEMP/gate-output.txt" 2> "$RUNNER_TEMP/gate-reason.txt"
+          tee -a "$GITHUB_STEP_SUMMARY" < "$RUNNER_TEMP/gate-reason.txt"
+          cat "$RUNNER_TEMP/gate-output.txt" >> "$GITHUB_OUTPUT"
 
       - name: Render the template
         id: render
@@ -60,22 +78,21 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           HEAD_BRANCH: ${{ github.ref_name }}
           HEAD_ACTOR: ${{ github.actor }}
+          BRANCH_NAME: ${{ steps.gate.outputs.name }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "$BASE_BRANCH"
-          # Only commit subjects are read from the branch; no branch-supplied action or
-          # build file is executed.
           git log --reverse --format=%s "origin/$BASE_BRANCH..$HEAD_SHA" > "$RUNNER_TEMP/subjects.txt"
           if [ ! -s "$RUNNER_TEMP/subjects.txt" ]; then
             echo "Branch adds no commits over $BASE_BRANCH; nothing to open." >> "$GITHUB_STEP_SUMMARY"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/workflows/scripts/render-maintainer-pr.py \
-            --template .github/maintainer-pr-template.md \
+          python3 "$RUNNER_TEMP/render-maintainer-pr.py" \
+            --template "$RUNNER_TEMP/maintainer-pr-template.md" \
             --subjects "$RUNNER_TEMP/subjects.txt" \
             --branch "$HEAD_BRANCH" \
+            --branch-name "$BRANCH_NAME" \
             --author "$HEAD_ACTOR" \
             --title-out "$RUNNER_TEMP/pr-title.txt" \
             --body-out "$RUNNER_TEMP/pr-body.md"

--- a/.github/workflows/maintainer-open-pr.yml
+++ b/.github/workflows/maintainer-open-pr.yml
@@ -1,0 +1,89 @@
+# Opens the pull request for an `mm/**` branch as the graalvmbot machine account, so the
+# pushing maintainer is not the PR author and stays eligible to review it. Title and body
+# come from .github/maintainer-pr-template.md.
+name: Maintainer Open PR
+
+on:
+  push:
+    branches:
+      - "mm/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: maintainer-open-pr-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  open-pr:
+    name: Open pull request as graalvmbot
+    # Commas on both sides match whole logins, so `kim` cannot match `kimeta`. An unlisted
+    # pusher skips the job rather than failing it, and an empty variable disables the
+    # workflow entirely.
+    if: >-
+      ${{ contains(format(',{0},', vars.MAINTAINER_PR_ACTORS), format(',{0},', github.actor)) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the pushed branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Render the template
+        id: render
+        env:
+          HEAD_SHA: ${{ github.sha }}
+          HEAD_BRANCH: ${{ github.ref_name }}
+          HEAD_ACTOR: ${{ github.actor }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$BASE_BRANCH"
+          # Only commit subjects are read from the branch; no branch-supplied script,
+          # action, or build file is executed.
+          git log --reverse --format=%s "origin/$BASE_BRANCH..$HEAD_SHA" > "$RUNNER_TEMP/subjects.txt"
+          if [ ! -s "$RUNNER_TEMP/subjects.txt" ]; then
+            echo "Branch adds no commits over $BASE_BRANCH; nothing to open." >> "$GITHUB_STEP_SUMMARY"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .github/workflows/scripts/render-maintainer-pr.py \
+            --template .github/maintainer-pr-template.md \
+            --subjects "$RUNNER_TEMP/subjects.txt" \
+            --branch "$HEAD_BRANCH" \
+            --author "$HEAD_ACTOR" \
+            --title-out "$RUNNER_TEMP/pr-title.txt" \
+            --body-out "$RUNNER_TEMP/pr-body.md"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Open the pull request
+        if: ${{ steps.render.outputs.skip == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GRAALBOT_PR_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.ref_name }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## $(cat "$RUNNER_TEMP/pr-title.txt")"
+            echo
+            cat "$RUNNER_TEMP/pr-body.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Repeated pushes to a published branch must not duplicate or reopen its pull
+          # request, so an existing open one is a successful no-op.
+          existing="$(gh pr list --head "$HEAD_BRANCH" --state open --json url --jq '.[0].url // empty')"
+          if [ -n "$existing" ]; then
+            echo "Existing pull request left unchanged: ${existing}" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          url="$(gh pr create --base "$BASE_BRANCH" --head "$HEAD_BRANCH" \
+            --title "$(cat "$RUNNER_TEMP/pr-title.txt")" \
+            --body-file "$RUNNER_TEMP/pr-body.md")"
+          echo "Opened ${url}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scripts/match-maintainer-branch.py
+++ b/.github/workflows/scripts/match-maintainer-branch.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Decide whether a pushed branch may be published as a bot-authored pull request.
+
+The allowlist is the `MAINTAINER_PR_BRANCHES` repository variable: a comma-separated list
+of `login:pattern` entries, where `pattern` is a glob matched against the branch name. A
+push is publishable when some entry names the pusher and its pattern matches the branch,
+which keeps every published branch owned by exactly one maintainer.
+
+Patterns use GitHub's branch-filter semantics rather than shell ones, so they read the same
+way as the `on.push.branches` filter in the workflow: `*` matches within one path segment,
+`**` crosses `/`, and `?` matches a single character. Used by
+`.github/workflows/maintainer-open-pr.yml`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+
+def parse_allowlist(allowlist: str) -> list[tuple[str, str]]:
+    """Parse `login:pattern` entries, ignoring blanks so trailing commas are harmless."""
+    entries: list[tuple[str, str]] = []
+    for raw in allowlist.split(","):
+        entry: str = raw.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            raise SystemExit(f"Allowlist entry is not `login:pattern`: {entry!r}")
+        login, pattern = entry.split(":", 1)
+        login, pattern = login.strip(), pattern.strip()
+        if not login or not pattern:
+            raise SystemExit(f"Allowlist entry has an empty login or pattern: {entry!r}")
+        entries.append((login, pattern))
+    return entries
+
+
+def compile_pattern(pattern: str) -> re.Pattern[str]:
+    """Compile a GitHub-style branch filter, where `*` stops at `/` but `**` does not."""
+    regex: str = ""
+    index: int = 0
+    while index < len(pattern):
+        character: str = pattern[index]
+        if character == "*":
+            if pattern.startswith("**", index):
+                regex += ".*"
+                index += 2
+                continue
+            regex += "[^/]*"
+        elif character == "?":
+            regex += "[^/]"
+        else:
+            regex += re.escape(character)
+        index += 1
+    return re.compile(f"^{regex}$")
+
+
+def matching_pattern(allowlist: str, actor: str, branch: str) -> str | None:
+    """Return the pattern that lets `actor` publish `branch`, or None if none does."""
+    for login, pattern in parse_allowlist(allowlist):
+        # Logins are compared case-insensitively because GitHub treats them that way;
+        # branch names are case-sensitive and are compared as pushed.
+        if login.lower() == actor.lower() and compile_pattern(pattern).fullmatch(branch):
+            return pattern
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--allowlist", required=True)
+    parser.add_argument("--actor", required=True)
+    parser.add_argument("--branch", required=True)
+    args = parser.parse_args()
+
+    pattern: str | None = matching_pattern(args.allowlist, args.actor, args.branch)
+    if pattern is None:
+        print(f"No MAINTAINER_PR_BRANCHES entry lets {args.actor} publish {args.branch}.")
+        print("allowed=false")
+        return
+    print(f"{args.branch} matches `{pattern}` for {args.actor}.")
+    print("allowed=true")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/match-maintainer-branch.py
+++ b/.github/workflows/scripts/match-maintainer-branch.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Decide whether a pushed branch may be published as a bot-authored pull request.
 
 The allowlist is the `MAINTAINER_PR_BRANCHES` repository variable: a comma-separated list

--- a/.github/workflows/scripts/match-maintainer-branch.py
+++ b/.github/workflows/scripts/match-maintainer-branch.py
@@ -8,7 +8,12 @@ which keeps every published branch owned by exactly one maintainer.
 
 Patterns use GitHub's branch-filter semantics rather than shell ones, so they read the same
 way as the `on.push.branches` filter in the workflow: `*` matches within one path segment,
-`**` crosses `/`, and `?` matches a single character. Used by
+`**` crosses `/`, and `?` matches a single character.
+
+On a match this also reports the branch's short name — the branch with the matched pattern's
+literal prefix removed, so `mm/auto-*` turns `mm/auto-benchmark-runner` into
+`benchmark-runner`. Each maintainer's own pattern therefore defines what counts as their
+prefix, and the name is what the PR title is built from. Used by
 `.github/workflows/maintainer-open-pr.yml`.
 """
 
@@ -16,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 
 
 def parse_allowlist(allowlist: str) -> list[tuple[str, str]]:
@@ -55,6 +61,14 @@ def compile_pattern(pattern: str) -> re.Pattern[str]:
     return re.compile(f"^{regex}$")
 
 
+def short_name(branch: str, pattern: str) -> str:
+    """Strip the pattern's literal prefix from `branch`, leaving the part the author chose."""
+    prefix: str = re.split(r"[*?]", pattern, maxsplit=1)[0]
+    name: str = branch[len(prefix):] if branch.startswith(prefix) else branch
+    # A wildcard-free pattern leaves nothing behind, so fall back to the last path segment.
+    return name or branch.rsplit("/", 1)[-1]
+
+
 def matching_pattern(allowlist: str, actor: str, branch: str) -> str | None:
     """Return the pattern that lets `actor` publish `branch`, or None if none does."""
     for login, pattern in parse_allowlist(allowlist):
@@ -72,13 +86,17 @@ def main() -> None:
     parser.add_argument("--branch", required=True)
     args = parser.parse_args()
 
+    # Human-readable reasoning goes to stderr, `key=value` results to stdout, so the
+    # workflow can append each stream where it belongs without parsing either.
     pattern: str | None = matching_pattern(args.allowlist, args.actor, args.branch)
     if pattern is None:
-        print(f"No MAINTAINER_PR_BRANCHES entry lets {args.actor} publish {args.branch}.")
+        print(f"No MAINTAINER_PR_BRANCHES entry lets {args.actor} publish {args.branch}.", file=sys.stderr)
         print("allowed=false")
         return
-    print(f"{args.branch} matches `{pattern}` for {args.actor}.")
+    name: str = short_name(args.branch, pattern)
+    print(f"{args.branch} matches `{pattern}` for {args.actor}; short name `{name}`.", file=sys.stderr)
     print("allowed=true")
+    print(f"name={name}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/render-maintainer-pr.py
+++ b/.github/workflows/scripts/render-maintainer-pr.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Render the PR title and body for a maintainer branch from a Markdown template.
+
+The template's first line that is neither blank nor part of a leading HTML comment is
+the title; everything after it is the body. Used by `.github/workflows/maintainer-open-pr.yml`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+PLACEHOLDER_SUBJECT = "{{SUBJECT}}"
+PLACEHOLDER_BRANCH = "{{BRANCH}}"
+PLACEHOLDER_AUTHOR = "{{AUTHOR}}"
+PLACEHOLDER_COMMITS = "{{COMMITS}}"
+
+
+def split_title_body(text: str) -> tuple[str, str]:
+    """Split rendered template text into its title line and the body that follows.
+
+    Leading blank lines and HTML comments are skipped so the template can carry authoring
+    instructions above the title. Comments after the title are kept: they are invisible on
+    GitHub and are how a template prompts the author to fill a section in.
+    """
+    lines: list[str] = text.splitlines()
+    in_comment: bool = False
+
+    for index, line in enumerate(lines):
+        stripped: str = line.strip()
+        if in_comment:
+            in_comment = "-->" not in stripped
+            continue
+        if not stripped:
+            continue
+        if stripped.startswith("<!--"):
+            in_comment = "-->" not in stripped
+            continue
+        return stripped, "\n".join(lines[index + 1:]).strip("\n")
+
+    raise SystemExit("Template contains no title line outside comments")
+
+
+def render(template: str, subjects: list[str], branch: str, author: str) -> tuple[str, str]:
+    commits: str = "\n".join(f"- {subject}" for subject in subjects)
+    rendered: str = (
+        template
+        .replace(PLACEHOLDER_SUBJECT, subjects[0])
+        .replace(PLACEHOLDER_BRANCH, branch)
+        .replace(PLACEHOLDER_AUTHOR, author)
+        .replace(PLACEHOLDER_COMMITS, commits)
+    )
+    return split_title_body(rendered)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template", required=True, type=Path)
+    parser.add_argument("--subjects", required=True, type=Path)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--author", required=True)
+    parser.add_argument("--title-out", required=True, type=Path)
+    parser.add_argument("--body-out", required=True, type=Path)
+    args = parser.parse_args()
+
+    subjects: list[str] = [
+        line.strip() for line in args.subjects.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    if not subjects:
+        raise SystemExit("No commit subjects to render")
+
+    title, body = render(
+        template=args.template.read_text(encoding="utf-8"),
+        subjects=subjects,
+        branch=args.branch,
+        author=args.author,
+    )
+    if not title:
+        raise SystemExit("Rendered title is empty")
+
+    args.title_out.write_text(title, encoding="utf-8")
+    args.body_out.write_text(body + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/render-maintainer-pr.py
+++ b/.github/workflows/scripts/render-maintainer-pr.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Copyright and related rights waived via CC0
+#
+# You should have received a copy of the CC0 legalcode along with this
+# work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 """Render the PR title and body for a maintainer branch from a Markdown template.
 
 The template's first line that is neither blank nor part of a leading HTML comment is

--- a/.github/workflows/scripts/render-maintainer-pr.py
+++ b/.github/workflows/scripts/render-maintainer-pr.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 PLACEHOLDER_SUBJECT = "{{SUBJECT}}"
 PLACEHOLDER_BRANCH = "{{BRANCH}}"
+PLACEHOLDER_BRANCH_NAME = "{{BRANCH_NAME}}"
 PLACEHOLDER_AUTHOR = "{{AUTHOR}}"
 PLACEHOLDER_COMMITS = "{{COMMITS}}"
 
@@ -41,11 +42,12 @@ def split_title_body(text: str) -> tuple[str, str]:
     raise SystemExit("Template contains no title line outside comments")
 
 
-def render(template: str, subjects: list[str], branch: str, author: str) -> tuple[str, str]:
+def render(template: str, subjects: list[str], branch: str, branch_name: str, author: str) -> tuple[str, str]:
     commits: str = "\n".join(f"- {subject}" for subject in subjects)
     rendered: str = (
         template
         .replace(PLACEHOLDER_SUBJECT, subjects[0])
+        .replace(PLACEHOLDER_BRANCH_NAME, branch_name)
         .replace(PLACEHOLDER_BRANCH, branch)
         .replace(PLACEHOLDER_AUTHOR, author)
         .replace(PLACEHOLDER_COMMITS, commits)
@@ -58,6 +60,7 @@ def main() -> None:
     parser.add_argument("--template", required=True, type=Path)
     parser.add_argument("--subjects", required=True, type=Path)
     parser.add_argument("--branch", required=True)
+    parser.add_argument("--branch-name", required=True)
     parser.add_argument("--author", required=True)
     parser.add_argument("--title-out", required=True, type=Path)
     parser.add_argument("--body-out", required=True, type=Path)
@@ -73,6 +76,7 @@ def main() -> None:
         template=args.template.read_text(encoding="utf-8"),
         subjects=subjects,
         branch=args.branch,
+        branch_name=args.branch_name,
         author=args.author,
     )
     if not title:


### PR DESCRIPTION
## What this does

Every PR I open for repository infrastructure sits in `Review required` with me as the author, and GitHub bars a pull request's author from approving it. Forge already publishes with the `GRAALBOT_PR_TOKEN` secret for exactly this reason — the producer stays eligible to review a bot-authored PR. This does the same for maintainer branches: pushing one opens the pull request as `graalvmbot`, which moves the pusher from author to reviewer.

## Each maintainer picks their own branches

`MAINTAINER_PR_BRANCHES` is a comma-separated list of `login:pattern` entries. A push publishes when some entry names the pusher **and** its pattern matches the branch, so every published branch has exactly one owner and each maintainer chooses which of their branches go through the bot:

```
mihailomarkovic:mm/auto-*,someone:sn/**
```

Patterns follow GitHub's branch-filter semantics rather than shell ones, so they read the same way as the `on.push.branches` filter in the same file: `*` matches inside one path segment, `**` crosses `/`, `?` matches one character. With the entry above, `mm/auto-benchmark` publishes and `mm/benchmark-runner` does not — an opt-in prefix rather than a whole namespace.

The matched pattern also defines the branch's short name, which is the branch with that pattern's literal prefix removed. `mm/auto-*` turns `mm/auto-benchmark-runner` into `benchmark-runner`, and the template titles the pull request `Auto PR: benchmark-runner`. Each maintainer's own pattern decides what counts as their prefix, so no prefix convention has to be shared.

A branch filter cannot read a variable, so the workflow triggers on `*/**` and the allowlist does the selection. `*` does not match `/`, so `master` and other unnamespaced branches never start a run, and a job-level `contains()` prefilter drops pushes from any login absent from the variable before a runner starts.

```yaml
if: ${{ contains(format(',{0}', vars.MAINTAINER_PR_BRANCHES), format(',{0}:', github.actor)) }}
```

The variable is comma-prefixed and the login colon-suffixed so the login matches as a whole word — without that, `kim` would match an allowlist containing `kimeta`. An unlisted pusher skips the job rather than failing it, so an ordinary branch push never reports a red check. While the variable is unset the job never runs, so merging this changes no behavior until it is set. Repeated pushes are a no-op: the job checks for an open PR on the same head branch before creating one.

## Title and body come from a template

`.github/maintainer-pr-template.md` owns both. The first line that is neither blank nor part of a leading HTML comment is the **title**; everything after it is the **body**:

| Placeholder | Expands to |
| --- | --- |
| `{{SUBJECT}}` | subject of the first commit the branch adds to `master` |
| `{{COMMITS}}` | bullet list of every commit subject on the branch |
| `{{BRANCH}}` | pushed branch name |
| `{{AUTHOR}}` | login of the account that pushed |
| `{{BRANCH_NAME}}` | branch with the maintainer's own prefix removed |

GitHub does **not** apply `pull_request_template.md` to pull requests created through the API, only to ones opened in the web UI, so the template is read and rendered explicitly by `.github/workflows/scripts/render-maintainer-pr.py` rather than left to GitHub.

Comments above the title are stripped; comments inside the body are kept, since they are invisible on GitHub and are how the template prompts for the description. Commit messages here are subject-only by convention, so the body arrives as a template to fill in — `gh pr edit` does that, and editing a body never changes the PR author.

## The branch contributes strings, not code

Forge splits validate-from-publish across `workflow_run` because a `push`-triggered workflow runs the workflow file *as it exists on the pushed branch*, which hands a branch-controlled definition the publication token. The same hazard applies to anything the job executes out of the checkout: a render step reading its script from the branch runs branch-authored code in the job that later holds `GRAALBOT_PR_TOKEN`, and steps in a job share `$GITHUB_ENV` and `$PATH`.

So the scripts and the template are read from the base branch instead:

```bash
git show "origin/$BASE_BRANCH:$path" > "$RUNNER_TEMP/$(basename "$path")"
```

What the pushed branch supplies is its commit subjects, as strings, via `git log --format=%s`. A `workflow_run` split would add the same boundary a second time, so it is not worth the indirection here. The consequence to know about: a change to the template or the renderer takes effect only once it is on `master`, not on the pull request that proposes it — the same way Forge already behaves.

