### PR TITLE
Hold stopped benchmark runs for human intervention; exempt gitignored config

### DIFF
--- a/forge/benchmarks/code_coverage_benchmark.py
+++ b/forge/benchmarks/code_coverage_benchmark.py
@@ -600,12 +600,12 @@ def _execute_cell(
             else "failure"
         )
         _record_completion(workspace, status, result.returncode)
-        if not _publication_marker_path(workspace).is_file():
-            publish_workspace(
-                workspace,
-                requested_status=status,
-                exit_code=result.returncode,
-            )
+        # A workflow that already wrote its immutable record only failed to
+        # push it, so Git publication is retried; a workflow that stopped
+        # earlier is held for a human instead of publishing a crash-time
+        # snapshot (§FS-code-coverage-benchmarking.3).
+        if not _publication_marker_path(workspace).is_file() and result_path.is_file():
+            publish_workspace(workspace, exit_code=result.returncode)
         if _publication_marker_path(workspace).is_file():
             _discard_source_worktree(source_worktree)
             print(f"Preserved benchmark workspace: {workspace.resolve()}")
@@ -613,22 +613,17 @@ def _execute_cell(
     except (BenchmarkError, OSError, subprocess.SubprocessError) as error:
         print(f"ERROR: Benchmark run {run_id} failed: {error}", file=sys.stderr)
         try:
+            # The run record makes the held workspace discoverable by
+            # retry-pending even when the failure preceded its first write.
             _ensure_run_record(workspace, identity)
             _record_completion(workspace, "failure", None)
-            if not _publication_marker_path(workspace).is_file():
-                publish_workspace(workspace, requested_status="failure")
-            if _publication_marker_path(workspace).is_file():
-                _discard_source_worktree(source_worktree)
-                print(f"Preserved benchmark workspace: {workspace.resolve()}")
-                return False, True
-        except (BenchmarkError, OSError, subprocess.SubprocessError) as publish_error:
+        except (BenchmarkError, OSError) as record_error:
             print(
-                f"ERROR: Benchmark result {run_id} was not published: "
-                f"{publish_error}",
+                f"ERROR: Benchmark run {run_id} has no run record: "
+                f"{record_error}",
                 file=sys.stderr,
             )
-    print(f"Preserved benchmark workspace: {workspace.resolve()}")
-    print(f"Preserved source worktree: {source_worktree.resolve()}")
+    _report_pending_intervention(workspace, source_worktree)
     return False, False
 
 
@@ -673,16 +668,20 @@ def _phase_coverage(
     }
 
 
-def _coverage_from_final_metrics(
-        workspace: Path,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]] | None:
-    path = (
+def _final_metrics_path(workspace: Path) -> Path:
+    return (
         workspace
         / "runtime"
         / "code-coverage"
         / "finalization"
         / "final-metrics.json"
     )
+
+
+def _coverage_from_final_metrics(
+        workspace: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]] | None:
+    path = _final_metrics_path(workspace)
     if not path.is_file():
         return None
     try:
