### PR TITLE
Fix benchmark finalization and commit authorship

### DIFF
--- a/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
+++ b/forge/.agents/rhei/templates/code-coverage-improvement/states.yaml
@@ -903,7 +903,15 @@ states:
         echo "missing or empty final-metrics.json" >&2
         exit 75
       fi
-      if ! python3 "{{repo_checkout}}/{{work_subdir}}/utility_scripts/schema_validator.py" \
+      # The validator must come from the same work path that wrote the metrics:
+      # `repo_checkout` is the tree under test, which in a benchmark is pinned.
+      # §FS-code-coverage-benchmarking.1
+      work_path="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["workPath"])' \
+          "$RHEI_INPUT_CONVERSION_PATH")" || {
+        echo "conversion.json missing or invalid" >&2
+        exit 75
+      }
+      if ! python3 "$work_path/utility_scripts/schema_validator.py" \
           code_coverage_final_metrics "$metrics" >&2; then
         echo "final-metrics.json failed schema validation" >&2
         exit 75
@@ -928,6 +936,8 @@ states:
         path: runtime/code-coverage/finalization/final-metrics.json
       - name: final-summary
         path: runtime/code-coverage/finalization/final-summary.md
+      - name: conversion
+        path: runtime/code-coverage/issues/conversion.json
 
   finalize-fix:
     description: Repair the cause of a failed finalization step or verification.

--- a/forge/benchmarks/code_coverage_benchmark.py
+++ b/forge/benchmarks/code_coverage_benchmark.py
@@ -1056,17 +1056,11 @@ def _commit_paths(repository: Path, paths: list[Path], subject: str) -> str:
         cwd=repository,
         check=True,
     )
+    # Commit with the ambient identity, like every other publication path. An
+    # override here reached GitHub as an address no account can own, so the
+    # published commits carried no author at all.
     subprocess.run(
-        [
-            "git",
-            "-c",
-            "user.name=metadata-forge",
-            "-c",
-            "user.email=metadata-forge@local",
-            "commit",
-            "-m",
-            subject,
-        ],
+        ["git", "commit", "-m", subject],
         cwd=repository,
         check=True,
     )

--- a/forge/examples/code-coverage-improvement-example/states.yaml
+++ b/forge/examples/code-coverage-improvement-example/states.yaml
@@ -592,7 +592,15 @@ states:
         echo "missing or empty final-metrics.json" >&2
         exit 75
       fi
-      if ! python3 "../../../forge/utility_scripts/schema_validator.py" \
+      # The validator must come from the same work path that wrote the metrics:
+      # the checkout under test is pinned in a benchmark run.
+      # §FS-code-coverage-benchmarking.1
+      work_path="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["workPath"])' \
+          "$RHEI_INPUT_CONVERSION_PATH")" || {
+        echo "conversion.json missing or invalid" >&2
+        exit 75
+      }
+      if ! python3 "$work_path/utility_scripts/schema_validator.py" \
           code_coverage_final_metrics "$metrics" >&2; then
         echo "final-metrics.json failed schema validation" >&2
         exit 75
@@ -617,6 +625,8 @@ states:
         path: runtime/code-coverage/finalization/final-metrics.json
       - name: final-summary
         path: runtime/code-coverage/finalization/final-summary.md
+      - name: conversion
+        path: runtime/code-coverage/issues/conversion.json
 
   finalize-fix:
     description: Repair the cause of a failed finalization step or verification.

--- a/forge/tests/test_code_coverage_benchmark.py
+++ b/forge/tests/test_code_coverage_benchmark.py
@@ -682,6 +682,38 @@ class CodeCoverageBenchmarkTemplateTests(unittest.TestCase):
             settings["agents"]["claude-code"]["command"],
         )
 