@@ -807,13 +806,7 @@ def _phase_tokens(
 
 
 def _stop_passes(workspace: Path, phase: str) -> int | None:
-    final_metrics = (
-        workspace
-        / "runtime"
-        / "code-coverage"
-        / "finalization"
-        / "final-metrics.json"
-    )
+    final_metrics = _final_metrics_path(workspace)
     if final_metrics.is_file():
         try:
             for decision in _read_json(final_metrics).get("stopDecisions", []):
@@ -873,16 +866,41 @@ def _failure_phase(workspace: Path) -> str | None:
     return mapping.get(task)
 
 
+def _report_pending_intervention(workspace: Path, source_worktree: Path) -> None:
+    """A benchmark run has no GitHub issue, so pending human intervention is
+    launcher-local state: nothing is published, and the operator either resumes
+    the workspace to terminal publication or explicitly publishes the failure
+    (§FS-code-coverage-benchmarking.3)."""
+    phase = _failure_phase(workspace)
+    reason = (
+        f"stopped in the {phase} phase"
+        if phase
+        else "stopped before terminal publication"
+    )
+    print(
+        f"PENDING HUMAN INTERVENTION: {reason}; nothing was published. "
+        "Resume the workspace or publish it with an explicit --status failure."
+    )
+    print(f"Preserved benchmark workspace: {workspace.resolve()}")
+    print(f"Preserved source worktree: {source_worktree.resolve()}")
+
+
 def _collect_result(
         workspace: Path,
-        requested_status: str,
+        requested_status: str | None,
         exit_code: int | None,
 ) -> dict[str, Any]:
+    # A written record is immutable for its runId, success or failure
+    # (§AR-code-coverage-benchmarking.3).
     result_path = _result_record_path(workspace)
     if result_path.is_file():
         existing: dict[str, Any] = _read_json(result_path)
         _validate([existing], RESULT_SCHEMA_PATH)
         return existing
+    if requested_status is None:
+        raise BenchmarkError(
+            "Publishing without a recorded result requires an explicit --status."
+        )
     run: dict[str, Any] = _read_json(_run_record_path(workspace))
     finalized = _coverage_from_final_metrics(workspace)
     if requested_status == "success" and finalized is None:
@@ -1310,12 +1328,11 @@ def publish_workspace(
     """Collect and idempotently publish one workspace's compact result."""
     workspace = workspace.resolve()
     run: dict[str, Any] = _read_json(_run_record_path(workspace))
-    status = requested_status or run.get("requestedStatus") or "failure"
     known_exit = exit_code
     if known_exit is None:
         candidate = run.get("rheiExitCode")
         known_exit = candidate if type(candidate) is int else None
-    result = _collect_result(workspace, status, known_exit)
+    result = _collect_result(workspace, requested_status, known_exit)
     publication = _publish_result(repository_root.resolve(), workspace, result)
     marker = {
         "schemaVersion": "1.0.0",
@@ -1567,10 +1584,18 @@ def retry_pending(args: argparse.Namespace) -> int:
     if not pending:
         return 0
     failures = 0
+    held = 0
     for workspace in pending:
+        run = _read_json(_run_record_path(workspace))
+        # Only a workspace with a written record retries publication; one
+        # without a record is held for a human decision
+        # (§FS-code-coverage-benchmarking.3).
+        if not _result_record_path(workspace).is_file():
+            held += 1
+            _report_pending_intervention(workspace, Path(run["sourceWorktree"]))
+            continue
         try:
             publish_workspace(workspace)
-            run = _read_json(_run_record_path(workspace))
             source = Path(run["sourceWorktree"])
             if source.exists():
                 _discard_source_worktree(source)
@@ -1580,6 +1605,8 @@ def retry_pending(args: argparse.Namespace) -> int:
                 f"ERROR: Could not publish {workspace}: {error}",
                 file=sys.stderr,
             )
+    if held:
+        print(f"{held} workspace(s) are pending human intervention.")
     return 1 if failures else 0
 
 

--- a/forge/docs/architecture/code-coverage-benchmarking.md
+++ b/forge/docs/architecture/code-coverage-benchmarking.md
@@ -137,10 +137,13 @@ A source-worktree gate failure happens before this sequence: the launcher
 reports the skipped cell and continues without creating a Rhei workspace or
 benchmark result. §FS-code-coverage-benchmarking.2
 
-The terminal program is not the only publication path. The launcher checks for
-a publication marker after Rhei returns. If Rhei stopped before publication, the
-launcher collects partial evidence and publishes a failure result. If collection
-or publication fails, both the source and workspace remain.
+The terminal program is the only automatic collection path. The launcher
+checks for a publication marker after Rhei returns. When the marker is missing
+but the workflow already wrote its result, the launcher retries Git
+publication of that exact record; when no result exists, it publishes nothing
+and reports the run as pending human intervention with the workspace and
+source paths preserved. The operator then resumes the workspace until terminal
+publication, or explicitly publishes the failure.
 §FS-code-coverage-benchmarking.3
 
 ```mermaid
@@ -159,9 +162,18 @@ sequenceDiagram
 
     L->>R: execute benchmark cell
     alt workflow stops before terminal publication
-        R-->>L: return without publication marker
-        L->>B: collect failure result
-        B->>W: read partial evidence and write result.json
+        R-->>L: return without publication marker or result.json
+        Note over W,S: retain workspace and source
+        L-->>O: report pending human intervention
+        alt operator resumes the workspace
+            O->>R: resume until terminal publication
+            R->>B: publish success result
+            B->>W: write result.json from terminal evidence
+        else operator publishes the failure
+            O->>L: publish --status failure
+            L->>B: collect failure result once
+            B->>W: read evidence and write result.json
+        end
     else terminal publication cannot push
         B->>W: result.json already written
         R-->>L: return without publication marker
@@ -191,22 +203,30 @@ sequenceDiagram
 
     O->>L: retry-pending
     L->>W: find run.json without publication.json
-    L->>B: republish preserved result.json
-    B->>M: fetch latest origin/master
-    B->>G: create fresh publication worktree
-    B->>P: append identical result by runId
-    P->>M: push result and descriptor branch
-    M-->>A: validate and open PR asynchronously
-    B->>G: remove publication worktree
-    B->>W: write publication.json
-    L->>S: remove source
-    L-->>O: retry completed
+    alt result.json exists
+        L->>B: republish preserved result.json
+        B->>M: fetch latest origin/master
+        B->>G: create fresh publication worktree
+        B->>P: append identical result by runId
+        P->>M: push result and descriptor branch
+        M-->>A: validate and open PR asynchronously
+        B->>G: remove publication worktree
+        B->>W: write publication.json
+        L->>S: remove source
+        L-->>O: retry completed
+    else no result.json
+        L-->>O: list workspace as pending human intervention
+    end
 ```
 
-`result.json` is written before Git publication and is immutable for its
-`runId`. A retry either finds an identical merged entry, reuses its exact
-remote publication branch, or proposes the same object. Different data with
-the same `runId` is an integrity error.
+`result.json` is written at most once, before Git publication, and is
+immutable for its `runId` whatever its status: a retry either finds an
+identical merged entry, reuses its exact remote publication branch, or
+proposes the same object, and different data with the same `runId` is an
+integrity error. Immutability is safe because no record is written
+automatically at a stop — a record exists only when the workflow reached
+terminal publication or the operator explicitly published a failure.
+§FS-code-coverage-benchmarking.3
 
 ## 4. Data locations
 

--- a/forge/docs/architecture/code-coverage-improvement.md
+++ b/forge/docs/architecture/code-coverage-improvement.md
@@ -560,7 +560,10 @@ The Rhei template should decompose the workflow into these phases:
    (§root/FS-metadata.2, §root/AR-test-harness.5). The step also fails the
    run when a legacy split-config file survives anywhere under the coordinate's
    test tree, which is how a tracing-agent artifact left behind by metadata
-   preparation is caught before publication rather than in review (§2). Nothing
+   preparation is caught before publication rather than in review (§2).
+   Gitignored files are exempt: the Gradle native plugin generates split-config
+   files under `build/` as part of its own pipeline, and an ignored file can
+   never be committed, so it is not a policy violation. Nothing
    at this stage validates the coverage tests under Native Image — the native
    build the stats step runs measures dynamic access and does not gate the run;
    a nonzero exit code names the failed step.

--- a/forge/docs/functional-spec/benchmarking.md
+++ b/forge/docs/functional-spec/benchmarking.md
@@ -237,9 +237,22 @@ the run identity, status, configuration, coverage gain, and token totals from
 the validated descriptor. Repository CI and the normal merge boundary remain
 responsible for accepting it. §FS-forge-publication-readiness
 
-The outer launcher must invoke the same metrics collector when Rhei terminates
-before reaching benchmark publication. Thus a failed or partial workflow remains
-a benchmark result rather than disappearing from the comparison.
+When Rhei terminates before reaching benchmark publication, the launcher must
+publish nothing. It preserves the workspace and the source worktree and
+reports the run as pending human intervention, printing the workspace path and
+the failed phase when known. A record collected automatically from partial
+evidence at the stop can mask the completed outcome once the workspace is
+resumed and finalized, so a crash-time snapshot must never be published. A
+failed or partial workflow still remains a benchmark result rather than
+disappearing from the comparison, but it enters the comparison only through an
+explicit human decision: the operator either resumes the workspace until the
+workflow reaches terminal publication, or explicitly publishes the run as a
+failure, which builds the record exactly once from the evidence present at
+that moment. Every written record, success or failure, is immutable for its
+`runId`. Because a benchmark run has no GitHub issue, pending human
+intervention is launcher-local state reported on the console and derivable
+from the workspace, not the `human-intervention` label flow
+(§FS-human-intervention-policy).
 
 The normalized result must be written into the workspace before Git publication,
 and a publication marker may be written only after the publication branch is
@@ -251,7 +264,9 @@ branch pushing fails, both the source worktree and workspace remain so
 completion can be retried without losing evidence.
 
 The launcher provides a command that discovers workspaces without a publication
-marker and retries their result publication without rerunning coverage.
+marker. A workspace that already holds a written result retries its Git
+publication without rerunning coverage; a workspace without one is listed as
+pending human intervention and left untouched.
 
 ## 4. Initial metrics record
 

--- a/forge/tests/test_code_coverage_benchmark.py
+++ b/forge/tests/test_code_coverage_benchmark.py
@@ -323,7 +323,9 @@ class CodeCoverageBenchmarkLifecycleTests(unittest.TestCase):
         execute.assert_not_called()
         publish.assert_not_called()
 
-    def test_retains_source_when_publication_has_no_marker(self) -> None:
+    def test_holds_stopped_run_for_human_intervention(self) -> None:
+        """A stop before terminal publication publishes nothing: the launcher
+        retains the workspace and source and reports the run as pending."""
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
         root = Path(temporary.name)
@@ -342,8 +344,63 @@ class CodeCoverageBenchmarkLifecycleTests(unittest.TestCase):
         ), patch.object(
                 benchmark,
                 "publish_workspace",
-                side_effect=benchmark.BenchmarkError("push failed"),
+        ) as publish, patch.object(
+                benchmark,
+                "_remove_worktree",
+        ) as remove, patch("builtins.print") as output:
+            outcome = benchmark._execute_cell(
+                self.suite,
+                self.cell,
+                "a" * 40,
+                root,
+            )
+
+        self.assertEqual((False, False), outcome)
+        publish.assert_not_called()
+        remove.assert_not_called()
+        messages = [str(call.args[0]) for call in output.call_args_list if call.args]
+        self.assertTrue(
+            any("PENDING HUMAN INTERVENTION" in message for message in messages)
+        )
+        workspace = root / "run-failure" / "code-coverage-99000"
+        run = benchmark._read_json(workspace / benchmark.RUN_RECORD)
+        self.assertEqual("failure", run["requestedStatus"])
+
+    def test_retries_publication_when_record_exists_without_marker(self) -> None:
+        """A workflow that wrote its record but could not push it retries Git
+        publication of that exact record instead of being held."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+
+        def execute(command: list[str], **_: object) -> subprocess.CompletedProcess:
+            workspace = Path(command[command.index("--output") + 1])
+            _write_json(workspace / benchmark.RESULT_RECORD, {"status": "success"})
+            return subprocess.CompletedProcess(command, 1)
+
+        def publish(workspace: Path, **_: object) -> dict[str, object]:
+            _write_json(
+                workspace / benchmark.PUBLICATION_MARKER,
+                {"schemaVersion": "1.0.0"},
+            )
+            return {"status": "success"}
+
+        with patch.object(
+                benchmark,
+                "_new_run_id",
+                return_value="run-retry",
         ), patch.object(
+                benchmark,
+                "_create_source_worktree",
+        ), patch.object(
+                benchmark.subprocess,
+                "run",
+                side_effect=execute,
+        ), patch.object(
+                benchmark,
+                "publish_workspace",
+                side_effect=publish,
+        ) as republish, patch.object(
                 benchmark,
                 "_remove_worktree",
         ) as remove, patch("builtins.print"):
@@ -354,8 +411,40 @@ class CodeCoverageBenchmarkLifecycleTests(unittest.TestCase):
                 root,
             )
 
-        self.assertEqual((False, False), outcome)
-        remove.assert_not_called()
+        self.assertEqual((True, True), outcome)
+        republish.assert_called_once()
+        remove.assert_called_once_with(root / "run-retry" / "source")
+
+    def test_retry_pending_republishes_records_and_lists_held_workspaces(self) -> None:
+        """Only a workspace with a written record retries publication; one
+        without a record is listed as pending human intervention."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        held = root / "run-held" / "code-coverage-99000"
+        publishable = root / "run-pub" / "code-coverage-99000"
+        for run_id, workspace in (("run-held", held), ("run-pub", publishable)):
+            _write_json(
+                workspace / benchmark.RUN_RECORD,
+                {
+                    "runId": run_id,
+                    "sourceWorktree": str(workspace.parent / "source"),
+                },
+            )
+        _write_json(publishable / benchmark.RESULT_RECORD, {"status": "failure"})
+
+        with patch.object(
+                benchmark,
+                "publish_workspace",
+        ) as publish, patch("builtins.print") as output:
+            code = benchmark.retry_pending(SimpleNamespace(workspace_root=root))
+
+        self.assertEqual(0, code)
+        publish.assert_called_once_with(publishable)
+        messages = [str(call.args[0]) for call in output.call_args_list if call.args]
+        self.assertTrue(
+            any("PENDING HUMAN INTERVENTION" in message for message in messages)
+        )
 
 
 class CodeCoverageBenchmarkMetricsTests(unittest.TestCase):
@@ -481,6 +570,30 @@ class CodeCoverageBenchmarkMetricsTests(unittest.TestCase):
         self.assertIsNone(result["deep"]["coverPasses"])
         self.assertIsNone(result["total"]["tokens"]["input"])
         self.assertIsNone(result["total"]["coverage"]["allMethods"])
+
+    def test_written_record_is_immutable_for_its_run_id(self) -> None:
+        """A written record is returned verbatim whatever status is requested
+        later, even when terminal evidence appears after the write."""
+        _, workspace = self._workspace()
+        self._write_run(workspace)
+        recorded = benchmark._collect_result(workspace, "failure", 7)
+        self.assertEqual("failure", recorded["status"])
+
+        final_metrics = benchmark._final_metrics_path(workspace)
+        final_metrics.parent.mkdir(parents=True)
+        shutil.copy2(FINAL_METRICS, final_metrics)
+
+        self.assertEqual(recorded, benchmark._collect_result(workspace, "success", 0))
+        self.assertEqual(recorded, benchmark._collect_result(workspace, None, None))
+
+    def test_collecting_a_new_record_requires_an_explicit_status(self) -> None:
+        """Without a written record there is no automatic failure default: the
+        operator must decide the status explicitly."""
+        _, workspace = self._workspace()
+        self._write_run(workspace)
+        with self.assertRaises(benchmark.BenchmarkError):
+            benchmark._collect_result(workspace, None, None)
+        self.assertFalse(benchmark._result_record_path(workspace).is_file())
 
     def test_merge_is_idempotent_and_rejects_conflicts(self) -> None:
         temporary = tempfile.TemporaryDirectory()

--- a/forge/tests/test_metrics_paths.py
+++ b/forge/tests/test_metrics_paths.py
@@ -556,6 +556,45 @@ class MetricsPathTests(unittest.TestCase):
                 "tests/src/org.example/demo/1.0.0/src/test/resources/META-INF/native-image/reachability-metadata.json"
             ))
 