+    def test_published_commits_keep_the_ambient_author(self) -> None:
+        """Benchmark commits are authored like every other publication path.
+
+        GitHub resolves a commit to an account by its author email, so an
+        override that no account owns publishes commits with no author at all.
+        """
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        repository = Path(temporary_directory.name) / "authored"
+        repository.mkdir()
+        for argument in (
+                ["git", "init", "--quiet", "-b", "master"],
+                ["git", "config", "user.name", "Benchmark Author"],
+                ["git", "config", "user.email", "author@example.com"],
+        ):
+            subprocess.run(argument, cwd=repository, check=True)
+        recorded = repository / "result.json"
+        recorded.write_text("{}\n", encoding="utf-8")
+
+        benchmark._commit_paths(repository, [recorded], "Record benchmark")
+
+        self.assertEqual(
+            subprocess.run(
+                ["git", "log", "-1", "--format=%an <%ae>"],
+                cwd=repository,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip(),
+            "Benchmark Author <author@example.com>",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/forge/tests/test_code_coverage_rhei_template.py
+++ b/forge/tests/test_code_coverage_rhei_template.py
@@ -195,5 +195,59 @@ class CodeCoverageRheiTemplateTests(unittest.TestCase):
         self.assertIn("jacoco.xml", finalization)
         self.assertIn("discovery-report.json", finalization)
 
+    def test_helpers_never_resolve_from_the_checkout_under_test(self) -> None:
+        """Every helper resolves from the work path, never from the checkout.
+
+        `repo_checkout` is the tree under test, which a benchmark pins to an
+        old commit; only `workPath` tracks the implementation that must measure
+        the run. A helper reached through the checkout silently runs pinned
+        tooling against current metrics. §FS-code-coverage-benchmarking.1
+        """
+        forge_root: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        states_paths: tuple[str, ...] = (
+            os.path.join(
+                forge_root,
+                ".agents",
+                "rhei",
+                "templates",
+                "code-coverage-improvement",
+                "states.yaml",
+            ),
+            os.path.join(
+                forge_root,
+                "examples",
+                "code-coverage-improvement-example",
+                "states.yaml",
+            ),
+        )
+        helper: re.Pattern = re.compile(
+            r"\S*(?:\{\{repo_checkout\}\}|\.\./\.\./\.\.)\S*"
+            r"(?:utility_scripts|schemas)\S*"
+        )
+
+        for states_path in states_paths:
+            with open(states_path, encoding="utf-8") as states_file:
+                source: str = states_file.read()
+            machine: dict = yaml.safe_load(_render_numeric_placeholders(source))
+
+            for name, state in machine["states"].items():
+                program: str = state.get("program", "")
+                with self.subTest(path=states_path, state=name):
+                    self.assertEqual(
+                        helper.findall(program),
+                        [],
+                        f"state '{name}' resolves a helper from the checkout "
+                        "under test; resolve it from conversion.json workPath",
+                    )
+
+            verify: dict = machine["states"]["finalize-verify"]
+            with self.subTest(path=states_path, state="finalize-verify"):
+                self.assertIn("schema_validator.py", verify["program"])
+                self.assertIn('["workPath"]', verify["program"])
+                self.assertIn(
+                    "conversion",
+                    {declared["name"] for declared in verify["inputs"]},
+                )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two defects in the benchmark publication path, each one commit.

## 1. The metrics validator ran from the pinned checkout

`finalize-verify` resolved `schema_validator.py` through `{{repo_checkout}}`,
the tree under test, so a benchmark run validated the runner's metrics with the
schema of its pinned input and could never finish:

```
ValidationError: Additional properties are not allowed
('finalMeasurementArtifacts' was unexpected)
final-metrics.json failed schema validation
```

exit 75, then `finalize-fix`, which cannot converge: regenerating always
produces the runner's schema and the pinned validator always rejects it. The
only way an agent could satisfy the check is to edit the pinned worktree, which
would corrupt the fixed benchmark input.

#10001 moved the six `{work_path}` helper call sites to the runner; this one
was out of reach because it substitutes at instantiate time instead of reading
`conversion.json`. The validator now comes from the same work path that wrote
the metrics, with `conversion.json` declared as an input, matching the
convention four other states already use.

No new variable: `workPath` already means "where the forge helpers live" and is
already correct in both modes -- the issue worktree's own `forge/` in a
generation run, the runner's `forge/` in a benchmark. After this change
`states.yaml` has no `{{repo_checkout}}` uses left and all 21 helper
resolutions go through the work path. `repo_checkout` keeps its single honest
meaning, the tree under test, in the task description and branch-base
instruction.

`examples/code-coverage-improvement-example/states.yaml` carried the identical
defect in rendered form (`../../../forge/utility_scripts/schema_validator.py`),
and the template tests assert against both files, so they move together.

## 2. Published benchmark commits had no author

Benchmark commits were authored `metadata-forge <metadata-forge@local>`. GitHub
resolves a commit to an account by author email, and that address is on a
domain no account can own, so every commit on a benchmark PR published with no
author at all -- see the commits on #10005.

The identity came from `_commit_paths()`, a private reimplementation of
`common_git.stage_and_commit()` that added two `git -c` overrides. It was the
only identity override in the publication path: all seven `publish_*.py` flows
commit with the ambient identity, which is why ordinary GenAI PRs attribute
correctly. The constant itself predates benchmarking and belongs to the local,
never-pushed metrics repositories, where an unroutable address is correct.

The override is removed, so benchmark commits are authored like every other
publication path.


Fixes #10007