+    def test_native_image_config_policy_skips_gitignored_build_output(self) -> None:
+        """The Gradle native plugin generates split-config files under `build/`; ignored files cannot be committed."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            metadata_dir = os.path.join(temp_dir, "metadata", "org.example", "demo")
+            test_project_dir = os.path.join(temp_dir, "tests", "src", "org.example", "demo", "1.0.0")
+            build_config_dir = os.path.join(
+                test_project_dir, "build", "native", "generated", "generateTestResourcesConfigFile"
+            )
+            test_metadata_dir = os.path.join(
+                test_project_dir, "src", "test", "resources", "META-INF", "native-image"
+            )
+            os.makedirs(metadata_dir)
+            os.makedirs(build_config_dir)
+            os.makedirs(test_metadata_dir)
+            with open(os.path.join(metadata_dir, "index.json"), "w", encoding="utf-8") as file:
+                json.dump(
+                    [
+                        {
+                            "metadata-version": "1.0.0",
+                            "test-version": "1.0.0",
+                            "tested-versions": ["1.0.1"],
+                        }
+                    ],
+                    file,
+                )
+            for directory in (build_config_dir, test_metadata_dir):
+                with open(os.path.join(directory, "resource-config.json"), "w", encoding="utf-8") as file:
+                    json.dump({"resources": {"includes": []}}, file)
+            _git(temp_dir, "init")
+            with open(os.path.join(temp_dir, ".gitignore"), "w", encoding="utf-8") as file:
+                file.write("**/build\n")
+
+            self.assertEqual(
+                find_legacy_test_native_image_config_files_for_coordinate(temp_dir, "org.example:demo:1.0.1"),
+                [
+                    "tests/src/org.example/demo/1.0.0/src/test/resources/META-INF/native-image/resource-config.json",
+                ],
+            )
+
     def test_create_run_metrics_includes_test_only_metadata_entries_only_when_positive(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             tests_root = os.path.join(

--- a/forge/utility_scripts/native_image_config_policy.py
+++ b/forge/utility_scripts/native_image_config_policy.py
@@ -62,7 +62,7 @@ def find_legacy_test_native_image_config_files_for_coordinate(repo_path: str, co
         for filename in filenames:
             if filename in LEGACY_TEST_NATIVE_IMAGE_CONFIG_FILENAMES:
                 paths.append(_repo_relative_path(repo_path, os.path.join(root, filename)))
-    return sorted(paths)
+    return sorted(_discard_git_ignored_paths(repo_path, paths))
 
 
 def find_changed_legacy_test_native_image_config_files_for_coordinate(
@@ -100,6 +100,27 @@ def is_legacy_test_native_image_config_path(path: str) -> bool:
         normalized.startswith(TEST_SOURCE_ROOT)
         and os.path.basename(normalized) in LEGACY_TEST_NATIVE_IMAGE_CONFIG_FILENAMES
     )
+
+
+def _discard_git_ignored_paths(repo_path: str, paths: list[str]) -> list[str]:
+    """Drop paths git ignores: the Gradle native plugin generates split-config
+    files under `build/`, and an ignored file can never be committed, so it is
+    not a policy violation (§AR-code-coverage-improvement.4)."""
+    if not paths:
+        return paths
+    result = subprocess.run(
+        ["git", "check-ignore", "--stdin"],
+        cwd=repo_path,
+        input="\n".join(paths),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        return paths
+    ignored = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    return [path for path in paths if path not in ignored]
 
 
 def _coordinate_test_project_prefix(repo_path: str, coordinates: str) -> str:


### PR DESCRIPTION
Closes #10011

## What this does

The h2 2.1.210 benchmark run exposed two defects. First, when Rhei stopped mid-run the launcher collected a failure record from partial evidence and published it; after the workspace was resumed and finalized, terminal publication republished that crash-time snapshot — #10009 went out as a 39.24pp failure while the completed run was a 60.91pp success (#10010). Second, the legacy native-image config policy walks the whole test project including `build/`, so it flags the `resource-config.json` that the native plugin's own `generateTestResourcesConfigFile` task generates there, failing finalization and costing an agent repair cycle plus a remeasurement on every affected run.

## Stopped runs are held for a human, not auto-published

Automatic failure publication is removed rather than patched. A stop before terminal publication now publishes nothing: the launcher preserves the workspace and the source worktree and reports the run as pending human intervention, printing the failed phase when known ([§FS-code-coverage-benchmarking.3](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/benchmark-stale-result-and-build-scan/forge/docs/functional-spec/benchmarking.md), [§AR-code-coverage-benchmarking.3](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/benchmark-stale-result-and-build-scan/forge/docs/architecture/code-coverage-benchmarking.md)). The operator either resumes the workspace until the workflow publishes the real result, or explicitly publishes the failure with `publish --status failure`, which builds the record exactly once from the evidence present at that moment. A failed run therefore still enters the comparison, but only through an explicit human decision — never as a crash-time snapshot that can mask the completed outcome.

Every written record, success or failure, is immutable for its `runId`, so a retry always reuses the same publication identity and branch:

| Workspace state at `retry-pending` | Outcome |
| --- | --- |
| publication marker present | already published, skipped |
| `result.json` present, no marker | Git publication retried with the identical record |
| no `result.json` | listed as pending human intervention, left untouched |

A benchmark run has no GitHub issue (the synthetic `99000` workspace), so pending human intervention is launcher-local console state, not the `human-intervention` label flow.

## Why gitignored config is exempt

`**/build` is gitignored at the repository root, so a split-config file under Gradle build output can never be committed or published — and unpublishable files are outside what the policy exists to catch ([§AR-code-coverage-improvement.4](https://github.com/oracle/graalvm-reachability-metadata/blob/mm/benchmark-stale-result-and-build-scan/forge/docs/architecture/code-coverage-improvement.md)). The walk-based finder now drops paths `git check-ignore` claims; the diff-based variants were already scoped to tracked and unignored files. Outside a git checkout (unit-test temp directories) the filter keeps every path.

The spec amendments land as their own commit ahead of the code.
